### PR TITLE
Add Red Maple to Hall of Fame data

### DIFF
--- a/_data/hall-of-fame.yml
+++ b/_data/hall-of-fame.yml
@@ -451,3 +451,15 @@ members:
         label: "街舞"
       - id: "tattoo"
         label: "刺青"
+
+  - id: "red_maple"
+    name: "Red Maple"
+    avatar: "/assets/img/guild/red_maple/avatar.webp"
+    page: "/guild/red_maple.html"
+    tags:
+      - id: "soul_chef"
+        label: "靈魂主廚"
+      - id: "digital_ascetic"
+        label: "數位苦行僧"
+      - id: "godot_dev"
+        label: "Godot 遊戲開發"


### PR DESCRIPTION
Added the missing entry for Red Maple (guild/red_maple.html) to `_data/hall-of-fame.yml`, including name, avatar path, and tags derived from the page content.

---
*PR created automatically by Jules for task [12284335062434684721](https://jules.google.com/task/12284335062434684721) started by @Lawa0921*