### PR TITLE
fix: add Lu Bu (呂布) to hall-of-fame member list

### DIFF
--- a/src/data/hall-of-fame.yml
+++ b/src/data/hall-of-fame.yml
@@ -897,3 +897,15 @@ members:
         label: "夢境魔女"
       - id: "forever_20"
         label: "永遠 20 歲"
+
+  - id: "lubu"
+    name: "呂布"
+    avatar: "/assets/img/guild/lubu/avatar.webp"
+    page: "/guild/lubu.html"
+    tags:
+      - id: "vtuber"
+        label: "個人勢 VTuber"
+      - id: "warlord"
+        label: "最強武將"
+      - id: "indie_games"
+        label: "獨立遊戲"


### PR DESCRIPTION
## Summary
- 呂布已有個人頁面 (`/guild/lubu.html`) 但未被加入 `hall-of-fame.yml`，導致公會總覽頁面不會顯示呂布
- 補上 lubu entry，tags：個人勢 VTuber、最強武將、獨立遊戲

## Test plan
- [ ] 開啟 `/guild` 確認呂布出現在成員列表中
- [ ] 點擊呂布卡片確認連結正確導向 `/guild/lubu.html`
- [ ] 確認頭像圖片正常載入

🤖 Generated with [Claude Code](https://claude.com/claude-code)