### PR TITLE
feat(games): 快速配對隊列 — 免房號自動配對（1v1+FFA，空池轉 AI）

### DIFF
--- a/docs/superpowers/plans/2026-06-11-dungeon-arcade-matchmaking-queue.md
+++ b/docs/superpowers/plans/2026-06-11-dungeon-arcade-matchmaking-queue.md
@@ -1,0 +1,38 @@
+# 快速配對隊列 實作計畫
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development。每任務 TDD。
+> Spec：`docs/superpowers/specs/2026-06-11-dungeon-arcade-matchmaking-queue-design.md`（先讀）。分支 `feature/matchmaking-queue`。
+
+**Goal:** QUICK MATCH 按鈕 → Upstash 隊列 → poll 中原子撮合（2 人=1v1、3-8 人=FFA、10 秒湊團窗）→ 自動建房/加入 → 60 秒空池提示轉 vs-AI。
+
+**鐵則:** 撮合決策只在 poll 請求中執行（serverless 無 worker）；`SET NX` 原子閘防重複撮合；entry TTL 15s+5s heartbeat；全部重用既有 host/join 流程（lobby/WebRTC/鎖步零改動）；帳單安全（排隊者每 3 秒 1 poll、每 poll ≤5 Redis 指令）。
+
+## 任務
+
+### Q1 撮合純函式（unit, deps:—）
+`net/matchmaking.ts`：`interface QueueEntry { id: string; name: string; rating: number; joinedAt: number }`；`tryFormMatch(waiting: QueueEntry[], now: number): { players: QueueEntry[]; mode: '1v1'|'ffa' } | null`——規則：waiting 依 joinedAt 升冪；最早者等待 <10_000ms → null；≥3 人 → 取最早 min(n,8) 人 mode 'ffa'；=2 人 → '1v1'；<2 → null。常數 `MATCH_WINDOW_MS=10_000` 可注入。測 ~8 例（窗邊界/2/3/8/9 人取 8/排序穩定/空池）。
+Commit：`feat(net): matchmaking tryFormMatch pure rules`
+
+### Q2 隊列儲存（unit, deps:—）
+`net/queueStore.ts`：照 `rankStore.ts` 模式 Memory+Upstash 雙實作＋`getQueueStore()` env 選擇。介面：`enqueue(entry, ttlSec)`／`heartbeat(id, ttlSec)`／`leave(id)`／`listWaiting(): Promise<QueueEntry[]>`（過期不回）／`claimMatchLock(ttlSec): Promise<boolean>`（SET NX）／`setMatch(playerId, info, ttlSec)`／`getMatch(playerId)`。Upstash：ZSET `queue:waiting`（score=joinedAt）＋`queue:entry:{id}`（TTL）＋`queue:match:{id}`；listWaiting 以 entry 存活為準並順手 ZREM 過期者。測 Memory 全介面＋過期語意 ~8 例（Upstash 路徑結構同 rankStore 由型別把關）。
+Commit：`feat(net): queue store (memory + upstash)`
+
+### Q3 API（unit, deps:Q1,Q2）
+`src/pages/api/queue.ts`（**prerender=false、測試檔命名 `_queue.test.ts` 防 Astro 當路由**，照 `_ffa-match.test.ts` 手法直呼 handler）：POST `{action:'join'|'heartbeat'|'poll'|'leave', id, name?, rating?}`。poll：先 `getMatch(id)` 有就回 `{matched}`；否則 `claimMatchLock(3)` 成功才 `listWaiting`→`tryFormMatch`→成立時 `createRoom`（重用既有 signal 建房或直接產 5 碼 room）＋對每位玩家 `setMatch`（host=最早者，info={room, role, mode, count, players}）→回自己的結果或 `{waiting, position, waitedMs}`。rate limit 照 match.ts。測 ~8 例（join→poll pending→兩人→雙方 poll 到互補角色／三人 FFA／鎖只成立一次／壞參 400）。
+Commit：`feat(api): /api/queue — join/heartbeat/poll/leave with atomic matching`
+
+### Q4 前端 client（unit, deps:—）
+`net/queueClient.ts`：`startQueue(opts: {id, name, rating, onUpdate(waitedMs), onMatched(info), onError, fetchFn?, now?, intervalMs?=3000, heartbeatMs?=5000}): { cancel(): void }`——join 後雙計時器（poll/heartbeat）、matched 即停、cancel 送 leave 並清計時器、fetch 失敗重試 3 次後 onError。mock fetch 測 ~6 例。
+Commit：`feat(net): queue client polling loop`
+
+### Q5 UI + e2e（deps:Q3,Q4）
+tetris.astro PLAY 分頁加 `#quick-match` 按鈕（mode-select 內最上方，風格同 ms-btn）＋排隊面板 `#queue-panel`（等待秒數、取消鈕、60 秒後出現「目前沒有玩家排隊，先跟 AI 打一場？」`#queue-ai-offer` 按鈕→走既有 startAi('normal')）。matched → host 走既有 hostGame/hostFfaGame(count)、guest joinGame/joinFfaGame(room)——重用 onStatus/lobby 流程（隊列局 lobby 顯示「配對成功，連線中…」，host 滿員自動開始：FFA 時 hostFfaGame 的 lobby start 在人到齊時自動觸發——最小做法：隊列局傳 autoStart 旗標）。識別：暱稱用既有 #online-name 或 'Player-xxxx'。**禁 inline style/!important**。e2e NEW `games-tetris-queue.spec.ts`：兩 context 都按 QUICK MATCH → 自動配成 1v1 開打（lockstep 存在）；三 context → FFA（migration/forfeit 機制照常）；取消離隊；（AI 提示用注入縮短常數驗 DOM）。
+Commit：`feat(ui): quick-match button + queue panel + auto host/join`
+
+### Q6 全套+PR（deps:Q5）
+全套 vitest＋全部遊戲 e2e（14 specs）＋build 三綠 → PR `feat(games): 快速配對隊列 — 免房號自動配對（1v1+FFA，空池轉 AI）`。
+
+## 風險
+- 撮合鎖 TTL 3s 內 crash → 下個 poll 重試（鎖過期自復原）。
+- 兩人同 ms join 順序：ZSET score 同分用 id 次序，撮合穩定。
+- FFA 自動開始與既有 lobby start 按鈕互斥（autoStart 不顯示按鈕）。

--- a/docs/superpowers/specs/2026-06-11-dungeon-arcade-matchmaking-queue-design.md
+++ b/docs/superpowers/specs/2026-06-11-dungeon-arcade-matchmaking-queue-design.md
@@ -1,0 +1,45 @@
+# 快速配對隊列（Matchmaking Queue）設計 spec
+
+> 來源：使用者需求「應該要有進入隊列配對玩家的功能」＋brainstorm 決策（2026-06-11）：**1v1+FFA 都做**；**等 60 秒沒人 → 提示轉 vs-AI**。
+> 既有路線圖階段 4「公開快速配對佇列」的實作版。
+
+## 目標
+
+主選單加「⚡ 快速對戰 QUICK MATCH」：按下進隊列，**免交換房號**自動配對開打。湊到 2 人配 1v1、湊到 3+ 人配 FFA（最多 8），永遠有得玩（空池轉 AI）。
+
+## 核心約束
+
+- **無背景 worker**：Vercel serverless 只在請求期間執行 → 配對決策在「隊列輪詢請求」處理中完成（誰 poll 誰幫忙撮合）。
+- **帳單安全**：Upstash 操作量＝排隊者每 3 秒 1 次 poll（每次 ≤5 個 Redis 指令），遠低於免費額度；無新增服務。
+- **全部重用既有連線流程**：配對結果＝「房號＋角色＋人數」，host 自動建房、guests 自動加入——lobby/WebRTC/鎖步/結算零改動。
+
+## 配對規則（v1 刻意簡單）
+
+1. 進隊列：`/api/queue` `{action:'join', id, name, rating?}` → ZSET `queue:waiting`（score=加入時間戳）＋ entry hash（TTL 15 秒，client 每 5 秒 heartbeat 續命；關頁/取消即過期或主動 leave）。
+2. 撮合（每次 poll 時嘗試，原子閘 `SET NX` 防並發重複撮合）：
+   - 等待者 ≥3 且最早者已等 ≥10 秒 → 取最早的 min(全部, 8) 人開 **FFA**。
+   - 等待者 =2 且最早者已等 ≥10 秒 → 開 **1v1**。
+   - （<10 秒先不撮，給更多人湊團的機會窗。）
+3. 配對成立：寫 `queue:match:{playerId}` = `{room, role:'host'|'guest', count, players}`（TTL 60s）；room 用既有 createRoom；**host＝等最久者**。
+4. client poll 到 match → host 走既有 hostGame/hostFfaGame(count)、guest 自動 join——UI 全自動，玩家只看到「配對成功，連線中…」。
+5. **60 秒沒配到** → 前端提示「目前沒有玩家在排隊，要先跟 AI 打一場嗎？」一鍵轉 vs-AI（不計排名）、或繼續等。
+6. ELO 配對：v1 不做分段（池太小），rating 記進 entry 供未來分段用（誠實標註）。
+
+## 檔案結構
+
+- `src/pages/api/queue.ts`（NEW）：join/heartbeat/poll/leave；撮合邏輯抽純函式。
+- `net/queueStore.ts`（NEW）：Memory＋Upstash 雙實作（照 rankStore 模式）。
+- `net/matchmaking.ts`（NEW）：`tryFormMatch(waiting, now)` 純函式（規則 2 全部在此，完整單測）。
+- `net/queueClient.ts`（NEW）：join/poll 迴圈/heartbeat/cancel（依賴注入 fetch/now）。
+- `tetris.astro`（MOD）：PLAY 分頁加 QUICK MATCH 按鈕＋排隊中 UI（等待秒數、取消、60s AI 提示）；配對成功自動接 host/join 流程。
+
+## 測試
+
+- unit：tryFormMatch 全規則（2 人/3 人/8 人上限/10 秒窗/排序）；queueStore 雙實作往返+TTL+原子閘；queueClient 輪詢/heartbeat/取消（mock fetch）。
+- API：join→poll(pending)→雙人 join→poll(matched 且兩端 role 互補)；過期 entry 不入撮合；併發撮合只成立一次。
+- e2e：兩 context 都按 QUICK MATCH → 自動配對 → 連上開打（1v1）；三 context → FFA。60s AI 提示（mock 時間或縮短常數注入）。
+- 零回歸：全套既有。
+
+## 非目標（YAGNI）
+
+- ELO 分段配對、跨模式偏好設定、隊列聊天室、重新排隊懲罰。

--- a/src/pages/api/_queue.test.ts
+++ b/src/pages/api/_queue.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * /api/queue 端點測試。
+ *
+ * 檔名以底線開頭（_queue.test.ts）防止 Astro 把測試檔當成路由打包，
+ * 並照 _ffa-match.test.ts 手法直呼 handler（每 case vi.resetModules()
+ * 取乾淨單例：無 Upstash env → MemoryQueueStore，端點與測試共用同一單例）。
+ *
+ * 時間控制：MemoryQueueStore 與端點都用 Date.now()，
+ * 用 vi.useFakeTimers + setSystemTime 推進湊團窗（10s）與 entry TTL（15s）。
+ */
+
+const T0 = 1_750_000_000_000;
+
+async function loadPost() {
+  const mod = await import('./queue');
+  return mod.POST;
+}
+
+/** 建一個 Astro APIContext 風格的呼叫物件（只用到 request / clientAddress）。 */
+function ctx(body: unknown, ip = '127.0.0.1') {
+  const request = new Request('http://localhost/api/queue', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { request, clientAddress: ip } as never;
+}
+
+type Post = Awaited<ReturnType<typeof loadPost>>;
+
+async function call(POST: Post, body: unknown): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await POST(ctx(body));
+  return { status: res.status, json: (await res.json()) as Record<string, unknown> };
+}
+
+async function join(POST: Post, id: string, name = id.toUpperCase(), rating = 1000) {
+  const r = await call(POST, { action: 'join', id, name, rating });
+  expect(r.status).toBe(200);
+  return r;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  vi.setSystemTime(T0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('POST /api/queue — 參數防護', () => {
+  it('壞 JSON → 400', async () => {
+    const POST = await loadPost();
+    const request = new Request('http://localhost/api/queue', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{ not json',
+    });
+    const res = await POST({ request, clientAddress: '127.0.0.1' } as never);
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe('bad json');
+  });
+
+  it('缺 id / 未知 action / 型別錯 → 400', async () => {
+    const POST = await loadPost();
+    expect((await call(POST, { action: 'poll' })).status).toBe(400); // 缺 id
+    expect((await call(POST, { action: 'destroy', id: 'a' })).status).toBe(400); // 未知 action
+    expect((await call(POST, { action: 'join', id: 42 })).status).toBe(400); // id 非字串
+    expect((await call(POST, { action: 'join', id: 'a', name: 7 })).status).toBe(400); // name 非字串
+    expect((await call(POST, { action: 'join', id: 'a', rating: 'x' })).status).toBe(400); // rating 非數字
+  });
+});
+
+describe('POST /api/queue — join 與 pending poll', () => {
+  it('join → poll 回 waiting（含 position 與 waitedMs）', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1', 'Alice');
+    vi.setSystemTime(T0 + 4_000); // 還在 10s 湊團窗內
+    const r = await call(POST, { action: 'poll', id: 'p1' });
+    expect(r.status).toBe(200);
+    expect(r.json.matched).toBeUndefined();
+    expect(r.json.waiting).toBe(true);
+    expect(r.json.position).toBe(1);
+    expect(r.json.waitedMs).toBe(4_000);
+  });
+
+  it('不在隊列中的 id poll → waiting:false（不報錯，client 可自行重新 join）', async () => {
+    const POST = await loadPost();
+    const r = await call(POST, { action: 'poll', id: 'ghost' });
+    expect(r.status).toBe(200);
+    expect(r.json.matched).toBeUndefined();
+    expect(r.json.waiting).toBe(false);
+  });
+});
+
+describe('POST /api/queue — 撮合', () => {
+  it('兩人 join → 過窗後雙方 poll 到互補 role（host=最早者）、同 room、mode 1v1', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1', 'Alice');
+    vi.setSystemTime(T0 + 1_000);
+    await join(POST, 'p2', 'Bob');
+    vi.setSystemTime(T0 + 11_000); // 最早者已等滿 10s 窗
+
+    const r1 = await call(POST, { action: 'poll', id: 'p1' });
+    const m1 = r1.json.matched as Record<string, unknown>;
+    expect(m1).toBeDefined();
+    expect(m1.mode).toBe('1v1');
+    expect(m1.count).toBe(2);
+    expect(m1.role).toBe('host'); // p1 最早 join → host
+    expect(typeof m1.room).toBe('string');
+    expect((m1.room as string)).toMatch(/^[A-Z0-9]{5}$/);
+    expect(m1.players).toEqual([
+      { id: 'p1', name: 'Alice' },
+      { id: 'p2', name: 'Bob' },
+    ]);
+
+    const r2 = await call(POST, { action: 'poll', id: 'p2' });
+    const m2 = r2.json.matched as Record<string, unknown>;
+    expect(m2).toBeDefined();
+    expect(m2.role).toBe('guest');
+    expect(m2.room).toBe(m1.room); // 同一房
+    expect(m2.mode).toBe('1v1');
+    expect(m2.players).toEqual(m1.players);
+
+    // matched 後 entry 必須從等待池移除（防殘留再撮合）
+    const { getQueueStore } = await import('@scripts/games/tetris/net/queueStore');
+    expect(await getQueueStore().listWaiting()).toEqual([]);
+  });
+
+  it('三人 join → 過窗後撮成 ffa、count=3、host=最早者', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1');
+    vi.setSystemTime(T0 + 500);
+    await join(POST, 'p2');
+    vi.setSystemTime(T0 + 900);
+    await join(POST, 'p3');
+    vi.setSystemTime(T0 + 10_500);
+
+    const r3 = await call(POST, { action: 'poll', id: 'p3' });
+    const m3 = r3.json.matched as Record<string, unknown>;
+    expect(m3).toBeDefined();
+    expect(m3.mode).toBe('ffa');
+    expect(m3.count).toBe(3);
+    expect(m3.role).toBe('guest');
+    expect((m3.players as Array<{ id: string }>).map((p) => p.id)).toEqual(['p1', 'p2', 'p3']);
+
+    const r1 = await call(POST, { action: 'poll', id: 'p1' });
+    expect((r1.json.matched as Record<string, unknown>).role).toBe('host');
+    expect((r1.json.matched as Record<string, unknown>).room).toBe(m3.room);
+  });
+
+  it('並發 poll：claimMatchLock 確保撮合只成立一次（兩人最終拿到同一 room）', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1');
+    await join(POST, 'p2');
+    vi.setSystemTime(T0 + 11_000);
+
+    // 兩個 poll 真並發進 handler：鎖只讓其中一個跑撮合
+    const [a, b] = await Promise.all([
+      call(POST, { action: 'poll', id: 'p1' }),
+      call(POST, { action: 'poll', id: 'p2' }),
+    ]);
+    // 沒拿到 matched 的那位，下一輪 poll 一定拿到（鎖落敗方走 getMatch 路徑）
+    const followUps = await Promise.all([
+      call(POST, { action: 'poll', id: 'p1' }),
+      call(POST, { action: 'poll', id: 'p2' }),
+    ]);
+    const rooms = new Set<string>();
+    for (const r of [a, b, ...followUps]) {
+      const m = r.json.matched as Record<string, unknown> | undefined;
+      if (m) rooms.add(m.room as string);
+    }
+    expect(rooms.size).toBe(1); // 只開了一間房（撮合只成立一次）
+
+    // 雙方各自都拿到 matched（並發輪或補一輪）
+    for (const id of ['p1', 'p2']) {
+      const r = await call(POST, { action: 'poll', id });
+      // match 紀錄仍在 TTL 內 → 重 poll 也回同一房
+      const m = r.json.matched as Record<string, unknown>;
+      expect(m).toBeDefined();
+      expect(rooms.has(m.room as string)).toBe(true);
+    }
+  });
+
+  it('過期 entry 不入撮合：超過 TTL 沒 heartbeat 的人不會被配進局', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1'); // t0 join，TTL 15s → t0+15s 過期
+    vi.setSystemTime(T0 + 16_000); // p1 已過期
+    await join(POST, 'p2');
+    await join(POST, 'p3');
+    vi.setSystemTime(T0 + 26_000); // p2 已等滿 10s 窗；p2/p3 entry 仍存活
+
+    const r = await call(POST, { action: 'poll', id: 'p2' });
+    const m = r.json.matched as Record<string, unknown>;
+    expect(m).toBeDefined();
+    expect(m.mode).toBe('1v1'); // 只剩 p2、p3 兩人 → 1v1，p1 不在局內
+    expect((m.players as Array<{ id: string }>).map((p) => p.id)).toEqual(['p2', 'p3']);
+
+    const r1 = await call(POST, { action: 'poll', id: 'p1' });
+    expect(r1.json.matched).toBeUndefined();
+    expect(r1.json.waiting).toBe(false); // 過期者既未配對也不在等待池
+  });
+});
+
+describe('POST /api/queue — heartbeat 與 leave', () => {
+  it('heartbeat 續命：超過原 TTL 仍可被撮合', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1'); // 無 heartbeat 的話 t0+15s 過期
+    vi.setSystemTime(T0 + 10_000);
+    const hb = await call(POST, { action: 'heartbeat', id: 'p1' });
+    expect(hb.status).toBe(200);
+    await join(POST, 'p2'); // joinedAt = t0+10s
+    vi.setSystemTime(T0 + 20_000); // p1 已等 20s（> 原 TTL 15s，靠 heartbeat 活著）
+
+    const r = await call(POST, { action: 'poll', id: 'p2' });
+    const m = r.json.matched as Record<string, unknown>;
+    expect(m).toBeDefined();
+    expect(m.role).toBe('guest'); // p1 最早 → host，p2 = guest
+    expect((m.players as Array<{ id: string }>).map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('leave 離隊：離開者不入撮合，剩 1 人 poll 仍 waiting', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1');
+    await join(POST, 'p2');
+    const lv = await call(POST, { action: 'leave', id: 'p1' });
+    expect(lv.status).toBe(200);
+    vi.setSystemTime(T0 + 11_000);
+
+    const r = await call(POST, { action: 'poll', id: 'p2' });
+    expect(r.json.matched).toBeUndefined();
+    expect(r.json.waiting).toBe(true);
+    expect(r.json.position).toBe(1); // p1 已離隊 → p2 排第一
+  });
+
+  it('撮合成功後重新 join 不吃舊 match 紀錄（不會被導回死房）', async () => {
+    const POST = await loadPost();
+    await join(POST, 'p1');
+    await join(POST, 'p2');
+    vi.setSystemTime(T0 + 11_000);
+    const first = await call(POST, { action: 'poll', id: 'p1' });
+    expect(first.json.matched).toBeDefined();
+
+    // p1 取消那局、立刻重新排隊：poll 不得回剛才的舊房
+    await join(POST, 'p1');
+    vi.setSystemTime(T0 + 12_000); // 還在新一輪湊團窗內
+    const again = await call(POST, { action: 'poll', id: 'p1' });
+    expect(again.json.matched).toBeUndefined();
+    expect(again.json.waiting).toBe(true);
+  });
+});

--- a/src/pages/api/queue.ts
+++ b/src/pages/api/queue.ts
@@ -1,0 +1,168 @@
+import type { APIRoute } from 'astro';
+import { getQueueStore, type MatchInfo, type QueueEntry, type QueueStore } from '@scripts/games/tetris/net/queueStore';
+import { tryFormMatch } from '@scripts/games/tetris/net/matchmaking';
+import { DEFAULT_RATING } from '@scripts/games/tetris/net/elo';
+
+export const prerender = false;
+
+/** entry 存活時間：靠 5s heartbeat 續命，斷線 15s 內自然出隊。 */
+const ENTRY_TTL_SEC = 15;
+/** 撮合原子閘 TTL：持鎖者 crash 也會在 3s 後自復原（下個 poll 重試）。 */
+const LOCK_TTL_SEC = 3;
+/** 配對結果存活時間：所有玩家 3s 一 poll，30s 綽綽有餘；過期即不可再領。 */
+const MATCH_TTL_SEC = 30;
+
+const json = (obj: unknown, status = 200): Response =>
+  new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' } });
+
+// 簡易 per-instance rate limit（照 match.ts 模式；搭配 Upstash 免費硬上限做雙保險）。
+// 隊列是輪詢型流量：每位排隊者 ~32 req/分（20 poll + 12 heartbeat），
+// 同 NAT 後最多 8 人共用一 IP → 上限取 600/分/實例（夠 8 人排隊、仍擋得住失控迴圈）。
+const hits = new Map<string, { n: number; reset: number }>();
+function limited(ip: string): boolean {
+  const now = Date.now();
+  const e = hits.get(ip);
+  if (!e || e.reset < now) {
+    hits.set(ip, { n: 1, reset: now + 60_000 });
+    return false;
+  }
+  e.n++;
+  return e.n > 600;
+}
+
+/** 5 碼房號（與 signal.ts makeRoomCode 同邏輯；signal 的 create 只發碼不落地，房號純粹是槽位 key 的命名空間）。 */
+function makeRoomCode(): string {
+  // 去掉易混字元（0/O/1/I/L）
+  const chars = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  let s = '';
+  for (let i = 0; i < 5; i++) s += chars[Math.floor(Math.random() * chars.length)];
+  return s;
+}
+
+/**
+ * 對外（與 queueClient.MatchedInfo 對齊）的配對結果：players 帶 {id, name} 供 lobby 顯示。
+ * queueStore.MatchInfo 的 players 型別是 string[]，但兩個實作都只做 JSON/淺拷貝 round-trip
+ * （shape-agnostic），故以此較豐富的形狀進出 store，僅在邊界轉型。
+ */
+interface QueueMatchInfo extends Omit<MatchInfo, 'players'> {
+  players: { id: string; name: string }[];
+}
+
+function setMatchInfo(store: QueueStore, playerId: string, info: QueueMatchInfo): Promise<void> {
+  return store.setMatch(playerId, info as unknown as MatchInfo, MATCH_TTL_SEC);
+}
+
+async function getMatchInfo(store: QueueStore, playerId: string): Promise<QueueMatchInfo | null> {
+  const m = (await store.getMatch(playerId)) as unknown as QueueMatchInfo | null;
+  // room 為空字串者是 join 時寫入的墓碑（覆蓋舊局殘留），視同無配對
+  return m && m.room ? m : null;
+}
+
+/** 撮合成立：開房、寫每位玩家的結果（host=最早者）、把他們移出等待池（防殘留再撮合）。 */
+async function formMatch(store: QueueStore, players: QueueEntry[], mode: '1v1' | 'ffa'): Promise<void> {
+  const room = makeRoomCode();
+  const roster = players.map((p) => ({ id: p.id, name: p.name }));
+  for (let i = 0; i < players.length; i++) {
+    await setMatchInfo(store, players[i].id, {
+      room,
+      role: i === 0 ? 'host' : 'guest', // players 已依 joinedAt 升冪 → 最早者當 host
+      mode,
+      count: players.length,
+      players: roster,
+    });
+    await store.leave(players[i].id);
+  }
+}
+
+/**
+ * POST /api/queue — 快速配對隊列。
+ * body: { action: 'join'|'heartbeat'|'poll'|'leave', id, name?, rating? }
+ *
+ * poll 回應（與 queueClient 對齊）：
+ *   配對成立 → { matched: { room, role, mode, count, players: [{id,name}] } }
+ *   仍在等   → { waiting: true, position, waitedMs }
+ *   不在隊列 → { waiting: false }（entry 過期等；client 可自行重新 join）
+ *
+ * 撮合決策只在 poll 中執行（serverless 無 worker），以 claimMatchLock（SET NX）
+ * 保證同一時刻只有一個 poll 跑撮合；鎖落敗方下一輪經 getMatch 領取結果。
+ */
+export const POST: APIRoute = async ({ request, clientAddress }) => {
+  let ip = 'unknown';
+  try { ip = clientAddress; } catch { /* 某些環境不提供 */ }
+  if (limited(ip)) return json({ error: 'rate limited' }, 429);
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'bad json' }, 400);
+  }
+
+  const { action, id } = body;
+  if (typeof id !== 'string' || id.length === 0 || id.length > 64) {
+    return json({ error: 'bad params' }, 400);
+  }
+  const store = getQueueStore();
+
+  switch (action) {
+    case 'join': {
+      const { name, rating } = body;
+      if (name !== undefined && (typeof name !== 'string' || name.length > 24)) {
+        return json({ error: 'bad params' }, 400);
+      }
+      if (rating !== undefined && (typeof rating !== 'number' || !Number.isFinite(rating))) {
+        return json({ error: 'bad params' }, 400);
+      }
+      const entry: QueueEntry = {
+        id,
+        name: (name as string | undefined) || 'Player',
+        rating: (rating as number | undefined) ?? DEFAULT_RATING,
+        joinedAt: Date.now(),
+      };
+      // 覆蓋上一局殘留的 match 紀錄（取消後立刻重排不得被導回死房）
+      await setMatchInfo(store, id, { room: '', role: 'guest', mode: '1v1', count: 0, players: [] });
+      await store.enqueue(entry, ENTRY_TTL_SEC);
+      return json({ ok: true });
+    }
+
+    case 'heartbeat': {
+      await store.heartbeat(id, ENTRY_TTL_SEC);
+      return json({ ok: true });
+    }
+
+    case 'leave': {
+      await store.leave(id);
+      return json({ ok: true });
+    }
+
+    case 'poll': {
+      // 1) 已有配對結果（別人撮合時把我配進去了）→ 直接領取
+      const existing = await getMatchInfo(store, id);
+      if (existing) return json({ matched: existing });
+
+      // 2) 嘗試取得撮合鎖；落敗代表有人正在撮合 → 本輪只回等待狀態
+      let waiting = await store.listWaiting();
+      if (await store.claimMatchLock(LOCK_TTL_SEC)) {
+        const formed = tryFormMatch(waiting, Date.now());
+        if (formed) {
+          await formMatch(store, formed.players, formed.mode);
+          const mine = formed.players.find((p) => p.id === id);
+          if (mine) {
+            const info = await getMatchInfo(store, id);
+            if (info) return json({ matched: info });
+          }
+          // 自己沒被配進這局（如第 9 人）→ 以剩餘者回報等待狀態
+          waiting = waiting.filter((w) => !formed.players.some((p) => p.id === w.id));
+        }
+      }
+
+      // 3) 仍在等：回 position 與 waitedMs；不在等待池（過期等）→ waiting:false
+      const pos = waiting.findIndex((w) => w.id === id);
+      if (pos === -1) return json({ waiting: false });
+      return json({ waiting: true, position: pos + 1, waitedMs: Date.now() - waiting[pos].joinedAt });
+    }
+
+    default:
+      return json({ error: 'bad params' }, 400);
+  }
+};

--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -44,6 +44,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
       <section class="mm-panel is-active" id="panel-play">
         <div class="mode-select" id="mode-select">
           <div class="ms-buttons">
+            <button class="ms-btn ms-quick" id="quick-match">QUICK MATCH</button>
             <button class="ms-btn ms-solo" data-mode="solo">SOLO</button>
             <button class="ms-btn" data-mode="ai" data-diff="easy">vs AI · EASY</button>
             <button class="ms-btn" data-mode="ai" data-diff="normal">vs AI · NORMAL</button>
@@ -97,6 +98,15 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
               <button class="ms-btn" id="online-join-btn">加入房間</button>
             </div>
             <p class="online-status" id="online-status"></p>
+          </div>
+        </div>
+        <div class="mode-select" id="queue-panel" hidden>
+          <h2 class="ss-title">QUICK MATCH</h2>
+          <p class="queue-status" id="queue-status">正在尋找玩家…</p>
+          <p class="queue-timer">已等待 <span id="queue-seconds">0</span> 秒</p>
+          <div class="ms-buttons">
+            <button class="ms-btn ms-solo" id="queue-ai-offer" type="button" hidden>目前沒有玩家排隊，先跟 AI 打一場？</button>
+            <button class="ms-btn ms-hard" id="queue-cancel" type="button">取消排隊</button>
           </div>
         </div>
         <p class="touch-notice" id="touch-notice" hidden>
@@ -260,11 +270,11 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   .ms-buttons {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 11px;
     width: 100%;
   }
   .ms-btn {
-    padding: 18px 20px;
+    padding: 15px 20px;
     font-family: inherit;
     font-size: 13px;
     letter-spacing: 2px;
@@ -317,6 +327,46 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
     letter-spacing: 1px;
     color: #9fb4d8;
   }
+
+  /* 快速配對（QUICK MATCH）：入口按鈕金色霓虹 + 排隊面板 */
+  .ms-quick {
+    border-color: rgba(255, 210, 63, 0.7);
+    box-shadow: 0 0 12px rgba(255, 210, 63, 0.3);
+    color: #ffe9a8;
+  }
+  .ms-quick:hover { box-shadow: 0 0 22px rgba(255, 210, 63, 0.8); }
+  .ms-quick::before {
+    content: '';
+    display: inline-block;
+    width: 1.3em;
+    height: 1.3em;
+    margin-right: 8px;
+    vertical-align: -0.28em;
+    background: url('/assets/games/tetris/icons/play.webp') center / contain no-repeat;
+  }
+  .queue-status {
+    margin: 0;
+    min-height: 1.4em;
+    text-align: center;
+    font-size: 11px;
+    line-height: 1.8;
+    letter-spacing: 1px;
+    color: #cfe9ff;
+    animation: lobbyPulse 1.4s ease-in-out infinite;
+  }
+  .queue-timer {
+    margin: 0;
+    text-align: center;
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: #6fa8d8;
+  }
+  .queue-timer span {
+    color: #ffd23f;
+    font-size: 13px;
+  }
+  #queue-ai-offer { font-size: 10px; line-height: 1.8; letter-spacing: 1px; }
+  #queue-ai-offer[hidden] { display: none; }
 
   /* 開局技能選擇步（SOLO / vs-AI）*/
   .ss-title {
@@ -436,7 +486,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
     /* 無實底：露出 .tetris-page 的地城氛圍，閱讀對比由面板卡提供 */
   }
   .mm-logo {
-    width: min(380px, 78vw);
+    width: min(330px, 72vw);
     height: auto;
     /* logo 已做亮度→alpha 透明去背，直接疊在氛圍上 */
     filter: drop-shadow(0 0 16px rgba(54, 230, 255, 0.35));
@@ -820,6 +870,8 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   import { SKIN_CATALOG, getSelectedSkin, setSelectedSkin, isUnlocked, resolveSkin } from '@scripts/games/tetris/render/skins';
   import { hostGame, joinGame, connectWallet, type NetStatus, type Identity } from '@scripts/games/tetris/net/netMain';
   import { hostFfaGame, joinFfaGame, type FfaNetStatus, type FfaIdentity } from '@scripts/games/tetris/net/ffaNetMain';
+  import { startQueue, type MatchedInfo, type QueueHandle } from '@scripts/games/tetris/net/queueClient';
+  import { DEFAULT_RATING } from '@scripts/games/tetris/net/elo';
 
   type Diff = 'easy' | 'normal' | 'hard';
   const SOLO_HINT = 'MOVE ←→ · ROTATE ↑/Z · DROP SPACE · HOLD SHIFT · ESC PAUSE · MUTE M';
@@ -863,6 +915,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   let menuOpen = false;
   let resultOpen = false;
   let perkOpen = false; // 三選一開啟中（ESC 互斥：perk 開啟時不開暫停選單）
+  let isQueueMatch = false; // 快速配對局：lobby 不顯示 START（autoStart）、文案改「配對成功」
   const pauseMenu = document.getElementById('pause-menu');
   const pauseTitle = document.getElementById('pause-title');
   const pauseHint = document.getElementById('pause-hint');
@@ -996,7 +1049,10 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
     if (lobby) lobby.hidden = false;
     if (room && lobbyCode) lobbyCode.textContent = room;
     if (lobbyWait) {
-      lobbyWait.textContent = phase === 'connecting' ? '連線中…' : phase === 'creating' ? '建立房間中…' : '等待對手加入…';
+      // 隊列局：玩家沒交換過房號，統一顯示配對成功（房號僅供 debug 觀察）
+      lobbyWait.textContent = isQueueMatch
+        ? '配對成功，連線中…'
+        : phase === 'connecting' ? '連線中…' : phase === 'creating' ? '建立房間中…' : '等待對手加入…';
       lobbyWait.classList.add('pending');
     }
   }
@@ -1162,13 +1218,19 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
         if (lobbyCount) lobbyCount.hidden = false;
         if (lobbyJoined) lobbyJoined.textContent = String(joined);
         if (lobbyTarget) lobbyTarget.textContent = String(playerCount);
-        if (lobbyWait) lobbyWait.textContent = joined >= playerCount ? '人數已滿，可開始' : '等待玩家加入…';
-        if (lobbyStart) {
-          lobbyStart.hidden = false;
-          lobbyStart.disabled = joined < 2; // 至少 2 人可開
+        if (isQueueMatch) {
+          // 隊列局：人到齊自動開始（hostFfaGame autoStart），不顯示 START 按鈕
+          if (lobbyWait) lobbyWait.textContent = '配對成功，連線中…';
+          if (lobbyStart) lobbyStart.hidden = true;
+        } else {
+          if (lobbyWait) lobbyWait.textContent = joined >= playerCount ? '人數已滿，可開始' : '等待玩家加入…';
+          if (lobbyStart) {
+            lobbyStart.hidden = false;
+            lobbyStart.disabled = joined < 2; // 至少 2 人可開
+          }
         }
       } else if (lobbyWait) {
-        lobbyWait.textContent = '已連線 · 等待房主開始…';
+        lobbyWait.textContent = isQueueMatch ? '配對成功，連線中…' : '已連線 · 等待房主開始…';
       }
     } else if (s.phase === 'connecting') {
       showLobby('connecting', s.room);
@@ -1224,6 +1286,119 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
       onHandle: (h) => { gameHandle = h; },
     }).catch((err: unknown) => onFfaStatus({ phase: 'error', message: String(err) }, false));
   }
+  // ---- 快速配對（QUICK MATCH）：進隊列 → 撮合 → 自動接 host/join ----
+  const queuePanel = document.getElementById('queue-panel');
+  const queueStatus = document.getElementById('queue-status');
+  const queueSeconds = document.getElementById('queue-seconds');
+  const queueAiOffer = document.getElementById('queue-ai-offer');
+  // 60 秒空池 AI 提示閾值：e2e 可用 ?queueAiMs= 或 window.__tetrisQueueAiMs 注入縮短
+  const queueAiOfferMs =
+    Number(params.get('queueAiMs')) ||
+    (window as unknown as { __tetrisQueueAiMs?: number }).__tetrisQueueAiMs ||
+    60_000;
+  let queueHandle: QueueHandle | null = null;
+  let queueTicker: ReturnType<typeof setInterval> | null = null;
+
+  /** 隊列識別：暱稱欄位有值用之，否則 Player-xxxx（同時作為對局身分 id）。 */
+  function queueIdentityId(): string {
+    const nameEl = document.getElementById('online-name') as HTMLInputElement | null;
+    const name = (nameEl?.value ?? '').trim();
+    return name || `Player-${Math.floor(Math.random() * 9000 + 1000)}`;
+  }
+
+  function stopQueueUi(): void {
+    if (queueTicker !== null) { clearInterval(queueTicker); queueTicker = null; }
+    if (queuePanel) queuePanel.hidden = true;
+  }
+
+  function beginQuickMatch(): void {
+    if (isTouch) { showTouchNotice(); return; }
+    if (started || queueHandle) return;
+    const qid = queueIdentityId();
+    if (modeSelect) modeSelect.hidden = true;
+    if (onlinePanel) onlinePanel.hidden = true;
+    if (queuePanel) queuePanel.hidden = false;
+    if (queueAiOffer) queueAiOffer.hidden = true;
+    if (queueStatus) queueStatus.textContent = '正在尋找玩家…';
+    if (queueSeconds) queueSeconds.textContent = '0';
+    const t0 = Date.now();
+    queueTicker = setInterval(() => {
+      const elapsed = Date.now() - t0;
+      if (queueSeconds) queueSeconds.textContent = String(Math.floor(elapsed / 1000));
+      if (elapsed >= queueAiOfferMs && queueAiOffer) queueAiOffer.hidden = false;
+    }, 250);
+    queueHandle = startQueue({
+      id: qid,
+      name: qid,
+      rating: DEFAULT_RATING,
+      onUpdate: () => { /* 等待秒數以本地 ticker 顯示（較平滑） */ },
+      onMatched: (info) => { queueHandle = null; onQueueMatched(qid, info); },
+      onError: () => {
+        queueHandle = null;
+        if (queueStatus) queueStatus.textContent = '配對服務連線失敗，請按取消返回再試';
+      },
+    });
+    blip(620, 0.07);
+  }
+
+  function onQueueMatched(qid: string, info: MatchedInfo): void {
+    stopQueueUi();
+    if (started || !canvas) return;
+    started = true;
+    isQueueMatch = true;
+    playerCount = info.count; // lobby「已加入 x / y 人」以實際成局人數為準
+    const identity: Identity = { id: qid, ranked: false }; // 隊列局不計排名
+    if (info.mode === '1v1') {
+      if (info.role === 'host') {
+        hostGame(canvas, identity, onStatus, { room: info.room })
+          .catch((err: unknown) => onStatus({ phase: 'error', message: String(err) }));
+      } else {
+        joinGame(canvas, info.room, identity, onStatus)
+          .catch((err: unknown) => onStatus({ phase: 'error', message: String(err) }));
+      }
+      return;
+    }
+    // FFA：host autoStart（人到齊自動開局）；guest 依 roster 序位固定槽位（免並發 claim race）
+    const maxGuests = info.count - 1;
+    if (info.role === 'host') {
+      hostFfaGame({
+        canvas,
+        identity,
+        maxGuests,
+        autoStart: true,
+        room: info.room,
+        onStatus: (s) => onFfaStatus(s, true),
+        onHandle: (h) => { gameHandle = h; },
+      }).catch((err: unknown) => onFfaStatus({ phase: 'error', message: String(err) }, true));
+    } else {
+      const rosterIdx = info.players.findIndex((p) => p.id === qid); // host=0 → guest 槽位 = idx-1
+      joinFfaGame({
+        canvas,
+        room: info.room,
+        identity,
+        maxGuests,
+        fixedSlot: rosterIdx > 0 ? rosterIdx - 1 : undefined,
+        onStatus: (s) => onFfaStatus(s, false),
+        onHandle: (h) => { gameHandle = h; },
+      }).catch((err: unknown) => onFfaStatus({ phase: 'error', message: String(err) }, false));
+    }
+  }
+
+  document.getElementById('quick-match')?.addEventListener('click', beginQuickMatch);
+  document.getElementById('queue-cancel')?.addEventListener('click', () => {
+    queueHandle?.cancel();
+    queueHandle = null;
+    stopQueueUi();
+    if (modeSelect) modeSelect.hidden = false; // 回模式選單（可再進線上面板）
+    blip(300, 0.08);
+  });
+  queueAiOffer?.addEventListener('click', () => {
+    queueHandle?.cancel();
+    queueHandle = null;
+    stopQueueUi();
+    startAiMode('normal');
+  });
+
   // lobby START（FFA host）：resolve 開始訊號，按鈕隱藏避免重複觸發。
   lobbyStart?.addEventListener('click', () => {
     if (lobbyStart) { lobbyStart.disabled = true; lobbyStart.hidden = true; }
@@ -1337,11 +1512,13 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
       if (isTouch) {
         showTouchNotice();
       } else {
-        // 還原模式選單：使用者可能先前點過「線上對戰」或技能選擇步而隱藏了 SOLO/AI
+        // 還原模式選單：使用者可能先前點過「線上對戰」/快速配對/技能選擇步而隱藏了 SOLO/AI
         if (modeSelect) modeSelect.hidden = false;
         if (onlinePanel) onlinePanel.hidden = true;
         if (skillSelect) skillSelect.hidden = true;
         skillSelectOpen = false;
+        if (queueHandle) { queueHandle.cancel(); queueHandle = null; } // 切走分頁＝棄排
+        stopQueueUi();
       }
     }
     if (name === 'leaderboard' && !lbLoaded) { lbLoaded = true; void loadLeaderboard(); }

--- a/src/scripts/games/tetris/net/ffaNetMain.test.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.test.ts
@@ -467,6 +467,46 @@ describe('guest-initiated 握手（negotiateHostFfaGuestInit / negotiateJoinFfaG
     expect(acceptedAnswer).toBe('ANSWER-FROM-HOST');
   });
 
+  it('negotiateJoinFfaGuestInit：fixedSlot 指定槽位 → 直接寫該槽不掃描（快速配對免並發 claim race）', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOMF';
+    // host 已回應 slot 1（slot 0 仍空 → 若有掃描會錯搶 slot 0）
+    await signal.putSlot(room, 'host-ack-1', 'ANSWER-1');
+
+    let acceptedAnswer: string | null = null;
+    const peerFactory = (): FfaGuestOfferPeer => {
+      let onmsg: ((r: string) => void) | null = null;
+      return {
+        createOffer: async () => 'OFFER-B',
+        acceptAnswer: async (a: string) => { acceptedAnswer = a; },
+        waitOpen: async () => {},
+        channel: {
+          send: () => {},
+          get open() { return true; },
+          set onmessage(fn: ((r: string) => void) | null) { onmsg = fn; },
+          get onmessage() { return onmsg; },
+        },
+      } as unknown as FfaGuestOfferPeer;
+    };
+
+    const result = await negotiateJoinFfaGuestInit({
+      room,
+      guestId: 'bob',
+      signal,
+      peerFactory,
+      fixedSlot: 1,
+      pollOpts: { timeoutMs: 50, intervalMs: 0 },
+    });
+
+    expect(result.slotIndex).toBe(1);
+    // slot 0 完全未被碰；offer 直接落在 slot 1
+    expect(signal.store.get(`${room}:guest-0-offer`)).toBeUndefined();
+    const off = JSON.parse(signal.store.get(`${room}:guest-1-offer`)!) as { id: string; offer: string };
+    expect(off.id).toBe('bob');
+    expect(off.offer).toBe('OFFER-B');
+    expect(acceptedAnswer).toBe('ANSWER-1');
+  });
+
   it('claimGuestSlot：選最低未被占用的 slot（已占用者跳過）', async () => {
     const signal = makeMockSignal();
     const room = 'R';

--- a/src/scripts/games/tetris/net/ffaNetMain.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.ts
@@ -458,12 +458,20 @@ export async function negotiateJoinFfaGuestInit(opts: {
   signal: FfaSignalClient;
   peerFactory: () => FfaGuestOfferPeer;
   maxGuests?: number;
+  /** 指定槽位（快速配對：依 roster 序位分槽）→ 直接寫該槽，免並發 claim race。 */
+  fixedSlot?: number;
   pollOpts?: { timeoutMs?: number; intervalMs?: number };
 }): Promise<NegotiateJoinGuestInitResult> {
   const { room, guestId, signal, peerFactory } = opts;
   const peer = peerFactory();
   const offer = await peer.createOffer();
-  const slotIndex = await claimGuestSlot(signal, room, guestId, offer, opts.maxGuests ?? 7);
+  let slotIndex: number;
+  if (opts.fixedSlot !== undefined) {
+    slotIndex = opts.fixedSlot;
+    await signal.putSlot(room, `guest-${slotIndex}-offer`, JSON.stringify({ id: guestId, offer } as GuestOfferMsg));
+  } else {
+    slotIndex = await claimGuestSlot(signal, room, guestId, offer, opts.maxGuests ?? 7);
+  }
 
   const answer = await signal.pollSlot(room, `host-ack-${slotIndex}`, opts.pollOpts);
   await peer.acceptAnswer(answer);
@@ -1241,8 +1249,12 @@ export async function hostFfaGame(opts: {
   canvas: HTMLCanvasElement;
   identity: FfaIdentity;
   maxGuests: number;
-  /** lobby「開始」訊號：resolve 後 host 停止收人並開局。 */
-  waitStart: () => Promise<void>;
+  /** lobby「開始」訊號：resolve 後 host 停止收人並開局（autoStart 隊列局可不傳）。 */
+  waitStart?: () => Promise<void>;
+  /** 人到齊（maxGuests 全連上）即自動開局，不等 waitStart（快速配對用；lobby 不顯示開始鈕）。 */
+  autoStart?: boolean;
+  /** 指定房號（快速配對：隊列已先發房號給全員）；未給則 signal.createRoom()。 */
+  room?: string;
   onStatus: FfaStatusCb;
   /** 對局握把回呼（ESC「離開對戰」用 leaveMatch）。 */
   onHandle?: (h: FfaGameHandle) => void;
@@ -1254,16 +1266,16 @@ export async function hostFfaGame(opts: {
   const slots = Math.min(Math.max(opts.maxGuests, 1), 7);
   try {
     opts.onStatus({ phase: 'creating' });
-    const room = await signal.createRoom();
+    const room = opts.room ?? (await signal.createRoom());
     const seed = randInt();
     const matchId = `${room}-${seed.toString(36)}`;
     opts.onStatus({ phase: 'lobby', room, connected: 0 });
 
-    // 背景持續接受 guest，直到 start 訊號（即使收滿仍等房主按開始）。
+    // 背景持續接受 guest，直到 start 訊號（即使收滿仍等房主按開始；autoStart 則滿員即開）。
     const connected = new Array<{ id: string; peer: FfaHostAnswerPeer } | undefined>(slots);
     let count = 0;
     let started = false;
-    void opts.waitStart().then(() => { started = true; });
+    if (opts.waitStart) void opts.waitStart().then(() => { started = true; });
 
     const deadline = Date.now() + HANDSHAKE_TIMEOUT_MS * 4; // lobby 可等久一點
     while (!started && Date.now() < deadline) {
@@ -1282,6 +1294,7 @@ export async function hostFfaGame(opts: {
         count++;
         progressed = true;
         opts.onStatus({ phase: 'lobby', room, connected: count });
+        if (opts.autoStart && count >= slots) started = true; // 隊列局：人到齊自動開始
         if (started || count >= slots) break;
       }
       if (started) break;
@@ -1340,6 +1353,8 @@ export async function joinFfaGame(opts: {
   /** 對局握把回呼（ESC「離開對戰」用 leaveMatch）。 */
   onHandle?: (h: FfaGameHandle) => void;
   maxGuests?: number;
+  /** 指定槽位（快速配對：依 roster 序位分槽，免並發 claim race）。 */
+  fixedSlot?: number;
   peerFactory?: () => FfaGuestOfferPeer;
   signal?: FfaSignalClient;
   /** ffa-init 等待逾時（預設沿用握手逾時）。 */
@@ -1355,6 +1370,7 @@ export async function joinFfaGame(opts: {
       signal,
       peerFactory,
       maxGuests: opts.maxGuests ?? 7,
+      fixedSlot: opts.fixedSlot,
     });
     opts.onStatus({ phase: 'lobby', room: opts.room });
 

--- a/src/scripts/games/tetris/net/matchmaking.test.ts
+++ b/src/scripts/games/tetris/net/matchmaking.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { tryFormMatch, MATCH_WINDOW_MS, type QueueEntry } from './matchmaking';
+
+function entry(id: string, joinedAt: number): QueueEntry {
+  return { id, name: `name-${id}`, rating: 1000, joinedAt };
+}
+
+const NOW = 100_000;
+
+describe('tryFormMatch', () => {
+  it('空池回 null', () => {
+    expect(tryFormMatch([], NOW)).toBeNull();
+  });
+
+  it('只有 1 人回 null（即使等很久）', () => {
+    expect(tryFormMatch([entry('a', NOW - 60_000)], NOW)).toBeNull();
+  });
+
+  it('2 人但最早者等待 <10 秒回 null（窗邊界 9999ms）', () => {
+    const waiting = [
+      entry('a', NOW - (MATCH_WINDOW_MS - 1)),
+      entry('b', NOW - 5_000),
+    ];
+    expect(tryFormMatch(waiting, NOW)).toBeNull();
+  });
+
+  it('2 人且最早者剛好等滿 10 秒 → 1v1（窗邊界 10000ms 含）', () => {
+    const waiting = [entry('a', NOW - MATCH_WINDOW_MS), entry('b', NOW - 1_000)];
+    const m = tryFormMatch(waiting, NOW);
+    expect(m).not.toBeNull();
+    expect(m!.mode).toBe('1v1');
+    expect(m!.players.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('3 人 → FFA 取全部 3 人', () => {
+    const waiting = [
+      entry('a', NOW - 20_000),
+      entry('b', NOW - 15_000),
+      entry('c', NOW - 1_000),
+    ];
+    const m = tryFormMatch(waiting, NOW);
+    expect(m!.mode).toBe('ffa');
+    expect(m!.players.map((p) => p.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('8 人 → FFA 取全部 8 人', () => {
+    const waiting = Array.from({ length: 8 }, (_, i) => entry(`p${i}`, NOW - 20_000 + i * 100));
+    const m = tryFormMatch(waiting, NOW);
+    expect(m!.mode).toBe('ffa');
+    expect(m!.players).toHaveLength(8);
+  });
+
+  it('9 人 → FFA 只取最早 8 人，最晚者不入選', () => {
+    const waiting = Array.from({ length: 9 }, (_, i) => entry(`p${i}`, NOW - 20_000 + i * 100));
+    const m = tryFormMatch(waiting, NOW);
+    expect(m!.mode).toBe('ffa');
+    expect(m!.players).toHaveLength(8);
+    expect(m!.players.map((p) => p.id)).toEqual(['p0', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7']);
+  });
+
+  it('輸入未排序也依 joinedAt 升冪取人，且不改動原陣列', () => {
+    const waiting = [
+      entry('late', NOW - 1_000),
+      entry('early', NOW - 30_000),
+      entry('mid', NOW - 12_000),
+    ];
+    const snapshot = waiting.map((e) => e.id);
+    const m = tryFormMatch(waiting, NOW);
+    expect(m!.players.map((p) => p.id)).toEqual(['early', 'mid', 'late']);
+    expect(waiting.map((e) => e.id)).toEqual(snapshot);
+  });
+
+  it('同 joinedAt 以 id 次序決勝，撮合結果穩定', () => {
+    const t = NOW - 20_000;
+    const a = [entry('zzz', t), entry('aaa', t), entry('mmm', t)];
+    const b = [entry('mmm', t), entry('zzz', t), entry('aaa', t)];
+    const ma = tryFormMatch(a, NOW)!;
+    const mb = tryFormMatch(b, NOW)!;
+    expect(ma.players.map((p) => p.id)).toEqual(['aaa', 'mmm', 'zzz']);
+    expect(mb.players.map((p) => p.id)).toEqual(ma.players.map((p) => p.id));
+  });
+
+  it('窗檢查看排序後的最早者，而非陣列第一個元素', () => {
+    // 陣列第一個元素等不到 10 秒，但排序後的最早者已等 12 秒 → 成立
+    const waiting = [entry('fresh', NOW - 2_000), entry('old', NOW - 12_000)];
+    const m = tryFormMatch(waiting, NOW);
+    expect(m).not.toBeNull();
+    expect(m!.mode).toBe('1v1');
+    expect(m!.players.map((p) => p.id)).toEqual(['old', 'fresh']);
+  });
+
+  it('windowMs 可注入覆寫預設常數', () => {
+    const waiting = [entry('a', NOW - 3_000), entry('b', NOW - 1_000)];
+    expect(tryFormMatch(waiting, NOW)).toBeNull();
+    const m = tryFormMatch(waiting, NOW, 2_000);
+    expect(m).not.toBeNull();
+    expect(m!.mode).toBe('1v1');
+  });
+});

--- a/src/scripts/games/tetris/net/matchmaking.ts
+++ b/src/scripts/games/tetris/net/matchmaking.ts
@@ -1,0 +1,49 @@
+/**
+ * 快速配對撮合規則（純函式，無 I/O）。
+ *
+ * 規則（v1 刻意簡單，spec：2026-06-11-dungeon-arcade-matchmaking-queue-design）：
+ * - waiting 依 joinedAt 升冪（同分以 id 字典序決勝，撮合穩定）。
+ * - 最早者等待 < windowMs → 先不撮（給更多人湊團的機會窗）。
+ * - ≥3 人 → 取最早 min(n, 8) 人開 FFA。
+ * - =2 人 → 1v1。
+ * - <2 人 → null。
+ */
+export interface QueueEntry {
+  id: string;
+  name: string;
+  rating: number;
+  joinedAt: number;
+}
+
+export type MatchMode = '1v1' | 'ffa';
+
+export interface FormedMatch {
+  players: QueueEntry[];
+  mode: MatchMode;
+}
+
+/** 湊團機會窗：最早者至少等這麼久才撮合。 */
+export const MATCH_WINDOW_MS = 10_000;
+
+/** FFA 單局人數上限。 */
+export const FFA_MAX_PLAYERS = 8;
+
+export function tryFormMatch(
+  waiting: QueueEntry[],
+  now: number,
+  windowMs: number = MATCH_WINDOW_MS,
+): FormedMatch | null {
+  if (waiting.length < 2) return null;
+
+  // 不改動呼叫端陣列；同 joinedAt 以 id 次序決勝
+  const sorted = [...waiting].sort(
+    (a, b) => a.joinedAt - b.joinedAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+
+  if (now - sorted[0].joinedAt < windowMs) return null;
+
+  if (sorted.length >= 3) {
+    return { players: sorted.slice(0, FFA_MAX_PLAYERS), mode: 'ffa' };
+  }
+  return { players: sorted, mode: '1v1' };
+}

--- a/src/scripts/games/tetris/net/netMain.ts
+++ b/src/scripts/games/tetris/net/netMain.ts
@@ -68,12 +68,12 @@ export async function connectWallet(): Promise<{ address: string; signMessage: (
 interface HelloMsg { t: 'hello'; seed: number; matchId: string; id: string; ranked: boolean }
 interface AckMsg { t: 'ack'; id: string; ranked: boolean }
 
-/** Host：建房 → 等對手 → 交握身分/seed → 開局（A 方）。 */
-export async function hostGame(canvas: HTMLCanvasElement, identity: Identity, onStatus: StatusCb): Promise<void> {
+/** Host：建房 → 等對手 → 交握身分/seed → 開局（A 方）。opts.room：快速配對已先發房號時沿用。 */
+export async function hostGame(canvas: HTMLCanvasElement, identity: Identity, onStatus: StatusCb, opts?: { room?: string }): Promise<void> {
   const transport = new WebRtcTransport();
   try {
     onStatus({ phase: 'creating' });
-    const room = await createRoom();
+    const room = opts?.room ?? (await createRoom());
     onStatus({ phase: 'waiting', room });
     const offer = await transport.createOffer();
     await putSlot(room, 'offer', offer);

--- a/src/scripts/games/tetris/net/queueClient.test.ts
+++ b/src/scripts/games/tetris/net/queueClient.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startQueue, MAX_FETCH_RETRIES, type MatchedInfo } from './queueClient';
+
+/** 記錄所有 POST body 的 mock fetch 工廠。 */
+function makeFetch(handler: (body: Record<string, unknown>, callIndex: number) => unknown) {
+  const calls: Record<string, unknown>[] = [];
+  const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+    calls.push(body);
+    const result = handler(body, calls.length - 1);
+    if (result instanceof Error) throw result;
+    return { ok: true, status: 200, json: async () => result } as unknown as Response;
+  });
+  return { fetchFn: fetchFn as unknown as typeof fetch, calls };
+}
+
+const MATCH: MatchedInfo = {
+  room: 'AB12C',
+  role: 'host',
+  mode: '1v1',
+  count: 2,
+  players: [
+    { id: 'p1', name: 'Alice' },
+    { id: 'p2', name: 'Bob' },
+  ],
+};
+
+function baseOpts(over: Partial<Parameters<typeof startQueue>[0]> = {}) {
+  return {
+    id: 'p1',
+    name: 'Alice',
+    rating: 1200,
+    onUpdate: vi.fn(),
+    onMatched: vi.fn(),
+    onError: vi.fn(),
+    intervalMs: 3000,
+    heartbeatMs: 5000,
+    ...over,
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('queueClient startQueue', () => {
+  it('join 後 poll 到 waiting → onUpdate(waitedMs)', async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'join') return { ok: true };
+      if (body.action === 'poll') return { waiting: true, position: 1, waitedMs: 3210 };
+      return { ok: true };
+    });
+    const opts = baseOpts({ fetchFn });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(0); // 讓 join 完成
+    expect(calls[0]).toMatchObject({ action: 'join', id: 'p1', name: 'Alice', rating: 1200 });
+
+    await vi.advanceTimersByTimeAsync(3000); // 第一次 poll
+    expect(opts.onUpdate).toHaveBeenCalledWith(3210);
+    expect(opts.onMatched).not.toHaveBeenCalled();
+    expect(opts.onError).not.toHaveBeenCalled();
+  });
+
+  it('poll 到 matched → 停掉雙計時器並 onMatched(info)', async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'join') return { ok: true };
+      if (body.action === 'poll') return { matched: MATCH };
+      return { ok: true };
+    });
+    const opts = baseOpts({ fetchFn });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(3000); // join + 第一次 poll → matched
+    expect(opts.onMatched).toHaveBeenCalledTimes(1);
+    expect(opts.onMatched).toHaveBeenCalledWith(MATCH);
+
+    const callsAfterMatch = calls.length;
+    await vi.advanceTimersByTimeAsync(60_000); // matched 後不該再有任何請求
+    expect(calls.length).toBe(callsAfterMatch);
+    expect(opts.onMatched).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() → 送 leave 並清計時器（之後不再 poll/heartbeat）', async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'poll') return { waiting: true, position: 1, waitedMs: 100 };
+      return { ok: true };
+    });
+    const opts = baseOpts({ fetchFn });
+    const handle = startQueue(opts);
+    await vi.advanceTimersByTimeAsync(3000); // join + 一次 poll
+
+    handle.cancel();
+    await vi.advanceTimersByTimeAsync(0); // 讓 leave 請求送出
+    expect(calls.some((c) => c.action === 'leave' && c.id === 'p1')).toBe(true);
+
+    const callsAfterCancel = calls.length;
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls.length).toBe(callsAfterCancel); // 沒有新的 poll/heartbeat
+    expect(opts.onError).not.toHaveBeenCalled();
+  });
+
+  it('heartbeat 依 heartbeatMs 週期送出', async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'poll') return { waiting: true, position: 1, waitedMs: 100 };
+      return { ok: true };
+    });
+    // 把 poll 間隔拉大，隔離 heartbeat 行為
+    const opts = baseOpts({ fetchFn, intervalMs: 100_000, heartbeatMs: 5000 });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(0); // join 完成
+
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(calls.filter((c) => c.action === 'heartbeat').length).toBe(1);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(calls.filter((c) => c.action === 'heartbeat').length).toBe(2);
+    expect(calls.filter((c) => c.action === 'heartbeat').every((c) => c.id === 'p1')).toBe(true);
+  });
+
+  it(`fetch 連續失敗（初次 + ${MAX_FETCH_RETRIES} 次重試）→ onError 且停止輪詢`, async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'join') return { ok: true };
+      return new Error('network down');
+    });
+    // heartbeat 拉遠，讓失敗計數只來自 poll
+    const opts = baseOpts({ fetchFn, intervalMs: 1000, heartbeatMs: 100_000 });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(0); // join 成功
+
+    // 失敗 1~MAX_FETCH_RETRIES 次：還在重試，不報錯
+    await vi.advanceTimersByTimeAsync(1000 * MAX_FETCH_RETRIES);
+    expect(opts.onError).not.toHaveBeenCalled();
+
+    // 第 MAX_FETCH_RETRIES+1 次連續失敗 → onError
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(opts.onError).toHaveBeenCalledTimes(1);
+
+    const callsAfterError = calls.length;
+    await vi.advanceTimersByTimeAsync(60_000); // 停止後不再有請求
+    expect(calls.length).toBe(callsAfterError);
+    expect(opts.onMatched).not.toHaveBeenCalled();
+  });
+
+  it('matched 之後不再送 heartbeat', async () => {
+    const { fetchFn, calls } = makeFetch((body) => {
+      if (body.action === 'join') return { ok: true };
+      if (body.action === 'poll') return { matched: MATCH };
+      return { ok: true };
+    });
+    const opts = baseOpts({ fetchFn, intervalMs: 3000, heartbeatMs: 5000 });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(3000); // 第一次 poll 就 matched（在 heartbeat 5000 之前）
+    expect(opts.onMatched).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(calls.filter((c) => c.action === 'heartbeat').length).toBe(0);
+  });
+
+  it('poll 一度失敗後成功 → 失敗計數歸零，不會誤觸 onError', async () => {
+    let failNext = true;
+    const { fetchFn } = makeFetch((body) => {
+      if (body.action === 'join') return { ok: true };
+      if (body.action === 'poll') {
+        if (failNext) {
+          failNext = false;
+          return new Error('blip');
+        }
+        return { waiting: true, position: 1, waitedMs: 500 };
+      }
+      return { ok: true };
+    });
+    const opts = baseOpts({ fetchFn, intervalMs: 1000, heartbeatMs: 100_000 });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(1000); // 失敗一次
+    expect(opts.onError).not.toHaveBeenCalled();
+
+    // 之後全部成功 → 連跑很多輪也不會 onError
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(opts.onError).not.toHaveBeenCalled();
+    expect(opts.onUpdate).toHaveBeenCalledWith(500);
+  });
+
+  it('伺服器回非 2xx 也算失敗（計入重試）', async () => {
+    const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+      if (body.action === 'join') {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) } as unknown as Response;
+      }
+      return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const opts = baseOpts({ fetchFn, intervalMs: 1000, heartbeatMs: 100_000 });
+    startQueue(opts);
+    await vi.advanceTimersByTimeAsync(1000 * (MAX_FETCH_RETRIES + 1));
+    expect(opts.onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scripts/games/tetris/net/queueClient.ts
+++ b/src/scripts/games/tetris/net/queueClient.ts
@@ -1,0 +1,140 @@
+/**
+ * 快速配對隊列前端 client：與 /api/queue 互動的輪詢迴圈。
+ *
+ * 職責（對應計畫 Q4）：
+ *   - startQueue：join 後啟動雙計時器（poll 每 intervalMs、heartbeat 每 heartbeatMs）
+ *   - poll 回 waiting → onUpdate(waitedMs)；回 matched → 停掉雙計時器並 onMatched(info)
+ *   - cancel()：送 leave 並清計時器
+ *   - fetch 連續失敗（初次 + MAX_FETCH_RETRIES 次重試）→ onError 並停止
+ *
+ * API 形狀（與 /api/queue 對齊，見計畫 Q3）：
+ *   POST { action: 'join'|'heartbeat'|'poll'|'leave', id, name?, rating? }
+ *   poll 回 { matched: { room, role, mode, count, players } }
+ *        或 { waiting: true, position, waitedMs }
+ */
+const API = '/api/queue';
+
+/** 連續 fetch 失敗的重試上限：初次失敗後再重試 3 次，仍失敗才 onError。 */
+export const MAX_FETCH_RETRIES = 3;
+
+export interface MatchedInfo {
+  room: string;
+  role: 'host' | 'guest';
+  mode: '1v1' | 'ffa';
+  count: number;
+  players: { id: string; name: string }[];
+}
+
+export interface StartQueueOpts {
+  id: string;
+  name: string;
+  rating: number;
+  onUpdate: (waitedMs: number) => void;
+  onMatched: (info: MatchedInfo) => void;
+  onError: (err: Error) => void;
+  /** 測試注入用；預設 globalThis.fetch。 */
+  fetchFn?: typeof fetch;
+  /** poll 間隔，預設 3000ms。 */
+  intervalMs?: number;
+  /** heartbeat 間隔，預設 5000ms。 */
+  heartbeatMs?: number;
+}
+
+export interface QueueHandle {
+  cancel(): void;
+}
+
+export function startQueue(opts: StartQueueOpts): QueueHandle {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const intervalMs = opts.intervalMs ?? 3000;
+  const heartbeatMs = opts.heartbeatMs ?? 5000;
+
+  let stopped = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let hbTimer: ReturnType<typeof setInterval> | null = null;
+  let consecutiveFailures = 0;
+
+  async function post(body: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const res = await fetchFn(API, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`queue api ${res.status}`);
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  function stopTimers(): void {
+    if (pollTimer !== null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    if (hbTimer !== null) {
+      clearInterval(hbTimer);
+      hbTimer = null;
+    }
+  }
+
+  /** 失敗一次：超過重試上限就 onError 並整個停掉；否則等下一個 tick 自然重試。 */
+  function recordFailure(err: unknown): void {
+    consecutiveFailures += 1;
+    if (consecutiveFailures > MAX_FETCH_RETRIES) {
+      stopped = true;
+      stopTimers();
+      opts.onError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  async function pollOnce(): Promise<void> {
+    try {
+      const r = await post({ action: 'poll', id: opts.id });
+      consecutiveFailures = 0;
+      if (stopped) return;
+      const matched = r.matched as MatchedInfo | undefined;
+      if (matched) {
+        stopped = true;
+        stopTimers();
+        opts.onMatched(matched);
+        return;
+      }
+      if (typeof r.waitedMs === 'number') opts.onUpdate(r.waitedMs);
+    } catch (err) {
+      if (!stopped) recordFailure(err);
+    }
+  }
+
+  async function heartbeatOnce(): Promise<void> {
+    try {
+      await post({ action: 'heartbeat', id: opts.id });
+      consecutiveFailures = 0;
+    } catch (err) {
+      if (!stopped) recordFailure(err);
+    }
+  }
+
+  // join → 成功後啟動雙計時器
+  void (async () => {
+    try {
+      await post({ action: 'join', id: opts.id, name: opts.name, rating: opts.rating });
+      if (stopped) return; // join 還沒回來就被 cancel
+      pollTimer = setInterval(() => void pollOnce(), intervalMs);
+      hbTimer = setInterval(() => void heartbeatOnce(), heartbeatMs);
+    } catch (err) {
+      if (!stopped) {
+        stopped = true;
+        opts.onError(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
+  })();
+
+  return {
+    cancel(): void {
+      if (stopped) return; // matched/onError 後 cancel 為 no-op（不重複送 leave）
+      stopped = true;
+      stopTimers();
+      void post({ action: 'leave', id: opts.id }).catch(() => {
+        /* leave 失敗交給 entry TTL 自然過期 */
+      });
+    },
+  };
+}

--- a/src/scripts/games/tetris/net/queueStore.test.ts
+++ b/src/scripts/games/tetris/net/queueStore.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryQueueStore } from './queueStore';
+import type { QueueEntry } from './queueStore';
+
+function entry(id: string, joinedAt: number, rating = 1000): QueueEntry {
+  return { id, name: `N-${id}`, rating, joinedAt };
+}
+
+describe('getQueueStore 環境選擇', () => {
+  beforeEach(() => {
+    vi.resetModules(); // 清掉模組單例，讓每個 case 重新判斷
+  });
+
+  it('有 UPSTASH_REDIS_REST_* → 用 Upstash（非 MemoryQueueStore）', async () => {
+    const mod = await import('./queueStore');
+    const store = mod.getQueueStore({
+      UPSTASH_REDIS_REST_URL: 'https://x.upstash.io',
+      UPSTASH_REDIS_REST_TOKEN: 'tok',
+    });
+    expect(store).not.toBeInstanceOf(mod.MemoryQueueStore);
+  });
+
+  it('完全無金鑰 → 退回 MemoryQueueStore', async () => {
+    const mod = await import('./queueStore');
+    expect(mod.getQueueStore({})).toBeInstanceOf(mod.MemoryQueueStore);
+  });
+
+  it('只設一半金鑰 → 拋錯（避免靜默退回記憶體）', async () => {
+    const mod = await import('./queueStore');
+    expect(() => mod.getQueueStore({ KV_REST_API_URL: 'https://x.upstash.io' })).toThrow();
+  });
+});
+
+describe('MemoryQueueStore 隊列語意', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('enqueue → listWaiting 回傳該 entry（完整欄位）', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('a', 100_000, 1200), 15);
+    expect(await s.listWaiting()).toEqual([{ id: 'a', name: 'N-a', rating: 1200, joinedAt: 100_000 }]);
+  });
+
+  it('listWaiting 依 joinedAt 升冪；同分以 id 次序（撮合穩定）', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('late', 100_500), 15);
+    await s.enqueue(entry('b-same', 100_000), 15);
+    await s.enqueue(entry('a-same', 100_000), 15);
+    expect((await s.listWaiting()).map((e) => e.id)).toEqual(['a-same', 'b-same', 'late']);
+  });
+
+  it('entry TTL 過期 → listWaiting 不回', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('a', 100_000), 15);
+    vi.advanceTimersByTime(15_001);
+    expect(await s.listWaiting()).toEqual([]);
+  });
+
+  it('heartbeat 續命：過原 TTL 後仍在隊列', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('a', 100_000), 15);
+    vi.advanceTimersByTime(14_000);
+    await s.heartbeat('a', 15);
+    vi.advanceTimersByTime(14_000); // 原 TTL 早已過，但 heartbeat 後尚未過
+    expect((await s.listWaiting()).map((e) => e.id)).toEqual(['a']);
+  });
+
+  it('heartbeat 不復活已過期或不存在的 entry', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('a', 100_000), 15);
+    vi.advanceTimersByTime(15_001);
+    await s.heartbeat('a', 15); // 已過期
+    await s.heartbeat('ghost', 15); // 從未存在
+    expect(await s.listWaiting()).toEqual([]);
+  });
+
+  it('leave 後不在 listWaiting', async () => {
+    const s = new MemoryQueueStore();
+    await s.enqueue(entry('a', 100_000), 15);
+    await s.enqueue(entry('b', 100_001), 15);
+    await s.leave('a');
+    expect((await s.listWaiting()).map((e) => e.id)).toEqual(['b']);
+  });
+
+  it('claimMatchLock 原子閘：首次 true、持鎖期間 false、TTL 過期後可再取', async () => {
+    const s = new MemoryQueueStore();
+    expect(await s.claimMatchLock(3)).toBe(true);
+    expect(await s.claimMatchLock(3)).toBe(false); // 鎖仍有效
+    vi.advanceTimersByTime(3_001);
+    expect(await s.claimMatchLock(3)).toBe(true); // 鎖過期自復原
+  });
+
+  it('setMatch/getMatch 往返；未設定回 null', async () => {
+    const s = new MemoryQueueStore();
+    const info = { room: 'AB12C', role: 'host' as const, mode: 'ffa' as const, count: 3, players: ['a', 'b', 'c'] };
+    await s.setMatch('a', info, 60);
+    expect(await s.getMatch('a')).toEqual(info);
+    expect(await s.getMatch('b')).toBeNull();
+  });
+
+  it('match TTL 過期 → getMatch 回 null', async () => {
+    const s = new MemoryQueueStore();
+    await s.setMatch('a', { room: 'AB12C', role: 'guest', mode: '1v1', count: 2, players: ['x', 'a'] }, 60);
+    vi.advanceTimersByTime(60_001);
+    expect(await s.getMatch('a')).toBeNull();
+  });
+});

--- a/src/scripts/games/tetris/net/queueStore.ts
+++ b/src/scripts/games/tetris/net/queueStore.ts
@@ -1,0 +1,159 @@
+/**
+ * 快速配對隊列的儲存層。
+ * 記憶體實作（本地/測試）與 Upstash Redis REST 實作（production），由 env 選擇（照 rankStore 模式）。
+ */
+
+import type { QueueEntry } from './matchmaking';
+
+export type { QueueEntry };
+
+/** 配對成立後寫給每位玩家的結果。 */
+export interface MatchInfo {
+  room: string;
+  role: 'host' | 'guest';
+  mode: '1v1' | 'ffa';
+  count: number;
+  players: string[];
+}
+
+export interface QueueStore {
+  /** 進隊列（entry TTL 秒，靠 heartbeat 續命）。 */
+  enqueue(entry: QueueEntry, ttlSec: number): Promise<void>;
+  /** 續命；entry 已過期或不存在則不復活。 */
+  heartbeat(id: string, ttlSec: number): Promise<void>;
+  /** 主動離隊。 */
+  leave(id: string): Promise<void>;
+  /** 仍存活的等待者，依 joinedAt 升冪（同分以 id 次序，撮合穩定）；過期不回。 */
+  listWaiting(): Promise<QueueEntry[]>;
+  /** 撮合原子閘（SET NX）；回傳 true 代表本次取得鎖。 */
+  claimMatchLock(ttlSec: number): Promise<boolean>;
+  /** 寫入某玩家的配對結果。 */
+  setMatch(playerId: string, info: MatchInfo, ttlSec: number): Promise<void>;
+  /** 讀取某玩家的配對結果；無或過期回 null。 */
+  getMatch(playerId: string): Promise<MatchInfo | null>;
+}
+
+const WAITING_KEY = 'queue:waiting';
+const LOCK_KEY = 'queue:lock';
+
+export class MemoryQueueStore implements QueueStore {
+  private entries = new Map<string, { entry: QueueEntry; exp: number }>();
+  private matches = new Map<string, { info: MatchInfo; exp: number }>();
+  private lockExp = 0;
+
+  async enqueue(entry: QueueEntry, ttlSec: number): Promise<void> {
+    this.entries.set(entry.id, { entry: { ...entry }, exp: Date.now() + ttlSec * 1000 });
+  }
+  async heartbeat(id: string, ttlSec: number): Promise<void> {
+    const e = this.entries.get(id);
+    if (!e || e.exp <= Date.now()) return; // 過期/不存在不復活
+    e.exp = Date.now() + ttlSec * 1000;
+  }
+  async leave(id: string): Promise<void> {
+    this.entries.delete(id);
+  }
+  async listWaiting(): Promise<QueueEntry[]> {
+    const now = Date.now();
+    const alive: QueueEntry[] = [];
+    for (const [id, e] of this.entries.entries()) {
+      if (e.exp <= now) {
+        this.entries.delete(id); // 順手清過期
+        continue;
+      }
+      alive.push({ ...e.entry });
+    }
+    return alive.sort((a, b) => a.joinedAt - b.joinedAt || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  }
+  async claimMatchLock(ttlSec: number): Promise<boolean> {
+    const now = Date.now();
+    if (this.lockExp > now) return false; // 鎖仍有效
+    this.lockExp = now + ttlSec * 1000;
+    return true;
+  }
+  async setMatch(playerId: string, info: MatchInfo, ttlSec: number): Promise<void> {
+    this.matches.set(playerId, { info: { ...info, players: [...info.players] }, exp: Date.now() + ttlSec * 1000 });
+  }
+  async getMatch(playerId: string): Promise<MatchInfo | null> {
+    const m = this.matches.get(playerId);
+    if (!m || m.exp <= Date.now()) return null;
+    return { ...m.info, players: [...m.info.players] };
+  }
+}
+
+/** Upstash Redis REST 實作。ZSET queue:waiting（score=joinedAt）＋ queue:entry:{id}（TTL）＋ queue:match:{id}。 */
+export class UpstashQueueStore implements QueueStore {
+  constructor(private url: string, private token: string) {}
+
+  private async cmd(...parts: string[]): Promise<unknown> {
+    const path = parts.map((p) => encodeURIComponent(p)).join('/');
+    const res = await fetch(`${this.url}/${path}`, { headers: { Authorization: `Bearer ${this.token}` } });
+    if (!res.ok) throw new Error(`upstash ${res.status}`);
+    return ((await res.json()) as { result?: unknown }).result ?? null;
+  }
+
+  async enqueue(entry: QueueEntry, ttlSec: number): Promise<void> {
+    await this.cmd('set', `queue:entry:${entry.id}`, JSON.stringify(entry), 'EX', String(ttlSec));
+    await this.cmd('zadd', WAITING_KEY, String(entry.joinedAt), entry.id);
+  }
+  async heartbeat(id: string, ttlSec: number): Promise<void> {
+    // EXPIRE 對不存在的 key 回 0（不復活），語意與 Memory 版一致
+    await this.cmd('expire', `queue:entry:${id}`, String(ttlSec));
+  }
+  async leave(id: string): Promise<void> {
+    await this.cmd('del', `queue:entry:${id}`);
+    await this.cmd('zrem', WAITING_KEY, id);
+  }
+  async listWaiting(): Promise<QueueEntry[]> {
+    // 以 entry key 存活為準；ZSET 內的殘留（entry 已 TTL 過期者）順手 ZREM
+    const ids = (await this.cmd('zrange', WAITING_KEY, '0', '-1')) as string[] | null;
+    if (!Array.isArray(ids) || ids.length === 0) return [];
+    const raw = (await this.cmd('mget', ...ids.map((id) => `queue:entry:${id}`))) as Array<string | null> | null;
+    const alive: QueueEntry[] = [];
+    const dead: string[] = [];
+    ids.forEach((id, i) => {
+      const v = Array.isArray(raw) ? raw[i] : null;
+      if (v === null || v === undefined) {
+        dead.push(id);
+        return;
+      }
+      try {
+        alive.push(JSON.parse(String(v)) as QueueEntry);
+      } catch {
+        dead.push(id); // 壞資料一併清掉
+      }
+    });
+    if (dead.length > 0) await this.cmd('zrem', WAITING_KEY, ...dead);
+    // ZSET 已依 score 排序；同分時 Redis 以 member 字典序，與 Memory 版一致
+    return alive;
+  }
+  async claimMatchLock(ttlSec: number): Promise<boolean> {
+    const r = await this.cmd('set', LOCK_KEY, '1', 'NX', 'EX', String(ttlSec));
+    return r === 'OK'; // NX 成功回 "OK"，已存在回 null
+  }
+  async setMatch(playerId: string, info: MatchInfo, ttlSec: number): Promise<void> {
+    await this.cmd('set', `queue:match:${playerId}`, JSON.stringify(info), 'EX', String(ttlSec));
+  }
+  async getMatch(playerId: string): Promise<MatchInfo | null> {
+    const r = await this.cmd('get', `queue:match:${playerId}`);
+    if (r === null || r === undefined) return null;
+    try {
+      return JSON.parse(String(r)) as MatchInfo;
+    } catch {
+      return null;
+    }
+  }
+}
+
+let singleton: QueueStore | null = null;
+export function getQueueStore(env: Record<string, string | undefined> = process.env): QueueStore {
+  if (singleton) return singleton;
+  // Upstash 原生命名，或 Vercel Marketplace（Upstash for Redis）注入的 KV_REST_API_* 命名
+  const url = env.UPSTASH_REDIS_REST_URL || env.KV_REST_API_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN || env.KV_REST_API_TOKEN;
+  // 只設了一半 → 主動報錯，避免生產環境靜默退回記憶體（重啟即失資料）
+  if ((url && !token) || (token && !url)) {
+    throw new Error('Upstash 設定不完整：REST URL 與 TOKEN 必須同時提供（KV_REST_API_URL/TOKEN 或 UPSTASH_REDIS_REST_URL/TOKEN）');
+  }
+  singleton = url && token ? new UpstashQueueStore(url, token) : new MemoryQueueStore();
+  return singleton;
+}

--- a/tests/e2e/games-tetris-queue.spec.ts
+++ b/tests/e2e/games-tetris-queue.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * 快速配對隊列端到端（Q5）：
+ *  ① 兩 context 都按 QUICK MATCH → 撮合 1v1 → 自動 host/join → 鎖步開打
+ *  ② 三 context → 撮合 FFA → host autoStart 人到齊自動開局 → 三端 ffaLockstep 同步
+ *  ③ 排隊後取消 → 面板關閉、可再正常進線上面板
+ *  ④ 空池等滿閾值（?queueAiMs= 注入縮短）→ AI 提示出現 → 點擊轉 vs-AI
+ *
+ * 撮合窗 10 秒（最早者等滿 10s 才成局）＋ 3s poll → 成局約 10-13s，預算給足。
+ * 隊列是 dev server 全域共用狀態 → serial 模式避免測試間玩家互相混配。
+ * WebRTC 需 chromium。
+ */
+test.describe('Dungeon Arcade — quick match queue', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.skip(({ browserName }) => browserName !== 'chromium', 'WebRTC requires chromium');
+  test.setTimeout(150_000);
+
+  test('two players press QUICK MATCH and auto-match into a 1v1 lockstep game', async ({ browser }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    const a = await ctxA.newPage();
+    const b = await ctxB.newPage();
+    try {
+      await a.goto('/games/tetris');
+      await b.goto('/games/tetris');
+
+      const t0 = Date.now();
+      await a.locator('#quick-match').click();
+      await b.locator('#quick-match').click();
+
+      // 排隊面板出現、秒數開始走
+      await expect(a.locator('#queue-panel')).toBeVisible();
+      await expect(b.locator('#queue-panel')).toBeVisible();
+
+      // 撮合（10s 窗 + 3s poll）→ 自動 host/join → 1v1 鎖步建立
+      await waitLockstep(a);
+      await waitLockstep(b);
+      console.log(`[queue-e2e] 1v1 matched+connected in ${Date.now() - t0}ms`);
+
+      // 雙方 confirmedFrame 推進（鎖步同步證明）
+      await expect.poll(() => readConfirmedFrame(a), { timeout: 25_000 }).toBeGreaterThan(10);
+      await expect.poll(() => readConfirmedFrame(b), { timeout: 25_000 }).toBeGreaterThan(10);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  test('three players press QUICK MATCH and auto-match into an FFA game (host auto-start)', async ({ browser }) => {
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const ctx3 = await browser.newContext();
+    const p1 = await ctx1.newPage();
+    const p2 = await ctx2.newPage();
+    const p3 = await ctx3.newPage();
+    try {
+      await p1.goto('/games/tetris');
+      await p2.goto('/games/tetris');
+      await p3.goto('/games/tetris');
+
+      const t0 = Date.now();
+      // 三人都在 10s 撮合窗內入隊 → ≥3 人成 FFA
+      await p1.locator('#quick-match').click();
+      await p2.locator('#quick-match').click();
+      await p3.locator('#quick-match').click();
+
+      // 撮合 → host autoStart（人到齊自動開局，無人按 START）→ 三端 ffaLockstep
+      await waitFfaLockstep(p1);
+      await waitFfaLockstep(p2);
+      await waitFfaLockstep(p3);
+      console.log(`[queue-e2e] FFA matched+connected in ${Date.now() - t0}ms`);
+
+      // 三端 playerIds 一致且為 3 人
+      const ids1 = await readFfaPlayerIds(p1);
+      const ids2 = await readFfaPlayerIds(p2);
+      const ids3 = await readFfaPlayerIds(p3);
+      expect(ids1.length).toBe(3);
+      expect(ids2).toEqual(ids1);
+      expect(ids3).toEqual(ids1);
+
+      // 三端 confirmedFrame 推進
+      await expect.poll(() => readFfaConfirmedFrame(p1), { timeout: 25_000 }).toBeGreaterThan(10);
+      await expect.poll(() => readFfaConfirmedFrame(p2), { timeout: 25_000 }).toBeGreaterThan(10);
+      await expect.poll(() => readFfaConfirmedFrame(p3), { timeout: 25_000 }).toBeGreaterThan(10);
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+      await ctx3.close();
+    }
+  });
+
+  test('cancel leaves the queue and returns to mode select (online panel still reachable)', async ({ page }) => {
+    await page.goto('/games/tetris');
+    await page.locator('#quick-match').click();
+    await expect(page.locator('#queue-panel')).toBeVisible();
+
+    await page.locator('#queue-cancel').click();
+    await expect(page.locator('#queue-panel')).toBeHidden();
+    await expect(page.locator('#quick-match')).toBeVisible(); // 模式選單已還原
+
+    // 仍可正常進線上面板
+    await page.locator('[data-mode="online"]').click();
+    await expect(page.locator('#online-create')).toBeVisible();
+  });
+
+  test('empty queue shows AI offer after threshold and clicking starts vs-AI', async ({ page }) => {
+    // 注入縮短閾值：1.5 秒就出 AI 提示（預設 60s）
+    await page.goto('/games/tetris?queueAiMs=1500');
+    await page.locator('#quick-match').click();
+    await expect(page.locator('#queue-panel')).toBeVisible();
+    await expect(page.locator('#queue-ai-offer')).toBeHidden(); // 未到閾值前不出現
+
+    // 閾值後提示出現
+    await expect(page.locator('#queue-ai-offer')).toBeVisible({ timeout: 10_000 });
+
+    // 點擊 → 離隊並轉 vs-AI（aiMain 掛 __tetrisDebug.run / match）
+    await page.locator('#queue-ai-offer').click();
+    await expect(page.locator('#queue-panel')).toBeHidden();
+    await page.waitForFunction(
+      () => {
+        const dbg = (window as unknown as { __tetrisDebug?: { run?: unknown; match?: unknown } }).__tetrisDebug;
+        return Boolean(dbg?.run ?? dbg?.match);
+      },
+      undefined,
+      { timeout: 20_000 },
+    );
+  });
+});
+
+/** 等 1v1 鎖步建立（netMain runGame 後掛 __tetrisDebug.lockstep）。 */
+async function waitLockstep(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { __tetrisDebug?: { lockstep?: unknown } }).__tetrisDebug?.lockstep),
+    undefined,
+    { timeout: 60_000 },
+  );
+}
+
+function readConfirmedFrame(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { lockstep?: { confirmedFrame?: number } } }).__tetrisDebug;
+    return dbg?.lockstep?.confirmedFrame ?? 0;
+  });
+}
+
+/** 等 FFA 鎖步建立（runFfaGame 後掛 __tetrisDebug.ffaLockstep）。 */
+async function waitFfaLockstep(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { __tetrisDebug?: { ffaLockstep?: unknown } }).__tetrisDebug?.ffaLockstep),
+    undefined,
+    { timeout: 60_000 },
+  );
+}
+
+function readFfaPlayerIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { ffaLockstep?: { playerIds?: string[] } } }).__tetrisDebug;
+    return dbg?.ffaLockstep?.playerIds ?? [];
+  });
+}
+
+function readFfaConfirmedFrame(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as { __tetrisDebug?: { ffaLockstep?: { confirmedFrame?: number } } }).__tetrisDebug;
+    return dbg?.ffaLockstep?.confirmedFrame ?? 0;
+  });
+}


### PR DESCRIPTION
## 快速配對隊列 — 免房號自動配對（1v1+FFA）

主選單「⚡ QUICK MATCH」進隊列：2 人配 1v1、3-8 人配 FFA（10 秒湊團窗、host=等最久者）；等 60 秒沒人 → 一鍵轉 vs-AI。撮合在 poll 請求中以 SET NX 原子完成（serverless 無 worker）；entry 15s TTL+heartbeat；配對結果=房號+角色，全部重用既有連線/鎖步/結算流程。

順手修掉真 race：隊列 FFA 兩 guest 並發 claimGuestSlot 撞槽 → 依 roster 序位直寫固定槽位（fixedSlot），TDD 覆蓋。

### 測試
- 單元 **743 全綠**（撮合規則/雙實作儲存/API 原子撮合/client 輪詢）
- e2e **37/37 全綠（14 specs）**：新 queue spec 4 例（兩人自動配 1v1 實測 ~15s、三人 FFA、取消、AI 提示轉場）＋全部既有零回歸
- 生產 build 綠；Upstash 用量：排隊者每 3 秒 1 poll ≤5 指令，遠低免費額度

🤖 Generated with [Claude Code](https://claude.com/claude-code)
