### PR TITLE
fix(guild/allen): remove grayscale filter from avatar default state

### DIFF
--- a/src/content/guild/allen.html
+++ b/src/content/guild/allen.html
@@ -134,11 +134,11 @@
 
         .avatar-img {
             width: 100%; height: 100%; object-fit: cover;
-            filter: grayscale(1) contrast(1.2);
-            transition: 0.5s;
+            filter: contrast(1.05) saturate(1.1);
+            transition: filter 0.4s;
         }
         .avatar-frame:hover .avatar-img {
-            filter: grayscale(0) contrast(1);
+            filter: contrast(1.1) saturate(1.2) brightness(1.05);
         }
         .avatar-frame::before {
             content: ''; position: absolute; inset: 0;


### PR DESCRIPTION
## Summary

- Allen 大頭貼預設顯示 `grayscale(1)` 全灰，只有 hover 才恢復彩色，視覺上有「停用/錯誤」的錯誤印象
- 移除灰階，改為彩色預設，hover 時輕微加強對比與飽和度

## Changes

- `filter: grayscale(1) contrast(1.2)` → `filter: contrast(1.05) saturate(1.1)`
- Hover: 輕微加強 `contrast(1.1) saturate(1.2) brightness(1.05)`
- `transition: 0.5s` → `transition: filter 0.4s`（明確指定屬性）

## Test plan

- [ ] 瀏覽 `/guild/allen`，確認大頭貼預設彩色顯示
- [ ] Hover 大頭貼，確認有輕微加強效果
- [ ] 移開後確認恢復正常狀態

🤖 Generated with [Claude Code](https://claude.com/claude-code)