### PR TITLE
Add Ah Shui to Hall of Fame

### DIFF
--- a/src/data/hall-of-fame.yml
+++ b/src/data/hall-of-fame.yml
@@ -583,3 +583,15 @@ members:
         label: "道具設計"
       - id: "structural_magic"
         label: "結構魔術"
+
+  - id: "ah_shui"
+    name: "阿水 Ah Shui"
+    avatar: "/assets/img/guild/ah_shui/avatar.webp"
+    page: "/guild/ah_shui.html"
+    tags:
+      - id: "event_host"
+        label: "活動主持人"
+      - id: "pipa_musician"
+        label: "琵琶演奏家"
+      - id: "culture_promoter"
+        label: "歌仔戲推廣"


### PR DESCRIPTION
This PR adds the guild member 'Ah Shui' to the Hall of Fame registry (`src/data/hall-of-fame.yml`). The data was extracted from her personal page (`src/content/guild/ah_shui.html`), ensuring her roles (Event Host, Pipa Musician, Culture Promoter) are correctly tagged and her avatar is linked.

Verification:
- Automated test `verify_ah_shui.py` confirmed the data exists in `window.GUILD_DATA`.
- Visual verification of the grid layout confirmed the member card renders correctly.

---
*PR created automatically by Jules for task [14632253563878582135](https://jules.google.com/task/14632253563878582135) started by @Lawa0921*