### PR TITLE
fix(guild/allen): battalion section RWD overflow on mobile

### DIFF
--- a/src/content/guild/allen.html
+++ b/src/content/guild/allen.html
@@ -455,7 +455,7 @@
 
         /* --- Battalion Section --- */
         .flex-wrap-container { display: flex; flex-wrap: wrap; gap: 2rem; align-items: center; }
-        .battalion-panel { flex: 1; min-width: 300px; }
+        .battalion-panel { flex: 1; min-width: 300px; box-sizing: border-box; }
         .battalion-panel-dashed { border: 1px dashed var(--c-yellow); }
 
         /* --- Subsection Headings --- */


### PR DESCRIPTION
## Summary
- `/guild/allen` 頁面的 THE BATTALION 區塊在手機版（375px）產生水平溢出
- 根因：`.battalion-panel` 的 `min-width: 300px` 未搭配 `box-sizing: border-box`，導致實際寬度 = 300 + 64(padding) + 2(border) = 366px，溢出 328px 容器
- 修復：加上 `box-sizing: border-box` 讓 min-width 包含 padding 和 border

## Test plan
- [ ] 手機版（375px）確認 Battalion 兩個面板正確堆疊、無水平捲動
- [ ] 桌面版確認兩個面板正常並排顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)