### PR TITLE
feat(net): host migration — 任何人中離對局都能續行（Stage B）

### DIFF
--- a/docs/superpowers/plans/2026-06-11-dungeon-arcade-host-migration.md
+++ b/docs/superpowers/plans/2026-06-11-dungeon-arcade-host-migration.md
@@ -1,0 +1,65 @@
+# Host Migration（中離續行 Stage B）實作計畫
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development。每任務 TDD：測試→紅→實作→綠→全套零回歸→commit。
+> Spec：`docs/superpowers/specs/2026-06-11-dungeon-arcade-host-migration-design.md`（先精讀全篇）。分支 `feature/host-migration`（自最新 master）。
+
+**Goal:** FFA host 中離 → 剩餘玩家選新 host、世代化 signaling 重連、輸入視野合併補課、舊 host 判敗、對局續行；失敗 20s 降級為現行為（中止不計分）。
+
+**Architecture:** 選舉＝最低 index 存活 guest 自任＋signaling 仲裁（取最低 index 的 offer）；重連＝重用 T11 guest-initiated 交握於 `mig{g}-` 世代槽位；補課＝各端送 `ffa-mig-sync`（cf+horizon+未消化輸入）給新 host 合併、回播 `ffa-mig-state`（合併輸入＋`hostForfeitF = max(horizon[舊host])+1`，禁 confirmedFrame+1）；熱插拔＝`MigratingTransport` facade 換 inner、FfaLockstep 不動。
+
+**Tech Stack:** TypeScript、Vitest（unit/mock-net）、Playwright（3-context e2e 關 host）。
+
+## 🔴 鐵則
+1. Stage A 既有行為零回歸（guest 中離路徑、487 單元、32 e2e）。
+2. 合併輸入冪等（`recordInput` 首寫保留；同幀同玩家輸入在各端必然相同——皆源自舊 host 有序轉發）。
+3. `hostForfeitF` 必可達（max horizon+1，向下夾 INPUT_DELAY）；**禁 confirmedFrame+1**（Stage A 死鎖教訓）。
+4. 純函式優先：選舉、merge、horizon 計算全部可單測；網路/Pixi 只做薄接線。
+5. 測試紀律：`timeout 90 npx vitest run <file> --testTimeout=8000 --no-file-parallelism`；不輪詢背景 job。
+
+## 檔案結構
+- `net/signalClient.ts` + `pages/api/signal.ts`（MOD）：`mig{1..6}-guest-{0..6}-offer`/`mig{1..6}-host-ack-{0..6}` 槽位。
+- `net/ffaMigration.ts`（NEW）：選舉/merge/horizon 純函式 + `MigratingTransport` + 遷移協調器（依賴注入 signaling/RTC/now，mock-net 可測）。
+- `net/ffaLockstep.ts`（MOD 最小）：暴露 `exportSyncState(): {cf, horizon, inputs}` 與 `importMergedInputs(inputs)`（讀寫 inbox/replayEvents 的受控接口）。
+- `net/ffaNetMain.ts`（MOD）：guest 的 host-down 路徑由「中止」改「啟動遷移→成功續行/逾時降級」；新 host 升格（hub+Stage A 偵測啟動）；`__tetrisDebug.migration`。
+- `render/`（MOD 小）：遷移中橫幅。
+- `tests/e2e/games-tetris-ffa-hostmig.spec.ts`（NEW）。
+
+## 任務
+
+### M1 世代化 signaling 槽位（unit, deps:—）
+isValidSlot 兩端（signalClient.ts/signal.ts）加 `mig{g}-` 前綴規則（g 1..6）；測：合法各形、g=0/7 拒、i=7 拒、既有槽位零回歸。
+Commit：`feat(net): generation-scoped migration signaling slots (mig{g}-...)`
+
+### M2 遷移純函式 + MigratingTransport（unit+mock-net, deps:—）
+`net/ffaMigration.ts`：
+```ts
+export function electHost(playerIds: string[], hostId: string, placedIds: string[], selfId: string): { role: 'host'|'join'; candidateId: string }
+// 候選=排除 hostId 與 placedIds 後原始 index 最低者；selfId===candidateId → role 'host'
+export interface SyncState { cf: number; horizon: Record<string, number>; inputs: Array<{f:number; p:string; a:string[]}> }
+export function mergeSync(states: SyncState[]): { inputs: SyncState['inputs']; horizon: Record<string, number> } // 冪等去重（f+p 鍵，首見保留）
+export function hostForfeitFrame(horizon: Record<string,number>, hostId: string, inputDelay: number): number // max(horizon[hostId]+1, inputDelay)
+export class MigratingTransport implements FfaLockstepTransport { constructor(inner); send/onMessage 委派; swap(inner): void /* 重綁訊息流到同一上層回呼，swap 期間緩衝 */ }
+```
+測（~12 例）：選舉（基本/候選已淘汰跳下一個/自己是候選/全淘汰邊界）；mergeSync 冪等與並集；hostForfeitFrame 夾值；MigratingTransport swap 前後訊息不漏不重（mock inner ×2）。
+Commit：`feat(net): migration primitives — election/merge/forfeit-frame + MigratingTransport`
+
+### M3 Lockstep 同步接口（unit, deps:—）
+ffaLockstep.ts 加 `exportSyncState()`（cf＝confirmedFrame、horizon＝各玩家 inbox+已套用的最大幀、inputs＝inbox 全部未消化幀＋自己已送未確認的本地幀）與 `importMergedInputs(inputs)`（走 recordInput 冪等）。測：export 形狀正確；import 後 advance 可越過原缺口；冪等重複 import 無害；既有 13 例零回歸。
+Commit：`feat(net): FfaLockstep sync-state export/import for host migration`
+
+### M4 遷移協調器 + netMain 接線（mock-net, deps:M1-M3）
+`ffaMigration.ts` 加 `runMigration(deps)`（注入 signal client、RTC 工廠、transport、lockstep、now/timeout）：guest host-down → electHost → host 角色：輪詢 mig 槽收 offer→answer→waitOpen→收各端 ffa-mig-sync→mergeSync→廣播 ffa-mig-state→swap 成 hub→啟動 Stage A 偵測；join 角色：寫 offer（**ELECTION_GRACE_MS=3000 後若發現更低 index 候選 offer 則讓位**）→等 ack→送 sync→收 state→import+scheduleForfeit→swap。任何步逾時（MIGRATION_TIMEOUT_MS=20000）→ reject → netMain 降級中止。netMain：host-down 分支改呼叫 runMigration；UI 橫幅「重新連線中…」；`__tetrisDebug.migration={gen,state}`；MAX_MIGRATIONS=6。
+測（mock-net ~8 例）：3 端完整遷移序列各端最終狀態 JSON 一致並續行到 victory；雙候選讓位收斂；逾時降級；新 host 再死→gen2 再遷移；Stage A guest 中離在新 host 下仍有效。
+Commit：`feat(net): host-migration orchestrator — elect/reconnect/merge/resume`
+
+### M5 e2e + 全套（e2e, deps:M4）
+NEW `games-tetris-ffa-hostmig.spec.ts`（照 ffa-forfeit spec 手法）：3-context 開打 → `ctxHost.close()` → g1/g2 `expect.poll`（60s）：migration state 達 'done'、舊 host placement=3、confirmedFrame 恢復推進 → 驅動分勝負 standings 一致。全套 vitest＋全部 13 支遊戲 e2e＋build 三綠。
+Commit：`test(e2e): FFA host-leave migration continuation (3-context)`
+
+### M6 收尾（manual+PR, deps:M5）
+介面走查（遷移橫幅截圖）→ spec 限制段補實測數據 → PR（標題 `feat(net): host migration — 任何人中離對局都能續行`，body 含測試數字與誠實限制）。
+
+## 風險
+- 真實 RTC 重連在 headless 的 ICE 時序：e2e 逾時預算 60s；失敗路徑本身也是合法降級（斷言遷移成功仍為硬目標）。
+- room TTL：M4 開頭確認 signal room 存活時長，不足則遷移前 touch（沿用既有 API）。
+- swap 競態：MigratingTransport swap 期間緩衝訊息（M2 測試明確覆蓋）。

--- a/docs/superpowers/specs/2026-06-11-dungeon-arcade-host-migration-design.md
+++ b/docs/superpowers/specs/2026-06-11-dungeon-arcade-host-migration-design.md
@@ -1,0 +1,58 @@
+# 中離續行 Stage B：Host Migration 設計 spec
+
+> 接續 `2026-06-11-dungeon-arcade-forfeit-continuation-design.md` 的 Stage B outline。
+> 目標：FFA（N≥3）**host 中離**時，剩餘玩家重組星狀拓樸續行、舊 host 判敗；達成使用者要求「任何人中離＝那個人判敗、其他人繼續」的完整版。
+
+## 行為規格
+
+| 情境 | 行為 |
+|---|---|
+| FFA host 中離、剩餘 ≥2 人 | 約 10–25 秒內：選出新 host → 經既有 signaling 重連 → 補齊輸入缺口 → 舊 host 判敗淘汰 → 對局續行；結算照常（剩餘簽章 ≥ ⌈N/2⌉ 即計分） |
+| 遷移失敗（重連逾時 `MIGRATION_TIMEOUT_MS=20000`） | 降級為現行為：「HOST 離線，對局中止」不計分（誠實降級） |
+| 新 host 又中離 | 同流程再遷移（世代 gen+1，上限 `MAX_MIGRATIONS=6`，超過降級中止） |
+| 1v1 host 中離 | 不適用（1v1 對手中離＝forfeit win，Stage A 已處理） |
+| 開局前（lobby）host 離開 | 維持現行為（lobby 取消） |
+
+## 核心設計
+
+### B.1 Host 離線偵測（guest 端）
+- `spoke.onClose`（Stage A 已掛）＋ host 頻道 10 秒靜默兜底（host 每 tick 都會送自己的幀；對局停滯時 host 仍持續送——靜默＝host 死）。觸發後進入遷移流程而非顯示中止。
+
+### B.2 新 host 選舉（無需通訊的確定性規則 + signaling 仲裁兜底）
+- 規則：**原始 slot index 最低、且本端視角尚未定名次（未淘汰/未棄權）的 guest** 為新 host 候選。
+- 各端視角可能在「最近 INPUT_DELAY 幀內剛淘汰的玩家」上短暫分歧 → 兜底：候選把 offer 寫入世代化槽位後，**其他端輪詢時一律取「存在 offer 的最低 index 候選」**為準（signaling 為仲裁）；非候選端等待 `ELECTION_GRACE_MS=3000` 後才輪詢，給最低 index 候選先手。雙候選並存時，較高 index 候選在輪詢中發現更低 index 的 offer 即放棄自任、轉為加入者。
+
+### B.3 世代化 signaling 槽位（重用 T11 整套交握）
+- `isValidSlot` 擴充：`mig{g}-guest-{i}-offer`、`mig{g}-host-ack-{i}`（g=1..6、i=0..6）；既有槽位不動。
+- 流程同 T11 guest-initiated：倖存 guest（非新 host）各自 `createOffer` → `mig{g}-guest-{i}-offer`（i=**原始** index，不重排）→ 新 host 輪詢已知倖存 index 的 offer → 逐一 answer 至 `mig{g}-host-ack-{i}` → waitOpen。
+- 房號沿用原 room code（Upstash room TTL 需 ≥ 對局時長：確認現值，不足則建房時延長或遷移時 touch）。
+
+### B.4 輸入視野合併（斷點補課，確定性命脈）
+問題：舊 host 死時各端收到的輸入前綴不等長（host 轉發到一半），且彼此缺對方在斷線窗內的輸入。
+- 重連完成後，每端（含新 host）送 `{t:'ffa-mig-sync', gen, cf: confirmedFrame, horizon: {playerId: maxFrame}, inputs: [...]}` 給新 host：`inputs` 為該端 inbox 中所有「尚未消化」幀＋自己 `cf` 之後已送出但未確認的本地輸入（從 lockstep 的 replayEvents/inbox 可重建；同一幀同玩家輸入在所有端必然相同——皆源自舊 host 的有序轉發——合併天然冪等，沿用 `recordInput` 首寫保留）。
+- 新 host 合併全部 sync → 廣播 `{t:'ffa-mig-state', gen, inputs: 合併集, hostForfeitF}`，其中 `hostForfeitF = max(各端 horizon[舊hostId])+1`（必可達停滯點，沿用 Stage A 教訓：**禁用 confirmedFrame+1**）。
+- 各端灌入合併輸入 → `scheduleForfeit(舊hostId, hostForfeitF)` → lockstep 自然推進到同一狀態 → 恢復正常 tick。replay 連續性自動成立（events/forfeits 照常累積，結算驗證不受影響）。
+
+### B.5 傳輸層熱插拔
+- `MigratingTransport implements FfaLockstepTransport`：facade，內部持有「當前 inner transport」（spoke 或 hub）；`swap(inner)` 重綁 onMessage/onControl 到同一上層回呼。FfaLockstep 不需改（仍只認一個 transport）。
+- 新 host 端：inner 由 spoke 換成 `FfaHubTransport`（接新建的 N-2 條 channel）＋啟動 Stage A 的 host 偵測（forfeit controller、靜默檢查）對新 guests 生效。
+- 其他 guest：inner 換成連向新 host 的 spoke。
+
+### B.6 UI
+- 遷移期間：盤面凍結＋橫幅「HOST 離線，重新連線中…」（Press Start 風格，含轉圈/省略號動畫，reduced-motion 靜態）；成功 → 橫幅消失、舊 host 盤面標 FORFEIT 續行；失敗 → 「對局中止」既有文案。
+- `__tetrisDebug` 加 `migration: { gen, state }` 供 e2e。
+
+## 測試策略
+- **unit**：slot regex 世代擴充；選舉規則純函式（含分歧視角兜底）；sync/merge 純函式（冪等、horizon 計算、hostForfeitF）。
+- **mock-net**：MigratingTransport swap 後鎖步不漏訊息；完整遷移序列（3 端 mock：host 死 → 選舉 → sync 合併 → forfeit → 各端狀態 JSON 一致續行到 victory）；雙候選並存收斂；遷移逾時降級。
+- **e2e**：3-context FFA 開打 → **關閉 host context** → g1/g2 經遷移續行（placement 含舊 host、confirmedFrame 恢復推進、打到分出勝負 standings 一致）。逾時預算 60s。
+- **零回歸**：全部既有（487 單元＋32 e2e）。
+
+## 風險與誠實限制
+- 重連用真實 WebRTC：本機/e2e 為 loopback 必成；跨網路 NAT 失敗 → 降級中止（與現狀同，不更差）。
+- 遷移窗內又有 guest 中離：遷移完成後由新 host 的 Stage A 偵測接手（最壞情況降級中止）。
+- 結託風險不變（⌈N/2⌉ 共識模型同前）。
+- Upstash 寫入：每次遷移 ≈ 2×(N-2)+2 次 slot 操作，量級可忽略。
+
+## 非目標（YAGNI）
+- 中離者重連回局、觀戰、lobby 階段 host 轉移、1v1 host migration（無意義）。

--- a/src/pages/api/signal.ts
+++ b/src/pages/api/signal.ts
@@ -11,6 +11,7 @@ const TTL_SEC = 300; // 房間槽位 5 分鐘過期
  * 1v1：offer / answer
  * N 人星狀（host-initiated，T9）：host-offer / guest-{0..6}-answer / host-ack-{0..6}
  * N 人星狀（guest-initiated，T11）：guest-{0..6}-offer / host-ack-{0..6}
+ * Host migration 世代化槽位：mig{1..6}-guest-{0..6}-offer / mig{1..6}-host-ack-{0..6}
  */
 function isValidSlot(slot: string): boolean {
   if (slot === 'offer' || slot === 'answer' || slot === 'host-offer') return true;
@@ -28,6 +29,13 @@ function isValidSlot(slot: string): boolean {
   if (ackMatch) {
     const idx = Number(ackMatch[1]);
     return idx >= 0 && idx <= 6;
+  }
+  // 世代化遷移槽位（host migration）：mig{1..6}-guest-{0..6}-offer / mig{1..6}-host-ack-{0..6}
+  const migMatch = slot.match(/^mig(\d+)-(?:guest-(\d+)-offer|host-ack-(\d+))$/);
+  if (migMatch) {
+    const gen = Number(migMatch[1]);
+    const idx = Number(migMatch[2] ?? migMatch[3]);
+    return gen >= 1 && gen <= 6 && idx >= 0 && idx <= 6;
   }
   return false;
 }

--- a/src/scripts/games/tetris/net/ffaLockstep.test.ts
+++ b/src/scripts/games/tetris/net/ffaLockstep.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { FfaLockstep, LoopbackHub } from './ffaLockstep';
+import type { FfaFrameMsg } from './ffaLockstep';
 import { simulateFfaReplay } from './ffaReplay';
 import type { InputAction } from '../engine/game';
 
@@ -374,5 +375,211 @@ describe('FfaLockstep.scheduleForfeit 幀排程確定性棄權', () => {
     // 存活端狀態一致
     const ref = stateFingerprint(alive[0]);
     for (const node of alive) expect(stateFingerprint(node)).toBe(ref);
+  });
+});
+
+describe('FfaLockstep 同步狀態 export/import（host migration M3）', () => {
+  /** 手動傳遞節點：send 進 sent 陣列、inject 直灌 onMessage（自己的輸入 tick 內已寫 inbox）。 */
+  function makeManualNode(
+    playerIds: string[],
+    localId: string,
+    seed: number,
+  ): { node: FfaLockstep; sent: FfaFrameMsg[]; inject: (m: unknown) => void } {
+    let cb: ((m: unknown) => void) | null = null;
+    const sent: FfaFrameMsg[] = [];
+    const node = new FfaLockstep({
+      playerIds,
+      localId,
+      seed,
+      transport: {
+        send: (m: FfaFrameMsg): void => {
+          sent.push(m);
+        },
+        onMessage: (c: (m: FfaFrameMsg) => void): void => {
+          cb = c as (m: unknown) => void;
+        },
+      },
+    });
+    return { node, sent, inject: (m: unknown) => cb!(m) };
+  }
+
+  /** 把 inputs 排序成確定性順序方便比對。 */
+  function sortInputs<T extends { f: number; p: string }>(inputs: T[]): T[] {
+    return [...inputs].sort((x, y) => x.f - y.f || x.p.localeCompare(y.p));
+  }
+
+  it('初始 exportSyncState 形狀正確：cf=0、horizon=預填上界（inputDelay-1）、inputs=預填空幀攤平', () => {
+    const { node } = makeManualNode(['A', 'B'], 'A', 1);
+    const s = node.exportSyncState();
+    expect(s.cf).toBe(0);
+    // 自己 = sendFrame(0)+inputDelay(3)-1 = 2；B = inbox 預填最大鍵 2
+    expect(s.horizon).toEqual({ A: 2, B: 2 });
+    expect(sortInputs(s.inputs)).toEqual([
+      { f: 0, p: 'A', a: [] },
+      { f: 0, p: 'B', a: [] },
+      { f: 1, p: 'A', a: [] },
+      { f: 1, p: 'B', a: [] },
+      { f: 2, p: 'A', a: [] },
+      { f: 2, p: 'B', a: [] },
+    ]);
+  });
+
+  it('tick 後 export：cf=confirmedFrame、自己 horizon=sendFrame+delay-1、inputs 含自己已送未消化幀；收到遠端幀後 horizon 更新', () => {
+    const { node, inject } = makeManualNode(['A', 'B'], 'A', 1);
+    node.tick(['left']); // 預填 0..2 消化 → cf=3；送出 A@3=['left']
+    node.tick([]); // 送出 A@4=[]；缺 B@3 → cf 仍 3
+    expect(node.confirmedFrame).toBe(3);
+
+    let s = node.exportSyncState();
+    expect(s.cf).toBe(3);
+    // A：sendFrame(2)+3-1=4；B：inbox 已空 → 已消化至 cf-1=2
+    expect(s.horizon).toEqual({ A: 4, B: 2 });
+    expect(sortInputs(s.inputs)).toEqual([
+      { f: 3, p: 'A', a: ['left'] },
+      { f: 4, p: 'A', a: [] },
+    ]);
+
+    // 收到 B@3（未消化前 export）→ horizon.B=3、inputs 含該幀
+    // 注意 export 必須在消化前觀察：B@3 進來後 advance 只在 tick 內跑 → 仍未消化
+    inject({ f: 3, p: 'B', a: ['right'] });
+    s = node.exportSyncState();
+    expect(s.horizon).toEqual({ A: 4, B: 3 });
+    expect(sortInputs(s.inputs)).toEqual([
+      { f: 3, p: 'A', a: ['left'] },
+      { f: 3, p: 'B', a: ['right'] },
+      { f: 4, p: 'A', a: [] },
+    ]);
+  });
+
+  it('視野不等的斷點補課：host 死後 A export → B import + scheduleForfeit → 兩端越過缺口續行且狀態一致', () => {
+    // 3 人局：A、B 為真節點，H（host）由測試腳本扮演。
+    const playerIds = ['A', 'B', 'H'];
+    const A = makeManualNode(playerIds, 'A', 77);
+    const B = makeManualNode(playerIds, 'B', 77);
+    let aPtr = 0; // A.sent 已投遞給 B 的指標
+    let bPtr = 0; // B.sent 已投遞給 A 的指標
+    const deliverAtoB = (): void => {
+      for (; aPtr < A.sent.length; aPtr++) B.inject(A.sent[aPtr]);
+    };
+    const deliverBtoA = (): void => {
+      for (; bPtr < B.sent.length; bPtr++) A.inject(B.sent[bPtr]);
+    };
+
+    // 正常 10 輪：雙向投遞 + H 每輪送空輸入幀 r+3（H 最後已知幀=12）
+    for (let r = 0; r < 10; r++) {
+      A.node.tick(r % 4 === 0 ? ['left'] : []);
+      B.node.tick(r % 5 === 0 ? ['rotateCW'] : []);
+      deliverAtoB();
+      deliverBtoA();
+      const h: FfaFrameMsg = { f: r + 3, p: 'H', a: [] };
+      A.inject(h);
+      B.inject(h);
+    }
+
+    // host 死亡窗 3 輪：H 無新幀；A→B 投遞中斷（視野不等），B→A 仍通（死前 host 已轉發）
+    for (let r = 10; r < 13; r++) {
+      A.node.tick([]);
+      B.node.tick([]);
+      deliverBtoA();
+    }
+    // 死亡窗內 A 的幀（13..15）在舊 host 上遺失，永不重送
+    aPtr = A.sent.length;
+
+    // 兩端皆卡在 13（缺 H@13）；B 另缺 A@13..15（原缺口）
+    expect(A.node.confirmedFrame).toBe(13);
+    expect(B.node.confirmedFrame).toBe(13);
+    const sA = A.node.exportSyncState();
+    const sB = B.node.exportSyncState();
+    expect(sA.horizon).toEqual({ A: 15, B: 15, H: 12 });
+    expect(sB.horizon).toEqual({ A: 12, B: 15, H: 12 });
+
+    // 合併補課：B 灌入 A 的視野（重複 import 一次驗證無害）；hostForfeitF = max(horizon.H)+1 = 13
+    B.node.importMergedInputs(sA.inputs);
+    B.node.importMergedInputs(sA.inputs);
+    A.node.importMergedInputs(sB.inputs);
+    A.node.scheduleForfeit('H', 13);
+    B.node.scheduleForfeit('H', 13);
+
+    // 續行（新 host 接手 → 雙向投遞恢復，只轉發新幀）
+    for (let r = 13; r < 25; r++) {
+      A.node.tick([]);
+      B.node.tick([]);
+      deliverAtoB();
+      deliverBtoA();
+    }
+
+    // 兩端皆越過原缺口（>15），H 判敗（3 人局墊底=3），狀態指紋一致
+    expect(A.node.confirmedFrame).toBeGreaterThan(15);
+    expect(B.node.confirmedFrame).toBeGreaterThan(15);
+    expect(A.node.confirmedFrame).toBe(B.node.confirmedFrame);
+    expect(A.node.getMatch().getPlacement().get('H')).toBe(3);
+    expect(B.node.getMatch().getPlacement().get('H')).toBe(3);
+    expect(A.node.getReplay().forfeits).toEqual([{ f: 13, p: 'H' }]);
+    expect(stateFingerprint(A.node)).toBe(stateFingerprint(B.node));
+  });
+
+  it('重複 import 自己的 export 無害：cf 與全盤狀態不變、後續鎖步與對照組一致', () => {
+    const playerIds = ['P0', 'P1', 'P2', 'P3'];
+    const run = (withReimport: boolean): { fp: string; cf: number } => {
+      const { nodes } = buildNodes(playerIds, 4242);
+      for (let f = 0; f < 10; f++) {
+        for (const node of nodes) node.tick(f % 3 === 0 ? ['softDrop'] : []);
+      }
+      if (withReimport) {
+        const cfBefore = nodes[0].confirmedFrame;
+        const fpBefore = stateFingerprint(nodes[0]);
+        nodes[0].importMergedInputs(nodes[0].exportSyncState().inputs);
+        nodes[0].importMergedInputs(nodes[0].exportSyncState().inputs);
+        expect(nodes[0].confirmedFrame).toBe(cfBefore);
+        expect(stateFingerprint(nodes[0])).toBe(fpBefore);
+      }
+      for (let f = 10; f < 30; f++) {
+        for (const node of nodes) node.tick([]);
+      }
+      const fp = stateFingerprint(nodes[0]);
+      for (const node of nodes) expect(stateFingerprint(node)).toBe(fp);
+      return { fp, cf: nodes[0].confirmedFrame };
+    };
+    const a = run(true);
+    const b = run(false);
+    expect(a.fp).toBe(b.fp);
+    expect(a.cf).toBe(b.cf);
+  });
+
+  it('importMergedInputs 壞輸入忽略：非陣列 / p 不在名單 / f 壞值 / a 壞形狀 → 不丟例外不污染；混入合法幀仍生效', () => {
+    const { node } = makeManualNode(['A', 'B'], 'A', 9);
+    node.tick(['hold']); // cf=3，缺 B@3 卡住
+    expect(node.confirmedFrame).toBe(3);
+    const fpBefore = stateFingerprint(node);
+
+    expect(() => node.importMergedInputs(null as never)).not.toThrow();
+    expect(() => node.importMergedInputs('junk' as never)).not.toThrow();
+    expect(() =>
+      node.importMergedInputs([
+        null,
+        42,
+        { f: NaN, p: 'B', a: [] },
+        { f: -1, p: 'B', a: [] },
+        { f: Infinity, p: 'B', a: [] },
+        { f: '3', p: 'B', a: [] },
+        { f: 3, p: 'ZZ', a: [] }, // p 不在名單
+        { f: 3, p: 'B', a: 'x' }, // a 非陣列
+        { f: 3, p: 'B', a: ['fly'] }, // 非法 action
+      ] as never),
+    ).not.toThrow();
+
+    node.tick([]);
+    expect(node.confirmedFrame).toBe(3); // 壞幀全被忽略 → 仍缺 B@3
+    expect(stateFingerprint(node)).toBe(fpBefore);
+    expect(node.exportSyncState().horizon.B).toBe(2); // 垃圾沒寫進 inbox
+
+    // 混入合法幀仍生效：B@3/B@4 補上後可推進
+    node.importMergedInputs([
+      { f: 3, p: 'B', a: ['right'] },
+      null as never,
+      { f: 4, p: 'B', a: [] },
+    ]);
+    node.tick([]);
+    expect(node.confirmedFrame).toBeGreaterThan(3);
   });
 });

--- a/src/scripts/games/tetris/net/ffaLockstep.test.ts
+++ b/src/scripts/games/tetris/net/ffaLockstep.test.ts
@@ -518,6 +518,110 @@ describe('FfaLockstep 同步狀態 export/import（host migration M3）', () => 
     expect(stateFingerprint(A.node)).toBe(stateFingerprint(B.node));
   });
 
+  it('exportSyncState 含 replay tail：已套用（已從 inbox 刪除）的非空幀一併匯出', () => {
+    const { node, inject } = makeManualNode(['A', 'B'], 'A', 1);
+    node.tick(['left']); // 預填 0..2 消化 → cf=3；送出 A@3=['left']
+    inject({ f: 3, p: 'B', a: [] });
+    node.tick([]); // 消化 f=3（A@3 套用後從 inbox 刪除）→ cf=4
+    expect(node.confirmedFrame).toBe(4);
+    // 沒有 tail 的話 A@3 已從 inbox 消失 → 落後端永遠補不到這幀
+    const s = node.exportSyncState();
+    expect(s.inputs).toContainEqual({ f: 3, p: 'A', a: ['left'] });
+  });
+
+  it('fillEmptyInputsUpTo：為缺幀者補空輸入（不覆蓋既有、跳過自己、壞值忽略）', () => {
+    const { node } = makeManualNode(['A', 'B'], 'A', 2);
+    node.tick([]);
+    node.tick([]); // cf=3 卡住（缺 B@3）；自己已記錄 A@3、A@4
+    expect(node.confirmedFrame).toBe(3);
+
+    // 既有輸入不覆蓋：先補 B@4 真輸入，再 fill 到 6 → B@3/B@5 補空、B@4 保留
+    node.importMergedInputs([{ f: 4, p: 'B', a: ['right'] }]);
+    node.fillEmptyInputsUpTo(6);
+    // 自己（A）的幀不由 fill 合成：A@5 尚未送出 → 不得被搶填空輸入
+    expect(node.exportSyncState().inputs).not.toContainEqual({ f: 5, p: 'A', a: [] });
+    node.tick([]); // 記錄 A@5 → f=3..5 齊備 → cf 推進到 6
+    expect(node.confirmedFrame).toBe(6);
+    // B@4=['right'] 已被套用 → 出現在 replay tail（驗證 fill 沒覆蓋它）
+    expect(node.exportSyncState().inputs).toContainEqual({ f: 4, p: 'B', a: ['right'] });
+
+    // 壞值一律忽略、不丟例外、不污染
+    const cfBefore = node.confirmedFrame;
+    expect(() => node.fillEmptyInputsUpTo(Number.NaN)).not.toThrow();
+    expect(() => node.fillEmptyInputsUpTo(-5)).not.toThrow();
+    expect(() => node.fillEmptyInputsUpTo(Number.POSITIVE_INFINITY)).not.toThrow();
+    expect(node.confirmedFrame).toBe(cfBefore);
+  });
+
+  it('cf 偏移的斷點補課：ahead 端已消化 laggard 缺幀 → replay tail + fillEmpty 收斂一致（e2e 實測根因）', () => {
+    // 真實 host 死亡時各端停滯點不同：A 多收到 host 死前 relay 的幀 → cf 超前 B，
+    // 且 A 已把 B 缺的幀「消化並從 inbox 刪除」——光靠 inbox 視野合併補不回來。
+    const playerIds = ['A', 'B', 'H'];
+    const A = makeManualNode(playerIds, 'A', 77);
+    const B = makeManualNode(playerIds, 'B', 77);
+    let aPtr = 0;
+    let bPtr = 0;
+    const deliverAtoB = (): void => {
+      for (; aPtr < A.sent.length; aPtr++) B.inject(A.sent[aPtr]);
+    };
+    const deliverBtoA = (): void => {
+      for (; bPtr < B.sent.length; bPtr++) A.inject(B.sent[bPtr]);
+    };
+
+    // 正常 10 輪：雙向投遞 + H 每輪送空輸入幀 r+3
+    for (let r = 0; r < 10; r++) {
+      A.node.tick(r % 4 === 0 ? ['left'] : []);
+      B.node.tick(r % 5 === 0 ? ['rotateCW'] : []);
+      deliverAtoB();
+      deliverBtoA();
+      const h: FfaFrameMsg = { f: r + 3, p: 'H', a: [] };
+      A.inject(h);
+      B.inject(h);
+    }
+
+    // 死亡窗 3 輪：B→A 與 H→A 仍通（A 收好收滿）、任何幀都到不了 B → A 超前消化
+    // （B 先 tick、投遞給 A、再 A tick → A 每輪都湊齊整幀，cf 一路推進）
+    for (let r = 10; r < 13; r++) {
+      B.node.tick(r === 10 ? ['rotateCW'] : []);
+      deliverBtoA();
+      A.inject({ f: r + 3, p: 'H', a: [] });
+      A.node.tick(r === 10 ? ['left'] : []);
+    }
+    aPtr = A.sent.length; // A 死亡窗的幀在舊 host 上遺失，永不重送
+
+    // A 超前（已消化 13..15）、B 卡 13；A 的 inbox 已沒有 B 缺的 13..15
+    expect(A.node.confirmedFrame).toBeGreaterThan(B.node.confirmedFrame);
+    expect(B.node.confirmedFrame).toBe(13);
+
+    // 遷移補課：交換視野 + 以 baseCf=max(cf) 回填空幀 + 同一棄權幀
+    const sA = A.node.exportSyncState();
+    const sB = B.node.exportSyncState();
+    const baseCf = Math.max(sA.cf, sB.cf);
+    const forfeitF = Math.max(sA.horizon.H, sB.horizon.H) + 1;
+    B.node.importMergedInputs(sA.inputs);
+    B.node.fillEmptyInputsUpTo(baseCf);
+    A.node.importMergedInputs(sB.inputs);
+    A.node.fillEmptyInputsUpTo(baseCf);
+    A.node.scheduleForfeit('H', forfeitF);
+    B.node.scheduleForfeit('H', forfeitF);
+
+    // 續行：雙向投遞恢復（新 host relay 新幀）
+    for (let r = 0; r < 12; r++) {
+      A.node.tick([]);
+      B.node.tick([]);
+      deliverAtoB();
+      deliverBtoA();
+    }
+
+    // 兩端越過缺口、cf 相等、H 判敗墊底、全盤指紋與 replay 完全一致
+    expect(B.node.confirmedFrame).toBeGreaterThan(baseCf);
+    expect(A.node.confirmedFrame).toBe(B.node.confirmedFrame);
+    expect(A.node.getMatch().getPlacement().get('H')).toBe(3);
+    expect(B.node.getMatch().getPlacement().get('H')).toBe(3);
+    expect(stateFingerprint(A.node)).toBe(stateFingerprint(B.node));
+    expect(JSON.stringify(A.node.getReplay())).toBe(JSON.stringify(B.node.getReplay()));
+  });
+
   it('重複 import 自己的 export 無害：cf 與全盤狀態不變、後續鎖步與對照組一致', () => {
     const playerIds = ['P0', 'P1', 'P2', 'P3'];
     const run = (withReimport: boolean): { fp: string; cf: number } => {

--- a/src/scripts/games/tetris/net/ffaLockstep.ts
+++ b/src/scripts/games/tetris/net/ffaLockstep.ts
@@ -30,6 +30,19 @@ export interface FfaLockstepTransport {
   onMessage(cb: (msg: FfaFrameMsg) => void): void;
 }
 
+/**
+ * 鎖步同步狀態快照（host migration 補課用，spec B.4）。
+ * cf      = confirmedFrame（已全員確認並推進的幀界線）。
+ * horizon = 每玩家「本端已知」的最大幀：max(inbox 未消化最大鍵, 已消化至 cf-1)；
+ *           自己另取 sendFrame+inputDelay-1（已送出但未確認的本地幀上界）。
+ * inputs  = inbox 所有未消化幀攤平（inbox 本來就含自己已送未消化的本地幀）。
+ */
+export interface FfaSyncState {
+  cf: number;
+  horizon: Record<string, number>;
+  inputs: Array<{ f: number; p: string; a: InputAction[] }>;
+}
+
 export interface FfaLockstepOptions {
   playerIds: string[];
   localId: string;
@@ -139,6 +152,49 @@ export class FfaLockstep {
       events: [...this.replayEvents],
       forfeits: [...this.replayForfeits],
     };
+  }
+
+  /**
+   * 匯出同步狀態快照（host migration 補課用）。
+   * 純讀取、不改任何內部狀態；inputs 的 a 為複本，呼叫端改動不影響 inbox。
+   */
+  exportSyncState(): FfaSyncState {
+    const horizon: Record<string, number> = {};
+    const inputs: FfaSyncState['inputs'] = [];
+    for (const id of this.playerIds) {
+      // 已消化至 cf-1（inbox 空時的下界）
+      let max = this.simFrame - 1;
+      for (const [f, a] of this.inbox.get(id)!) {
+        if (f > max) max = f;
+        inputs.push({ f, p: id, a: [...a] });
+      }
+      // 自己＝已送出但未確認的本地幀上界（正常情況即 inbox 最大鍵；
+      // 自己已淘汰被 autofill 消化時取 max 保單調）
+      if (id === this.localId) {
+        max = Math.max(max, this.sendFrame + this.inputDelay - 1);
+      }
+      horizon[id] = max;
+    }
+    return { cf: this.simFrame, horizon, inputs };
+  }
+
+  /**
+   * 灌入合併後的輸入集（host migration 補課用）。
+   * 逐筆走 recordInput（冪等：首寫保留）；p 不在名單或壞形狀（f 非有限非負數、
+   * a 非合法 action 陣列）一律忽略——合併集可能來自網路，不可信。
+   * 不主動推進；下一次 tick 的 advance 自然越過補上的缺口。
+   */
+  importMergedInputs(inputs: Array<{ f: number; p: string; a: InputAction[] }>): void {
+    if (!Array.isArray(inputs)) return;
+    for (const raw of inputs) {
+      if (!raw || typeof raw !== 'object') continue;
+      const e = raw as Record<string, unknown>;
+      if (typeof e.f !== 'number' || !Number.isFinite(e.f) || e.f < 0) continue;
+      if (typeof e.p !== 'string' || !this.inbox.has(e.p)) continue;
+      if (!Array.isArray(e.a)) continue;
+      if (!e.a.every((x) => typeof x === 'string' && VALID_ACTIONS.has(x))) continue;
+      this.recordInput(e.p, e.f, [...(e.a as InputAction[])]);
+    }
   }
 
   // ── 內部 ──────────────────────────────────────────────────────────────

--- a/src/scripts/games/tetris/net/ffaLockstep.ts
+++ b/src/scripts/games/tetris/net/ffaLockstep.ts
@@ -7,6 +7,15 @@ const SIM_DT = 1000 / 60;
  * 故「從未送幀的玩家」的全員停滯點 = INPUT_DELAY（FfaForfeitController 計算 F 用）。 */
 export const INPUT_DELAY = 3;
 
+/**
+ * exportSyncState 附帶的 replay tail 視窗（幀數，60fps 下 10 秒）。
+ * Host 死亡時各端停滯點不同（cf 偏移）：超前端可能已把落後端缺的幀「消化並從
+ * inbox 刪除」——這些幀的非空輸入只存在於 replayEvents。匯出 tail 讓合併補課
+ * 能覆蓋 [laggard.cf, ahead.cf) 的缺口（實測偏移 ≈ INPUT_DELAY＋relay 在途量，
+ * 600 幀為十倍以上裕度；空幀不需匯出——由 fillEmptyInputsUpTo 確定性回填）。
+ */
+export const SYNC_REPLAY_TAIL_FRAMES = 600;
+
 /** 合法的輸入動作字串集合，用於 onMessage shape 驗證（網路訊息不可信）。 */
 const VALID_ACTIONS: ReadonlySet<string> = new Set<InputAction>([
   'left', 'right', 'rotateCW', 'rotateCCW', 'softDrop', 'hardDrop', 'hold',
@@ -157,6 +166,9 @@ export class FfaLockstep {
   /**
    * 匯出同步狀態快照（host migration 補課用）。
    * 純讀取、不改任何內部狀態；inputs 的 a 為複本，呼叫端改動不影響 inbox。
+   * inputs ＝ inbox 未消化幀 ＋ replay tail（近 SYNC_REPLAY_TAIL_FRAMES 幀內
+   * 已套用的非空幀）——cf 偏移時超前端已消化、落後端仍缺的幀只能從 tail 補。
+   * 兩來源幀域不重疊（inbox ≥ cf > replay）→ 無重複鍵。
    */
   exportSyncState(): FfaSyncState {
     const horizon: Record<string, number> = {};
@@ -175,7 +187,30 @@ export class FfaLockstep {
       }
       horizon[id] = max;
     }
+    const tailFrom = this.simFrame - SYNC_REPLAY_TAIL_FRAMES;
+    for (const e of this.replayEvents) {
+      if (e.f >= tailFrom) inputs.push({ f: e.f, p: e.p, a: [...e.a] });
+    }
     return { cf: this.simFrame, horizon, inputs };
+  }
+
+  /**
+   * 以 baseCf（合併視野的 max cf）回填空輸入（host migration 補課用）。
+   * 須在 importMergedInputs「之後」呼叫：超前端已套用的幀中，非空輸入必在其
+   * replay tail（已隨 merge 灌入）；merge 後仍缺的 (f, p) 即為空幀 → 確定性補 []。
+   * 跳過自己：本地輸入只在送出當下記錄，絕不合成（避免搶填未來要送的幀）；
+   * 協定保證 baseCf ≤ 任一玩家已送幀上界＋1，故自己的幀必已齊。
+   * frame 非有限數或 ≤ cf → no-op（網路來值不可信）。
+   */
+  fillEmptyInputsUpTo(frame: number): void {
+    if (typeof frame !== 'number' || !Number.isFinite(frame)) return;
+    for (let f = this.simFrame; f < frame; f++) {
+      for (const id of this.playerIds) {
+        if (id === this.localId) continue;
+        const map = this.inbox.get(id)!;
+        if (!map.has(f)) map.set(f, []);
+      }
+    }
   }
 
   /**
@@ -220,6 +255,7 @@ export class FfaLockstep {
 
   /** 寫入某玩家某幀輸入（冪等：已存在則不覆蓋，避免重複廣播造成不一致）。 */
   private recordInput(id: string, frame: number, actions: InputAction[]): void {
+    if (frame < this.simFrame) return; // 已模擬過的幀＝死歷史（遲到重播/補課 tail）→ 不寫，免汙染 inbox
     const map = this.inbox.get(id);
     if (!map) return;
     if (map.has(frame)) return; // 冪等：保留首次確認的輸入

--- a/src/scripts/games/tetris/net/ffaMigration.test.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.test.ts
@@ -317,16 +317,21 @@ function makeMockRtc() {
   return { guestPeer, hostPeer, registry };
 }
 
-/** mock MigLockstep：固定 exportSyncState、記錄 import/scheduleForfeit。 */
+/** mock MigLockstep：固定 exportSyncState、記錄 import/fill/scheduleForfeit（calls 記呼叫順序）。 */
 function mockMigLockstep(state: FfaSyncState) {
   const scheduled: Array<{ p: string; f: number }> = [];
   const imported: SyncState['inputs'][] = [];
+  const filled: number[] = [];
+  const calls: string[] = [];
   return {
     scheduled,
     imported,
+    filled,
+    calls,
     exportSyncState: () => state,
-    importMergedInputs: (inputs: SyncState['inputs']) => { imported.push(inputs); },
-    scheduleForfeit: (p: string, f: number) => { scheduled.push({ p, f }); },
+    importMergedInputs: (inputs: SyncState['inputs']) => { imported.push(inputs); calls.push('import'); },
+    fillEmptyInputsUpTo: (f: number) => { filled.push(f); calls.push('fill'); },
+    scheduleForfeit: (p: string, f: number) => { scheduled.push({ p, f }); calls.push('forfeit'); },
   };
 }
 
@@ -484,6 +489,10 @@ describe('runMigration（遷移協調器，mock-net）', () => {
       expect(ls.imported).toHaveLength(1);
       expect(ls.imported[0]).toContainEqual({ f: 41, p: 'g1', a: ['left'] });
       expect(ls.imported[0]).toContainEqual({ f: 44, p: 'h', a: ['right'] });
+      // 空幀回填：baseCf = max(cf) = 38，且必在 import 之後、forfeit 之前
+      //（fill 先跑會把空幀搶寫進 inbox、擋掉 merge 的真輸入 → 鎖步發散）
+      expect(ls.filled).toEqual([38]);
+      expect(ls.calls).toEqual(['import', 'fill', 'forfeit']);
     }
   });
 
@@ -571,5 +580,7 @@ describe('runMigration（遷移協調器，mock-net）', () => {
     expect(state).toBeTruthy();
     expect(state!.hostForfeitF).toBe(15);
     expect(state!.gen).toBe(1);
+    // baseCf = max(host cf=10, g2 sync cf=9) → 落後端據此回填空幀
+    expect(state!.baseCf).toBe(10);
   });
 });

--- a/src/scripts/games/tetris/net/ffaMigration.test.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.test.ts
@@ -4,10 +4,17 @@ import {
   mergeSync,
   hostForfeitFrame,
   MigratingTransport,
+  runMigration,
   type SyncState,
   type MigratableInner,
+  type MigGuestPeer,
+  type MigHostPeer,
+  type MigChannel,
+  type RunMigrationDeps,
 } from './ffaMigration';
-import type { FfaFrameMsg } from './ffaLockstep';
+import { FfaLockstep, type FfaFrameMsg, type FfaSyncState } from './ffaLockstep';
+import { FfaHubTransport, FfaSpokeTransport } from './ffaTransport';
+import { isValidSlot } from './signalClient';
 import type { InputAction } from '../engine/game';
 
 /** 測試用 mock inner transport：記錄送出、可手動觸發收訊。 */
@@ -227,5 +234,342 @@ describe('MigratingTransport（傳輸層熱插拔 facade）', () => {
     const got: FfaFrameMsg[] = [];
     mt.onMessage((m) => got.push(m));
     expect(got).toEqual([frame(0, 'h'), frame(1, 'newhost')]); // 不漏不重、保序
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// M4：runMigration 遷移協調器（mock-net：記憶體 signal store + 直連 mock RTC）
+// ═════════════════════════════════════════════════════════════════════════
+
+/** 記憶體 mock signal store；putSlot/getSlot 都以 isValidSlot 驗證（抓錯誤的槽位命名）。 */
+function makeMigSignal() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async putSlot(room: string, slot: string, data: string): Promise<void> {
+      if (!isValidSlot(slot)) throw new Error(`invalid slot: ${slot}`);
+      store.set(`${room}:${slot}`, data);
+    },
+    async getSlot(room: string, slot: string): Promise<string | null> {
+      if (!isValidSlot(slot)) throw new Error(`invalid slot: ${slot}`);
+      return store.get(`${room}:${slot}`) ?? null;
+    },
+  };
+}
+
+/** 雙向 buffered loopback channel pair（onmessage 設定前緩衝、設定當下 flush；可切斷）。 */
+function bufferedPair() {
+  let blocked = false;
+  interface Inbox { deliver(raw: string): void }
+  function makeEnd(getPeer: () => Inbox): MigChannel & Inbox {
+    let cb: ((raw: string) => void) | null = null;
+    const queue: string[] = [];
+    return {
+      open: true,
+      onclose: null,
+      get onmessage() { return cb; },
+      set onmessage(fn: ((raw: string) => void) | null) {
+        cb = fn;
+        if (fn) while (queue.length) fn(queue.shift()!);
+      },
+      send(raw: string) {
+        if (blocked) return;
+        getPeer().deliver(raw);
+      },
+      deliver(raw: string) {
+        if (cb) cb(raw);
+        else queue.push(raw);
+      },
+    };
+  }
+  const a: MigChannel & Inbox = makeEnd(() => b);
+  const b: MigChannel & Inbox = makeEnd(() => a);
+  return { a, b, block: () => { blocked = true; } };
+}
+
+/** mock RTC：guest createOffer 回 token、host createAnswer 以 token 從 registry 取直連 pair。 */
+function makeMockRtc() {
+  const registry = new Map<string, MigChannel>();
+  let seq = 0;
+  const guestPeer = (): MigGuestPeer => {
+    const { a, b } = bufferedPair();
+    const token = `OFFER-${seq++}`;
+    registry.set(token, b);
+    return {
+      createOffer: async () => token,
+      acceptAnswer: async (_ans: string) => {},
+      waitOpen: async () => {},
+      channel: a,
+    };
+  };
+  const hostPeer = (): MigHostPeer => {
+    let ch: MigChannel | null = null;
+    return {
+      createAnswer: async (offer: string) => {
+        ch = registry.get(offer) ?? null;
+        if (!ch) throw new Error(`unknown offer: ${offer}`);
+        return `ANS-${offer}`;
+      },
+      waitOpen: async () => {},
+      get channel() { return ch!; },
+    };
+  };
+  return { guestPeer, hostPeer, registry };
+}
+
+/** mock MigLockstep：固定 exportSyncState、記錄 import/scheduleForfeit。 */
+function mockMigLockstep(state: FfaSyncState) {
+  const scheduled: Array<{ p: string; f: number }> = [];
+  const imported: SyncState['inputs'][] = [];
+  return {
+    scheduled,
+    imported,
+    exportSyncState: () => state,
+    importMergedInputs: (inputs: SyncState['inputs']) => { imported.push(inputs); },
+    scheduleForfeit: (p: string, f: number) => { scheduled.push({ p, f }); },
+  };
+}
+
+/** 共用 deps 工廠（測試各自覆寫差異欄位）。 */
+function migDeps(over: Partial<RunMigrationDeps> & Pick<RunMigrationDeps, 'selfId' | 'lockstep' | 'transport'>): RunMigrationDeps {
+  return {
+    signal: makeMigSignal(),
+    room: 'R',
+    gen: 1,
+    playerIds: ['h', 'g1', 'g2'],
+    hostId: 'h',
+    placedIds: [],
+    hostPeerFactory: makeMockRtc().hostPeer,
+    guestPeerFactory: makeMockRtc().guestPeer,
+    electionGraceMs: 0,
+    pollIntervalMs: 1,
+    timeoutMs: 4_000,
+    ...over,
+  };
+}
+
+describe('runMigration（遷移協調器，mock-net）', () => {
+  it('完整遷移：3 端真鎖步、視野不等 → G1 成 host、G2 join → 兩端補課一致、續行到 victory、H placement=3、replay 一致', async () => {
+    const playerIds = ['h', 'g1', 'g2'];
+    const seed = 4242;
+
+    // 原始星狀拓樸：H 為 hub，G1/G2 各持 spoke；G1/G2 的 lockstep 透過 MigratingTransport facade。
+    const p1 = bufferedPair();
+    const p2 = bufferedPair();
+    const hub0 = new FfaHubTransport([p1.a, p2.a]);
+    const facade1 = new MigratingTransport(new FfaSpokeTransport(p1.b) as unknown as MigratableInner);
+    const facade2 = new MigratingTransport(new FfaSpokeTransport(p2.b) as unknown as MigratableInner);
+
+    const hLs = new FfaLockstep({ playerIds, localId: 'h', seed, transport: hub0 });
+    const g1Ls = new FfaLockstep({ playerIds, localId: 'g1', seed, transport: facade1 });
+    const g2Ls = new FfaLockstep({ playerIds, localId: 'g2', seed, transport: facade2 });
+
+    // 正常跑 40 幀
+    for (let f = 0; f < 40; f++) { hLs.tick([]); g1Ls.tick([]); g2Ls.tick([]); }
+
+    // 模擬 H 死前最後幾幀只送達 G1：切斷 H↔G2，H/G1 再各 tick 3 次 → G2 視野落後
+    p2.block();
+    for (let f = 0; f < 3; f++) { hLs.tick([]); g1Ls.tick([]); }
+    expect(g1Ls.exportSyncState().horizon.h).toBeGreaterThan(g2Ls.exportSyncState().horizon.h);
+
+    // H 死亡 → G1/G2 各自跑 runMigration（共用 mock signal/RTC）
+    const signal = makeMigSignal();
+    const rtc = makeMockRtc();
+    const common = {
+      signal, room: 'R', gen: 1, playerIds, hostId: 'h',
+      hostPeerFactory: rtc.hostPeer, guestPeerFactory: rtc.guestPeer,
+      electionGraceMs: 0, pollIntervalMs: 1, timeoutMs: 4_000,
+    };
+    const [r1, r2] = await Promise.all([
+      runMigration({ ...common, selfId: 'g1', placedIds: [...g1Ls.getMatch().getPlacement().keys()], lockstep: g1Ls, transport: facade1 }),
+      runMigration({ ...common, selfId: 'g2', placedIds: [...g2Ls.getMatch().getPlacement().keys()], lockstep: g2Ls, transport: facade2 }),
+    ]);
+    expect(r1.role).toBe('host');
+    expect(r2.role).toBe('join');
+    // 世代化槽位被使用（g2 原始 index=2 → 槽位 index 1；g1 beacon → 槽位 index 0）
+    expect(signal.store.get('R:mig1-guest-1-offer')).toBeTruthy();
+    expect(signal.store.get('R:mig1-host-ack-1')).toBeTruthy();
+    expect(signal.store.get('R:mig1-guest-0-offer')).toBeTruthy();
+
+    // 續行：G2 狂 hardDrop 先死 → 分出勝負
+    let f = 0;
+    for (; f < 20_000 && g1Ls.getMatch().phase === 'playing'; f++) {
+      g1Ls.tick([]);
+      g2Ls.tick(f % 2 === 0 ? ['hardDrop'] : []);
+    }
+    expect(g1Ls.getMatch().phase).toBe('result');
+    expect(g2Ls.getMatch().phase).toBe('result');
+
+    // 舊 host 判敗：placement = 3（最後一名）
+    expect(g1Ls.getMatch().getPlacement().get('h')).toBe(3);
+    expect(g2Ls.getMatch().getPlacement().get('h')).toBe(3);
+    // 兩端狀態一致：standings + 完整 replay（events/forfeits/frameCount）JSON 相等
+    expect(g1Ls.getStandings()).toEqual(g2Ls.getStandings());
+    expect(g1Ls.getStandings()[0]).toBe('g1');
+    expect(JSON.stringify(g1Ls.getReplay())).toBe(JSON.stringify(g2Ls.getReplay()));
+    expect(g1Ls.getReplay().forfeits.map((x) => x.p)).toEqual(['h']);
+  });
+
+  it('雙候選讓位：G1/G2 都自判候選（不同 placedIds 視野）→ G2 在 answer 前發現 G1 offer → 讓位 join、收斂單一 host', async () => {
+    const signal = makeMigSignal();
+    const rtc = makeMockRtc();
+    const ls1 = mockMigLockstep({ cf: 10, horizon: { h: 12, g1: 12, g2: 12 }, inputs: [] });
+    const ls2 = mockMigLockstep({ cf: 10, horizon: { h: 12, g1: 12, g2: 12 }, inputs: [] });
+    const f1 = new MigratingTransport(mockInner());
+    const f2 = new MigratingTransport(mockInner());
+    const common = {
+      signal, hostPeerFactory: rtc.hostPeer, guestPeerFactory: rtc.guestPeer,
+      electionGraceMs: 40, pollIntervalMs: 1, timeoutMs: 4_000,
+    };
+    const [r1, r2] = await Promise.all([
+      // G1 視野：無人淘汰 → 候選 g1（自己）
+      runMigration(migDeps({ ...common, selfId: 'g1', placedIds: [], lockstep: ls1, transport: f1 })),
+      // G2 視野：g1 剛淘汰（分歧）→ 候選 g2（自己）→ 讓位
+      runMigration(migDeps({ ...common, selfId: 'g2', placedIds: ['g1'], lockstep: ls2, transport: f2 })),
+    ]);
+    expect(r1.role).toBe('host');
+    expect(r2.role).toBe('join');
+    if (r2.role === 'join') expect(r2.hostId).toBe('g1');
+    // 兩端對舊 host 排程同一棄權幀
+    expect(ls1.scheduled).toEqual(ls2.scheduled);
+    expect(ls1.scheduled[0].p).toBe('h');
+  });
+
+  it('逾時：join 等不到 ack / host 等不到 offer → MIGRATION_TIMEOUT 後 throw（netMain 據此降級）', async () => {
+    // join：候選 g1 永不出現 → 等 ack 逾時
+    await expect(runMigration(migDeps({
+      selfId: 'g2',
+      lockstep: mockMigLockstep({ cf: 0, horizon: {}, inputs: [] }),
+      transport: new MigratingTransport(mockInner()),
+      timeoutMs: 80, pollIntervalMs: 5,
+    }))).rejects.toThrow(/timeout/i);
+
+    // host：倖存者 g2 永不寫 offer → 收 offer 逾時
+    await expect(runMigration(migDeps({
+      selfId: 'g1',
+      lockstep: mockMigLockstep({ cf: 0, horizon: {}, inputs: [] }),
+      transport: new MigratingTransport(mockInner()),
+      timeoutMs: 80, pollIntervalMs: 5,
+    }))).rejects.toThrow(/timeout/i);
+  });
+
+  it('hostForfeitF 用 merge 後 horizon（兩端視野取 max，非任一端單獨視野）；合併輸入兩端都灌入', async () => {
+    const signal = makeMigSignal();
+    const rtc = makeMockRtc();
+    // g1 視野：h 到 40；g2 視野：h 到 45 → merged horizon.h = 45 → F = 46
+    const ls1 = mockMigLockstep({
+      cf: 38, horizon: { h: 40, g1: 43, g2: 39 },
+      inputs: [{ f: 41, p: 'g1', a: ['left'] }],
+    });
+    const ls2 = mockMigLockstep({
+      cf: 36, horizon: { h: 45, g1: 41, g2: 42 },
+      inputs: [{ f: 44, p: 'h', a: ['right'] }],
+    });
+    const f1 = new MigratingTransport(mockInner());
+    const f2 = new MigratingTransport(mockInner());
+    const common = {
+      signal, hostPeerFactory: rtc.hostPeer, guestPeerFactory: rtc.guestPeer,
+      electionGraceMs: 0, pollIntervalMs: 1, timeoutMs: 4_000,
+    };
+    const [r1, r2] = await Promise.all([
+      runMigration(migDeps({ ...common, selfId: 'g1', lockstep: ls1, transport: f1 })),
+      runMigration(migDeps({ ...common, selfId: 'g2', lockstep: ls2, transport: f2 })),
+    ]);
+    expect(r1.role).toBe('host');
+    expect(r2.role).toBe('join');
+    expect(ls1.scheduled).toEqual([{ p: 'h', f: 46 }]);
+    expect(ls2.scheduled).toEqual([{ p: 'h', f: 46 }]);
+    // 合併輸入＝兩端 inputs 並集，兩端都收到
+    for (const ls of [ls1, ls2]) {
+      expect(ls.imported).toHaveLength(1);
+      expect(ls.imported[0]).toContainEqual({ f: 41, p: 'g1', a: ['left'] });
+      expect(ls.imported[0]).toContainEqual({ f: 44, p: 'h', a: ['right'] });
+    }
+  });
+
+  it('gen2：遷移成功後新 host 再死 → 以 gen=2 槽位再遷移成功', async () => {
+    const playerIds = ['h', 'g1', 'g2', 'g3'];
+    const signal = makeMigSignal();
+    const rtc = makeMockRtc();
+    const state = (): FfaSyncState => ({ cf: 5, horizon: { h: 7, g1: 7, g2: 7, g3: 7 }, inputs: [] });
+    const ls = [mockMigLockstep(state()), mockMigLockstep(state()), mockMigLockstep(state())];
+    const fa = [
+      new MigratingTransport(mockInner()),
+      new MigratingTransport(mockInner()),
+      new MigratingTransport(mockInner()),
+    ];
+    const common = {
+      signal, playerIds, hostPeerFactory: rtc.hostPeer, guestPeerFactory: rtc.guestPeer,
+      electionGraceMs: 0, pollIntervalMs: 1, timeoutMs: 4_000,
+    };
+    // gen1：h 死 → g1 host、g2/g3 join
+    const gen1 = await Promise.all([
+      runMigration(migDeps({ ...common, gen: 1, hostId: 'h', selfId: 'g1', lockstep: ls[0], transport: fa[0] })),
+      runMigration(migDeps({ ...common, gen: 1, hostId: 'h', selfId: 'g2', lockstep: ls[1], transport: fa[1] })),
+      runMigration(migDeps({ ...common, gen: 1, hostId: 'h', selfId: 'g3', lockstep: ls[2], transport: fa[2] })),
+    ]);
+    expect(gen1.map((r) => r.role)).toEqual(['host', 'join', 'join']);
+
+    // gen2：新 host g1 再死（h 已判敗 → placedIds 含 h）→ g2 host、g3 join，槽位走 mig2-
+    const gen2 = await Promise.all([
+      runMigration(migDeps({ ...common, gen: 2, hostId: 'g1', placedIds: ['h'], selfId: 'g2', lockstep: ls[1], transport: fa[1] })),
+      runMigration(migDeps({ ...common, gen: 2, hostId: 'g1', placedIds: ['h'], selfId: 'g3', lockstep: ls[2], transport: fa[2] })),
+    ]);
+    expect(gen2.map((r) => r.role)).toEqual(['host', 'join']);
+    // gen2 槽位確實使用 mig2- 前綴（g3 原始 index=3 → 槽位 index 2）
+    expect(signal.store.get('R:mig2-guest-2-offer')).toBeTruthy();
+    expect(signal.store.get('R:mig2-host-ack-2')).toBeTruthy();
+    // gen2 兩端對 g1 排程同一棄權幀（gen1 對 h 的排程仍在前）
+    expect(ls[1].scheduled[1]).toEqual({ p: 'g1', f: 8 });
+    expect(ls[2].scheduled[1]).toEqual({ p: 'g1', f: 8 });
+  });
+
+  it('壞 sync 訊息忽略不炸：host 收到非 JSON / 錯 gen / 壞 shape 的 sync 後，仍以合法 sync 完成遷移', async () => {
+    const playerIds = ['h', 'g1', 'g2'];
+    const signal = makeMigSignal();
+    const rtc = makeMockRtc();
+    const ls1 = mockMigLockstep({ cf: 10, horizon: { h: 12, g1: 12, g2: 9 }, inputs: [] });
+    const f1 = new MigratingTransport(mockInner());
+
+    // 手動扮演 g2（join 端）：寫 offer → 等 ack → 先送垃圾再送合法 sync
+    const gp = rtc.guestPeer();
+    const offer = await gp.createOffer();
+    await signal.putSlot('R', 'mig1-guest-1-offer', JSON.stringify({ id: 'g2', offer }));
+
+    const hostPromise = runMigration(migDeps({
+      signal, playerIds, selfId: 'g1', lockstep: ls1, transport: f1,
+      hostPeerFactory: rtc.hostPeer, guestPeerFactory: rtc.guestPeer,
+      timeoutMs: 4_000, pollIntervalMs: 1, electionGraceMs: 0,
+    }));
+
+    // 等 host 寫 ack
+    let ack: string | null = null;
+    for (let i = 0; i < 1000 && !ack; i++) {
+      ack = await signal.getSlot('R', 'mig1-host-ack-1');
+      if (!ack) await new Promise((r) => setTimeout(r, 2));
+    }
+    expect(ack).toBeTruthy();
+    await gp.acceptAnswer(ack!);
+    const received: string[] = [];
+    gp.channel.onmessage = (raw: string) => received.push(raw);
+
+    // 垃圾訊息：非 JSON、錯 gen、壞 shape → host 一律忽略
+    gp.channel.send('not-json');
+    gp.channel.send(JSON.stringify({ t: 'ffa-mig-sync', gen: 99, cf: 0, horizon: {}, inputs: [] }));
+    gp.channel.send(JSON.stringify({ t: 'ffa-mig-sync', gen: 1, cf: 'x', horizon: {}, inputs: [] }));
+    gp.channel.send(JSON.stringify({ t: 'ffa-mig-sync', gen: 1, cf: 0, horizon: { h: NaN }, inputs: [] }));
+    // 合法 sync（g2 視野 h 到 14 > g1 的 12 → F 應為 15）
+    gp.channel.send(JSON.stringify({ t: 'ffa-mig-sync', gen: 1, cf: 9, horizon: { h: 14, g1: 11, g2: 12 }, inputs: [] }));
+
+    const r1 = await hostPromise;
+    expect(r1.role).toBe('host');
+    expect(ls1.scheduled).toEqual([{ p: 'h', f: 15 }]);
+    // g2 端收到 ffa-mig-state 廣播（含 merged inputs + hostForfeitF）
+    const state = received
+      .map((raw) => { try { return JSON.parse(raw) as Record<string, unknown>; } catch { return null; } })
+      .find((m) => m && m.t === 'ffa-mig-state');
+    expect(state).toBeTruthy();
+    expect(state!.hostForfeitF).toBe(15);
+    expect(state!.gen).toBe(1);
   });
 });

--- a/src/scripts/games/tetris/net/ffaMigration.test.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import {
+  electHost,
+  mergeSync,
+  hostForfeitFrame,
+  MigratingTransport,
+  type SyncState,
+  type MigratableInner,
+} from './ffaMigration';
+import type { FfaFrameMsg } from './ffaLockstep';
+import type { InputAction } from '../engine/game';
+
+/** 測試用 mock inner transport：記錄送出、可手動觸發收訊。 */
+function mockInner(): MigratableInner & {
+  sentFrames: FfaFrameMsg[];
+  sentControls: Array<Record<string, unknown>>;
+  emit(msg: FfaFrameMsg): void;
+  emitControl(msg: Record<string, unknown>): void;
+} {
+  let msgCb: ((msg: FfaFrameMsg) => void) | null = null;
+  let ctrlCb: ((msg: Record<string, unknown>) => void) | null = null;
+  return {
+    sentFrames: [] as FfaFrameMsg[],
+    sentControls: [] as Array<Record<string, unknown>>,
+    send(msg: FfaFrameMsg): void {
+      this.sentFrames.push(msg);
+    },
+    sendControl(msg: Record<string, unknown>): void {
+      this.sentControls.push(msg);
+    },
+    onMessage(cb: (msg: FfaFrameMsg) => void): void {
+      msgCb = cb;
+    },
+    onControl(cb: (msg: Record<string, unknown>) => void): void {
+      ctrlCb = cb;
+    },
+    emit(msg: FfaFrameMsg): void {
+      msgCb?.(msg);
+    },
+    emitControl(msg: Record<string, unknown>): void {
+      ctrlCb?.(msg);
+    },
+  };
+}
+
+const frame = (f: number, p: string, a: InputAction[] = []): FfaFrameMsg => ({ f, p, a });
+
+describe('electHost（新 host 選舉純函式）', () => {
+  const players = ['h', 'g1', 'g2', 'g3'];
+
+  it('基本：排除 host 後原始 index 最低的存活 guest 為候選；自己非候選 → join', () => {
+    const r = electHost(players, 'h', [], 'g2');
+    expect(r).toEqual({ role: 'join', candidateId: 'g1' });
+  });
+
+  it('候選已淘汰：g1 在 placedIds → 跳到下一個 g2', () => {
+    const r = electHost(players, 'h', ['g1'], 'g3');
+    expect(r).toEqual({ role: 'join', candidateId: 'g2' });
+  });
+
+  it('自己是候選 → role host', () => {
+    const r = electHost(players, 'h', [], 'g1');
+    expect(r).toEqual({ role: 'host', candidateId: 'g1' });
+  });
+
+  it('其他 guest 全淘汰、只剩自己 → 自己是候選 host', () => {
+    const r = electHost(players, 'h', ['g1', 'g2'], 'g3');
+    expect(r).toEqual({ role: 'host', candidateId: 'g3' });
+  });
+
+  it('全淘汰邊界：所有 guest 都在 placedIds → 無候選（candidateId 空字串、join）', () => {
+    const r = electHost(players, 'h', ['g1', 'g2', 'g3'], 'g3');
+    expect(r).toEqual({ role: 'join', candidateId: '' });
+  });
+});
+
+describe('mergeSync（輸入視野合併純函式）', () => {
+  it('並集：兩端不相交的 inputs 全數保留', () => {
+    const a: SyncState = {
+      cf: 10,
+      horizon: { h: 12, g1: 11 },
+      inputs: [{ f: 11, p: 'g1', a: ['left'] }],
+    };
+    const b: SyncState = {
+      cf: 9,
+      horizon: { h: 10, g2: 13 },
+      inputs: [{ f: 12, p: 'g2', a: ['right'] }],
+    };
+    const m = mergeSync([a, b]);
+    expect(m.inputs).toHaveLength(2);
+    expect(m.inputs).toContainEqual({ f: 11, p: 'g1', a: ['left'] });
+    expect(m.inputs).toContainEqual({ f: 12, p: 'g2', a: ['right'] });
+  });
+
+  it('冪等去重：同 (f,p) 鍵在多個 state 出現 → 首見保留', () => {
+    const a: SyncState = {
+      cf: 0,
+      horizon: {},
+      inputs: [{ f: 5, p: 'g1', a: ['hardDrop'] }],
+    };
+    const b: SyncState = {
+      cf: 0,
+      horizon: {},
+      inputs: [{ f: 5, p: 'g1', a: ['left'] }], // 理論上不會不同，但首見必須保留
+    };
+    const m = mergeSync([a, b]);
+    expect(m.inputs).toEqual([{ f: 5, p: 'g1', a: ['hardDrop'] }]);
+  });
+
+  it('horizon：每玩家取所有 state 的最大值', () => {
+    const a: SyncState = { cf: 0, horizon: { h: 10, g1: 8 }, inputs: [] };
+    const b: SyncState = { cf: 0, horizon: { h: 7, g1: 9, g2: 4 }, inputs: [] };
+    const m = mergeSync([a, b]);
+    expect(m.horizon).toEqual({ h: 10, g1: 9, g2: 4 });
+  });
+
+  it('冪等：同一組 state 重複合併結果相同；空輸入 → 空結果', () => {
+    const a: SyncState = {
+      cf: 3,
+      horizon: { g1: 6 },
+      inputs: [{ f: 6, p: 'g1', a: [] }],
+    };
+    const once = mergeSync([a]);
+    const twice = mergeSync([a, a]);
+    expect(twice).toEqual(once);
+    expect(mergeSync([])).toEqual({ inputs: [], horizon: {} });
+  });
+});
+
+describe('hostForfeitFrame（舊 host 判敗幀）', () => {
+  it('一般情況：max horizon[host]+1（必可達停滯點，非 confirmedFrame+1）', () => {
+    expect(hostForfeitFrame({ h: 42, g1: 40 }, 'h', 3)).toBe(43);
+  });
+
+  it('向下夾 INPUT_DELAY：host horizon 過低或缺席 → 回 inputDelay', () => {
+    expect(hostForfeitFrame({ h: 1 }, 'h', 3)).toBe(3); // 1+1=2 < 3 → 夾到 3
+    expect(hostForfeitFrame({}, 'h', 3)).toBe(3); // 從未送幀 → INPUT_DELAY
+  });
+});
+
+describe('MigratingTransport（傳輸層熱插拔 facade）', () => {
+  it('委派：send/sendControl 走 inner；inner 來訊（幀+控制）到上層回呼', () => {
+    const inner = mockInner();
+    const mt = new MigratingTransport(inner);
+    const got: FfaFrameMsg[] = [];
+    const gotCtrl: Array<Record<string, unknown>> = [];
+    mt.onMessage((m) => got.push(m));
+    mt.onControl((m) => gotCtrl.push(m));
+
+    mt.send(frame(1, 'g1', ['left']));
+    mt.sendControl({ t: 'ffa-mig-sync', gen: 1 });
+    expect(inner.sentFrames).toEqual([frame(1, 'g1', ['left'])]);
+    expect(inner.sentControls).toEqual([{ t: 'ffa-mig-sync', gen: 1 }]);
+
+    inner.emit(frame(2, 'h'));
+    inner.emitControl({ t: 'ffa-forfeit', p: 'g2' });
+    expect(got).toEqual([frame(2, 'h')]);
+    expect(gotCtrl).toEqual([{ t: 'ffa-forfeit', p: 'g2' }]);
+  });
+
+  it('緩衝：上層回呼註冊前 inner 來訊 → 註冊時依序 flush、不漏不重', () => {
+    const inner = mockInner();
+    const mt = new MigratingTransport(inner);
+    inner.emit(frame(0, 'h'));
+    inner.emit(frame(1, 'h'));
+    inner.emitControl({ t: 'ffa-mig-state', gen: 1 });
+
+    const got: FfaFrameMsg[] = [];
+    const gotCtrl: Array<Record<string, unknown>> = [];
+    mt.onMessage((m) => got.push(m));
+    mt.onControl((m) => gotCtrl.push(m));
+    expect(got).toEqual([frame(0, 'h'), frame(1, 'h')]); // 依序 flush
+    expect(gotCtrl).toEqual([{ t: 'ffa-mig-state', gen: 1 }]);
+
+    // flush 後不重：再來訊只多一筆
+    inner.emit(frame(2, 'h'));
+    expect(got).toEqual([frame(0, 'h'), frame(1, 'h'), frame(2, 'h')]);
+  });
+
+  it('swap：前後雙向訊息不漏不重 —— swap 後 send 走新 inner、新 inner 來訊到同一回呼、舊 inner 來訊丟棄', () => {
+    const inner1 = mockInner();
+    const inner2 = mockInner();
+    const mt = new MigratingTransport(inner1);
+    const got: FfaFrameMsg[] = [];
+    const gotCtrl: Array<Record<string, unknown>> = [];
+    mt.onMessage((m) => got.push(m));
+    mt.onControl((m) => gotCtrl.push(m));
+
+    // swap 前：走 inner1
+    mt.send(frame(1, 'g1'));
+    inner1.emit(frame(1, 'h'));
+    expect(inner1.sentFrames).toEqual([frame(1, 'g1')]);
+    expect(got).toEqual([frame(1, 'h')]);
+
+    mt.swap(inner2);
+
+    // swap 後：送出走 inner2，inner1 不再收到
+    mt.send(frame(2, 'g1'));
+    mt.sendControl({ t: 'ffa-mig-sync', gen: 1 });
+    expect(inner2.sentFrames).toEqual([frame(2, 'g1')]);
+    expect(inner2.sentControls).toEqual([{ t: 'ffa-mig-sync', gen: 1 }]);
+    expect(inner1.sentFrames).toEqual([frame(1, 'g1')]); // 不重送舊 inner
+
+    // 新 inner 來訊（幀+控制）到「同一」上層回呼，不需重新註冊
+    inner2.emit(frame(2, 'newhost'));
+    inner2.emitControl({ t: 'ffa-leave', p: 'g3' });
+    expect(got).toEqual([frame(1, 'h'), frame(2, 'newhost')]);
+    expect(gotCtrl).toEqual([{ t: 'ffa-leave', p: 'g3' }]);
+
+    // 舊 inner（死掉的 host 通道）swap 後殘留來訊 → 丟棄，不重不漏
+    inner1.emit(frame(3, 'h'));
+    inner1.emitControl({ t: 'ffa-stale' });
+    expect(got).toEqual([frame(1, 'h'), frame(2, 'newhost')]);
+    expect(gotCtrl).toEqual([{ t: 'ffa-leave', p: 'g3' }]);
+  });
+
+  it('swap 期間緩衝：上層尚未註冊回呼時 swap，新舊 inner 的既收訊息依序 flush 不漏', () => {
+    const inner1 = mockInner();
+    const inner2 = mockInner();
+    const mt = new MigratingTransport(inner1);
+
+    inner1.emit(frame(0, 'h')); // swap 前、註冊前收到 → 緩衝
+    mt.swap(inner2);
+    inner2.emit(frame(1, 'newhost')); // swap 後、註冊前收到 → 緩衝
+    inner1.emit(frame(9, 'h')); // 舊 inner swap 後來訊 → 丟棄
+
+    const got: FfaFrameMsg[] = [];
+    mt.onMessage((m) => got.push(m));
+    expect(got).toEqual([frame(0, 'h'), frame(1, 'newhost')]); // 不漏不重、保序
+  });
+});

--- a/src/scripts/games/tetris/net/ffaMigration.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.ts
@@ -1,15 +1,14 @@
-import type { FfaLockstepTransport, FfaFrameMsg } from './ffaLockstep';
+import { INPUT_DELAY, type FfaLockstepTransport, type FfaFrameMsg, type FfaSyncState } from './ffaLockstep';
+import { FfaHubTransport, FfaSpokeTransport, type RelayChannel } from './ffaTransport';
 
 /**
- * Host Migration（中離續行 Stage B）—— 遷移基元。
+ * Host Migration（中離續行 Stage B）—— 遷移基元 + 協調器。
  *
- * 本檔目前包含 M2 範圍：
  *  - electHost：新 host 選舉（無需通訊的確定性規則，spec B.2）
  *  - SyncState / mergeSync：輸入視野合併（斷點補課，spec B.4）
  *  - hostForfeitFrame：舊 host 判敗幀（max horizon+1、夾 INPUT_DELAY，禁 confirmedFrame+1）
  *  - MigratingTransport：傳輸層熱插拔 facade（spec B.5）
- *
- * M4 之後會在同檔加遷移協調器（runMigration）。
+ *  - runMigration：遷移協調器（M4；全依賴注入，mock-net 可測）
  */
 
 /**
@@ -84,13 +83,14 @@ export function hostForfeitFrame(
 
 /**
  * MigratingTransport 可持有的 inner 形狀（結構相容：FfaHubTransport / FfaSpokeTransport 皆滿足）。
- * 比 FfaLockstepTransport 多 sendControl/onControl（Hub/Spoke 既有的控制訊息通道）。
+ * 比 FfaLockstepTransport 多 sendControl/onControl（Hub/Spoke 既有的控制訊息通道）；
+ * 兩者為可選——不支援控制通道的 inner（測試 mock）也可被包，控制訊息成 no-op。
  */
 export interface MigratableInner {
   send(msg: FfaFrameMsg): void;
   onMessage(cb: (msg: FfaFrameMsg) => void): void;
-  sendControl(msg: Record<string, unknown>): void;
-  onControl(cb: (msg: Record<string, unknown>) => void): void;
+  sendControl?(msg: Record<string, unknown>): void;
+  onControl?(cb: (msg: Record<string, unknown>) => void): void;
 }
 
 /**
@@ -122,7 +122,7 @@ export class MigratingTransport implements FfaLockstepTransport {
       if (this.cb) this.cb(msg);
       else this.msgBuffer.push(msg);
     });
-    inner.onControl((msg) => {
+    inner.onControl?.((msg) => {
       if (this.inner !== inner) return;
       if (this.controlCb) this.controlCb(msg);
       else this.ctrlBuffer.push(msg);
@@ -140,7 +140,7 @@ export class MigratingTransport implements FfaLockstepTransport {
   }
 
   sendControl(msg: Record<string, unknown>): void {
-    this.inner.sendControl(msg);
+    this.inner.sendControl?.(msg);
   }
 
   onMessage(cb: (msg: FfaFrameMsg) => void): void {
@@ -160,4 +160,311 @@ export class MigratingTransport implements FfaLockstepTransport {
       for (const m of buffered) cb(m);
     }
   }
+}
+
+// ═════════════════════════════════════════════════════════════════════════
+// M4：runMigration —— 遷移協調器（spec B.2/B.3/B.4/B.5）
+//
+// 協定（世代 g，槽位沿用 T11 guest-initiated 交握）：
+//   1. electHost 決定角色（本端視野）。
+//   2. 「所有」參與者（含自任 host）先 createOffer 寫入 mig{g}-guest-{i}-offer：
+//      自任 host 的 offer 兼作「選舉 beacon」——讓位仲裁的依據，且讓位後可直接被
+//      真 host answer（不必重寫）。i = 該玩家在 playerIds 的原始 index - 1
+//      （host 在 index 0 → guest 原始 index 1..7 → 槽位 0..6）。
+//   3. 自任 host：等 ELECTION_GRACE_MS（給更低 index 的真候選時間寫 beacon）→
+//      檢查是否存在更低 index 的 offer：有 → 自己誤判為候選，改走 join；無 → host。
+//   4. host：輪詢倖存者 offer → 逐一 createAnswer 寫 mig{g}-host-ack-{i} → waitOpen →
+//      暫掛 per-channel 收訊收集 ffa-mig-sync（channel 需在 onmessage 設定前緩衝，
+//      真實路徑由 wrapChannel 保證）→ 收齊（含自己 exportSyncState）→ mergeSync →
+//      建 FfaHubTransport → 廣播 ffa-mig-state（合併輸入 + hostForfeitF）→
+//      自己 import + scheduleForfeit → swap(hub)。
+//   5. join：等 ack → acceptAnswer → waitOpen → spoke → 送 ffa-mig-sync →
+//      等 ffa-mig-state → import + scheduleForfeit → swap(spoke)。
+//   6. 任一步逾時（MIGRATION_TIMEOUT_MS）→ throw（netMain catch 後降級為中止）。
+// ═════════════════════════════════════════════════════════════════════════
+
+/** 整體遷移逾時（任一步超過即 reject → netMain 降級中止）。 */
+export const MIGRATION_TIMEOUT_MS = 20_000;
+/** 選舉先手窗：自任 host 寫完 beacon 後等待此時長，再做讓位檢查。 */
+export const ELECTION_GRACE_MS = 3_000;
+/** 同一局最多遷移次數（mig1..mig6 槽位上限；超過降級中止）。 */
+export const MAX_MIGRATIONS = 6;
+
+/** signaling 最小依賴（FfaSignalClient 子集；mock-net 可注入記憶體 Map）。 */
+export interface MigSignal {
+  putSlot(room: string, slot: string, data: string): Promise<void>;
+  getSlot(room: string, slot: string): Promise<string | null>;
+}
+
+/** 遷移用 channel 形狀（RelayChannel + 可賦值 onmessage；真實路徑為 wrapChannel 產物）。 */
+export type MigChannel = RelayChannel & { onmessage?: ((raw: string) => void) | null };
+
+/** 新 host 端對某倖存者的 RTC peer（收 offer 回 answer；同 FfaHostAnswerPeer 形狀）。 */
+export interface MigHostPeer {
+  createAnswer(offer: string): Promise<string>;
+  waitOpen(): Promise<void>;
+  readonly channel: MigChannel;
+}
+
+/** 加入端對新 host 的 RTC peer（建 offer 收 answer；同 FfaGuestOfferPeer 形狀）。 */
+export interface MigGuestPeer {
+  createOffer(): Promise<string>;
+  acceptAnswer(answer: string): Promise<void>;
+  waitOpen(): Promise<void>;
+  readonly channel: MigChannel;
+}
+
+/** 遷移所需的 lockstep 最小形狀（FfaLockstep 子集；mock 友善）。 */
+export interface MigLockstep {
+  exportSyncState(): FfaSyncState;
+  importMergedInputs(inputs: SyncState['inputs']): void;
+  scheduleForfeit(p: string, f: number): void;
+}
+
+export interface RunMigrationDeps {
+  signal: MigSignal;
+  room: string;
+  /** 遷移世代 1..6（決定 mig{g}- 槽位）。 */
+  gen: number;
+  /** 開局 ffa-init 的 playerIds（全端一致、永不重排）。 */
+  playerIds: string[];
+  /** 剛死掉的 host（gen1 = playerIds[0]；gen2+ = 上一代新 host）。 */
+  hostId: string;
+  selfId: string;
+  /** 本端視野中已定名次者（選舉排除；視野分歧由 beacon 仲裁兜底）。 */
+  placedIds: string[];
+  lockstep: MigLockstep;
+  /** 對局現役 transport facade（成功後 swap 到新拓樸）。 */
+  transport: MigratingTransport;
+  hostPeerFactory: () => MigHostPeer;
+  guestPeerFactory: () => MigGuestPeer;
+  inputDelay?: number;
+  now?: () => number;
+  timeoutMs?: number;
+  electionGraceMs?: number;
+  pollIntervalMs?: number;
+}
+
+export type RunMigrationResult =
+  /** 自己成為新 host：netMain 用 hub + guestIds 啟動 Stage A 偵測（wireFfaForfeit）。 */
+  | { role: 'host'; hostId: string; hub: FfaHubTransport; guestIds: string[] }
+  /** 加入新 host：netMain 對 spoke 重掛 host-down 偵測（gen+1 備用）。hostId = 本端認定的新 host。 */
+  | { role: 'join'; hostId: string; spoke: FfaSpokeTransport };
+
+/** mig offer 槽位酬載：{id, offer}（同 T11 GuestOfferMsg 形狀）。 */
+function parseMigOffer(raw: string): { id: string; offer: string } | null {
+  try {
+    const m = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof m.id === 'string' && typeof m.offer === 'string') {
+      return { id: m.id, offer: m.offer };
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+/** 驗證 ffa-mig-sync（原始字串）：gen 必須相符、shape 完整；畸形回 null（網路訊息不可信）。 */
+function parseMigSync(raw: unknown, gen: number): SyncState | null {
+  let m: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      m = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!m || typeof m !== 'object') return null;
+  const o = m as Record<string, unknown>;
+  if (o.t !== 'ffa-mig-sync' || o.gen !== gen) return null;
+  if (typeof o.cf !== 'number' || !Number.isFinite(o.cf)) return null;
+  if (!o.horizon || typeof o.horizon !== 'object' || Array.isArray(o.horizon)) return null;
+  const horizon: Record<string, number> = {};
+  for (const [k, v] of Object.entries(o.horizon as Record<string, unknown>)) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+    horizon[k] = v;
+  }
+  if (!Array.isArray(o.inputs)) return null;
+  // inputs 細項由 importMergedInputs 再驗一次；這裡確保 mergeSync 不會炸
+  const inputs = (o.inputs as unknown[]).filter((e): e is SyncState['inputs'][number] => {
+    if (!e || typeof e !== 'object') return false;
+    const i = e as Record<string, unknown>;
+    return typeof i.f === 'number' && Number.isFinite(i.f)
+      && typeof i.p === 'string' && Array.isArray(i.a);
+  });
+  return { cf: o.cf, horizon, inputs };
+}
+
+/** 驗證 ffa-mig-state（控制訊息物件）：gen 相符、inputs 陣列、hostForfeitF 有限非負。 */
+function parseMigState(
+  msg: Record<string, unknown>,
+  gen: number,
+): { inputs: SyncState['inputs']; hostForfeitF: number } | null {
+  if (msg.t !== 'ffa-mig-state' || msg.gen !== gen) return null;
+  if (!Array.isArray(msg.inputs)) return null;
+  if (typeof msg.hostForfeitF !== 'number' || !Number.isFinite(msg.hostForfeitF) || msg.hostForfeitF < 0) return null;
+  return { inputs: msg.inputs as SyncState['inputs'], hostForfeitF: msg.hostForfeitF };
+}
+
+/**
+ * 遷移協調器（host 死亡後由每個倖存 guest 各自呼叫）。
+ * 全依賴注入：signaling / RTC / lockstep / transport / 時鐘與節奏皆可 mock。
+ * 成功 → 回傳新角色與新拓樸；任一步逾時或無候選 → throw（呼叫端降級中止）。
+ */
+export async function runMigration(deps: RunMigrationDeps): Promise<RunMigrationResult> {
+  const now = deps.now ?? Date.now;
+  const timeoutMs = deps.timeoutMs ?? MIGRATION_TIMEOUT_MS;
+  const grace = deps.electionGraceMs ?? ELECTION_GRACE_MS;
+  const interval = deps.pollIntervalMs ?? 500;
+  const inputDelay = deps.inputDelay ?? INPUT_DELAY;
+  const deadline = now() + timeoutMs;
+  const g = deps.gen;
+  const placed = new Set(deps.placedIds);
+
+  // 原始 index（playerIds 不重排）→ 槽位 index：guest 在 playerIds[1..7] → 槽位 0..6。
+  const slotIndexOf = (id: string): number => deps.playerIds.indexOf(id) - 1;
+  const offerSlot = (id: string): string => `mig${g}-guest-${slotIndexOf(id)}-offer`;
+  const ackSlot = (id: string): string => `mig${g}-host-ack-${slotIndexOf(id)}`;
+
+  const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+  const ensureTime = (label: string): void => {
+    if (now() > deadline) throw new Error(`migration timeout: ${label}`);
+  };
+  /** 為一步驟掛上「剩餘預算」逾時（waitOpen / acceptAnswer 等可能永久卡住）。 */
+  function withDeadline<T>(p: Promise<T>, label: string): Promise<T> {
+    const remain = deadline - now();
+    if (remain <= 0) return Promise.reject(new Error(`migration timeout: ${label}`));
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`migration timeout: ${label}`)), remain);
+      p.then(
+        (v) => { clearTimeout(timer); resolve(v); },
+        (e) => { clearTimeout(timer); reject(e); },
+      );
+    });
+  }
+
+  /** 輪詢槽位直到有值或 deadline。 */
+  async function pollUntil(slot: string, label: string): Promise<string> {
+    for (;;) {
+      const v = await deps.signal.getSlot(deps.room, slot);
+      if (v) return v;
+      ensureTime(label);
+      await sleep(interval);
+    }
+  }
+
+  /** 建 offer 並寫入自己的槽位（join 的 offer ＝ host 候選的選舉 beacon，同一條路）。 */
+  async function writeOwnOffer(peer: MigGuestPeer): Promise<void> {
+    const offer = await withDeadline(peer.createOffer(), 'createOffer');
+    await deps.signal.putSlot(deps.room, offerSlot(deps.selfId), JSON.stringify({ id: deps.selfId, offer }));
+  }
+
+  /** join 流程：等 ack → 接通 → 送 sync → 收 state → 補課 + 排程舊 host 判敗 → swap。 */
+  async function joinFlow(peer: MigGuestPeer, candidateId: string): Promise<RunMigrationResult> {
+    const answer = await pollUntil(ackSlot(deps.selfId), 'host-ack');
+    await withDeadline(peer.acceptAnswer(answer), 'acceptAnswer');
+    await withDeadline(peer.waitOpen(), 'waitOpen');
+    const spoke = new FfaSpokeTransport(peer.channel);
+
+    // 先掛 state 等待、再送 sync（state 必在 host 收齊全員 sync 後才廣播，此順序是保險）。
+    let resolveState: (s: { inputs: SyncState['inputs']; hostForfeitF: number }) => void = () => {};
+    const statePromise = new Promise<{ inputs: SyncState['inputs']; hostForfeitF: number }>((res) => {
+      resolveState = res;
+    });
+    spoke.onControl((msg) => {
+      const st = parseMigState(msg, g);
+      if (st) resolveState(st);
+    });
+    const sync = deps.lockstep.exportSyncState();
+    spoke.sendControl({ t: 'ffa-mig-sync', gen: g, cf: sync.cf, horizon: sync.horizon, inputs: sync.inputs });
+
+    const state = await withDeadline(statePromise, 'ffa-mig-state');
+    deps.lockstep.importMergedInputs(state.inputs);
+    deps.lockstep.scheduleForfeit(deps.hostId, state.hostForfeitF);
+    deps.transport.swap(spoke);
+    return { role: 'join', hostId: candidateId, spoke };
+  }
+
+  /** host 流程：收齊倖存者 offer → answer → 收齊 sync → merge → 廣播 state → swap hub。 */
+  async function hostFlow(): Promise<RunMigrationResult> {
+    // 倖存者（本端視野）依原始順序輪詢；排除舊 host 與自己。
+    const expected = deps.playerIds.filter(
+      (id) => id !== deps.hostId && id !== deps.selfId && !placed.has(id),
+    );
+    if (expected.length === 0) throw new Error('migration: no survivors to host');
+
+    const channels: MigChannel[] = [];
+    const guestIds: string[] = [];
+    const collected: SyncState[] = [];
+    const remaining = new Set(expected);
+
+    while (remaining.size > 0) {
+      let progressed = false;
+      for (const id of expected) {
+        if (!remaining.has(id)) continue;
+        const raw = await deps.signal.getSlot(deps.room, offerSlot(id));
+        if (!raw) continue;
+        const parsed = parseMigOffer(raw);
+        if (!parsed) { remaining.delete(id); continue; } // 壞 offer：放棄該端（不可恢復）
+        const peer = deps.hostPeerFactory();
+        const answer = await withDeadline(peer.createAnswer(parsed.offer), 'createAnswer');
+        await deps.signal.putSlot(deps.room, ackSlot(id), answer);
+        await withDeadline(peer.waitOpen(), 'waitOpen');
+        // 暫掛收訊收集 ffa-mig-sync（遷移期間 guest 凍結，不會送幀；
+        // 設定 onmessage 當下 channel 既有緩衝會 flush —— wrapChannel 保證不漏早到的 sync）。
+        peer.channel.onmessage = (rawMsg: string) => {
+          const s = parseMigSync(rawMsg, g);
+          if (s) collected.push(s);
+        };
+        channels.push(peer.channel);
+        guestIds.push(id);
+        remaining.delete(id);
+        progressed = true;
+      }
+      if (remaining.size === 0) break;
+      ensureTime('collect offers');
+      if (!progressed) await sleep(interval);
+    }
+
+    // 收齊各端 sync（收訊由 channel handler 非同步推進；這裡輪詢計數）。
+    while (collected.length < channels.length) {
+      ensureTime('collect syncs');
+      await sleep(interval);
+    }
+
+    // 合併（含自己的視野）→ 舊 host 判敗幀 = merge 後 horizon（禁 confirmedFrame+1）。
+    const merged = mergeSync([deps.lockstep.exportSyncState(), ...collected]);
+    const hostForfeitF = hostForfeitFrame(merged.horizon, deps.hostId, inputDelay);
+
+    // 建 hub（接管各 channel 收訊）→ 廣播 ffa-mig-state → 自己補課 + swap。
+    const hub = new FfaHubTransport(channels);
+    hub.sendControl({ t: 'ffa-mig-state', gen: g, inputs: merged.inputs, hostForfeitF });
+    deps.lockstep.importMergedInputs(merged.inputs);
+    deps.lockstep.scheduleForfeit(deps.hostId, hostForfeitF);
+    deps.transport.swap(hub);
+    return { role: 'host', hostId: deps.selfId, hub, guestIds };
+  }
+
+  // ── 選舉與角色分派 ──────────────────────────────────────────────────────
+  const elected = electHost(deps.playerIds, deps.hostId, deps.placedIds, deps.selfId);
+
+  if (elected.role !== 'host') {
+    if (!elected.candidateId) throw new Error('migration: no host candidate');
+    const peer = deps.guestPeerFactory();
+    await writeOwnOffer(peer);
+    return joinFlow(peer, elected.candidateId);
+  }
+
+  // 自任 host：先寫 beacon offer（仲裁依據；讓位後可直接被真 host answer）。
+  const beaconPeer = deps.guestPeerFactory();
+  await writeOwnOffer(beaconPeer);
+  if (grace > 0) await sleep(grace); // 給更低 index 的真候選先手時間
+  // 讓位檢查：存在更低原始 index 的 offer → 自己誤判為候選（視野落後），改走 join。
+  const myIdx = slotIndexOf(deps.selfId);
+  for (const id of deps.playerIds) {
+    if (id === deps.hostId || id === deps.selfId) continue;
+    const idx = slotIndexOf(id);
+    if (idx < 0 || idx >= myIdx) continue;
+    const v = await deps.signal.getSlot(deps.room, offerSlot(id));
+    if (v) return joinFlow(beaconPeer, id);
+  }
+  return hostFlow();
 }

--- a/src/scripts/games/tetris/net/ffaMigration.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.ts
@@ -1,0 +1,163 @@
+import type { FfaLockstepTransport, FfaFrameMsg } from './ffaLockstep';
+
+/**
+ * Host Migration（中離續行 Stage B）—— 遷移基元。
+ *
+ * 本檔目前包含 M2 範圍：
+ *  - electHost：新 host 選舉（無需通訊的確定性規則，spec B.2）
+ *  - SyncState / mergeSync：輸入視野合併（斷點補課，spec B.4）
+ *  - hostForfeitFrame：舊 host 判敗幀（max horizon+1、夾 INPUT_DELAY，禁 confirmedFrame+1）
+ *  - MigratingTransport：傳輸層熱插拔 facade（spec B.5）
+ *
+ * M4 之後會在同檔加遷移協調器（runMigration）。
+ */
+
+/**
+ * 新 host 選舉（純函式）。
+ * 候選＝playerIds 中排除 hostId 與 placedIds（已定名次/已棄權）後，原始 slot index 最低者。
+ * selfId === candidateId → 自任 host；無任何候選（全淘汰邊界）→ candidateId 空字串、role 'join'。
+ */
+export function electHost(
+  playerIds: string[],
+  hostId: string,
+  placedIds: string[],
+  selfId: string,
+): { role: 'host' | 'join'; candidateId: string } {
+  const placed = new Set(placedIds);
+  const candidateId = playerIds.find((id) => id !== hostId && !placed.has(id)) ?? '';
+  const role: 'host' | 'join' = candidateId !== '' && candidateId === selfId ? 'host' : 'join';
+  return { role, candidateId };
+}
+
+/**
+ * 單一端在 host 死亡斷點的同步快照（ffa-mig-sync 的酬載核心）。
+ *  - cf：該端 confirmedFrame
+ *  - horizon：該端視野中各玩家「已知輸入的最大幀」
+ *  - inputs：該端 inbox 中尚未消化的幀＋自己已送出未確認的本地幀
+ */
+export interface SyncState {
+  cf: number;
+  horizon: Record<string, number>;
+  inputs: Array<{ f: number; p: string; a: string[] }>;
+}
+
+/**
+ * 合併各端 SyncState（純函式、冪等）。
+ *  - inputs：以 (f, p) 為鍵去重、首見保留（同幀同玩家輸入在各端必然相同——皆源自舊 host 有序轉發）。
+ *  - horizon：每玩家取所有 state 的最大值。
+ */
+export function mergeSync(states: SyncState[]): {
+  inputs: SyncState['inputs'];
+  horizon: Record<string, number>;
+} {
+  const seen = new Set<string>();
+  const inputs: SyncState['inputs'] = [];
+  const horizon: Record<string, number> = {};
+  for (const s of states) {
+    for (const inp of s.inputs) {
+      const key = `${inp.f}|${inp.p}`;
+      if (seen.has(key)) continue; // 冪等：首見保留
+      seen.add(key);
+      inputs.push(inp);
+    }
+    for (const [p, f] of Object.entries(s.horizon)) {
+      const prev = horizon[p];
+      horizon[p] = prev === undefined ? f : Math.max(prev, f);
+    }
+  }
+  return { inputs, horizon };
+}
+
+/**
+ * 舊 host 判敗生效幀：max(horizon[hostId]) + 1，向下夾 inputDelay。
+ * 「+1 於已知輸入最大幀」＝必可達的全員停滯點；host 從未送幀 → INPUT_DELAY。
+ * 禁用 confirmedFrame+1（Stage A 死鎖教訓：該幀可能永遠湊不齊全員輸入）。
+ */
+export function hostForfeitFrame(
+  horizon: Record<string, number>,
+  hostId: string,
+  inputDelay: number,
+): number {
+  const h = horizon[hostId];
+  return Math.max((h === undefined ? -1 : h) + 1, inputDelay);
+}
+
+/**
+ * MigratingTransport 可持有的 inner 形狀（結構相容：FfaHubTransport / FfaSpokeTransport 皆滿足）。
+ * 比 FfaLockstepTransport 多 sendControl/onControl（Hub/Spoke 既有的控制訊息通道）。
+ */
+export interface MigratableInner {
+  send(msg: FfaFrameMsg): void;
+  onMessage(cb: (msg: FfaFrameMsg) => void): void;
+  sendControl(msg: Record<string, unknown>): void;
+  onControl(cb: (msg: Record<string, unknown>) => void): void;
+}
+
+/**
+ * 傳輸層熱插拔 facade（spec B.5）。
+ *
+ * FfaLockstep 只認一個 transport；遷移時不動 lockstep，改由本類在內部換 inner：
+ *  - send/sendControl：永遠委派給「當前」inner。
+ *  - 收訊（幀＋控制）：綁定時以「該 inner 是否仍為當前」做 stale 防護——
+ *    swap 後舊 inner（死掉的 host 通道）殘留來訊一律丟棄（不重）。
+ *  - 緩衝：上層回呼註冊前收到的訊息暫存，註冊時依序 flush（不漏、保序）；
+ *    swap 不清緩衝（swap 前合法收到的訊息仍要送達上層）。
+ */
+export class MigratingTransport implements FfaLockstepTransport {
+  private inner: MigratableInner;
+  private cb: ((msg: FfaFrameMsg) => void) | null = null;
+  private controlCb: ((msg: Record<string, unknown>) => void) | null = null;
+  private msgBuffer: FfaFrameMsg[] = [];
+  private ctrlBuffer: Array<Record<string, unknown>> = [];
+
+  constructor(inner: MigratableInner) {
+    this.inner = inner;
+    this.bind(inner);
+  }
+
+  /** 把 inner 的收訊流重綁到同一上層回呼（含 stale 防護與註冊前緩衝）。 */
+  private bind(inner: MigratableInner): void {
+    inner.onMessage((msg) => {
+      if (this.inner !== inner) return; // swap 後舊 inner 殘留來訊 → 丟棄
+      if (this.cb) this.cb(msg);
+      else this.msgBuffer.push(msg);
+    });
+    inner.onControl((msg) => {
+      if (this.inner !== inner) return;
+      if (this.controlCb) this.controlCb(msg);
+      else this.ctrlBuffer.push(msg);
+    });
+  }
+
+  /** 熱插拔：換掉 inner（spoke↔hub），訊息流重綁到同一上層回呼。 */
+  swap(inner: MigratableInner): void {
+    this.inner = inner;
+    this.bind(inner);
+  }
+
+  send(msg: FfaFrameMsg): void {
+    this.inner.send(msg);
+  }
+
+  sendControl(msg: Record<string, unknown>): void {
+    this.inner.sendControl(msg);
+  }
+
+  onMessage(cb: (msg: FfaFrameMsg) => void): void {
+    this.cb = cb;
+    if (this.msgBuffer.length > 0) {
+      const buffered = this.msgBuffer;
+      this.msgBuffer = [];
+      for (const m of buffered) cb(m); // 依序 flush，不漏不重
+    }
+  }
+
+  onControl(cb: (msg: Record<string, unknown>) => void): void {
+    this.controlCb = cb;
+    if (this.ctrlBuffer.length > 0) {
+      const buffered = this.ctrlBuffer;
+      this.ctrlBuffer = [];
+      for (const m of buffered) cb(m);
+    }
+  }
+}

--- a/src/scripts/games/tetris/net/ffaMigration.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.ts
@@ -308,6 +308,11 @@ function parseMigState(
  * 遷移協調器（host 死亡後由每個倖存 guest 各自呼叫）。
  * 全依賴注入：signaling / RTC / lockstep / transport / 時鐘與節奏皆可 mock。
  * 成功 → 回傳新角色與新拓樸；任一步逾時或無候選 → throw（呼叫端降級中止）。
+ *
+ * 呼叫端規約：**已知自己已定名次（淘汰/棄權）者不得呼叫**——其低 index offer
+ * 會讓真候選在讓位檢查中誤讓位 → 全員 join → 選舉死鎖（netMain 已把關）。
+ * 視野落後、尚不知自己已定名次者照常參與：即使其誤判自任 host，
+ * 仲裁會收斂到它當 host —— host 只是純 relay，已淘汰者亦可勝任。
  */
 export async function runMigration(deps: RunMigrationDeps): Promise<RunMigrationResult> {
   const now = deps.now ?? Date.now;

--- a/src/scripts/games/tetris/net/ffaMigration.ts
+++ b/src/scripts/games/tetris/net/ffaMigration.ts
@@ -218,6 +218,8 @@ export interface MigGuestPeer {
 export interface MigLockstep {
   exportSyncState(): FfaSyncState;
   importMergedInputs(inputs: SyncState['inputs']): void;
+  /** 以 baseCf 回填空輸入（須在 importMergedInputs 之後呼叫——首寫保留，反序會擋掉真輸入）。 */
+  fillEmptyInputsUpTo(f: number): void;
   scheduleForfeit(p: string, f: number): void;
 }
 
@@ -293,15 +295,16 @@ function parseMigSync(raw: unknown, gen: number): SyncState | null {
   return { cf: o.cf, horizon, inputs };
 }
 
-/** 驗證 ffa-mig-state（控制訊息物件）：gen 相符、inputs 陣列、hostForfeitF 有限非負。 */
+/** 驗證 ffa-mig-state（控制訊息物件）：gen 相符、inputs 陣列、hostForfeitF/baseCf 有限非負。 */
 function parseMigState(
   msg: Record<string, unknown>,
   gen: number,
-): { inputs: SyncState['inputs']; hostForfeitF: number } | null {
+): { inputs: SyncState['inputs']; hostForfeitF: number; baseCf: number } | null {
   if (msg.t !== 'ffa-mig-state' || msg.gen !== gen) return null;
   if (!Array.isArray(msg.inputs)) return null;
   if (typeof msg.hostForfeitF !== 'number' || !Number.isFinite(msg.hostForfeitF) || msg.hostForfeitF < 0) return null;
-  return { inputs: msg.inputs as SyncState['inputs'], hostForfeitF: msg.hostForfeitF };
+  if (typeof msg.baseCf !== 'number' || !Number.isFinite(msg.baseCf) || msg.baseCf < 0) return null;
+  return { inputs: msg.inputs as SyncState['inputs'], hostForfeitF: msg.hostForfeitF, baseCf: msg.baseCf };
 }
 
 /**
@@ -370,8 +373,8 @@ export async function runMigration(deps: RunMigrationDeps): Promise<RunMigration
     const spoke = new FfaSpokeTransport(peer.channel);
 
     // 先掛 state 等待、再送 sync（state 必在 host 收齊全員 sync 後才廣播，此順序是保險）。
-    let resolveState: (s: { inputs: SyncState['inputs']; hostForfeitF: number }) => void = () => {};
-    const statePromise = new Promise<{ inputs: SyncState['inputs']; hostForfeitF: number }>((res) => {
+    let resolveState: (s: { inputs: SyncState['inputs']; hostForfeitF: number; baseCf: number }) => void = () => {};
+    const statePromise = new Promise<{ inputs: SyncState['inputs']; hostForfeitF: number; baseCf: number }>((res) => {
       resolveState = res;
     });
     spoke.onControl((msg) => {
@@ -383,6 +386,8 @@ export async function runMigration(deps: RunMigrationDeps): Promise<RunMigration
 
     const state = await withDeadline(statePromise, 'ffa-mig-state');
     deps.lockstep.importMergedInputs(state.inputs);
+    // cf 偏移補課：merge 後仍缺的 (f<baseCf, p) 即空幀 → 回填（必在 import 之後）。
+    deps.lockstep.fillEmptyInputsUpTo(state.baseCf);
     deps.lockstep.scheduleForfeit(deps.hostId, state.hostForfeitF);
     deps.transport.swap(spoke);
     return { role: 'join', hostId: candidateId, spoke };
@@ -435,14 +440,19 @@ export async function runMigration(deps: RunMigrationDeps): Promise<RunMigration
       await sleep(interval);
     }
 
-    // 合併（含自己的視野）→ 舊 host 判敗幀 = merge 後 horizon（禁 confirmedFrame+1）。
-    const merged = mergeSync([deps.lockstep.exportSyncState(), ...collected]);
+    // 合併（含自己的視野）→ 舊 host 判敗幀 = merge 後 horizon（禁 confirmedFrame+1）；
+    // baseCf = 各端 cf 的 max：超前端已套用的幀中非空輸入必在其 replay tail（已進 merge），
+    // 落後端 merge 後仍缺的 (f<baseCf, p) 即空幀 → fillEmptyInputsUpTo 確定性回填。
+    const allStates = [deps.lockstep.exportSyncState(), ...collected];
+    const merged = mergeSync(allStates);
+    const baseCf = allStates.reduce((m, s) => Math.max(m, s.cf), 0);
     const hostForfeitF = hostForfeitFrame(merged.horizon, deps.hostId, inputDelay);
 
     // 建 hub（接管各 channel 收訊）→ 廣播 ffa-mig-state → 自己補課 + swap。
     const hub = new FfaHubTransport(channels);
-    hub.sendControl({ t: 'ffa-mig-state', gen: g, inputs: merged.inputs, hostForfeitF });
+    hub.sendControl({ t: 'ffa-mig-state', gen: g, inputs: merged.inputs, hostForfeitF, baseCf });
     deps.lockstep.importMergedInputs(merged.inputs);
+    deps.lockstep.fillEmptyInputsUpTo(baseCf); // 必在 import 之後（首寫保留）
     deps.lockstep.scheduleForfeit(deps.hostId, hostForfeitF);
     deps.transport.swap(hub);
     return { role: 'host', hostId: deps.selfId, hub, guestIds };

--- a/src/scripts/games/tetris/net/ffaNetMain.test.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.test.ts
@@ -14,6 +14,7 @@ import {
   checkSilence,
   FfaForfeitController,
   wireFfaForfeit,
+  createGuestHostWatch,
   type FfaSignalClient,
   type FfaInitMsg,
   type FfaHostAnswerPeer,
@@ -576,6 +577,63 @@ describe('checkSilence（純函式靜默逾時判定）', () => {
     expect(checkSilence(lastMsgAt, 9_000, 10_000)).toEqual([]);
     // 剛好邊界（now - at === timeout）不算超時（嚴格大於）
     expect(checkSilence(lastMsgAt, 10_000, 10_000)).toEqual([]);
+  });
+});
+
+describe('createGuestHostWatch（guest 端 host 頻道靜默兜底偵測，Stage B）', () => {
+  it('host 頻道靜默超過 timeout → onHostDown 觸發一次；noteActivity 重置計時', () => {
+    let nowMs = 0;
+    let downs = 0;
+    const w = createGuestHostWatch({
+      onHostDown: () => { downs++; },
+      isActive: () => true,
+      now: () => nowMs,
+      timeoutMs: 10_000,
+    });
+    nowMs = 9_000;
+    w.check();
+    expect(downs).toBe(0); // 未超時
+    nowMs = 10_000;
+    w.check();
+    expect(downs).toBe(0); // 剛好邊界（嚴格大於才算）
+    nowMs = 10_001;
+    w.check();
+    expect(downs).toBe(1); // 超時 → 觸發
+    nowMs = 10_002;
+    w.check();
+    expect(downs).toBe(1); // 觸發後計時已重置 → 不重複轟炸
+
+    // 有活動（host 中繼幀）→ 重置；之後再靜默才會再觸發
+    nowMs = 15_000;
+    w.noteActivity();
+    nowMs = 25_000;
+    w.check();
+    expect(downs).toBe(1); // 15000→25000 恰好 10000，未嚴格超時
+    nowMs = 25_001;
+    w.check();
+    expect(downs).toBe(2);
+  });
+
+  it('isActive=false（遷移中/已中止/對局結束）→ 不計靜默且重置基準（恢復後重新起算）', () => {
+    let nowMs = 0;
+    let active = false;
+    let downs = 0;
+    const w = createGuestHostWatch({
+      onHostDown: () => { downs++; },
+      isActive: () => active,
+      now: () => nowMs,
+      timeoutMs: 10_000,
+    });
+    nowMs = 60_000;
+    w.check(); // 非 active：不觸發、基準同步到 now
+    expect(downs).toBe(0);
+    active = true;
+    nowMs = 65_000;
+    w.check();
+    expect(downs).toBe(0); // 恢復後僅累積 5s，不觸發
+    nowMs = 70_001;
+    w.check();
+    expect(downs).toBe(1); // 自恢復基準起超過 10s → 觸發
   });
 });
 

--- a/src/scripts/games/tetris/net/ffaNetMain.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.ts
@@ -11,6 +11,13 @@ import { FfaBoards } from '../render/FfaBoards';
 import { FfaLockstep, INPUT_DELAY, type FfaFrameMsg, type FfaLockstepTransport } from './ffaLockstep';
 import type { FfaReplay } from './ffaReplay';
 import { FfaHubTransport, FfaSpokeTransport, type RelayChannel } from './ffaTransport';
+import {
+  MigratingTransport,
+  runMigration,
+  MAX_MIGRATIONS,
+  type MigratableInner,
+  type MigSignal,
+} from './ffaMigration';
 import { createRoom as realCreateRoom, putSlot as realPutSlot, getSlot as realGetSlot, pollSlot as realPollSlot } from './signalClient';
 import { buildFfaResultMessage } from './auth';
 import { WebRtcTransport } from './webrtcTransport';
@@ -728,6 +735,42 @@ export function wireFfaForfeit(opts: {
   return ctl;
 }
 
+/**
+ * Guest 端 host 頻道靜默兜底偵測（Stage B：host-down 不只靠 spoke.onClose，
+ * 也對 host 頻道做同款 lastMsgAt 檢查——host 對局中每 tick 都會中繼幀，
+ * 靜默超過 timeoutMs ＝ host 死，觸發遷移）。
+ *
+ * - noteActivity()：收到任何中繼幀時呼叫（所有幀都經 host 中繼 → 任何來訊＝host 活著）。
+ * - check()：定時呼叫；isActive() 為 false（遷移中/已中止/對局已結束/自己已是 host）時
+ *   不計靜默並把基準重置到 now（恢復後重新起算，避免凍結期被誤判）。
+ * - 觸發後基準亦重置（onHostDown 由呼叫端做重入防護，這裡避免每秒重複轟炸）。
+ */
+export function createGuestHostWatch(opts: {
+  onHostDown: () => void;
+  isActive: () => boolean;
+  now?: () => number;
+  timeoutMs?: number;
+}): { noteActivity(): void; check(): void } {
+  const now = opts.now ?? Date.now;
+  const timeoutMs = opts.timeoutMs ?? SILENCE_TIMEOUT_MS;
+  let last = now();
+  return {
+    noteActivity(): void {
+      last = now();
+    },
+    check(): void {
+      if (!opts.isActive()) {
+        last = now();
+        return;
+      }
+      if (now() - last > timeoutMs) {
+        last = now();
+        opts.onHostDown();
+      }
+    },
+  };
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // KO 簽章回報（可測：不依賴 DOM；fetch / signMessage 可注入）
 // ─────────────────────────────────────────────────────────────────────────
@@ -789,6 +832,17 @@ export async function reportFfaRanked(opts: {
 // 對局 UI 主迴圈（組裝；Pixi/DOM 由 e2e/手動驗證，此處保持可被建構）
 // ─────────────────────────────────────────────────────────────────────────
 
+/** Host migration（Stage B）所需的外部依賴；不傳＝維持 Stage A 行為（host 離線即中止）。 */
+export interface FfaMigrationOpts {
+  /** signaling client（putSlot/getSlot 子集即可）。 */
+  signal: MigSignal;
+  /** 原房號（mig{g}- 槽位沿用同一 room）。 */
+  room: string;
+  /** 測試注入；預設真實 WebRTC 工廠。 */
+  hostPeerFactory?: () => FfaHostAnswerPeer;
+  guestPeerFactory?: () => FfaGuestOfferPeer;
+}
+
 export interface RunFfaOpts {
   canvas: HTMLCanvasElement;
   playerIds: string[];
@@ -801,6 +855,8 @@ export interface RunFfaOpts {
   guestIds?: string[];
   /** 對手斷線回呼（可選；UI 可掛 DISCONNECTED 橫幅）。 */
   onDisconnect?: () => void;
+  /** guest 端傳入 → host 離線時啟動遷移續行（Stage B）；省略＝Stage A 中止。 */
+  migration?: FfaMigrationOpts;
   fetchFn?: typeof fetch;
 }
 
@@ -825,25 +881,143 @@ export interface FfaGameHandle {
  */
 export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
   const { canvas, playerIds, localId, seed, matchId, signMessage } = opts;
+  const realTransport = opts.transport as FfaLockstepTransport & FfaControlHooks;
+
+  // Stage B：lockstep 永遠透過 MigratingTransport facade 收發 ——
+  // host migration 成功時 swap 內層（spoke→新 spoke / spoke→hub），lockstep 不動。
+  const facade = new MigratingTransport(realTransport as unknown as MigratableInner);
 
   // 立即接管 transport：建 lockstep 前進來的幀先進暫存佇列。
-  // host 端在收訊路徑 tap 中繼幀 → FfaForfeitController.noteFrame（中離 F 計算）。
+  // tap：host 端餵 FfaForfeitController.noteFrame（中離 F 計算）；
+  //      guest 端餵 hostWatch.noteActivity（任何中繼幀＝host 活著）。
   let forfeitCtl: FfaForfeitController | null = null;
+  let hostWatch: { noteActivity(): void; check(): void } | null = null;
   const wrapped = takeoverTransport(
-    tapFrames(opts.transport, (m) => forfeitCtl?.noteFrame(m)),
+    tapFrames(facade, (m) => { forfeitCtl?.noteFrame(m); hostWatch?.noteActivity(); }),
   );
   const lockstep = new FfaLockstep({ playerIds, localId, seed, transport: wrapped });
 
-  // 中離續行接線：所有端收 ffa-forfeit → scheduleForfeit；
-  // host（有 guestIds）另啟偵測（channel close / ffa-leave / 靜默逾時）。
-  let disconnected = false; // guest 端：host 頻道關閉 → Stage A 對局中止
-  forfeitCtl = wireFfaForfeit({
+  // ── 中離 / 遷移狀態 ────────────────────────────────────────────────────
+  let disconnected = false; // 對局中止（Stage A 降級路徑）
+  let migrating = false;    // 遷移中（凍結 tick、顯示橫幅）
+  let migrationGen = 0;
+  let migrationState: 'idle' | 'migrating' | 'done' | 'failed' = 'idle';
+  let currentHostId = playerIds[0];
+  let isHostNow = !!opts.guestIds;
+  /** host-down 來源世代戳：遷移成功後舊 spoke 的殘留 close 事件一律忽略。 */
+  let closeEpoch = 0;
+
+  // 橫幅文字（Pixi stage 可能尚未就緒 → 先記住、就緒時套用）。
+  let bannerText: string | null = null;
+  let applyBanner: (text: string | null) => void = () => {};
+  const setBanner = (text: string | null): void => {
+    bannerText = text;
+    applyBanner(text);
+  };
+
+  function abortMatch(): void {
+    if (disconnected) return;
+    disconnected = true;
+    setBanner('HOST 離線\n對局中止');
+    opts.onDisconnect?.();
+  }
+
+  /** 綁定當前 epoch 的 host-down 回呼（舊拓樸殘留事件不觸發新一輪遷移）。 */
+  const makeHostDownCb = (): (() => void) => {
+    const epoch = closeEpoch;
+    return () => {
+      if (epoch !== closeEpoch) return;
+      void handleHostDown();
+    };
+  };
+
+  /**
+   * forfeit 接線（初次 + 升格 host 後重掛）：
+   * 控制訊息走 facade（swap 後仍生效）；close 偵測掛在「當前真實拓樸」上。
+   */
+  const wireForfeit = (
+    closeSource: FfaControlHooks,
+    guestIds?: string[],
+    onHostClose?: () => void,
+  ): FfaForfeitController | null => wireFfaForfeit({
     lockstep,
     playerIds,
-    transport: opts.transport as FfaLockstepTransport & FfaControlHooks,
-    guestIds: opts.guestIds,
-    onHostClose: () => { disconnected = true; opts.onDisconnect?.(); },
+    transport: {
+      send: (m) => facade.send(m),
+      onMessage: () => {}, // 幀收訊已由 lockstep 持有（wireFfaForfeit 不用 onMessage）
+      sendControl: (m) => facade.sendControl(m),
+      onControl: (cb) => facade.onControl(cb),
+      onChannelClose: closeSource.onChannelClose?.bind(closeSource),
+      onClose: closeSource.onClose?.bind(closeSource),
+    } as FfaLockstepTransport & FfaControlHooks,
+    guestIds,
+    onHostClose,
   });
+
+  /**
+   * Host 離線（spoke close 或靜默兜底）→ Stage B：啟動遷移續行；
+   * 無遷移依賴 / 超過 MAX_MIGRATIONS / 遷移失敗 → 降級為 Stage A 中止。
+   */
+  async function handleHostDown(): Promise<void> {
+    if (disconnected || migrating || isHostNow) return;
+    if (lockstep.getMatch().phase !== 'playing') return; // 已分出勝負：結果已定，不需遷移
+    const mig = opts.migration;
+    if (!mig || migrationGen >= MAX_MIGRATIONS) {
+      abortMatch();
+      return;
+    }
+    migrating = true;
+    migrationGen++;
+    migrationState = 'migrating';
+    setBanner('HOST 離線\n重新連線中…');
+    try {
+      const placedIds = [...lockstep.getMatch().getPlacement().keys()];
+      const res = await runMigration({
+        signal: mig.signal,
+        room: mig.room,
+        gen: migrationGen,
+        playerIds,
+        hostId: currentHostId,
+        selfId: localId,
+        placedIds,
+        lockstep,
+        transport: facade,
+        hostPeerFactory: mig.hostPeerFactory ?? realHostAnswerPeerFactory,
+        guestPeerFactory: mig.guestPeerFactory ?? realGuestOfferPeerFactory,
+      });
+      currentHostId = res.hostId;
+      closeEpoch++; // 舊 spoke 殘留 close 從此失效
+      if (res.role === 'host') {
+        // 升格新 host：對新拓樸啟動 Stage A 偵測（channel close / ffa-leave / 靜默）。
+        isHostNow = true;
+        forfeitCtl = wireForfeit(res.hub, res.guestIds);
+      } else {
+        // 仍是 guest：對新 spoke 重掛 host-down 偵測（gen+1 備用）。
+        res.spoke.onClose(makeHostDownCb());
+        hostWatch?.noteActivity();
+      }
+      migrationState = 'done';
+      migrating = false;
+      setBanner(null);
+    } catch {
+      migrationState = 'failed';
+      migrating = false;
+      abortMatch();
+    }
+  }
+
+  // 中離續行接線：所有端收 ffa-forfeit → scheduleForfeit；
+  // host（有 guestIds）另啟偵測（channel close / ffa-leave / 靜默逾時）；
+  // guest 掛 host-down（close 快速路徑 + 靜默兜底定時器）。
+  forfeitCtl = wireForfeit(realTransport, opts.guestIds, makeHostDownCb());
+  if (!opts.guestIds) {
+    hostWatch = createGuestHostWatch({
+      onHostDown: () => { void handleHostDown(); },
+      isActive: () =>
+        !disconnected && !migrating && !isHostNow && lockstep.getMatch().phase === 'playing',
+    });
+    setInterval(() => hostWatch?.check(), SILENCE_CHECK_INTERVAL_MS);
+  }
 
   // 暫存本幀本地輸入（InputController 透過 emit 累加）。
   let pendingActions: InputAction[] = [];
@@ -860,7 +1034,7 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
     const boards = new FfaBoards(stage, playerIds, localId, tex);
     const sound = new SoundManager();
 
-    // 中央橫幅（Stage A：host 離線 → 對局中止文案）。
+    // 中央橫幅（host 離線：遷移中「重新連線中…」/ 降級「對局中止」）。
     const banner = new Text({
       text: '',
       style: { fontFamily: '"Press Start 2P", monospace', fontSize: 22, fill: 0xffffff, align: 'center' },
@@ -868,6 +1042,11 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
     banner.anchor.set(0.5);
     banner.visible = false;
     stage.hudLayer.addChild(banner);
+    applyBanner = (text: string | null): void => {
+      banner.text = text ?? '';
+      banner.visible = text !== null;
+    };
+    applyBanner(bannerText); // stage 就緒前已設定的文字（中止/遷移中）補套用
 
     function relayout(): void {
       stage.layoutBackground();
@@ -899,7 +1078,7 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
       const dt = ticker.deltaMS;
       const match = lockstep.getMatch();
 
-      if (match.phase === 'playing' && !disconnected) {
+      if (match.phase === 'playing' && !disconnected && !migrating) {
         acc += dt;
         let guard = 0;
         while (acc >= SIM_DT && guard < 8) {
@@ -921,10 +1100,9 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
       standings.push(...lockstep.getStandings());
 
       if (disconnected && !resultReported) {
-        // Stage A：host 中離＝全局中止（Stage B 再做 host migration）。
+        // 降級中止（遷移失敗 / 無遷移依賴 / 超過 MAX_MIGRATIONS）：不計分。
+        // 橫幅文字由 abortMatch() 經 setBanner 設定。
         resultReported = true;
-        banner.text = 'HOST 離線\n對局中止';
-        banner.visible = true;
       } else if (match.phase === 'result' && !resultReported) {
         resultReported = true;
         sound.topout();
@@ -947,17 +1125,20 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
       stage,
       boards,
       standings,
+      migration: {
+        get gen() { return migrationGen; },
+        get state() { return migrationState; },
+      },
     };
   });
 
-  const isHost = !!opts.guestIds;
   return {
     leaveMatch(): void {
       // guest：先送 ffa-leave（host 快速路徑立即判敗、其餘端續行）；
-      // host：Stage A host 離開＝全局中止，不送訊息（guest 由頻道 close 偵測）。
-      if (!isHost) {
-        (opts.transport as FfaLockstepTransport & FfaControlHooks)
-          .sendControl?.({ t: 'ffa-leave' });
+      // host（含遷移升格的新 host）：離開＝交給其餘端的偵測/遷移處理，不送訊息。
+      // 走 facade → 遷移後仍送往「當前」host。
+      if (!isHostNow) {
+        facade.sendControl({ t: 'ffa-leave' });
       }
     },
   };
@@ -1172,6 +1353,8 @@ export async function joinFfaGame(opts: {
       matchId,
       transport,
       signMessage: opts.identity.ranked ? opts.identity.signMessage : undefined,
+      // Stage B：host 離線 → 用同一 room 的 mig{g}- 槽位遷移續行（真實 RTC 工廠為預設）。
+      migration: { signal, room: opts.room },
     });
     opts.onHandle?.(handle);
   } catch (e) {

--- a/src/scripts/games/tetris/net/ffaNetMain.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.ts
@@ -962,6 +962,13 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
     if (disconnected || migrating || isHostNow) return;
     if (lockstep.getMatch().phase !== 'playing') return; // 已分出勝負：結果已定，不需遷移
     const mig = opts.migration;
+    // 協定規約：已知自己已定名次者「不參與」遷移（不寫 offer）。
+    // 否則其低 index offer 會讓真候選誤讓位 → 全員 join → 選舉死鎖。
+    // 代價：被淘汰者在 host 死後無法續看（自身名次已定，誠實降級）。
+    if (lockstep.getMatch().getPlacement().has(localId)) {
+      abortMatch();
+      return;
+    }
     if (!mig || migrationGen >= MAX_MIGRATIONS) {
       abortMatch();
       return;

--- a/src/scripts/games/tetris/net/signalClient.test.ts
+++ b/src/scripts/games/tetris/net/signalClient.test.ts
@@ -54,6 +54,32 @@ describe('isValidSlot：槽位白名單驗證', () => {
   it('guest-answer（缺 index）→ 非法', () => expect(isValidSlot('guest-answer')).toBe(false));
   it('host-ack（缺 index）→ 非法', () => expect(isValidSlot('host-ack')).toBe(false));
   it('OFFER（大寫）→ 非法（大小寫敏感）', () => expect(isValidSlot('OFFER')).toBe(false));
+
+  // --- 世代化遷移槽位（host migration：mig{1..6}-guest-{0..6}-offer / mig{1..6}-host-ack-{0..6}）---
+  it('mig1-guest-0-offer 合法（最小世代/最小 index）', () =>
+    expect(isValidSlot('mig1-guest-0-offer')).toBe(true));
+  it('mig6-guest-6-offer 合法（最大世代/最大 index）', () =>
+    expect(isValidSlot('mig6-guest-6-offer')).toBe(true));
+  it('mig1-host-ack-0 合法（最小世代/最小 index）', () =>
+    expect(isValidSlot('mig1-host-ack-0')).toBe(true));
+  it('mig6-host-ack-6 合法（最大世代/最大 index）', () =>
+    expect(isValidSlot('mig6-host-ack-6')).toBe(true));
+  it('mig3-guest-2-offer 合法（中間值）', () =>
+    expect(isValidSlot('mig3-guest-2-offer')).toBe(true));
+  it('mig0-guest-0-offer（g=0）→ 非法', () =>
+    expect(isValidSlot('mig0-guest-0-offer')).toBe(false));
+  it('mig7-guest-0-offer（g=7 超範圍）→ 非法', () =>
+    expect(isValidSlot('mig7-guest-0-offer')).toBe(false));
+  it('mig1-guest-7-offer（i=7 超範圍）→ 非法', () =>
+    expect(isValidSlot('mig1-guest-7-offer')).toBe(false));
+  it('mig7-host-ack-0（g=7 超範圍）→ 非法', () =>
+    expect(isValidSlot('mig7-host-ack-0')).toBe(false));
+  it('mig1-host-ack-7（i=7 超範圍）→ 非法', () =>
+    expect(isValidSlot('mig1-host-ack-7')).toBe(false));
+  it('mig-guest-0-offer（缺世代數字）→ 非法', () =>
+    expect(isValidSlot('mig-guest-0-offer')).toBe(false));
+  it('mig1-guest-0-answer（遷移流程無 answer 形式）→ 非法', () =>
+    expect(isValidSlot('mig1-guest-0-answer')).toBe(false));
 });
 
 describe('isValidSlot 用在 getSlot：非法槽位直接拋錯（不發 fetch）', () => {

--- a/src/scripts/games/tetris/net/signalClient.ts
+++ b/src/scripts/games/tetris/net/signalClient.ts
@@ -5,6 +5,7 @@
  *   1v1：offer / answer
  *   N 人星狀（host-initiated，T9 保留）：host-offer / guest-{0..6}-answer / host-ack-{0..6}
  *   N 人星狀（guest-initiated，T11 真實 WebRTC）：guest-{0..6}-offer / host-ack-{0..6}
+ *   Host migration 世代化槽位：mig{1..6}-guest-{0..6}-offer / mig{1..6}-host-ack-{0..6}
  */
 const API = '/api/signal';
 
@@ -28,6 +29,13 @@ export function isValidSlot(slot: string): boolean {
   if (ackMatch) {
     const idx = Number(ackMatch[1]);
     return idx >= 0 && idx <= 6;
+  }
+  // 世代化遷移槽位（host migration）：mig{1..6}-guest-{0..6}-offer / mig{1..6}-host-ack-{0..6}
+  const migMatch = slot.match(/^mig(\d+)-(?:guest-(\d+)-offer|host-ack-(\d+))$/);
+  if (migMatch) {
+    const gen = Number(migMatch[1]);
+    const idx = Number(migMatch[2] ?? migMatch[3]);
+    return gen >= 1 && gen <= 6 && idx >= 0 && idx <= 6;
   }
   return false;
 }

--- a/tests/e2e/games-tetris-ffa-hostmig.spec.ts
+++ b/tests/e2e/games-tetris-ffa-hostmig.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Host Migration（中離續行 Stage B）端到端：3 context（host + g1 + g2）開 FFA 對局
+ * 進 playing 後，直接 `ctxHost.close()` 模擬 HOST 關閉分頁，驗證：
+ *  1. g1 / g2 都完成遷移（`__tetrisDebug.migration.state === 'done'`，gen=1）
+ *  2. 舊 host 被判敗：placement = 3（3 人局第一個淘汰者墊底）
+ *  3. 對局未凍結——g1 / g2 的 confirmedFrame 在遷移後恢復推進
+ *  4. 驅動 g2 狂硬降 topout → 對局分出勝負：兩端 phase='result'、standings 一致、
+ *     舊 host 墊底（standings[2] === host 的 playerId）
+ *
+ * 時間預算：context.close() → DataChannel close 快速路徑（秒級）；headless 下若
+ * close 事件不發則退靜默逾時兜底（SILENCE_TIMEOUT_MS=10s）。遷移本身含
+ * ELECTION_GRACE_MS=3s 選舉先手窗 + 真實 WebRTC 重交握，上限 MIGRATION_TIMEOUT_MS=20s。
+ * 故 migration state poll 預算 90s（10s 靜默 + 20s 遷移上限 + 緩衝）。WebRTC 需 chromium。
+ */
+test.describe('Dungeon Arcade — FFA host-leave migration continuation', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'WebRTC requires chromium');
+  test.setTimeout(180_000);
+
+  test('closing the HOST context migrates to a new host and the match continues to a result', async ({ browser }) => {
+    const ctxHost = await browser.newContext();
+    const ctxG1 = await browser.newContext();
+    const ctxG2 = await browser.newContext();
+    const host = await ctxHost.newPage();
+    const g1 = await ctxG1.newPage();
+    const g2 = await ctxG2.newPage();
+
+    // 遷移失敗時的根因分析素材：收集 guest 端 console（pageerror 與 error/warning log）。
+    const guestLogs: string[] = [];
+    for (const [name, p] of [['g1', g1], ['g2', g2]] as const) {
+      p.on('console', (msg) => {
+        if (msg.type() === 'error' || msg.type() === 'warning') {
+          guestLogs.push(`[${name}][console.${msg.type()}] ${msg.text()}`);
+        }
+      });
+      p.on('pageerror', (err) => guestLogs.push(`[${name}][pageerror] ${err.message}`));
+    }
+
+    try {
+      await host.goto('/games/tetris?mode=online');
+      await g1.goto('/games/tetris?mode=online');
+      await g2.goto('/games/tetris?mode=online');
+
+      // 三端都選 3 人（N≥3 → FFA 路徑）
+      await selectCount(host, 3);
+      await selectCount(g1, 3);
+      await selectCount(g2, 3);
+
+      // Host 建房，兩 guest 依序加入（避免 index race；g1 = playerIds[1] = 遷移候選）
+      await host.locator('#online-create').click();
+      const room = await readRoom(host);
+      expect(room).toMatch(/^[A-Z0-9]{5}$/);
+
+      await g1.locator('#online-room').fill(room);
+      await g1.locator('#online-join-btn').click();
+      await waitLobbyJoined(host, 2);
+
+      await g2.locator('#online-room').fill(room);
+      await g2.locator('#online-join-btn').click();
+      await waitLobbyJoined(host, 3);
+
+      // Host 按開始 → 三端 lockstep 建立、進 playing
+      await host.locator('#lobby-start').click();
+      await waitFfaReady(host);
+      await waitFfaReady(g1);
+      await waitFfaReady(g2);
+      for (const p of [host, g1, g2]) {
+        await expect.poll(() => readPhase(p), { timeout: 20_000 }).toBe('playing');
+      }
+
+      // 對局確實在跑（confirmedFrame > 30）後才關 HOST，避免握手期 close 干擾
+      await expect.poll(() => readConfirmedFrame(host), { timeout: 25_000 }).toBeGreaterThan(30);
+      await expect.poll(() => readConfirmedFrame(g1), { timeout: 25_000 }).toBeGreaterThan(30);
+      await expect.poll(() => readConfirmedFrame(g2), { timeout: 25_000 }).toBeGreaterThan(30);
+
+      // 關閉前先記下 host 的 playerId（之後要驗證它被判敗、墊底）
+      const hostId = await readLocalId(host);
+      expect(hostId).not.toBe('');
+
+      // === 1. 模擬 HOST 關閉分頁 ===
+      const closedAt = Date.now();
+      await ctxHost.close();
+
+      // === 2. g1 / g2 都完成遷移：migration.state === 'done'（gen=1）===
+      // 預算 90s：偵測（close 快速路徑秒級 / 靜默兜底 10s）+ 遷移上限 20s + 緩衝。
+      try {
+        await expect.poll(() => readMigration(g1), { timeout: 90_000 })
+          .toEqual({ gen: 1, state: 'done' });
+        await expect.poll(() => readMigration(g2), { timeout: 90_000 })
+          .toEqual({ gen: 1, state: 'done' });
+      } catch (e) {
+        // 遷移未達 done：吐出兩端 migration 狀態與 console log 供根因分析後再丟出。
+        const m1 = await readMigration(g1).catch(() => null);
+        const m2 = await readMigration(g2).catch(() => null);
+        console.log(`[hostmig-e2e] FAILED migration — g1=${JSON.stringify(m1)} g2=${JSON.stringify(m2)}`);
+        for (const line of guestLogs) console.log(`[hostmig-e2e] ${line}`);
+        throw e;
+      }
+      const migrateMs = Date.now() - closedAt;
+      console.log(`[hostmig-e2e] migration done on both guests after ${migrateMs}ms (host close → state done)`);
+
+      // === 3. 舊 host 被判敗：placement = 3（3 人局第一個淘汰）===
+      await expect.poll(() => readPlacementOf(g1, hostId), { timeout: 30_000 }).toBe(3);
+      await expect.poll(() => readPlacementOf(g2, hostId), { timeout: 30_000 }).toBe(3);
+
+      // === 4. 對局未凍結：g1 / g2 的 confirmedFrame 恢復推進 ===
+      const cfG1 = await readConfirmedFrame(g1);
+      const cfG2 = await readConfirmedFrame(g2);
+      await expect.poll(() => readConfirmedFrame(g1), { timeout: 20_000 }).toBeGreaterThan(cfG1);
+      await expect.poll(() => readConfirmedFrame(g2), { timeout: 20_000 }).toBeGreaterThan(cfG2);
+
+      // === 5. 驅動 g2 狂硬降 topout → 分出勝負（剩 g1 一人 → victory → result）===
+      for (let i = 0; i < 150; i++) {
+        await g2.keyboard.press('Space');
+        if (i % 10 === 0 && (await readPhase(g2)) === 'result') break;
+      }
+      await expect.poll(() => readPhase(g1), { timeout: 30_000 }).toBe('result');
+      await expect.poll(() => readPhase(g2), { timeout: 30_000 }).toBe('result');
+
+      // === 6. standings 一致且舊 host 墊底 ===
+      const stG1 = await readStandings(g1);
+      const stG2 = await readStandings(g2);
+      expect(stG1.length).toBe(3);
+      expect(stG2).toEqual(stG1);
+      expect(stG1[2]).toBe(hostId); // 中離者（舊 host）墊底
+    } finally {
+      await ctxHost.close(); // 已關閉時為 no-op
+      await ctxG1.close();
+      await ctxG2.close();
+    }
+  });
+});
+
+async function selectCount(page: Page, n: number): Promise<void> {
+  await page.locator(`.pc-btn[data-count="${n}"]`).click();
+}
+
+async function readRoom(page: Page): Promise<string> {
+  const code = page.locator('#lobby-code');
+  await expect(code).toContainText(/[A-Z0-9]{5}/, { timeout: 20_000 });
+  const text = (await code.textContent()) ?? '';
+  return text.match(/[A-Z0-9]{5}/)?.[0] ?? '';
+}
+
+/** 等 host lobby 顯示已加入 n 人（含 host 自己）。 */
+async function waitLobbyJoined(page: Page, n: number): Promise<void> {
+  await expect.poll(
+    async () => {
+      const t = (await page.locator('#lobby-joined').textContent()) ?? '0';
+      return Number(t);
+    },
+    { timeout: 40_000 },
+  ).toBeGreaterThanOrEqual(n);
+}
+
+async function waitFfaReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { __tetrisDebug?: { ffaLockstep?: unknown } }).__tetrisDebug?.ffaLockstep),
+    undefined,
+    { timeout: 40_000 },
+  );
+}
+
+function readPhase(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { match?: { phase?: string } } }).__tetrisDebug;
+    return dbg?.match?.phase ?? 'none';
+  });
+}
+
+function readConfirmedFrame(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { ffaLockstep?: { confirmedFrame?: number } } }).__tetrisDebug;
+    return dbg?.ffaLockstep?.confirmedFrame ?? 0;
+  });
+}
+
+function readLocalId(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { ffaLockstep?: { localId?: string } } }).__tetrisDebug;
+    return dbg?.ffaLockstep?.localId ?? '';
+  });
+}
+
+/** 讀遷移狀態（{gen, state}）；debug 介面未就緒回 {gen:-1, state:'none'}。 */
+function readMigration(page: Page): Promise<{ gen: number; state: string }> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as {
+      __tetrisDebug?: { migration?: { gen: number; state: string } };
+    }).__tetrisDebug;
+    const m = dbg?.migration;
+    return m ? { gen: m.gen, state: m.state } : { gen: -1, state: 'none' };
+  });
+}
+
+/** 讀某 playerId 在 match placement 中的名次；尚未定名次回 0。 */
+function readPlacementOf(page: Page, id: string): Promise<number> {
+  return page.evaluate((pid) => {
+    const dbg = (window as unknown as { __tetrisDebug?: { match?: { getPlacement?: () => Map<string, number> } } }).__tetrisDebug;
+    const pl = dbg?.match?.getPlacement?.();
+    return pl?.get(pid) ?? 0;
+  }, id);
+}
+
+function readStandings(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { match?: { getStandings?: () => string[] } } }).__tetrisDebug;
+    return dbg?.match?.getStandings?.() ?? [];
+  });
+}


### PR DESCRIPTION
## Host Migration — 任何人中離，對局都能續行（中離續行 Stage B 完結）

接續 Stage A（guest 中離續行，PR #151），本 PR 補上最後一塊：**host 中離時剩餘玩家重組星狀拓樸續行**。至此「任何人中離＝那個人判敗、其他人繼續打」完整成立。

### 機制
- guest 偵測 host 死（channel close ＋ 10s 靜默兜底）→ 顯示「重新連線中…」凍結
- **確定性選舉**：最低 index 存活 guest 自任新 host（offer 兼選舉 beacon，signaling 仲裁分歧視角、雙候選自動讓位收斂）
- **世代化槽位** `mig{g}-...`（g≤6，支援連續遷移）重用既有 guest-initiated WebRTC 交握
- **輸入視野合併**：各端送 cf+horizon+未消化輸入（含 replay tail 600 幀，解「超前端已消化、落後端永久缺幀」的 cf 偏移問題——e2e 實測偏移達 25 幀）→ 新 host 合併回播＋確定性空幀回填＋算出**必可達**的舊 host 棄權幀 → 全員同幀判敗舊 host 續行
- replay/結算連續性自動成立（events/forfeits 照常累積、剩餘 ≥⌈N/2⌉ 簽章照常計分）
- 失敗 20s 降級為現行為（中止不計分，不會比現狀差）

### 測試
- 單元/mock-net **530 全綠**（M1-M5 累計 +43：槽位/選舉/合併/facade swap/同步接口/協調器完整遷移兩端 replay 逐字相等）
- e2e **33/33 全綠**（13 specs）：新增 3-context **實際關閉 host** → 兩 guest 遷移 state done（實測 ~22s）→ 舊 host placement=3 → 續行到分出勝負 standings 一致；全部既有零回歸
- 生產 build 綠

### e2e 抓到的真 bug（mock-net 測不到）
host 死亡窗內各端停滯點偏移（實測 cf 89 vs 64）→ 超前端已消化並刪除落後端缺的幀 → 視野合併補不回 → 落後端永久卡死。修法：sync 附 replay tail＋merge 後確定性空幀回填＋import→fill→forfeit 順序鐵則（TDD 根因重現）。

### 誠實限制
被淘汰者在 host 死後不參與遷移（無法續看，防選舉死鎖）；多跳視野分歧最壞情況降級中止；真實跨網路 NAT 重連失敗亦降級（與現狀同）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
