### PR TITLE
Fix overlap of 'SCROLL TO' text on Elora's guild page

### DIFF
--- a/src/content/guild/elora.html
+++ b/src/content/guild/elora.html
@@ -353,9 +353,10 @@
                 </div>
             </div>
 
-            <div style="position: absolute; bottom: 2rem; left: 50%; transform: translateX(-50%); opacity: 0.5; font-family: var(--f-mono); font-size: 0.8rem;">
-                SCROLL TO IGNITE
-            </div>
+        </div>
+
+        <div style="position: absolute; bottom: 2rem; left: 50%; transform: translateX(-50%); opacity: 0.5; font-family: var(--f-mono); font-size: 0.8rem;">
+            SCROLL TO IGNITE
         </div>
     </section>
 


### PR DESCRIPTION
Moved the "SCROLL TO IGNITE" prompt outside the content container in `src/content/guild/elora.html` to prevent it from overlapping with the profile description. It is now positioned relative to the hero section, ensuring it stays at the bottom of the viewport.

---
*PR created automatically by Jules for task [3755862381797287175](https://jules.google.com/task/3755862381797287175) started by @Lawa0921*