### PR TITLE
fix: 修正呂布頁面中諭的性別描述為大女兒

### DIFF
--- a/src/content/guild/lubu.html
+++ b/src/content/guild/lubu.html
@@ -959,7 +959,7 @@
             </p>
 
             <ul class="family-list" style="margin-top: 1.5rem;">
-                <li><span class="hl-red">諭</span>：大兒子，搗蛋鬼一號。</li>
+                <li><span class="hl-red">諭</span>：大女兒，搗蛋鬼一號。</li>
                 <li><span class="hl-red">小貓淵</span>：二女兒，偶爾會在直播中亂入。最近跟小舞兔一起在麥塊蓋房子。</li>
                 <li><span class="hl-red">小舞兔</span>：老么，可愛擔當。</li>
             </ul>


### PR DESCRIPTION
## Summary
- 修正呂布 guild 頁面「將軍府邸」區塊中，諭的描述從「大兒子」改為「大女兒」
- 呂布三個小孩都是女兒，原本誤寫為兒子

## Test plan
- [ ] 開啟 `/guild/lubu` 頁面，確認「將軍府邸」區塊中三個小孩的描述正確顯示為大女兒、二女兒、老么

🤖 Generated with [Claude Code](https://claude.com/claude-code)