### PR TITLE
fix: 修正 lyanna 公會頁面圖片裁切問題

### DIFF
--- a/src/content/guild/lyanna.html
+++ b/src/content/guild/lyanna.html
@@ -36,7 +36,7 @@
             --font-body: 'Noto Serif TC', serif;
             --font-sans: 'Lato', sans-serif;
             --card-width: 320px;
-            --card-height: 480px;
+            --card-height: 400px;
         }
 
         * {
@@ -292,13 +292,12 @@
         }
 
         /* Avatar Specifics */
-        .avatar-container {
+        .narrative-visual.avatar-container {
             display: flex;
             justify-content: center;
             align-items: center;
-            /* Override box-shadow on parent for cleaner look */
-            box-shadow: none !important;
-            background: none !important;
+            box-shadow: none;
+            background: none;
             min-height: auto;
             padding: 2rem;
         }
@@ -351,6 +350,7 @@
             width: 100%;
             height: 100%;
             object-fit: cover;
+            object-position: top center;
             border-radius: 2px;
             display: block;
         }
@@ -511,7 +511,7 @@
                 width: 100%;
                 max-width: 320px;
                 margin: 0 auto;
-                aspect-ratio: 2/3;
+                aspect-ratio: 4/5;
                 box-shadow: 0 10px 30px rgba(0,0,0,0.1);
                 border-radius: 8px;
                 overflow: hidden;


### PR DESCRIPTION
## Summary
- 修正 avatar 頭像因 `object-fit: cover` 居中裁切導致頭頂被切掉，加入 `object-position: top center`
- 修正 card deck 投影片容器比例（2:3 → 4:5）匹配 slide 圖片原始比例，消除左右裁切
- 移除 CSS `!important`，改用更高特異性選擇器 `.narrative-visual.avatar-container` 符合專案規範

## Test plan
- [ ] 桌面版確認 avatar 頭頂完整顯示
- [ ] 桌面版確認 card deck 投影片內容（標題、icon）無裁切
- [ ] 手機版確認 avatar 與 card 顯示正常
- [ ] 確認 card deck 滾動動畫正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)