### PR TITLE
fix(api): harden /api/ffa-match settlement trust model（部署後邏輯複核）

### DIFF
--- a/src/pages/api/_ffa-match.test.ts
+++ b/src/pages/api/_ffa-match.test.ts
@@ -177,6 +177,85 @@ describe('POST /api/ffa-match — 共識結算', () => {
     expect((await r3.json()).outcome).toBe('already');
   });
 
+  it('client 提供的 ratings 被忽略（防偽造基底分數）：結算後分數由後端基底算出', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, replay, matchId } = buildScenario(77, 3); // 門檻 2
+    // 兩位回報者都附上偽造 ratings（宣稱冠軍基底 9000 分）
+    const forged: Record<string, number> = {};
+    for (const id of standings) forged[id.toLowerCase()] = 9000;
+    await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+        ratings: forged,
+      }),
+    );
+    const res = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[1].address,
+        standings,
+        signature: await sign(wallets[1], matchId, standings),
+        replay,
+        ratings: forged,
+      }),
+    );
+    expect((await res.json()).outcome).toBe('applied');
+
+    // 端點必須以後端讀到的基底（新玩家=DEFAULT_RATING）計分，偽造的 9000 不得生效
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    const { DEFAULT_RATING } = await import('@scripts/games/tetris/net/elo');
+    const champ = await getRankStore().getPlayer(standings[0].toLowerCase());
+    expect(champ).not.toBeNull();
+    expect(champ!.rating).toBeGreaterThan(DEFAULT_RATING); // 冠軍漲分
+    expect(champ!.rating).toBeLessThan(DEFAULT_RATING + 100); // 但絕非 9000 基底
+  });
+
+  it('回報者不在 standings 內（非參與者）→ 403', async () => {
+    const POST = await loadPost();
+    const { standings, replay, matchId } = buildScenario(42, 3);
+    const outsider = Wallet.createRandom(); // 簽章有效，但不是對局參與者
+    const sig = await sign(outsider, matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: outsider.address, standings, signature: sig, replay }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('standings 人數 < 3 → 400（2 人必須走 1v1 /api/match 雙方確認路徑）', async () => {
+    const POST = await loadPost();
+    const res = await POST(
+      ctx({
+        matchId: 'ffa-1-x',
+        reporterId: '0x0000000000000000000000000000000000000001',
+        standings: ['0xa', '0xb'],
+        signature: '0xsig',
+        replay: { seed: 1, playerIds: [], frameCount: 0, events: [] },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('player count');
+  });
+
+  it('standings 人數 > 8 → 400（超出對局人數上限）', async () => {
+    const POST = await loadPost();
+    const nine = Array.from({ length: 9 }, (_, i) => `0x${i}`);
+    const res = await POST(
+      ctx({
+        matchId: 'ffa-1-x',
+        reporterId: nine[0],
+        standings: nine,
+        signature: '0xsig',
+        replay: { seed: 1, playerIds: [], frameCount: 0, events: [] },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('player count');
+  });
+
   it('未提供 ratings 時由後端讀現有分數，仍能結算', async () => {
     const POST = await loadPost();
     const { wallets, standings, replay, matchId } = buildScenario(123, 3); // 門檻 2

--- a/src/pages/api/ffa-match.ts
+++ b/src/pages/api/ffa-match.ts
@@ -49,14 +49,25 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     typeof reporterId !== 'string' ||
     typeof signature !== 'string' ||
     !Array.isArray(standings) ||
-    standings.length < 2 ||
     !standings.every((x) => typeof x === 'string')
   ) {
     return json({ error: 'bad params' }, 400);
   }
+  // FFA 僅限 3..8 人：2 人必須走 /api/match 的 1v1 雙方確認路徑
+  // （否則 ceil(2/2)=1 會讓單一簽章即可結算，繞過雙方共識）。
+  if (standings.length < 3 || standings.length > 8) {
+    return json({ error: 'player count out of range (3..8)' }, 400);
+  }
   const m = matchId;
   const reporter = (reporterId as string).toLowerCase();
   const order = standings as string[];
+  const lowerStandings = order.map((id) => id.toLowerCase());
+
+  // 回報者必須是對局參與者：非參與者的簽章不得計入共識
+  // （否則任意外部錢包可對捏造對局投票，影響他人積分）。
+  if (!lowerStandings.includes(reporter)) {
+    return json({ error: 'reporter not a participant' }, 403);
+  }
 
   // ── replay 抽驗：名次必須由 seed + 各玩家輸入重現 ──
   const replay = body.replay as FfaReplay | undefined;
@@ -80,16 +91,13 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     return json({ error: 'bad signature' }, 401);
   }
 
-  // ── ratings：缺則由後端讀各玩家現有分數（小寫化 id 比照 reportFfaResult 計分用 id）──
+  // ── ratings：一律由後端讀各玩家現有分數。client 傳入的 ratings 不可信
+  //   （否則回報者可偽造基底分數直接灌分），故無條件忽略。──
   const store = getRankStore();
-  const lowerStandings = order.map((id) => id.toLowerCase());
-  let ratings = body.ratings as Record<string, number> | undefined;
-  if (!ratings || typeof ratings !== 'object') {
-    ratings = {};
-    for (const id of lowerStandings) {
-      const rec = await store.getPlayer(id);
-      ratings[id] = rec?.rating ?? DEFAULT_RATING;
-    }
+  const ratings: Record<string, number> = {};
+  for (const id of lowerStandings) {
+    const rec = await store.getPlayer(id);
+    ratings[id] = rec?.rating ?? DEFAULT_RATING;
   }
 
   const outcome = await reportFfaResult({


### PR DESCRIPTION
## 部署後邏輯複核發現的三個結算端點信任漏洞（已修＋TDD）

對剛上線的 `/api/ffa-match` 做逐行邏輯複核，發現三個信任模型漏洞：

| # | 漏洞 | 影響 | 修法 |
|---|---|---|---|
| 1 | **client 傳入的 `ratings` 被當 ELO 基底** | 回報者可偽造基底（如 9000）直接灌分——紅燈測試實證修復前真的可成功 | 無條件忽略 `body.ratings`，一律後端讀分 |
| 2 | **standings.length=2 時門檻 ceil(2/2)=1** | 單一簽章即可結算，繞過 1v1 雙方確認路徑 | FFA 限 3–8 人；2 人走 `/api/match` |
| 3 | **回報者不需是參與者** | 任意外部錢包可對捏造對局投票、影響他人積分 | reporter 必須在 standings 內，否則 403 |

對照 1v1 `/api/match`：它的結算需要 opponent 本人簽章的回報（`getReport(matchId, opponent)`），外人無法寫入受害者紀錄——本修復讓 FFA 端點回到同一信任等級。

### 驗證
- TDD：4 個紅燈測試（偽造 ratings 那條在修復前能灌到 ~9016 分）→ 修復後全綠
- 全套 vitest：**366/366 綠**（38 檔，+4）
- `npm run build` 綠
- 正常 client（`ffaNetMain.reportFfaRanked`）從不送 `ratings`、回報者必為參與者、UI 已把 N=2 導向 1v1 —— 零行為破壞

### 仍存的已知限制（誠實揭露，P2P 本質）
攻擊者若控制 ⌈N/2⌉ 個「參與對局」的錢包，仍可捏造含受害者的對局結算（已文件化的 P2P 權衡）。本修復把門檻從「任意 1 個錢包」拉回「過半參與者錢包」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
