### PR TITLE
fix(guild): rooji regions pin no longer covers the section heading

### DIFF
--- a/src/content/guild/rooji_shuanglian.html
+++ b/src/content/guild/rooji_shuanglian.html
@@ -254,6 +254,7 @@ body::after{content:"";position:fixed;inset:0;z-index:1;pointer-events:none;opac
 #process .band{position:relative;border-top:1px solid rgba(110,90,64,.3);
   border-bottom:1px solid rgba(110,90,64,.3);padding:22px 0;margin-bottom:2px;overflow:hidden}
 #process .band img{width:100%;display:block;will-change:clip-path;
+  aspect-ratio:1600/894;object-fit:cover; /* 預留高度 — lazy 載入後不位移，pin 位置才不會失準 */
   clip-path:inset(0 100% 0 0)}            /* JS scrub wipes this open L→R */
 #process .stages{display:grid;grid-template-columns:repeat(4,1fr);margin-top:26px}
 #process .stages .s{text-align:center;padding:0 10px;position:relative;opacity:0;
@@ -1087,6 +1088,17 @@ document.querySelectorAll('.tea-card').forEach(card=>{
     card.style.transform=`translateY(-10px) perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg)`;
   });
 });
+
+/* lazy 圖載入會推移版面 — 重算 ScrollTrigger 位置，否則 regions pin 會提早釘住、蓋住標題 */
+(function(){
+  let t;
+  document.querySelectorAll('img[loading="lazy"]').forEach(img=>{
+    if(img.complete) return;
+    img.addEventListener('load',()=>{
+      clearTimeout(t);t=setTimeout(()=>ScrollTrigger.refresh(),200);
+    },{once:true});
+  });
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 問題

https://www.supergalen.com/guild/rooji_shuanglian 的「茶，從這些山，來到你的桌上。」標題會被下方的橫向山頭畫廊（pinned gallery）蓋住。

## 根因

`#process .band img`（製茶工序寬幅圖，lazy load、無保留高度）載入後把版面往下推約 670px，但 GSAP ScrollTrigger 的 pin 位置在那之前就已量測完成且從未重算，導致 regions 畫廊提早 670px 釘住成全螢幕固定層，正好蓋在還在畫面中間的標題上。

## 修正

1. **治本**：`#process .band img` 加上 `aspect-ratio:1600/894`，圖片載入前就先佔好高度，版面不再位移
2. **保險網**：任何 lazy 圖片載入後 debounce 200ms 呼叫 `ScrollTrigger.refresh()`，防止其他圖片造成同類漂移

## 驗證（Playwright @ localhost:4321）

- pinStart 與 pin-spacer 版面位置完全一致（9353 = 9353），釘住瞬間 `.rpin` 距視窗頂 0px，無跳動
- 標題底部在 pin 起點之前就已自然捲出畫面，截圖確認不再被蓋住
- console 0 錯誤、無橫向 overflow、手機版（390×844）正常降級為直向堆疊

🤖 Generated with [Claude Code](https://claude.com/claude-code)