### PR TITLE
Fix RWD horizontal scrolling on /guild/flora

### DIFF
--- a/src/content/guild/flora.html
+++ b/src/content/guild/flora.html
@@ -39,11 +39,15 @@
             box-sizing: border-box;
         }
 
-        body {
+        html, body {
             background-color: var(--c-bg);
             color: var(--c-text);
             font-family: var(--font-body);
             overflow-x: hidden;
+            width: 100%;
+        }
+
+        body {
             opacity: 0;
             transition: opacity 1s ease;
             cursor: default;
@@ -548,7 +552,7 @@
                 flex-direction: column !important;
                 gap: 2rem;
                 padding: 2rem 1rem !important; /* Further reduce padding */
-                width: 100% !important;
+                width: auto !important;
                 max-width: 100% !important;
                 border-radius: 10px !important;
                 box-shadow: 5px 5px 15px rgba(0,0,0,0.1) !important;
@@ -915,8 +919,9 @@
         // 2. PASTRY CARDS ENTRANCE
         gsap.utils.toArray('.pastry-card').forEach((card, i) => {
             // Parallax entrance
-            const dir = i % 2 === 0 ? -100 : 100; // Alternating sides
-            const rot = i % 2 === 0 ? -5 : 5;
+            const isMobile = window.innerWidth < 768;
+            const dir = isMobile ? 0 : (i % 2 === 0 ? -100 : 100); // Alternating sides
+            const rot = isMobile ? 0 : (i % 2 === 0 ? -5 : 5);
 
             gsap.from(card, {
                 x: dir,


### PR DESCRIPTION
This PR fixes the horizontal scrolling issue observed on mobile devices for the `/guild/flora` page.

Changes:
- **CSS**: Added `overflow-x: hidden` and `width: 100%` to `html, body` global styles. Enforced `width: auto !important` for `.card-grimoire` within the mobile media query to prevent fixed-width overflow.
- **JS (GSAP)**: Implemented a check for mobile viewport width (`< 768px`). If detected, the initial GSAP animation states for `x` (translation) and `rotation` are set to `0` instead of off-screen values. This prevents elements from stretching the document width during the animation initialization phase.

Verification:
- Confirmed `scrollWidth` equals `clientWidth` (390px) on an emulated iPhone 12 viewport using a Playwright script.
- Visually verified layout integrity via screenshots.

---
*PR created automatically by Jules for task [13112556444324402242](https://jules.google.com/task/13112556444324402242) started by @Lawa0921*