### PR TITLE
Register Joying in Hall of Fame

### DIFF
--- a/src/data/hall-of-fame.yml
+++ b/src/data/hall-of-fame.yml
@@ -607,3 +607,15 @@ members:
         label: "琵琶演奏家"
       - id: "culture_promoter"
         label: "歌仔戲推廣"
+
+  - id: "joying"
+    name: "Joying"
+    avatar: "/assets/img/guild/joying/avatar.webp"
+    page: "/guild/joying.html"
+    tags:
+      - id: "tactical_guide"
+        label: "戰術嚮導"
+      - id: "atmosphere_specialist"
+        label: "氛圍專家"
+      - id: "crisis_control"
+        label: "危機控管"


### PR DESCRIPTION
Added `joying` to `src/data/hall-of-fame.yml` with tags derived from `src/content/guild/joying.html` ("Tactical Guide", "Atmosphere Specialist", "Crisis Control"). Verified correct data loading and frontend rendering.

---
*PR created automatically by Jules for task [9049200625669754272](https://jules.google.com/task/9049200625669754272) started by @Lawa0921*