### PR TITLE
Fix ev01 guild page lightbox visibility

### DIFF
--- a/src/content/guild/ev01.html
+++ b/src/content/guild/ev01.html
@@ -1310,15 +1310,6 @@
         <div class="cursor-glow" id="cursor-glow"></div>
         <div class="particles-container" id="particles"></div>
 
-        <!-- 圖片燈箱 -->
-        <div class="lightbox" id="lightbox">
-        <button class="lightbox-close" aria-label="關閉">&times;</button>
-        <button class="lightbox-nav lightbox-prev" aria-label="上一張">&#10094;</button>
-        <img src="" alt="放大圖片" id="lightbox-img">
-        <button class="lightbox-nav lightbox-next" aria-label="下一張">&#10095;</button>
-        <div class="lightbox-counter" id="lightbox-counter"></div>
-    </div>
-
     <nav class="nav">
         <a href="/guild/" class="back-btn">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 24 24"
@@ -1339,7 +1330,7 @@
             <!-- Header -->
             <header class="card-header">
                 <div class="avatar-wrapper">
-                    <img src="../assets/img/guild/ev01/avatar.webp" alt="Ev01 Avatar" class="avatar">
+                    <img src="/assets/img/guild/ev01/avatar.webp" alt="Ev01 Avatar" class="avatar">
                     <div class="status-badge">LV.MAX</div>
                 </div>
                 <div class="character-info">
@@ -1617,14 +1608,14 @@
 
             <div class="gallery-section">
                 <div class="gallery-grid">
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-1.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-2.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-3.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-4.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-5.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-6.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-7.webp" loading="lazy"></div>
-                    <div class="gallery-item"><img src="../assets/img/guild/ev01/gallery-8.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-1.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-2.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-3.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-4.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-5.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-6.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-7.webp" loading="lazy"></div>
+                    <div class="gallery-item"><img src="/assets/img/guild/ev01/gallery-8.webp" loading="lazy"></div>
                 </div>
             </div>
 
@@ -1635,6 +1626,15 @@
         </article>
     </main>
     </div><!-- End of page-content -->
+
+    <!-- 圖片燈箱 -->
+    <div class="lightbox" id="lightbox">
+        <button class="lightbox-close" aria-label="關閉">&times;</button>
+        <button class="lightbox-nav lightbox-prev" aria-label="上一張">&#10094;</button>
+        <img src="" alt="放大圖片" id="lightbox-img">
+        <button class="lightbox-nav lightbox-next" aria-label="下一張">&#10095;</button>
+        <div class="lightbox-counter" id="lightbox-counter"></div>
+    </div>
 
     <script>
         // =============================================


### PR DESCRIPTION
This PR fixes an issue where the lightbox on the `ev01` guild page was not visible or functioning correctly. The root cause was identified as a combination of CSS stacking context issues (lightbox nested inside a filtered container) and potentially unreliable relative paths. The fix involves moving the lightbox to the root of the body and using absolute paths for images.

---
*PR created automatically by Jules for task [13730399790429641234](https://jules.google.com/task/13730399790429641234) started by @Lawa0921*