### PR TITLE
feat(games): 手感打磨 — 連續 softdrop／HOLD 左移／AI 會 hold 不自滅／DAS·ARR·SDF 可調

### DIFF
--- a/docs/superpowers/specs/2026-06-12-dungeon-arcade-gamefeel-design.md
+++ b/docs/superpowers/specs/2026-06-12-dungeon-arcade-gamefeel-design.md
@@ -1,0 +1,18 @@
+# 遊戲手感打磨（Gamefeel Polish）設計 spec
+
+> 來源：真實玩家實測回饋（2026-06-12，使用者轉述）。逐項拆解＋根因查證。旋轉系統（SRS）玩家確認無問題，不動。
+
+## 回饋拆解與根因
+
+| # | 回饋 | 根因（已查證） | 修法 |
+|---|---|---|---|
+| G1 | 「softdrop 沒做好——有輸入時就要持續下落」 | `InputController.REPEATABLE` 只有 left/right；按住 ↓ 只觸發一次 softDrop | softDrop 加入連續觸發：**無 DAS 充能、立即以 `sdf` 間隔重複**（預設 30ms）。input 層產生更多 softDrop action 進鎖步，determinism 安全 |
+| G2 | 「HOLD 放左邊比較好；NEXT/HOLD 太不明顯；同邊會把 hold 當 next 放錯」 | 對戰版面（1v1/AI/FFA 本機盤）`HudView.setLayout` 把 HOLD+NEXT 疊同一欄；SOLO 已是 hold 左/next 右 | 對戰版面本機盤 HOLD 移**盤左**、NEXT 留盤右（對齊 SOLO 慣例）；HOLD/NEXT 標題字級+亮度提升、區塊框線強化。對手小盤不變 |
+| G3 | 「AI 不會 hold」＋「hard AI 自己疊死」 | `ai/bot.ts`（El-Tetris）零 hold 概念；評估只看當前塊 | bot 每手同時評估「當前塊最佳放置」與「hold 換塊後最佳放置」取優（含首次 hold 建倉）；體檢評估權重修自滅（升級為 Dellacherie 特徵組：landing height/eroded cells/row+col transitions/holes/wells，網路成熟參數）。難度仍以決策延遲+失誤率區分 |
+| G4 | 「現代方塊可調 ARR/DAS/SDF」 | 寫死 `{das:150, arr:35}` | 設定面板（PLAY 分頁齒輪）：DAS 50-300/ARR 0-80/SDF 0-60（0=瞬降）滑桿＋恢復預設；localStorage `tetris-handling`；四種模式開局讀取 |
+
+## 非目標
+旋轉系統、無延遲固定模式（玩家可用 ARR=0 達成）、觸控支援。
+
+## 測試
+G1/G4：InputController 單測（sdf 重複節奏、ARR=0 行為、設定載入回退）；G3：bot 單測（hold 路徑分數較優時選 hold、不會自殺疊高基準：固定 seed 跑 N 手存活/消行數門檻回歸）；G2：layout 單測（hold 錨點在盤左）＋截圖人工驗收；e2e 既有全部零回歸（鍵盤行為變更注意 ai/items spec 的 ArrowDown 假設）。

--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -50,6 +50,29 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
             <button class="ms-btn ms-hard" data-mode="ai" data-diff="hard">vs AI · HARD</button>
             <button class="ms-btn ms-online" data-mode="online">vs ONLINE</button>
           </div>
+          <button class="handling-open" id="handling-open" type="button" aria-expanded="false" aria-controls="handling-panel">HANDLING 手感設定</button>
+          <div class="handling-panel" id="handling-panel" hidden>
+            <div class="hp-row">
+              <label class="hp-label" for="handling-das">DAS</label>
+              <input class="hp-slider" id="handling-das" type="range" min="50" max="300" step="5" data-handling="das" />
+              <span class="hp-val" id="handling-das-val">150ms</span>
+            </div>
+            <div class="hp-row">
+              <label class="hp-label" for="handling-arr">ARR</label>
+              <input class="hp-slider" id="handling-arr" type="range" min="0" max="80" step="5" data-handling="arr" />
+              <span class="hp-val" id="handling-arr-val">35ms</span>
+            </div>
+            <div class="hp-row">
+              <label class="hp-label" for="handling-sdf">SDF</label>
+              <input class="hp-slider" id="handling-sdf" type="range" min="0" max="60" step="5" data-handling="sdf" />
+              <span class="hp-val" id="handling-sdf-val">30ms</span>
+            </div>
+            <p class="hp-hint">ARR 0 = 瞬移 · SDF 0 = 瞬降 · 調整於下一局生效</p>
+            <div class="hp-actions">
+              <button class="ms-btn hp-btn" id="handling-reset" type="button">恢復預設</button>
+              <button class="ms-btn ms-solo hp-btn" id="handling-done" type="button">完成</button>
+            </div>
+          </div>
         </div>
         <div class="mode-select" id="skill-select" hidden>
           <h2 class="ss-title">SELECT SKILL</h2>
@@ -292,6 +315,75 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   .ms-wallet.connected { border-color: rgba(77, 255, 136, 0.8); color: #4dff88; }
 
   .mode-select[hidden] { display: none; }
+
+  /* HANDLING 手感設定（PLAY 分頁，mode-select 下方小連結 → 滑桿面板） */
+  .handling-open {
+    font-family: inherit;
+    font-size: 9px;
+    letter-spacing: 1px;
+    color: #6fa8d8;
+    background: transparent;
+    border: none;
+    padding: 4px 8px;
+    cursor: pointer;
+    transition: color 0.15s ease, text-shadow 0.15s ease;
+  }
+  .handling-open:hover {
+    color: #36e6ff;
+    text-shadow: 0 0 8px rgba(54, 230, 255, 0.6);
+  }
+  .handling-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+    padding: 14px 16px;
+    background: rgba(8, 12, 22, 0.8);
+    border: 1px solid rgba(54, 230, 255, 0.35);
+    border-radius: 10px;
+  }
+  .handling-panel[hidden] { display: none; }
+  .hp-row {
+    display: grid;
+    grid-template-columns: 3.2em 1fr 4.4em;
+    align-items: center;
+    gap: 10px;
+  }
+  .hp-label {
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: #9fcdf2;
+  }
+  .hp-slider {
+    width: 100%;
+    height: 18px;
+    accent-color: #36e6ff;
+    background: transparent;
+    cursor: pointer;
+  }
+  .hp-val {
+    font-size: 9px;
+    letter-spacing: 1px;
+    text-align: right;
+    color: #4dff88;
+  }
+  .hp-hint {
+    margin: 0;
+    font-size: 8px;
+    letter-spacing: 1px;
+    line-height: 1.7;
+    text-align: center;
+    color: #5a7299;
+  }
+  .hp-actions {
+    display: flex;
+    gap: 10px;
+  }
+  .hp-btn {
+    flex: 1;
+    padding: 10px 12px;
+    font-size: 10px;
+  }
   .online-join { display: flex; gap: 10px; align-items: stretch; }
   #online-join-btn { white-space: nowrap; flex: 0 0 auto; padding-left: 16px; padding-right: 16px; }
   .online-input {
@@ -818,6 +910,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   import { startAi } from '@scripts/games/tetris/render/aiMain';
   import { SKILLS, type SkillId, type PerkChoice, type PerkId } from '@scripts/games/tetris/engine/run';
   import { SKIN_CATALOG, getSelectedSkin, setSelectedSkin, isUnlocked, resolveSkin } from '@scripts/games/tetris/render/skins';
+  import { HANDLING_DEFAULT, loadHandling, saveHandling, type Handling } from '@scripts/games/tetris/input/handling';
   import { hostGame, joinGame, connectWallet, type NetStatus, type Identity } from '@scripts/games/tetris/net/netMain';
   import { hostFfaGame, joinFfaGame, type FfaNetStatus, type FfaIdentity } from '@scripts/games/tetris/net/ffaNetMain';
 
@@ -848,6 +941,56 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
       });
     });
   });
+  // ---- HANDLING 手感設定（DAS/ARR/SDF 滑桿；改動即存，下一局開局讀取）----
+  const handlingOpen = document.getElementById('handling-open');
+  const handlingPanel = document.getElementById('handling-panel');
+  const handlingSliders = Array.from(document.querySelectorAll<HTMLInputElement>('.hp-slider'));
+
+  function renderHandling(h: Handling): void {
+    handlingSliders.forEach((s) => {
+      const key = s.dataset.handling as keyof Handling | undefined;
+      if (!key) return;
+      s.value = String(h[key]);
+      const val = document.getElementById(`handling-${key}-val`);
+      if (val) val.textContent = `${h[key]}ms`;
+    });
+  }
+
+  function readHandlingFromSliders(): Handling {
+    const h: Handling = { ...HANDLING_DEFAULT };
+    handlingSliders.forEach((s) => {
+      const key = s.dataset.handling as keyof Handling | undefined;
+      if (key) h[key] = Number(s.value);
+    });
+    return h;
+  }
+
+  handlingOpen?.addEventListener('click', () => {
+    if (!handlingPanel) return;
+    const open = handlingPanel.hidden;
+    if (open) renderHandling(loadHandling()); // 開啟時同步現值
+    handlingPanel.hidden = !open;
+    handlingOpen.setAttribute('aria-expanded', open ? 'true' : 'false');
+    blip(open ? 560 : 300, 0.06);
+  });
+  handlingSliders.forEach((s) => {
+    s.addEventListener('input', () => {
+      const h = readHandlingFromSliders();
+      renderHandling(h);
+      saveHandling(h); // 改動即存，下一局生效
+    });
+  });
+  document.getElementById('handling-reset')?.addEventListener('click', () => {
+    renderHandling(HANDLING_DEFAULT);
+    saveHandling({ ...HANDLING_DEFAULT });
+    blip(640, 0.06);
+  });
+  document.getElementById('handling-done')?.addEventListener('click', () => {
+    if (handlingPanel) handlingPanel.hidden = true;
+    handlingOpen?.setAttribute('aria-expanded', 'false');
+    blip(680, 0.06);
+  });
+
   const touchNotice = document.getElementById('touch-notice');
   // 觸控裝置（多半無實體鍵盤）→ 收掉遊玩入口、明講請用電腦；排行榜/檔案分頁仍可用
   const isTouch = matchMedia('(pointer: coarse)').matches;

--- a/src/scripts/games/tetris/ai/AiController.test.ts
+++ b/src/scripts/games/tetris/ai/AiController.test.ts
@@ -18,3 +18,38 @@ describe('AiController', () => {
       .toBeLessThan((slow as unknown as { intervalMs: number }).intervalMs);
   });
 });
+
+/** 固定 seed 自打：AI 自己對著重力玩，回傳消行數/塊數/最終狀態。 */
+function selfPlay(seed: number, maxPieces: number) {
+  const g = new TetrisGame({ seed });
+  const ai = new AiController((a) => g.input(a), () => g.getState(), 'hard');
+  let pieces = 0;
+  let ticks = 0;
+  const MAX_TICKS = 120000; // 安全上限（16ms × 120000 = 32 分鐘模擬時間）
+  while (pieces < maxPieces && g.getState().status === 'playing' && ticks < MAX_TICKS) {
+    ai.update(16);
+    g.step(16);
+    for (const e of g.drainEvents()) if (e.kind === 'lock') pieces++;
+    ticks++;
+  }
+  const s = g.getState();
+  return { lines: s.lines, pieces, status: s.status };
+}
+
+describe('AiController — 防自滅回歸基準（hard 純重力自打）', () => {
+  // 舊版（El-Tetris + 每 80ms 走一步）基線：600 塊目標下全 seed topout——
+  // seed 42: 370 塊 132 行 topout / seed 7: 374 塊 134 行 topout / seed 555: 324 塊 113 行 topout。
+  // 高等級重力（level 13+ 間隔 ≤ 18ms）超過逐步走子速度 → 亂放 → 疊死。
+  it('固定 seed 自打 600 塊：不 topout 且消行 ≥ 150（舊版在此 topout）', () => {
+    const r = selfPlay(42, 600);
+    expect(r.status).toBe('playing');
+    expect(r.pieces).toBe(600);
+    expect(r.lines).toBeGreaterThanOrEqual(150);
+  });
+
+  it('換一個 seed 也不會自己疊死', () => {
+    const r = selfPlay(555, 600);
+    expect(r.status).toBe('playing');
+    expect(r.lines).toBeGreaterThanOrEqual(150);
+  });
+});

--- a/src/scripts/games/tetris/ai/AiController.ts
+++ b/src/scripts/games/tetris/ai/AiController.ts
@@ -1,47 +1,99 @@
 import type { GameState } from '../engine/types';
 import type { InputAction } from '../engine/game';
-import { bestPlacement, type Placement } from './bot';
+import { BOARD_WIDTH } from '../engine/constants';
+import { decide, dropPlacement, type Placement } from './bot';
 
 export type Difficulty = 'easy' | 'normal' | 'hard';
 
-const INTERVALS: Record<Difficulty, number> = { easy: 420, normal: 200, hard: 80 };
+/** 每塊的思考延遲（毫秒）——難度主要分層 */
+const THINK_MS: Record<Difficulty, number> = { easy: 420, normal: 200, hard: 80 };
+/** 失誤率：以此機率把目標落點偏移一欄（hard = 0，真的強） */
+const MISTAKE_RATE: Record<Difficulty, number> = { easy: 0.18, normal: 0.07, hard: 0 };
 
-/** 依難度的思考間隔，逐步把當前方塊走到 bestPlacement 目標。 */
+/**
+ * AI 控制器：每塊先「思考」THINK_MS，再一口氣執行決策序列
+ * （hold? → 旋轉 → 平移 → 硬降）。一次出完避免高等級重力跑贏逐步走子
+ * 而亂放疊死；難度由思考延遲＋失誤率分層。
+ */
 export class AiController {
-  private intervalMs: number;
+  private intervalMs: number; // 思考延遲（保留欄位名供測試/相容）
+  private mistakeRate: number;
   private acc = 0;
-  private target: Placement | null = null;
-  private targetPieceKey = '';
+  private seenKey = '';
 
   constructor(
     private emit: (action: InputAction) => void,
     private getState: () => GameState,
     difficulty: Difficulty,
+    private rng: () => number = Math.random,
   ) {
-    this.intervalMs = INTERVALS[difficulty];
+    this.intervalMs = THINK_MS[difficulty];
+    this.mistakeRate = MISTAKE_RATE[difficulty];
   }
 
-  /** 前進 dtMs；每隔 intervalMs 走一步（旋轉→平移→硬降）。 */
+  /** 局面識別 key：換塊 / hold / 消行 / 垃圾進場都會改變 → 重新思考 */
+  private stateKey(s: GameState): string {
+    let filled = 0;
+    for (const row of s.board) for (const c of row) if (c !== null) filled++;
+    return `${s.active?.type}|${s.hold ?? ''}|${s.next.join('')}|${filled}`;
+  }
+
+  /** 前進 dtMs；同一局面累積到思考延遲後，一次執行整套輸入序列。 */
   update(dtMs: number): void {
     const s = this.getState();
     if (s.status !== 'playing' || !s.active) return;
 
-    // 換了新方塊就重新規劃目標
-    const key = `${s.active.type}@${s.next[0] ?? ''}:${s.board.length}`;
-    if (this.target === null || key !== this.targetPieceKey) {
-      this.target = bestPlacement(s.board, s.active.type);
-      this.targetPieceKey = key;
+    const key = this.stateKey(s);
+    if (key !== this.seenKey) {
+      this.seenKey = key;
+      this.acc = 0;
     }
 
     this.acc += dtMs;
     if (this.acc < this.intervalMs) return;
     this.acc = 0;
-    if (!this.target) { this.emit('hardDrop'); return; }
+    this.executeTurn(s);
+  }
 
-    const a = s.active;
-    if (a.rotation !== this.target.rotation) this.emit('rotateCW');
-    else if (a.x > this.target.x) this.emit('left');
-    else if (a.x < this.target.x) this.emit('right');
-    else { this.emit('hardDrop'); this.target = null; }
+  /** 規劃並一口氣出完：hold?（每塊限一次）→ 旋轉 → 平移 → 硬降。 */
+  private executeTurn(s: GameState): void {
+    const d = decide({
+      board: s.board,
+      current: s.active!.type,
+      hold: s.hold,
+      next: s.next[0] ?? null,
+      canHold: s.canHold,
+    });
+    if (!d) {
+      this.emit('hardDrop');
+      return;
+    }
+
+    let target: Placement = d.placement;
+
+    // 失誤：偏移一欄（仍須是合法落點，否則維持原目標）
+    if (this.mistakeRate > 0 && this.rng() < this.mistakeRate) {
+      const type = d.useHold ? (s.hold ?? s.next[0] ?? s.active!.type) : s.active!.type;
+      const dir = this.rng() < 0.5 ? -1 : 1;
+      if (dropPlacement(s.board, type, target.rotation, target.x + dir)) {
+        target = { rotation: target.rotation, x: target.x + dir };
+      }
+    }
+
+    if (d.useHold) this.emit('hold'); // 引擎同步換塊（空 hold = 直接抽 next）
+
+    for (let i = 0; i < target.rotation; i++) this.emit('rotateCW');
+
+    // 旋轉可能踢牆改 x → 讀回實際位置再平移
+    let active = this.getState().active;
+    let guard = 0;
+    while (active && active.x !== target.x && guard++ < BOARD_WIDTH + 4) {
+      this.emit(active.x > target.x ? 'left' : 'right');
+      const after = this.getState().active;
+      if (after && after.x === active.x) break; // 被擋住：就地落下
+      active = after;
+    }
+
+    this.emit('hardDrop');
   }
 }

--- a/src/scripts/games/tetris/ai/bot.test.ts
+++ b/src/scripts/games/tetris/ai/bot.test.ts
@@ -1,71 +1,119 @@
 import { describe, it, expect } from 'vitest';
-import { evaluateBoard, scoreBoard, dropPlacement, bestPlacement } from './bot';
-import { createBoard } from '../engine/board';
-import { canPlace } from '../engine/board';
-import { getCells, spawnPiece } from '../engine/piece';
+import { evaluateBoard, scoreDrop, dropPlacement, bestPlacement, decide } from './bot';
+import { createBoard, canPlace } from '../engine/board';
 import { BOARD_WIDTH, TOTAL_HEIGHT } from '../engine/constants';
-import type { PieceType } from '../engine/types';
+import type { Matrix, PieceType } from '../engine/types';
 
-describe('evaluateBoard', () => {
-  it('空盤：高度/洞/崎嶇/消行皆 0', () => {
+const LAST = TOTAL_HEIGHT - 1;
+
+/** 底部 depth 列填滿、只留 wellCol 一欄空（深井盤面）。 */
+function boardWithWell(depth: number, wellCol: number): Matrix {
+  const b = createBoard();
+  for (let y = TOTAL_HEIGHT - depth; y < TOTAL_HEIGHT; y++) {
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      if (x !== wellCol) b[y][x] = 'G';
+    }
+  }
+  return b;
+}
+
+describe('evaluateBoard（Dellacherie 特徵）', () => {
+  it('空盤：row transitions = 2×高度、col transitions = 寬度、洞/井 0', () => {
     const f = evaluateBoard(createBoard());
-    expect(f).toEqual({ aggregateHeight: 0, holes: 0, bumpiness: 0, completeLines: 0 });
+    // 每空列撞左右牆各一次；每空欄到底床一次
+    expect(f).toEqual({
+      rowTransitions: 2 * TOTAL_HEIGHT,
+      colTransitions: BOARD_WIDTH,
+      holes: 0,
+      wells: 0,
+    });
   });
 
-  it('單欄疊兩格 → 高度2、崎嶇2（與相鄰兩側各差2，但只算相鄰對）', () => {
+  it('被蓋住的空格算洞，且增加 column transitions', () => {
     const b = createBoard();
-    const last = TOTAL_HEIGHT - 1;
-    b[last][0] = 'I';
-    b[last - 1][0] = 'I';
+    b[LAST - 1][3] = 'I'; // 其下 (LAST,3) 為空 → 洞
     const f = evaluateBoard(b);
-    expect(f.aggregateHeight).toBe(2);
-    // 欄0高2、欄1高0 → |2-0|=2；其餘相鄰皆0
-    expect(f.bumpiness).toBe(2);
-    expect(f.holes).toBe(0);
+    expect(f.holes).toBe(1);
+    // 欄3：空→填(+1)→空(+1)→底床(+1) = 3；其他欄各 1
+    expect(f.colTransitions).toBe(BOARD_WIDTH - 1 + 3);
   });
 
-  it('頂端有格、其下為空 → 算一個洞', () => {
-    const b = createBoard();
-    const last = TOTAL_HEIGHT - 1;
-    b[last - 1][3] = 'I'; // 上方有方塊
-    // (last,3) 為空 → 洞 1
-    expect(evaluateBoard(b).holes).toBe(1);
+  it('棋盤格列的 row transitions 高於實心列', () => {
+    const solid = createBoard();
+    const checker = createBoard();
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      solid[LAST][x] = 'G';
+      if (x % 2 === 0) checker[LAST][x] = 'G';
+    }
+    expect(evaluateBoard(checker).rowTransitions)
+      .toBeGreaterThan(evaluateBoard(solid).rowTransitions);
   });
 
-  it('填滿底列 → completeLines 1', () => {
+  it('兩側填滿夾一欄深 3 的井 → cumulative wells = 3+2+1 = 6', () => {
     const b = createBoard();
-    const last = TOTAL_HEIGHT - 1;
-    for (let x = 0; x < BOARD_WIDTH; x++) b[last][x] = 'I';
-    expect(evaluateBoard(b).completeLines).toBe(1);
-  });
-});
-
-describe('scoreBoard', () => {
-  it('消行越多分越高', () => {
-    const b = createBoard();
-    expect(scoreBoard(b, 4)).toBeGreaterThan(scoreBoard(b, 0));
-  });
-  it('有洞分數較低', () => {
-    const flat = createBoard();
-    const holed = createBoard();
-    const last = TOTAL_HEIGHT - 1;
-    holed[last - 1][3] = 'I'; // 製造一個洞 + 高度
-    expect(scoreBoard(holed, 0)).toBeLessThan(scoreBoard(flat, 0));
+    for (let y = LAST - 2; y <= LAST; y++) {
+      b[y][0] = 'G';
+      b[y][2] = 'G';
+    }
+    expect(evaluateBoard(b).wells).toBe(6);
+    expect(evaluateBoard(b).holes).toBe(0);
   });
 });
 
 describe('dropPlacement', () => {
-  it('在空盤直落 O 到底，回傳鎖定後盤面與 0 消行', () => {
+  it('在空盤直落 O 到底：0 消行、landingHeight 0.5、eroded 0', () => {
     const res = dropPlacement(createBoard(), 'O', 0, 4);
     expect(res).not.toBeNull();
     expect(res!.lines).toBe(0);
-    // O 落到最底兩列
-    expect(res!.board[TOTAL_HEIGHT - 1][4]).toBe('O');
-    expect(res!.board[TOTAL_HEIGHT - 1][5]).toBe('O');
+    expect(res!.board[LAST][4]).toBe('O');
+    expect(res!.board[LAST][5]).toBe('O');
+    // O 佔最底兩列，中心高度 (0+1)/2
+    expect(res!.landingHeight).toBeCloseTo(0.5);
+    expect(res!.erodedCells).toBe(0);
   });
+
   it('越界的 x 回傳 null', () => {
     expect(dropPlacement(createBoard(), 'O', 0, -5)).toBeNull();
     expect(dropPlacement(createBoard(), 'O', 0, BOARD_WIDTH)).toBeNull();
+  });
+
+  it('消行時回報 erodedCells = 消行數 × 本塊被消格數', () => {
+    // 底列只缺 x=4,5；O 落下 → 消 1 行、O 有 2 格在該行 → eroded = 2
+    const b = createBoard();
+    for (let x = 0; x < BOARD_WIDTH; x++) if (x !== 4 && x !== 5) b[LAST][x] = 'G';
+    const res = dropPlacement(b, 'O', 0, 4);
+    expect(res!.lines).toBe(1);
+    expect(res!.erodedCells).toBe(2);
+  });
+});
+
+describe('scoreDrop', () => {
+  it('消行的落法分數高於不消行', () => {
+    const b = boardWithWell(1, 0);
+    const clearing = dropPlacement(b, 'I', 1, -2)!; // 直立 I 填井 → 消 1 行
+    const flat = dropPlacement(b, 'I', 0, 3)!;      // 平放疊上面 → 蓋洞
+    expect(clearing.lines).toBe(1);
+    expect(flat.lines).toBe(0);
+    expect(scoreDrop(clearing)).toBeGreaterThan(scoreDrop(flat));
+  });
+
+  it('落點越高分數越低（landing height 懲罰）', () => {
+    const empty = createBoard();
+    const tall = createBoard();
+    for (let y = LAST - 9; y <= LAST; y++) for (let x = 0; x < 4; x++) tall[y][x] = 'G';
+    const low = dropPlacement(empty, 'O', 0, 0)!;
+    const high = dropPlacement(tall, 'O', 0, 0)!;
+    // 疊高處的盤面分數本來就差，至少 landingHeight 特徵要反映高度
+    expect(high.landingHeight).toBeGreaterThan(low.landingHeight);
+    expect(scoreDrop(high)).toBeLessThan(scoreDrop(low));
+  });
+
+  it('製造洞的盤面分數較低', () => {
+    const flatBoard = createBoard();
+    const holed = createBoard();
+    holed[LAST - 1][3] = 'I'; // 一個洞
+    const mk = (board: Matrix) => ({ board, lines: 0, landingHeight: 0, erodedCells: 0 });
+    expect(scoreDrop(mk(holed))).toBeLessThan(scoreDrop(mk(flatBoard)));
   });
 });
 
@@ -75,16 +123,12 @@ describe('bestPlacement', () => {
     for (const t of types) {
       const p = bestPlacement(createBoard(), t);
       expect(p).not.toBeNull();
-      // 該落點以 spawn 旋轉/欄位放在頂端應可放
       expect(canPlace(createBoard(), { type: t, rotation: p!.rotation, x: p!.x, y: 0 })).toBe(true);
     }
   });
 
   it('能消行時會選擇消行的落點', () => {
-    // 底列只缺第 0 欄；直立 I 落在第 0 欄可消 1 行
-    const b = createBoard();
-    const last = TOTAL_HEIGHT - 1;
-    for (let x = 1; x < BOARD_WIDTH; x++) b[last][x] = 'G';
+    const b = boardWithWell(1, 0);
     const p = bestPlacement(b, 'I');
     expect(p).not.toBeNull();
     const res = dropPlacement(b, 'I', p!.rotation, p!.x);
@@ -94,5 +138,50 @@ describe('bestPlacement', () => {
   it('同盤面同方塊回傳相同落點（確定性）', () => {
     const b = createBoard();
     expect(bestPlacement(b, 'T')).toEqual(bestPlacement(b, 'T'));
+  });
+});
+
+describe('decide（hold 意識決策）', () => {
+  it('當前 S 很爛、hold 有 I 且有深井 → 選 hold 並用 I 清 4 行', () => {
+    const b = boardWithWell(4, 0);
+    const d = decide({ board: b, current: 'S', hold: 'I', next: 'T', canHold: true });
+    expect(d).not.toBeNull();
+    expect(d!.useHold).toBe(true);
+    const res = dropPlacement(b, 'I', d!.placement.rotation, d!.placement.x);
+    expect(res!.lines).toBe(4);
+  });
+
+  it('hold 為空時偷看 next：next 的 I 較優 → hold 建倉換 I', () => {
+    const b = boardWithWell(4, 0);
+    const d = decide({ board: b, current: 'S', hold: null, next: 'I', canHold: true });
+    expect(d!.useHold).toBe(true);
+    const res = dropPlacement(b, 'I', d!.placement.rotation, d!.placement.x);
+    expect(res!.lines).toBe(4);
+  });
+
+  it('canHold = false（本塊已 hold 過）絕不再 hold', () => {
+    const b = boardWithWell(4, 0);
+    const d = decide({ board: b, current: 'S', hold: 'I', next: 'I', canHold: false });
+    expect(d!.useHold).toBe(false);
+  });
+
+  it('hold 與當前同型 → 不做無謂 hold', () => {
+    const b = boardWithWell(4, 0);
+    const d = decide({ board: b, current: 'I', hold: 'I', next: 'T', canHold: true });
+    expect(d!.useHold).toBe(false);
+  });
+
+  it('當前塊已較優（I vs hold 的 S）→ 不 hold', () => {
+    const b = boardWithWell(4, 0);
+    const d = decide({ board: b, current: 'I', hold: 'S', next: 'T', canHold: true });
+    expect(d!.useHold).toBe(false);
+    const res = dropPlacement(b, 'I', d!.placement.rotation, d!.placement.x);
+    expect(res!.lines).toBe(4);
+  });
+
+  it('決策確定性：同輸入同輸出', () => {
+    const b = boardWithWell(2, 5);
+    const input = { board: b, current: 'T' as PieceType, hold: 'L' as PieceType, next: 'J' as PieceType, canHold: true };
+    expect(decide(input)).toEqual(decide(input));
   });
 });

--- a/src/scripts/games/tetris/ai/bot.ts
+++ b/src/scripts/games/tetris/ai/bot.ts
@@ -1,64 +1,83 @@
 import type { ActivePiece, Matrix, PieceType, Rotation } from '../engine/types';
 import { BOARD_WIDTH, TOTAL_HEIGHT } from '../engine/constants';
 import { canPlace, lockPiece, clearLines } from '../engine/board';
+import { getCells } from '../engine/piece';
 
+/** Dellacherie 盤面特徵（消行後的盤面）。 */
 export interface BoardFeatures {
-  aggregateHeight: number;
+  rowTransitions: number;
+  colTransitions: number;
   holes: number;
-  bumpiness: number;
-  completeLines: number;
+  wells: number; // cumulative wells（每井 1+2+…+深度）
 }
 
-// El-Tetris 權重
-const W_HEIGHT = -0.510066;
-const W_LINES = 0.760666;
-const W_HOLES = -0.35663;
-const W_BUMP = -0.184483;
+// Dellacherie 成熟權重（Thiery & Scherrer 文獻常用組）
+const W_LANDING = -4.500158825;
+const W_ERODED = 3.4181268;
+const W_ROW_T = -3.2178882;
+const W_COL_T = -9.348695;
+const W_HOLES = -7.899265;
+const W_WELLS = -3.3855972;
 
-/** 每欄高度（TOTAL_HEIGHT - 最高填滿列索引；空欄=0）。 */
-function columnHeights(board: Matrix): number[] {
-  const heights = new Array(BOARD_WIDTH).fill(0);
+export function evaluateBoard(board: Matrix): BoardFeatures {
+  // Row transitions：左右牆視為填滿，每列水平掃描 filled↔empty 變化數
+  let rowTransitions = 0;
+  for (let y = 0; y < TOTAL_HEIGHT; y++) {
+    let prev = true; // 左牆
+    for (let x = 0; x < BOARD_WIDTH; x++) {
+      const filled = board[y][x] !== null;
+      if (filled !== prev) rowTransitions++;
+      prev = filled;
+    }
+    if (!prev) rowTransitions++; // 右牆
+  }
+
+  // Column transitions：頂上視為空、底床視為填滿
+  let colTransitions = 0;
+  for (let x = 0; x < BOARD_WIDTH; x++) {
+    let prev = false; // 盤頂上方
+    for (let y = 0; y < TOTAL_HEIGHT; y++) {
+      const filled = board[y][x] !== null;
+      if (filled !== prev) colTransitions++;
+      prev = filled;
+    }
+    if (!prev) colTransitions++; // 底床
+  }
+
+  // Holes：欄內上方有填格的空格數
+  let holes = 0;
+  for (let x = 0; x < BOARD_WIDTH; x++) {
+    let covered = false;
+    for (let y = 0; y < TOTAL_HEIGHT; y++) {
+      if (board[y][x] !== null) covered = true;
+      else if (covered) holes++;
+    }
+  }
+
+  // Cumulative wells：左右皆填滿（牆算填滿）的空格，往下累計連續空深（1+2+…+d）
+  let wells = 0;
   for (let x = 0; x < BOARD_WIDTH; x++) {
     for (let y = 0; y < TOTAL_HEIGHT; y++) {
-      if (board[y][x] !== null) {
-        heights[x] = TOTAL_HEIGHT - y;
-        break;
+      if (board[y][x] !== null) continue;
+      const leftFilled = x === 0 || board[y][x - 1] !== null;
+      const rightFilled = x === BOARD_WIDTH - 1 || board[y][x + 1] !== null;
+      if (leftFilled && rightFilled) {
+        for (let k = y; k < TOTAL_HEIGHT && board[k][x] === null; k++) wells++;
       }
     }
   }
-  return heights;
-}
 
-export function evaluateBoard(board: Matrix): BoardFeatures {
-  const heights = columnHeights(board);
-  const aggregateHeight = heights.reduce((a, h) => a + h, 0);
-
-  let bumpiness = 0;
-  for (let x = 0; x < BOARD_WIDTH - 1; x++) bumpiness += Math.abs(heights[x] - heights[x + 1]);
-
-  let holes = 0;
-  for (let x = 0; x < BOARD_WIDTH; x++) {
-    const top = TOTAL_HEIGHT - heights[x];
-    for (let y = top + 1; y < TOTAL_HEIGHT; y++) {
-      if (board[y][x] === null) holes++;
-    }
-  }
-
-  let completeLines = 0;
-  for (let y = 0; y < TOTAL_HEIGHT; y++) {
-    if (board[y].every((c) => c !== null)) completeLines++;
-  }
-
-  return { aggregateHeight, holes, bumpiness, completeLines };
-}
-
-/** 盤面評分（lines 為本次落子消除的行數，分開傳入）。越高越好。 */
-export function scoreBoard(board: Matrix, lines: number): number {
-  const f = evaluateBoard(board);
-  return W_LINES * lines + W_HEIGHT * f.aggregateHeight + W_HOLES * f.holes + W_BUMP * f.bumpiness;
+  return { rowTransitions, colTransitions, holes, wells };
 }
 
 export interface Placement { rotation: Rotation; x: number; }
+
+export interface DropResult {
+  board: Matrix;        // 消行後盤面
+  lines: number;        // 消除行數
+  landingHeight: number; // 落點高度（方塊中心離底床的高度，消行前）
+  erodedCells: number;  // 消行數 ×（本塊位於被消行內的格數）
+}
 
 /** 把 (type,rotation,x) 從頂端直落到底、鎖定、消行。無法放置回傳 null。 */
 export function dropPlacement(
@@ -66,29 +85,89 @@ export function dropPlacement(
   type: PieceType,
   rotation: Rotation,
   x: number,
-): { board: Matrix; lines: number } | null {
+): DropResult | null {
   let piece: ActivePiece = { type, rotation, x, y: 0 };
   if (!canPlace(board, piece)) return null;
   while (canPlace(board, { ...piece, y: piece.y + 1 })) piece = { ...piece, y: piece.y + 1 };
+
+  const cells = getCells(piece);
+  let minY = TOTAL_HEIGHT;
+  let maxY = -1;
+  for (const c of cells) {
+    if (c.y < minY) minY = c.y;
+    if (c.y > maxY) maxY = c.y;
+  }
+  const landingHeight = TOTAL_HEIGHT - 1 - (minY + maxY) / 2;
+
   const locked = lockPiece(board, piece);
   const { board: cleared, rows } = clearLines(locked);
-  return { board: cleared, lines: rows.length };
+  const lines = rows.length;
+  const pieceCellsErased = cells.reduce((n, c) => n + (rows.includes(c.y) ? 1 : 0), 0);
+  return { board: cleared, lines, landingHeight, erodedCells: lines * pieceCellsErased };
 }
 
-/** 枚舉所有旋轉 × 欄位的直落落點，選評分最高者。確定性 tie-break（先 rotation、後 x）。 */
-export function bestPlacement(board: Matrix, type: PieceType): Placement | null {
-  let best: Placement | null = null;
-  let bestScore = -Infinity;
+/** Dellacherie 落子評分。越高越好。 */
+export function scoreDrop(r: DropResult): number {
+  const f = evaluateBoard(r.board);
+  return (
+    W_LANDING * r.landingHeight +
+    W_ERODED * r.erodedCells +
+    W_ROW_T * f.rowTransitions +
+    W_COL_T * f.colTransitions +
+    W_HOLES * f.holes +
+    W_WELLS * f.wells
+  );
+}
+
+export interface ScoredPlacement { placement: Placement; score: number; }
+
+/** 枚舉所有旋轉 × 欄位的直落落點，回傳最高分落點與分數。確定性 tie-break（先 rotation、後 x）。 */
+export function bestPlacementScored(board: Matrix, type: PieceType): ScoredPlacement | null {
+  let best: ScoredPlacement | null = null;
   for (let rotation = 0 as Rotation; rotation < 4; rotation = (rotation + 1) as Rotation) {
     for (let x = -2; x <= BOARD_WIDTH; x++) {
       const res = dropPlacement(board, type, rotation, x);
       if (!res) continue;
-      const score = scoreBoard(res.board, res.lines);
-      if (score > bestScore) {
-        bestScore = score;
-        best = { rotation, x };
-      }
+      const score = scoreDrop(res);
+      if (!best || score > best.score) best = { placement: { rotation, x }, score };
     }
   }
   return best;
+}
+
+/** 相容介面：只回傳最佳落點。 */
+export function bestPlacement(board: Matrix, type: PieceType): Placement | null {
+  return bestPlacementScored(board, type)?.placement ?? null;
+}
+
+export interface DecideInput {
+  board: Matrix;
+  current: PieceType;
+  hold: PieceType | null;   // hold 槽現有方塊（null = 空）
+  next: PieceType | null;   // next[0]（hold 為空時 hold 會換到這塊）
+  canHold: boolean;         // 本塊是否還能 hold（每塊限一次）
+}
+
+export interface Decision {
+  useHold: boolean;
+  placement: Placement; // useHold 時為換出方塊（hold 或 next）的落點
+}
+
+/**
+ * hold 意識決策：同時評估「當前塊最佳落點」與「hold 換塊後（hold 有塊=swap、
+ * 空=用 next[0]）最佳落點」，hold 路徑嚴格較優才換（平手留在當前塊，避免無謂 hold）。
+ */
+export function decide(input: DecideInput): Decision | null {
+  const cur = bestPlacementScored(input.board, input.current);
+
+  let alt: ScoredPlacement | null = null;
+  if (input.canHold) {
+    const altType = input.hold ?? input.next;
+    if (altType && altType !== input.current) {
+      alt = bestPlacementScored(input.board, altType);
+    }
+  }
+
+  if (alt && (!cur || alt.score > cur.score)) return { useHold: true, placement: alt.placement };
+  return cur ? { useHold: false, placement: cur.placement } : null;
 }

--- a/src/scripts/games/tetris/input/InputController.test.ts
+++ b/src/scripts/games/tetris/input/InputController.test.ts
@@ -29,3 +29,68 @@ describe('InputController DAS/ARR', () => {
     expect(actions).toEqual(['rotateCW']);
   });
 });
+
+describe('InputController softDrop SDF', () => {
+  it('按下立即觸發一次', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 160, arr: 40 });
+    ic.press('softDrop');
+    expect(actions).toEqual(['softDrop']);
+  });
+
+  it('按住以 sdf 間隔重複（預設 30ms：100ms 內共 4 次），無 DAS 充能', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 160, arr: 40 });
+    ic.press('softDrop'); // 1 次（立即）
+    for (let i = 0; i < 10; i++) ic.update(10); // 100ms：30/60/90ms 各一次
+    expect(actions).toEqual(['softDrop', 'softDrop', 'softDrop', 'softDrop']);
+  });
+
+  it('放開後停止重複', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 160, arr: 40 });
+    ic.press('softDrop');
+    ic.release('softDrop');
+    ic.update(1000);
+    expect(actions).toEqual(['softDrop']);
+  });
+
+  it('sdf=0 視為瞬降：每次 update 觸發多次但有單幀上限', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 160, arr: 40, sdf: 0 });
+    ic.press('softDrop'); // 1 次
+    ic.update(16);
+    expect(actions.length).toBeGreaterThan(1);
+    expect(actions.length).toBeLessThanOrEqual(1 + 20); // 單幀上限保護
+    const afterOneFrame = actions.length;
+    ic.update(16); // 持續按住：下一幀再觸發、同樣受上限
+    expect(actions.length).toBeGreaterThan(afterOneFrame);
+    expect(actions.length).toBeLessThanOrEqual(afterOneFrame + 20);
+    expect(actions.every((a) => a === 'softDrop')).toBe(true);
+  });
+
+  it('left/right 既有 DAS/ARR 行為不受 softDrop 影響（同時按住互不干擾）', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 160, arr: 40 });
+    ic.press('left');     // left x1
+    ic.press('softDrop'); // softDrop x1
+    ic.update(100); // left 未達 DAS；softDrop 30/60/90 → x3
+    expect(actions.filter((a) => a === 'left')).toEqual(['left']);
+    expect(actions.filter((a) => a === 'softDrop')).toHaveLength(4);
+    ic.update(80); // left 跨 DAS(160) → 第 2 次；softDrop 至 180ms → 共 7 次
+    expect(actions.filter((a) => a === 'left')).toHaveLength(2);
+    expect(actions.filter((a) => a === 'softDrop')).toHaveLength(7);
+    ic.release('softDrop');
+    ic.update(40); // left 每 ARR 一次；softDrop 已放開
+    expect(actions.filter((a) => a === 'left')).toHaveLength(3);
+    expect(actions.filter((a) => a === 'softDrop')).toHaveLength(7);
+  });
+
+  it('softDrop 不走 DAS 充能：未指定 sdf 也不會等 das 才重複', () => {
+    const actions: string[] = [];
+    const ic = new InputController((a) => actions.push(a), { das: 500, arr: 40 });
+    ic.press('softDrop');
+    ic.update(60); // 遠小於 das=500，但 sdf=30 應已重複 2 次
+    expect(actions).toEqual(['softDrop', 'softDrop', 'softDrop']);
+  });
+});

--- a/src/scripts/games/tetris/input/InputController.ts
+++ b/src/scripts/games/tetris/input/InputController.ts
@@ -1,11 +1,13 @@
 import type { InputAction } from '../engine/game';
 
-export interface DasArr { das: number; arr: number; }
+export interface DasArr { das: number; arr: number; sdf?: number; }
 type Emit = (action: InputAction) => void;
 
 const REPEATABLE: InputAction[] = ['left', 'right'];
+const SDF_DEFAULT_MS = 30;
+const SDF_MAX_PER_UPDATE = 20; // sdf<=0（瞬降）的單幀觸發上限，防爆
 
-/** 管理左右長按的 DAS/ARR；其餘 action 單次觸發。以 update(dt) 推進。 */
+/** 管理左右長按的 DAS/ARR 與 softDrop 長按的 SDF；其餘 action 單次觸發。以 update(dt) 推進。 */
 export class InputController {
   private held: Partial<Record<InputAction, { sinceMs: number; charged: boolean }>> = {};
   constructor(private emit: Emit, private cfg: DasArr) {}
@@ -17,6 +19,9 @@ export class InputController {
       if (action === 'left') delete this.held['right'];
       if (action === 'right') delete this.held['left'];
       this.held[action] = { sinceMs: 0, charged: false };
+    }
+    if (action === 'softDrop') {
+      this.held['softDrop'] = { sinceMs: 0, charged: true }; // 無 DAS 充能，直接進重複期
     }
   }
 
@@ -42,6 +47,24 @@ export class InputController {
           this.emit(action);
         }
       }
+    }
+    this.updateSoftDrop(dtMs);
+  }
+
+  private updateSoftDrop(dtMs: number): void {
+    const st = this.held['softDrop'];
+    if (!st) return;
+    const sdf = this.cfg.sdf ?? SDF_DEFAULT_MS;
+    if (sdf <= 0) {
+      // 0ms＝瞬降：每次 update 觸發多次，但設單幀上限防爆
+      for (let i = 0; i < SDF_MAX_PER_UPDATE; i++) this.emit('softDrop');
+      st.sinceMs = 0;
+      return;
+    }
+    st.sinceMs += dtMs;
+    while (st.sinceMs >= sdf) {
+      st.sinceMs -= sdf;
+      this.emit('softDrop');
     }
   }
 }

--- a/src/scripts/games/tetris/input/handling.test.ts
+++ b/src/scripts/games/tetris/input/handling.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { HANDLING_DEFAULT, HANDLING_RANGE, loadHandling, saveHandling } from './handling';
+
+describe('handling 設定（DAS/ARR/SDF）', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('未設定時回傳預設值（不汙染：回傳副本）', () => {
+    const h = loadHandling();
+    expect(h).toEqual({ das: 150, arr: 35, sdf: 30 });
+    h.das = 999;
+    expect(loadHandling().das).toBe(HANDLING_DEFAULT.das);
+  });
+
+  it('save → load 往返一致', () => {
+    saveHandling({ das: 80, arr: 0, sdf: 0 });
+    expect(loadHandling()).toEqual({ das: 80, arr: 0, sdf: 0 });
+  });
+
+  it('越界值 clamp 到範圍內', () => {
+    localStorage.setItem('tetris-handling', JSON.stringify({ das: 10, arr: 999, sdf: -5 }));
+    expect(loadHandling()).toEqual({
+      das: HANDLING_RANGE.das.min,
+      arr: HANDLING_RANGE.arr.max,
+      sdf: HANDLING_RANGE.sdf.min,
+    });
+  });
+
+  it('壞 JSON 回預設', () => {
+    localStorage.setItem('tetris-handling', '{not json');
+    expect(loadHandling()).toEqual(HANDLING_DEFAULT);
+  });
+
+  it('欄位缺漏或非數字 → 該欄位回預設', () => {
+    localStorage.setItem('tetris-handling', JSON.stringify({ das: 200, arr: 'fast' }));
+    expect(loadHandling()).toEqual({ das: 200, arr: HANDLING_DEFAULT.arr, sdf: HANDLING_DEFAULT.sdf });
+  });
+
+  it('localStorage 不可用（隱私模式 throw）→ load 回預設、save 靜默', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('denied'); });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('denied'); });
+    expect(loadHandling()).toEqual(HANDLING_DEFAULT);
+    expect(() => saveHandling({ das: 100, arr: 20, sdf: 10 })).not.toThrow();
+  });
+});

--- a/src/scripts/games/tetris/input/handling.ts
+++ b/src/scripts/games/tetris/input/handling.ts
@@ -1,0 +1,52 @@
+/**
+ * 玩家可調操作手感（handling）設定：DAS / ARR / SDF（皆為 ms）。
+ * - localStorage key `tetris-handling`，所有模式（solo/AI/1v1/FFA）開局讀取。
+ * - 壞 JSON / 越界 / 隱私模式 throw 一律回退到安全值（與 skins.ts 同慣例）。
+ */
+export interface Handling {
+  das: number;
+  arr: number;
+  sdf: number;
+}
+
+export const HANDLING_DEFAULT: Handling = { das: 150, arr: 35, sdf: 30 };
+
+export const HANDLING_RANGE = {
+  das: { min: 50, max: 300 },
+  arr: { min: 0, max: 80 }, // 0 = 瞬移
+  sdf: { min: 0, max: 60 }, // 0 = 瞬降
+} as const;
+
+const STORAGE_KEY = 'tetris-handling';
+
+/** 非有限數字 → 該欄位預設；否則 clamp 進範圍。 */
+function sanitize(key: keyof Handling, raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return HANDLING_DEFAULT[key];
+  const { min, max } = HANDLING_RANGE[key];
+  return Math.min(max, Math.max(min, raw));
+}
+
+/** 讀取玩家 handling 設定；任何錯誤回傳預設副本。 */
+export function loadHandling(): Handling {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...HANDLING_DEFAULT };
+    const parsed = JSON.parse(raw) as Partial<Record<keyof Handling, unknown>>;
+    return {
+      das: sanitize('das', parsed?.das),
+      arr: sanitize('arr', parsed?.arr),
+      sdf: sanitize('sdf', parsed?.sdf),
+    };
+  } catch {
+    return { ...HANDLING_DEFAULT };
+  }
+}
+
+/** 寫入玩家 handling 設定；隱私模式等任何錯誤靜默吸收。 */
+export function saveHandling(h: Handling): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(h));
+  } catch {
+    // 靜默
+  }
+}

--- a/src/scripts/games/tetris/net/ffaNetMain.ts
+++ b/src/scripts/games/tetris/net/ffaNetMain.ts
@@ -2,6 +2,7 @@ import { Text } from 'pixi.js';
 import { type InputAction } from '../engine/game';
 import { KEYMAP_1P } from '../input/keymap';
 import { InputController } from '../input/InputController';
+import { loadHandling } from '../input/handling';
 import { PixiStage } from '../render/PixiStage';
 import { SoundManager } from '../audio/SoundManager';
 import { loadGameTextures } from '../render/assets';
@@ -1042,7 +1043,7 @@ export function runFfaGame(opts: RunFfaOpts): FfaGameHandle {
 
   // 暫存本幀本地輸入（InputController 透過 emit 累加）。
   let pendingActions: InputAction[] = [];
-  const input = new InputController((a) => pendingActions.push(a), { das: 150, arr: 35 });
+  const input = new InputController((a) => pendingActions.push(a), loadHandling());
 
   void PixiStage.create(canvas).then(async (stage) => {
     // 皮膚只影響本地渲染（貼圖/調色），不進鎖步協定。

--- a/src/scripts/games/tetris/net/netMain.ts
+++ b/src/scripts/games/tetris/net/netMain.ts
@@ -188,14 +188,19 @@ function runGame(canvas: HTMLCanvasElement, transport: WebRtcTransport, opts: Ru
     silenceWarn.visible = false;
     stage.hudLayer.addChild(silenceWarn);
 
-    let lay: MatchLayout = computeMatchLayout(stage.width, stage.height);
+    let lay: MatchLayout = computeMatchLayout(stage.width, stage.height, localSide);
+    // G2：本機側 HOLD 拆到盤左、NEXT 留盤右（對齊 SOLO 慣例）；對手側維持單欄堆疊。
+    const layoutHud = (hud: HudView, side: MatchLayout['a']): void => {
+      if (side.holdAnchor) hud.setLayoutSolo(side.holdAnchor, side.hudAnchor, lay.cellSize);
+      else hud.setLayout(side.hudAnchor, lay.cellSize);
+    };
     function relayout(): void {
-      lay = computeMatchLayout(stage.width, stage.height);
+      lay = computeMatchLayout(stage.width, stage.height, localSide);
       stage.layoutBackground();
       boardA.setLayout(lay.cellSize, lay.a.origin);
       boardB.setLayout(lay.cellSize, lay.b.origin);
-      hudA.setLayout(lay.a.hudAnchor, lay.cellSize);
-      hudB.setLayout(lay.b.hudAnchor, lay.cellSize);
+      layoutHud(hudA, lay.a);
+      layoutHud(hudB, lay.b);
       fxA.setLayout(lay.cellSize, lay.a.origin);
       fxB.setLayout(lay.cellSize, lay.b.origin);
       meter.setLayout(lay.meter);

--- a/src/scripts/games/tetris/net/netMain.ts
+++ b/src/scripts/games/tetris/net/netMain.ts
@@ -4,6 +4,7 @@ import { type Side } from '../engine/match';
 import { getCells } from '../engine/piece';
 import { KEYMAP_1P } from '../input/keymap';
 import { InputController } from '../input/InputController';
+import { loadHandling } from '../input/handling';
 import { PixiStage } from '../render/PixiStage';
 import { BoardView } from '../render/BoardView';
 import { HudView } from '../render/HudView';
@@ -156,7 +157,7 @@ function runGame(canvas: HTMLCanvasElement, transport: WebRtcTransport, opts: Ru
   // 立刻建立 Lockstep：其 onMessage 馬上接管 transport，渲染初始化期間對手送來的幀會
   // 先排進 inbox（不會在 async 載入空檔被丟棄）。
   const lockstep = new Lockstep({ seed, localSide, transport: tappedTransport });
-  const input = new InputController((a) => lockstep.pressLocal(a), { das: 150, arr: 35 });
+  const input = new InputController((a) => lockstep.pressLocal(a), loadHandling());
 
   void PixiStage.create(canvas).then(async (stage) => {
     // 皮膚只影響本地渲染（貼圖/調色），不進鎖步協定。

--- a/src/scripts/games/tetris/render/FfaBoards.ts
+++ b/src/scripts/games/tetris/render/FfaBoards.ts
@@ -79,7 +79,12 @@ export class FfaBoards {
       if (!s) continue;
       s.layout = slot;
       s.board.setLayout(slot.cellSize, slot.origin);
-      s.hud.setLayout({ x: slot.origin.x + slot.cellSize * (BOARD_WIDTH + 0.4), y: slot.origin.y }, slot.cellSize);
+      // G2：本機盤 HOLD 拆到盤左、NEXT 留盤右（對齊 SOLO 慣例）；對手小盤維持單欄堆疊。
+      if (slot.isLocal && slot.holdAnchor && slot.infoAnchor) {
+        s.hud.setLayoutSolo(slot.holdAnchor, slot.infoAnchor, slot.cellSize);
+      } else {
+        s.hud.setLayout({ x: slot.origin.x + slot.cellSize * (BOARD_WIDTH + 0.4), y: slot.origin.y }, slot.cellSize);
+      }
       s.fx.setLayout(slot.cellSize, slot.origin);
     }
     this.standings.setLayout(lay.standings.anchor, lay.standings.scale);

--- a/src/scripts/games/tetris/render/HudView.ts
+++ b/src/scripts/games/tetris/render/HudView.ts
@@ -1,14 +1,15 @@
-import { Container, Sprite, Text, type Texture, type TextStyleOptions } from 'pixi.js';
+import { Container, Graphics, Sprite, Text, type Texture, type TextStyleOptions } from 'pixi.js';
 import { GlowFilter } from 'pixi-filters';
 import type { GameState, PieceType } from '../engine/types';
 import { SHAPES } from '../engine/constants';
 import { pieceTint, type Point } from './layout';
 
 const PIXEL_FONT = '"Press Start 2P", Consolas, monospace';
+/** G2 顯眼化：標籤由暗灰藍改霓虹青、字級加大，HOLD/NEXT 一眼可辨。 */
 const LABEL_STYLE: TextStyleOptions = {
   fontFamily: PIXEL_FONT,
-  fontSize: 9,
-  fill: 0x6fa8d8,
+  fontSize: 11,
+  fill: 0x36e6ff,
   letterSpacing: 1,
 };
 const VALUE_STYLE: TextStyleOptions = {
@@ -20,6 +21,9 @@ const VALUE_STYLE: TextStyleOptions = {
 /** 繪製 HOLD / NEXT / SCORE / LEVEL / LINES / COMBO。 */
 export class HudView {
   private root = new Container();
+  /** HOLD / NEXT 細框背板（G2 顯眼化；風格同盤後 scrim：墨底＋霓虹細框）。 */
+  private holdPlate = new Graphics();
+  private nextPlate = new Graphics();
   private holdSlot = new Container();
   private nextSlots: Container[] = [];
   private score = new Text({ text: '0', style: VALUE_STYLE });
@@ -36,6 +40,7 @@ export class HudView {
     hudLayer.addChild(this.root);
     this.root.filters = [new GlowFilter({ color: 0x36e6ff, outerStrength: 1.1, innerStrength: 0, distance: 8 })];
 
+    this.root.addChild(this.holdPlate, this.nextPlate); // 背板先加 → 在槽位/文字後面
     this.root.addChild(this.holdSlot);
     for (let i = 0; i < this.nextCount; i++) {
       const c = new Container();
@@ -72,7 +77,7 @@ export class HudView {
 
   /** 字級隨格大小縮放（HUD 在大盤面時也清楚可讀）。 */
   private applyScale(cellSize: number): void {
-    const label = Math.max(9, Math.round(cellSize * 0.3));
+    const label = Math.max(11, Math.round(cellSize * 0.38)); // G2：標題字級 +2 檔
     const value = Math.max(14, Math.round(cellSize * 0.62));
     for (const t of [this.holdSlotLabel, this.nextLabel, this.scoreLabel, this.levelLabel, this.linesLabel]) {
       t.style.fontSize = label;
@@ -81,10 +86,37 @@ export class HudView {
     this.combo.style.fontSize = Math.max(11, Math.round(cellSize * 0.4));
   }
 
-  /** 單欄堆疊（對戰雙盤用）：anchor = HUD 欄左上角。 */
+  /**
+   * 畫 HOLD / NEXT 背板（圓角墨底＋霓虹細框，風格同盤後 scrim）。
+   * holdTop / nextTop 為各區標題左上角；nextH 為 NEXT 區內容高（標題之下）。
+   */
+  private drawPlates(holdTop: Point, nextTop: Point, cellSize: number): void {
+    const pad = cellSize * 0.3;
+    const w = cellSize * 3.1;
+    const lh = cellSize * 0.5;
+    const slotH = cellSize * 2.4;
+    const r = cellSize * 0.35;
+    const holdH = lh + slotH;
+    const nextH = lh + this.nextSlots.length * slotH * 0.78;
+    const stroke = { color: 0x36e6ff, alpha: 0.45, width: Math.max(1, cellSize * 0.05) };
+    this.holdPlate.clear();
+    this.holdPlate
+      .roundRect(holdTop.x - pad, holdTop.y - pad, w, holdH + pad * 2, r)
+      .fill({ color: 0x04060d, alpha: 0.55 })
+      .stroke(stroke);
+    this.nextPlate.clear();
+    this.nextPlate
+      .roundRect(nextTop.x - pad, nextTop.y - pad, w, nextH + pad * 2, r)
+      .fill({ color: 0x04060d, alpha: 0.55 })
+      .stroke(stroke);
+  }
+
+  /** 單欄堆疊（對戰雙盤的「對手側」用）：anchor = HUD 欄左上角。維持現狀、不畫背板。 */
   setLayout(anchor: Point, cellSize: number): void {
     this.cellSize = cellSize;
     this.applyScale(cellSize);
+    this.holdPlate.clear();
+    this.nextPlate.clear();
     const x = anchor.x;
     let y = anchor.y;
     const gap = cellSize * 0.5;
@@ -110,10 +142,14 @@ export class HudView {
     this.combo.position.set(x, y);
   }
 
-  /** SOLO 版：HOLD 置於盤左、NEXT＋分數置於盤右（盤面置中、左右平衡的構圖）。 */
+  /**
+   * 拆欄版：HOLD 置於盤左、NEXT＋分數置於盤右（盤面置中、左右平衡的構圖）。
+   * SOLO 與對戰版面的「本機盤」共用（G2：對齊 SOLO 慣例、防 hold/next 誤認）。
+   */
   setLayoutSolo(holdAnchor: Point, infoAnchor: Point, cellSize: number): void {
     this.cellSize = cellSize;
     this.applyScale(cellSize);
+    this.drawPlates(holdAnchor, infoAnchor, cellSize);
     const gap = cellSize * 0.5;
     const slotH = cellSize * 2.4;
     const lh = cellSize * 0.5;

--- a/src/scripts/games/tetris/render/aiMain.ts
+++ b/src/scripts/games/tetris/render/aiMain.ts
@@ -5,6 +5,7 @@ import { applySkill, resetSlow } from '../engine/items';
 import { SoloRun, type SkillId } from '../engine/run';
 import { KEYMAP_1P } from '../input/keymap';
 import { InputController } from '../input/InputController';
+import { loadHandling } from '../input/handling';
 import { AiController, type Difficulty } from '../ai/AiController';
 import { PixiStage } from './PixiStage';
 import { BoardView } from './BoardView';
@@ -104,7 +105,7 @@ export async function startAi(
   let run = new SoloRun({ skill, seed, mode: 'ai' }); // 玩家（A）側能量/技能；AI 不用技能（v1）
   let slowLeftMs = 0; // 時之沙剩餘（tick dt 倒數 → 暫停相容）
   // A = 人類；B = AI（透過相同的 match.input API）
-  const inA = new InputController((a) => match.input('A', a), { das: 150, arr: 35 });
+  const inA = new InputController((a) => match.input('A', a), loadHandling());
   let ai = new AiController((act) => match.input('B', act), () => match.b.getState(), difficulty);
 
   let introMs = 2400;

--- a/src/scripts/games/tetris/render/aiMain.ts
+++ b/src/scripts/games/tetris/render/aiMain.ts
@@ -76,10 +76,12 @@ export async function startAi(
     stage.layoutBackground();
     boardA.setLayout(lay.cellSize, lay.a.origin);
     boardB.setLayout(lay.cellSize, lay.b.origin);
-    hudA.setLayout(lay.a.hudAnchor, lay.cellSize);
+    // G2：本機（A）HOLD 拆到盤左、NEXT 留盤右（對齊 SOLO 慣例）；對手（B）維持單欄堆疊。
+    const aHold = lay.a.holdAnchor ?? lay.a.hudAnchor;
+    hudA.setLayoutSolo(aHold, lay.a.hudAnchor, lay.cellSize);
     hudB.setLayout(lay.b.hudAnchor, lay.cellSize);
-    // 能量條放 A 側 HUD 欄右半（HOLD/NEXT 內容寬約 2.2 格，2.8 起不重疊）
-    itemHud?.setLayout({ x: lay.a.hudAnchor.x + lay.cellSize * 2.8, y: lay.a.hudAnchor.y }, lay.cellSize);
+    // 能量條掛 HOLD 下方（同 SOLO：標籤 0.5 + 槽 2.4 + 間距 0.5 格）
+    itemHud?.setLayout({ x: aHold.x, y: aHold.y + lay.cellSize * 3.4 }, lay.cellSize);
     fxA.setLayout(lay.cellSize, lay.a.origin);
     fxB.setLayout(lay.cellSize, lay.b.origin);
     meter.setLayout(lay.meter);

--- a/src/scripts/games/tetris/render/ffaLayout.test.ts
+++ b/src/scripts/games/tetris/render/ffaLayout.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeFfaLayout, PLAYER_TINTS, type FfaSlotLayout } from './ffaLayout';
+import { HOLD_W_CELLS } from './matchLayout';
 import { BOARD_WIDTH, VISIBLE_HEIGHT } from '../engine/constants';
 
 /** slot 的可見遊玩矩形（AABB）：origin 左上 + cellSize×(10×20)。 */
@@ -103,6 +104,32 @@ describe('computeFfaLayout', () => {
   it('空 playerIds → throw', () => {
     expect(() => computeFfaLayout([], 'p0', 1280, 720)).toThrow();
   });
+});
+
+describe('FFA 本機盤 HOLD 拆到盤左（G2）', () => {
+  /** 本機盤 holdAnchor 存在、HOLD 框在盤左、與所有盤不相交、不出畫面；NEXT 留盤右；對手盤無 holdAnchor。 */
+  function assertLocalHoldSplit(n: number, stageW: number, stageH: number): void {
+    const lay = computeFfaLayout(ids(n), 'p0', stageW, stageH);
+    const local = lay.slots.find((s) => s.isLocal)!;
+    expect(local.holdAnchor, `N=${n}: 本機盤應有 holdAnchor`).toBeDefined();
+    expect(local.infoAnchor, `N=${n}: 本機盤應有 infoAnchor`).toBeDefined();
+    const cs = local.cellSize;
+    // HOLD 框 AABB：寬 = HOLD_W_CELLS 格、高保守取滿盤高
+    const hr = { x: local.holdAnchor!.x, y: local.holdAnchor!.y, w: cs * HOLD_W_CELLS, h: cs * VISIBLE_HEIGHT };
+    expect(hr.x, `N=${n}: HOLD 不可出畫面`).toBeGreaterThanOrEqual(0);
+    expect(hr.x + hr.w, `N=${n}: HOLD 整塊應在本機盤左`).toBeLessThanOrEqual(local.origin.x);
+    for (const s of lay.slots) {
+      expect(overlaps(hr, rectOf(s)), `N=${n}: HOLD 框與 ${s.id} 盤重疊`).toBe(false);
+    }
+    expect(local.infoAnchor!.x, `N=${n}: NEXT 留盤右`).toBeGreaterThanOrEqual(local.origin.x + cs * BOARD_WIDTH);
+    for (const s of lay.slots.filter((x) => !x.isLocal)) {
+      expect(s.holdAnchor, `N=${n}: 對手盤 ${s.id} 應維持現狀（無 holdAnchor）`).toBeUndefined();
+    }
+  }
+
+  it('N=2（1v1 退化路徑）：本機盤 HOLD 在盤左且與兩盤不相交', () => assertLocalHoldSplit(2, 1280, 720));
+  it('N=3：本機盤 HOLD 在盤左、與本機/對手盤皆不相交', () => assertLocalHoldSplit(3, 1280, 720));
+  it('N=8：本機盤 HOLD 在盤左、與全部 8 盤不相交', () => assertLocalHoldSplit(8, 1600, 900));
 });
 
 describe('Pixi 渲染類別 import smoke（型別/匯出存在；像素渲染留 T11 e2e）', () => {

--- a/src/scripts/games/tetris/render/ffaLayout.ts
+++ b/src/scripts/games/tetris/render/ffaLayout.ts
@@ -1,9 +1,12 @@
 import { BOARD_WIDTH, VISIBLE_HEIGHT } from '../engine/constants';
-import { computeMatchLayout } from './matchLayout';
+import { computeMatchLayout, HOLD_W_CELLS, HOLD_GAP_CELLS } from './matchLayout';
 import type { Point } from './layout';
 
 /** 盤面長寬比（10:20 = 0.5）。 */
 const BOARD_ASPECT = BOARD_WIDTH / VISIBLE_HEIGHT;
+
+/** 本機盤左右側欄（格數）：HOLD 與 NEXT/分數欄對稱（G2，對齊 SOLO 慣例）。 */
+const SIDE_COLS = HOLD_W_CELLS + HOLD_GAP_CELLS; // 4.1
 
 /** 每位玩家一塊版面。isLocal 決定大盤/環繞小盤與 HUD 詳略。 */
 export interface FfaSlotLayout {
@@ -11,6 +14,10 @@ export interface FfaSlotLayout {
   cellSize: number;
   origin: Point; // 該盤左上（可見遊玩區，扣掉緩衝列後的第一列）
   isLocal: boolean;
+  /** 僅本機盤有值：HOLD 槽錨點（盤左）。對手盤維持單欄堆疊現狀。 */
+  holdAnchor?: Point;
+  /** 僅本機盤有值：NEXT/分數欄錨點（盤右）。 */
+  infoAnchor?: Point;
 }
 
 export interface FfaLayout {
@@ -73,11 +80,19 @@ export function computeFfaLayout(
   // ── N<=2：退化到既有 1v1 雙盤版面（鐵則 #3）──
   // 本機固定取 A 側（左）、對手取 B 側（右）；cellSize 與 1v1 對稱雙盤一致。
   if (playerIds.length <= 2) {
-    const m = computeMatchLayout(stageW, stageH);
+    const m = computeMatchLayout(stageW, stageH); // 本機固定 A 側 → m.a 帶 holdAnchor
     const slots: FfaSlotLayout[] = playerIds.map((id) => {
       const isLocal = id === local;
       const src = isLocal ? m.a : m.b;
-      return { id, cellSize: m.cellSize, origin: { x: src.origin.x, y: src.origin.y }, isLocal };
+      return {
+        id,
+        cellSize: m.cellSize,
+        origin: { x: src.origin.x, y: src.origin.y },
+        isLocal,
+        ...(isLocal
+          ? { holdAnchor: src.holdAnchor, infoAnchor: { x: src.hudAnchor.x, y: src.hudAnchor.y } }
+          : {}),
+      };
     });
     const standingsAnchor: Point = { x: Math.round(stageW * 0.5 - m.cellSize * 1.2), y: Math.round(stageH * 0.04) };
     return { slots, standings: { anchor: standingsAnchor, scale: 1 } };
@@ -98,8 +113,19 @@ export function computeFfaLayout(
   const localFrac = oppCount <= 3 ? 0.5 : 0.46;
   const localBoxW = innerW * localFrac - gap / 2;
   const localBoxH = innerH;
-  const localCell = fitCellSize(localBoxW, localBoxH);
+  // 本機盤左右各留一側欄（HOLD 在盤左、NEXT/分數在盤右）→ 寬度按整組（盤+兩側欄）算，
+  // 空間不足時 cellSize 自然縮一檔、保不重疊（G2 鐵則）。
+  const localCell = Math.max(
+    1,
+    Math.floor(Math.min(localBoxW / (BOARD_WIDTH + SIDE_COLS * 2), localBoxH / VISIBLE_HEIGHT)),
+  );
+  // 左右側欄等寬 → 盤本體仍在左區水平置中；垂直照舊置中。
   const localOrigin = centerInBox(margin, margin, localBoxW, localBoxH, localCell);
+  const localHoldAnchor: Point = { x: Math.round(localOrigin.x - SIDE_COLS * localCell), y: localOrigin.y };
+  const localInfoAnchor: Point = {
+    x: Math.round(localOrigin.x + (BOARD_WIDTH + HOLD_GAP_CELLS) * localCell),
+    y: localOrigin.y,
+  };
 
   // 右區網格容納 oppCount 個對手盤。
   const gridX = margin + localBoxW + gap;
@@ -138,7 +164,14 @@ export function computeFfaLayout(
   let oppIndex = 0;
   for (const id of playerIds) {
     if (id === local) {
-      slots.push({ id, cellSize: localCell, origin: { ...localOrigin }, isLocal: true });
+      slots.push({
+        id,
+        cellSize: localCell,
+        origin: { ...localOrigin },
+        isLocal: true,
+        holdAnchor: { ...localHoldAnchor },
+        infoAnchor: { ...localInfoAnchor },
+      });
       continue;
     }
     const r = Math.floor(oppIndex / cols);

--- a/src/scripts/games/tetris/render/main.ts
+++ b/src/scripts/games/tetris/render/main.ts
@@ -6,6 +6,7 @@ import { applySkill, resetSlow } from '../engine/items';
 import { SoloRun, stackHeight, type SkillId, type PerkChoice, type PerkId } from '../engine/run';
 import { KEYMAP_1P } from '../input/keymap';
 import { InputController } from '../input/InputController';
+import { loadHandling } from '../input/handling';
 import { PixiStage } from './PixiStage';
 import { BoardView } from './BoardView';
 import { HudView } from './HudView';
@@ -130,7 +131,7 @@ export async function startTetris(
   const onResize = () => relayout();
   stage.app.renderer.on('resize', onResize);
 
-  const input = new InputController((action) => game.input(action), { das: 150, arr: 35 });
+  const input = new InputController((action) => game.input(action), loadHandling());
   const sound = new SoundManager();
   let paused = false;
   let gameOverShown = false;

--- a/src/scripts/games/tetris/render/matchLayout.test.ts
+++ b/src/scripts/games/tetris/render/matchLayout.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { computeMatchLayout, HOLD_W_CELLS } from './matchLayout';
+import { BOARD_WIDTH, VISIBLE_HEIGHT } from '../engine/constants';
+import type { Point } from './layout';
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+/** 兩矩形是否重疊（嚴格相交，邊貼齊不算重疊）。 */
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+const boardRect = (o: Point, cs: number): Rect => ({ x: o.x, y: o.y, w: cs * BOARD_WIDTH, h: cs * VISIBLE_HEIGHT });
+/** HOLD 框 AABB：寬 = HOLD_W_CELLS 格；高保守取滿盤高（鐵則：水平就要完全分離）。 */
+const holdRect = (a: Point, cs: number): Rect => ({ x: a.x, y: a.y, w: cs * HOLD_W_CELLS, h: cs * VISIBLE_HEIGHT });
+
+describe('computeMatchLayout：本機側 HOLD 拆到盤左（G2）', () => {
+  it('localSide=A（預設）：a.holdAnchor 在 A 盤左、與兩盤/計量條不相交、不出畫面；NEXT 留盤右；對手側無 holdAnchor', () => {
+    for (const [w, h] of [[1280, 720], [1024, 600], [1600, 900]] as const) {
+      const lay = computeMatchLayout(w, h);
+      const cs = lay.cellSize;
+      expect(lay.a.holdAnchor, `${w}x${h}: 本機側應有 holdAnchor`).toBeDefined();
+      const hr = holdRect(lay.a.holdAnchor!, cs);
+      expect(hr.x, `${w}x${h}: HOLD 不可出畫面`).toBeGreaterThanOrEqual(0);
+      expect(hr.x + hr.w, `${w}x${h}: HOLD 整塊應在 A 盤左`).toBeLessThanOrEqual(lay.a.origin.x);
+      expect(overlaps(hr, boardRect(lay.a.origin, cs)), `${w}x${h}: HOLD 與 A 盤重疊`).toBe(false);
+      expect(overlaps(hr, boardRect(lay.b.origin, cs)), `${w}x${h}: HOLD 與 B 盤重疊`).toBe(false);
+      expect(overlaps(hr, lay.meter), `${w}x${h}: HOLD 與計量條重疊`).toBe(false);
+      // NEXT/分數欄留在盤右
+      expect(lay.a.hudAnchor.x).toBeGreaterThanOrEqual(lay.a.origin.x + cs * BOARD_WIDTH);
+      // 對手側維持單欄堆疊現狀
+      expect(lay.b.holdAnchor).toBeUndefined();
+    }
+  });
+
+  it('localSide=B：b.holdAnchor 在 B 盤左、NEXT 欄在 B 盤右且不出畫面；A 側維持現狀', () => {
+    const stageW = 1280;
+    const lay = computeMatchLayout(stageW, 720, 'B');
+    const cs = lay.cellSize;
+    expect(lay.b.holdAnchor).toBeDefined();
+    const hr = holdRect(lay.b.holdAnchor!, cs);
+    expect(hr.x + hr.w, 'HOLD 整塊應在 B 盤左').toBeLessThanOrEqual(lay.b.origin.x);
+    expect(overlaps(hr, boardRect(lay.a.origin, cs)), 'HOLD 與 A 盤重疊').toBe(false);
+    expect(overlaps(hr, boardRect(lay.b.origin, cs)), 'HOLD 與 B 盤重疊').toBe(false);
+    expect(overlaps(hr, lay.meter), 'HOLD 與計量條重疊').toBe(false);
+    expect(lay.b.hudAnchor.x, 'NEXT 留 B 盤右').toBeGreaterThanOrEqual(lay.b.origin.x + cs * BOARD_WIDTH);
+    expect(lay.b.hudAnchor.x + cs * HOLD_W_CELLS, 'NEXT 欄不可出畫面').toBeLessThanOrEqual(stageW);
+    expect(lay.a.holdAnchor).toBeUndefined();
+  });
+});

--- a/src/scripts/games/tetris/render/matchLayout.ts
+++ b/src/scripts/games/tetris/render/matchLayout.ts
@@ -3,15 +3,24 @@ import type { Point } from './layout';
 
 const HUD_COLS = 4;
 const METER_COLS = 2;
-/** 左右兩盤 + 兩側 HUD + 中央計量條的總欄數 */
-const TOTAL_COLS = 2 * BOARD_WIDTH + 2 * HUD_COLS + METER_COLS; // 30
+/** 本機側 HOLD 槽寬（格）＋與盤的間距（格）——對齊 SOLO 慣例（main.ts holdW 3.2 / sideGap 0.9）。 */
+export const HOLD_W_CELLS = 3.2;
+export const HOLD_GAP_CELLS = 0.9;
+const HOLD_COLS = HOLD_W_CELLS + HOLD_GAP_CELLS; // 4.1
+/** 左右兩盤 + 兩側 HUD + 中央計量條 + 本機側盤左 HOLD 欄的總欄數 */
+const TOTAL_COLS = HOLD_COLS + 2 * BOARD_WIDTH + 2 * HUD_COLS + METER_COLS; // 34.1
 
 export const P1_TINT = 0x36e6ff; // 青
 export const P2_TINT = 0xff4d6d; // 洋紅
 
+export type MatchSide = 'A' | 'B';
+
 export interface SideLayout {
   origin: Point;
+  /** 單欄 HUD 錨點；本機側時為 NEXT/分數欄（盤右）。 */
   hudAnchor: Point;
+  /** 僅本機側有值：HOLD 槽錨點（盤左，對齊 SOLO 慣例）。對手側維持單欄堆疊、無此欄。 */
+  holdAnchor?: Point;
   tint: number;
 }
 export interface MatchLayout {
@@ -21,8 +30,12 @@ export interface MatchLayout {
   meter: { x: number; y: number; w: number; h: number };
 }
 
-/** 對稱雙盤版面：A 在左、B 在右、計量條置中。對標 ui/C-battle-symmetric.jpg。 */
-export function computeMatchLayout(stageW: number, stageH: number): MatchLayout {
+/**
+ * 對稱雙盤版面：A 在左、B 在右、計量條置中。對標 ui/C-battle-symmetric.jpg。
+ * G2：本機側（localSide）HOLD 拆到該盤左側、NEXT/分數留盤右（對齊 SOLO 慣例、防 hold/next 誤認）；
+ * 對手側維持單欄堆疊。多出的 HOLD 欄已計入 TOTAL_COLS → cellSize 自然縮一檔、保不重疊。
+ */
+export function computeMatchLayout(stageW: number, stageH: number, localSide: MatchSide = 'A'): MatchLayout {
   const byHeight = (stageH * 0.82) / VISIBLE_HEIGHT;
   const byWidth = (stageW * 0.94) / TOTAL_COLS;
   const cs = Math.max(10, Math.floor(Math.min(byHeight, byWidth)));
@@ -32,16 +45,52 @@ export function computeMatchLayout(stageW: number, stageH: number): MatchLayout 
   const wellH = cs * VISIBLE_HEIGHT;
   const originY = Math.round((stageH - wellH) / 2);
 
+  const meterRect = (meterX: number) => ({
+    x: meterX + METER_COLS * cs * 0.5 - cs * 0.3,
+    y: originY,
+    w: cs * 0.6,
+    h: wellH,
+  });
+
+  if (localSide === 'A') {
+    // 欄序：[A HOLD][A 盤][A 資訊][計量條][B HUD][B 盤]
+    const aHoldX = startX;
+    const aBoardX = Math.round(startX + HOLD_COLS * cs);
+    const aInfoX = Math.round(startX + (HOLD_COLS + BOARD_WIDTH + HOLD_GAP_CELLS) * cs);
+    const meterX = Math.round(startX + (HOLD_COLS + BOARD_WIDTH + HUD_COLS) * cs);
+    const bHudX = Math.round(startX + (HOLD_COLS + BOARD_WIDTH + HUD_COLS + METER_COLS + 0.3) * cs);
+    const bBoardX = Math.round(startX + (HOLD_COLS + BOARD_WIDTH + HUD_COLS + METER_COLS + HUD_COLS) * cs);
+    return {
+      cellSize: cs,
+      a: {
+        origin: { x: aBoardX, y: originY },
+        hudAnchor: { x: aInfoX, y: originY },
+        holdAnchor: { x: aHoldX, y: originY },
+        tint: P1_TINT,
+      },
+      b: { origin: { x: bBoardX, y: originY }, hudAnchor: { x: bHudX, y: originY }, tint: P2_TINT },
+      meter: meterRect(meterX),
+    };
+  }
+
+  // localSide === 'B'：欄序 [A 盤][A HUD][計量條][B HOLD][B 盤][B 資訊]
   const aBoardX = startX;
   const aHudX = Math.round(startX + (BOARD_WIDTH + 0.3) * cs);
   const meterX = Math.round(startX + (BOARD_WIDTH + HUD_COLS) * cs);
-  const bHudX = Math.round(startX + (BOARD_WIDTH + HUD_COLS + METER_COLS + 0.3) * cs);
-  const bBoardX = Math.round(startX + (BOARD_WIDTH + HUD_COLS + METER_COLS + HUD_COLS) * cs);
-
+  const bHoldX = Math.round(startX + (BOARD_WIDTH + HUD_COLS + METER_COLS) * cs);
+  const bBoardX = Math.round(startX + (BOARD_WIDTH + HUD_COLS + METER_COLS + HOLD_COLS) * cs);
+  const bInfoX = Math.round(
+    startX + (BOARD_WIDTH + HUD_COLS + METER_COLS + HOLD_COLS + BOARD_WIDTH + HOLD_GAP_CELLS) * cs,
+  );
   return {
     cellSize: cs,
     a: { origin: { x: aBoardX, y: originY }, hudAnchor: { x: aHudX, y: originY }, tint: P1_TINT },
-    b: { origin: { x: bBoardX, y: originY }, hudAnchor: { x: bHudX, y: originY }, tint: P2_TINT },
-    meter: { x: meterX + METER_COLS * cs * 0.5 - cs * 0.3, y: originY, w: cs * 0.6, h: wellH },
+    b: {
+      origin: { x: bBoardX, y: originY },
+      hudAnchor: { x: bInfoX, y: originY },
+      holdAnchor: { x: bHoldX, y: originY },
+      tint: P2_TINT,
+    },
+    meter: meterRect(meterX),
   };
 }

--- a/tests/e2e/games-tetris-menu.spec.ts
+++ b/tests/e2e/games-tetris-menu.spec.ts
@@ -53,3 +53,43 @@ test.describe('Tetris 主選單三分頁', () => {
     await expect(page.locator('#online-panel')).toBeHidden();
   });
 });
+
+// G4：HANDLING 手感設定（DAS/ARR/SDF 滑桿，localStorage `tetris-handling`，下一局生效）
+// 開關鈕在面板底部，dev server 的 astro-dev-toolbar 會攔截 pointer events（僅 dev 存在）→ 先移除。
+async function removeDevToolbar(page: import('@playwright/test').Page): Promise<void> {
+  await page
+    .locator('astro-dev-toolbar')
+    .evaluate((el) => el.remove(), undefined, { timeout: 3000 })
+    .catch(() => {}); // production build 無 toolbar
+}
+
+test.describe('Tetris HANDLING 手感設定', () => {
+  test('開面板 → 調 DAS → localStorage 反映且重載後保留', async ({ page }) => {
+    await page.goto('/games/tetris');
+    await removeDevToolbar(page);
+    await page.locator('#handling-open').click();
+    await expect(page.locator('#handling-panel')).toBeVisible();
+    await page.locator('#handling-das').fill('250');
+    await expect(page.locator('#handling-das-val')).toHaveText('250ms');
+    const stored = await page.evaluate(() => localStorage.getItem('tetris-handling'));
+    expect(JSON.parse(stored ?? '{}')).toEqual({ das: 250, arr: 35, sdf: 30 });
+    await page.reload();
+    await removeDevToolbar(page);
+    await page.locator('#handling-open').click();
+    await expect(page.locator('#handling-das')).toHaveValue('250');
+  });
+
+  test('恢復預設回 150/35/30，「完成」收合面板', async ({ page }) => {
+    await page.goto('/games/tetris');
+    await page.evaluate(() => localStorage.setItem('tetris-handling', JSON.stringify({ das: 80, arr: 0, sdf: 0 })));
+    await removeDevToolbar(page);
+    await page.locator('#handling-open').click();
+    await expect(page.locator('#handling-das')).toHaveValue('80'); // 開啟時同步現值
+    await page.locator('#handling-reset').click();
+    await expect(page.locator('#handling-das')).toHaveValue('150');
+    const stored = await page.evaluate(() => localStorage.getItem('tetris-handling'));
+    expect(JSON.parse(stored ?? '{}')).toEqual({ das: 150, arr: 35, sdf: 30 });
+    await page.locator('#handling-done').click();
+    await expect(page.locator('#handling-panel')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## 遊戲手感打磨 — 真實玩家回饋逐項修復

來源：朋友實測回饋的系統性拆解（spec 內有逐項根因）。

| 回饋 | 根因 | 修復 |
|---|---|---|
| softdrop 沒做好 | REPEATABLE 只有左右，按住↓只觸發一次 | 連續 SDF（預設 30ms、0=瞬降） |
| HOLD/NEXT 同邊會放錯、太不明顯 | 對戰版面 HOLD+NEXT 疊同欄 | 本機盤 HOLD 移盤左（1v1/AI/FFA 對齊 SOLO 慣例）＋標題霓虹青加亮+墨底框背板 |
| AI 不會 hold、hard AI 自己疊死 | bot 零 hold 概念；**level 13+ 重力跑贏 AI 每 80ms 走一步 → 亂放疊死** | Dellacherie 六特徵評估＋hold 雙路徑評估＋同 tick 出完整手；舊版 6 seed 全 topout（~370 塊）→ 新版 600 塊全存活、消 238/240 行、每局 hold ~200 次 |
| 可調 ARR/DAS/SDF | 寫死 {das:150, arr:35} | PLAY 分頁設定面板（滑桿+恢復預設，localStorage，四模式生效） |

旋轉系統（SRS）玩家確認無問題，未動。

### 測試
單元 **727 全綠**（+20：SDF 節奏/handling 載入/Dellacherie hold 與防自滅回歸基準/版面不重疊 AABB）；e2e **35/35（13 specs）**；build 綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
