### PR TITLE
feat(ai): AI 難度重平衡 — hard 人類能贏＋新增 INSANE 超級模式

### DIFF
--- a/src/pages/games/tetris.astro
+++ b/src/pages/games/tetris.astro
@@ -49,6 +49,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
             <button class="ms-btn" data-mode="ai" data-diff="easy">vs AI · EASY</button>
             <button class="ms-btn" data-mode="ai" data-diff="normal">vs AI · NORMAL</button>
             <button class="ms-btn ms-hard" data-mode="ai" data-diff="hard">vs AI · HARD</button>
+            <button class="ms-btn ms-insane" data-mode="ai" data-diff="insane" title="神級 AI：人類無法戰勝">vs AI · INSANE<span class="ms-sub">人類無法戰勝</span></button>
             <button class="ms-btn ms-online" data-mode="online">vs ONLINE</button>
           </div>
           <button class="handling-open" id="handling-open" type="button" aria-expanded="false" aria-controls="handling-panel">HANDLING 手感設定</button>
@@ -318,6 +319,24 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   .ms-solo:hover { box-shadow: 0 0 22px rgba(77, 255, 136, 0.75); }
   .ms-hard { border-color: rgba(255, 77, 109, 0.7); box-shadow: 0 0 12px rgba(255, 77, 109, 0.3); }
   .ms-hard:hover { box-shadow: 0 0 22px rgba(255, 77, 109, 0.8); }
+  /* INSANE：神級超級模式（原 hard 參數）——紫紅警示霓虹 + 副標警語 */
+  .ms-insane {
+    color: #ffd2f2;
+    border-color: rgba(255, 45, 168, 0.8);
+    box-shadow: 0 0 12px rgba(255, 45, 168, 0.35), inset 0 0 18px rgba(168, 32, 255, 0.18);
+  }
+  .ms-insane:hover {
+    color: #ffeafa;
+    box-shadow: 0 0 26px rgba(255, 45, 168, 0.85), inset 0 0 22px rgba(168, 32, 255, 0.3);
+  }
+  .ms-sub {
+    display: block;
+    margin-top: 6px;
+    font-size: 8px;
+    letter-spacing: 3px;
+    color: #ff5ec4;
+    text-shadow: 0 0 8px rgba(255, 45, 168, 0.6);
+  }
   .ms-online { border-color: rgba(193, 92, 255, 0.7); box-shadow: 0 0 12px rgba(193, 92, 255, 0.3); }
   .ms-online:hover { box-shadow: 0 0 22px rgba(193, 92, 255, 0.8); }
   .ms-wallet { border-color: rgba(255, 210, 63, 0.7); box-shadow: 0 0 12px rgba(255, 210, 63, 0.3); font-size: 11px; }
@@ -966,7 +985,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
   import { startQueue, type MatchedInfo, type QueueHandle } from '@scripts/games/tetris/net/queueClient';
   import { DEFAULT_RATING } from '@scripts/games/tetris/net/elo';
 
-  type Diff = 'easy' | 'normal' | 'hard';
+  type Diff = 'easy' | 'normal' | 'hard' | 'insane';
   const SOLO_HINT = 'MOVE ←→ · ROTATE ↑/Z · DROP SPACE · HOLD SHIFT · ESC PAUSE · MUTE M';
   const ONLINE_HINT = 'ONLINE · MOVE ←→ · ROTATE ↑/Z · DROP SPACE · HOLD SHIFT · ESC MENU · MUTE M';
 
@@ -1231,7 +1250,7 @@ const skillCards = Object.entries(SKILLS).map(([id, s]) => ({ id, name: s.name, 
     if (started || !canvas) return;
     started = true;
     mainMenu?.remove();
-    const diff = (['easy', 'normal', 'hard'].includes(diffRaw ?? '') ? diffRaw : 'normal') as Diff;
+    const diff = (['easy', 'normal', 'hard', 'insane'].includes(diffRaw ?? '') ? diffRaw : 'normal') as Diff;
     setHint(`vs AI [${diff.toUpperCase()}] · MOVE ←→ · ROTATE ↑/Z · DROP SPACE · HOLD SHIFT${skill ? ' · SKILL V' : ''} · ESC PAUSE · M MUTE`);
     startAi(canvas, diff, { onEnd: (w) => showResult(w === 'A' ? 'YOU WIN' : 'AI WINS'), skinId: getSelectedSkin(wallet?.address), skill })
       .then((h) => { gameHandle = h; gameRunning = true; pausable = true; })

--- a/src/scripts/games/tetris/ai/AiController.test.ts
+++ b/src/scripts/games/tetris/ai/AiController.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { TetrisGame } from '../engine/game';
-import { AiController } from './AiController';
+import { AiController, type Difficulty } from './AiController';
+
+/** 決定性 rng（LCG）：失誤判定可重現，速率探針不抖動。 */
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => ((s = (Math.imul(s, 1664525) + 1013904223) >>> 0) / 2 ** 32);
+}
 
 describe('AiController', () => {
   it('在足夠時間內會讓對手盤面落子（自己會下棋）', () => {
@@ -11,18 +17,32 @@ describe('AiController', () => {
     expect(g.getState().board.flat().filter((c) => c).length).toBeGreaterThan(0);
   });
 
-  it('困難比簡單思考更快（間隔更短）', () => {
-    const fast = new AiController(() => {}, () => new TetrisGame({ seed: 1 }).getState(), 'hard');
-    const slow = new AiController(() => {}, () => new TetrisGame({ seed: 1 }).getState(), 'easy');
-    expect((fast as unknown as { intervalMs: number }).intervalMs)
-      .toBeLessThan((slow as unknown as { intervalMs: number }).intervalMs);
+  it('難度越高思考越快：insane < hard < normal < easy', () => {
+    const delay = (d: Difficulty) => {
+      const ai = new AiController(() => {}, () => new TetrisGame({ seed: 1 }).getState(), d);
+      return (ai as unknown as { intervalMs: number }).intervalMs;
+    };
+    expect(delay('insane')).toBeLessThan(delay('hard'));
+    expect(delay('hard')).toBeLessThan(delay('normal'));
+    expect(delay('normal')).toBeLessThan(delay('easy'));
+  });
+
+  it('insane 零失誤（mistakeRate = 0），其餘難度有失誤率', () => {
+    const rate = (d: Difficulty) => {
+      const ai = new AiController(() => {}, () => new TetrisGame({ seed: 1 }).getState(), d);
+      return (ai as unknown as { mistakeRate: number }).mistakeRate;
+    };
+    expect(rate('insane')).toBe(0);
+    expect(rate('hard')).toBeGreaterThan(0);
+    expect(rate('normal')).toBeGreaterThan(rate('hard'));
+    expect(rate('easy')).toBeGreaterThan(rate('normal'));
   });
 });
 
 /** 固定 seed 自打：AI 自己對著重力玩，回傳消行數/塊數/最終狀態。 */
-function selfPlay(seed: number, maxPieces: number) {
+function selfPlay(difficulty: Difficulty, seed: number, maxPieces: number) {
   const g = new TetrisGame({ seed });
-  const ai = new AiController((a) => g.input(a), () => g.getState(), 'hard');
+  const ai = new AiController((a) => g.input(a), () => g.getState(), difficulty, lcg(seed * 7 + 1));
   let pieces = 0;
   let ticks = 0;
   const MAX_TICKS = 120000; // 安全上限（16ms × 120000 = 32 分鐘模擬時間）
@@ -36,20 +56,66 @@ function selfPlay(seed: number, maxPieces: number) {
   return { lines: s.lines, pieces, status: s.status };
 }
 
-describe('AiController — 防自滅回歸基準（hard 純重力自打）', () => {
+describe('AiController — 防自滅回歸基準（insane 純重力自打）', () => {
   // 舊版（El-Tetris + 每 80ms 走一步）基線：600 塊目標下全 seed topout——
   // seed 42: 370 塊 132 行 topout / seed 7: 374 塊 134 行 topout / seed 555: 324 塊 113 行 topout。
   // 高等級重力（level 13+ 間隔 ≤ 18ms）超過逐步走子速度 → 亂放 → 疊死。
+  // 「最強」基準由 insane 承接（原 hard 80ms/零失誤參數整組搬到 insane）。
   it('固定 seed 自打 600 塊：不 topout 且消行 ≥ 150（舊版在此 topout）', () => {
-    const r = selfPlay(42, 600);
+    const r = selfPlay('insane', 42, 600);
     expect(r.status).toBe('playing');
     expect(r.pieces).toBe(600);
     expect(r.lines).toBeGreaterThanOrEqual(150);
   });
 
   it('換一個 seed 也不會自己疊死', () => {
-    const r = selfPlay(555, 600);
+    const r = selfPlay('insane', 555, 600);
     expect(r.status).toBe('playing');
     expect(r.lines).toBeGreaterThanOrEqual(150);
+  });
+});
+
+/**
+ * 速率探針：各難度純重力自打 30 秒「模擬時間」（16ms 固定步進，非牆鐘），
+ * 斷言消行速率落在設計帶。玩家回饋：舊 hard（80ms+零失誤）≈ 3 行/秒人類不可能贏 →
+ * hard 目標 0.4–1.0 行/秒（人類能贏）、insane 維持神級 > 2 行/秒、easy < 0.4 新手友善。
+ */
+function linesPerSecond(difficulty: Difficulty, seed: number, durationMs = 30_000): number {
+  const g = new TetrisGame({ seed });
+  const ai = new AiController((a) => g.input(a), () => g.getState(), difficulty, lcg(seed * 31 + 7));
+  let t = 0;
+  while (t < durationMs && g.getState().status === 'playing') {
+    ai.update(16);
+    g.step(16);
+    t += 16;
+  }
+  return g.getState().lines / (t / 1000);
+}
+
+/** 3 個 seed 平均，壓低單局 7-bag 運氣抖動。 */
+function avgRate(difficulty: Difficulty): number {
+  const seeds = [42, 555, 7];
+  return seeds.reduce((sum, s) => sum + linesPerSecond(difficulty, s), 0) / seeds.length;
+}
+
+describe('AiController — 難度速率帶（30 秒模擬時間自打）', () => {
+  it('easy < 0.4 行/秒（新手友善）', () => {
+    expect(avgRate('easy')).toBeLessThan(0.4);
+  });
+
+  it('normal 介於 easy 帶與 hard 帶之間（0.2–0.8 行/秒）', () => {
+    const r = avgRate('normal');
+    expect(r).toBeGreaterThan(0.2);
+    expect(r).toBeLessThan(0.8);
+  });
+
+  it('hard 0.4–1.0 行/秒（強但人類能贏；舊版 ≈ 3 行/秒）', () => {
+    const r = avgRate('hard');
+    expect(r).toBeGreaterThanOrEqual(0.4);
+    expect(r).toBeLessThanOrEqual(1.0);
+  });
+
+  it('insane > 2 行/秒（神級超級模式 = 原 hard 不降速）', () => {
+    expect(avgRate('insane')).toBeGreaterThan(2);
   });
 });

--- a/src/scripts/games/tetris/ai/AiController.ts
+++ b/src/scripts/games/tetris/ai/AiController.ts
@@ -3,12 +3,16 @@ import type { InputAction } from '../engine/game';
 import { BOARD_WIDTH } from '../engine/constants';
 import { decide, dropPlacement, type Placement } from './bot';
 
-export type Difficulty = 'easy' | 'normal' | 'hard';
+export type Difficulty = 'easy' | 'normal' | 'hard' | 'insane';
 
-/** 每塊的思考延遲（毫秒）——難度主要分層 */
-const THINK_MS: Record<Difficulty, number> = { easy: 420, normal: 200, hard: 80 };
-/** 失誤率：以此機率把目標落點偏移一欄（hard = 0，真的強） */
-const MISTAKE_RATE: Record<Difficulty, number> = { easy: 0.18, normal: 0.07, hard: 0 };
+/**
+ * 每塊的思考延遲（毫秒）——難度主要分層。
+ * 重平衡（玩家回饋：舊 hard 80ms+零失誤 ≈ 3 行/秒，人類不可能贏）：
+ * easy/normal/hard 全面放慢到人類節奏，原 hard 參數整組保留為 insane 神級超級模式。
+ */
+const THINK_MS: Record<Difficulty, number> = { easy: 900, normal: 650, hard: 480, insane: 80 };
+/** 失誤率：以此機率把目標落點偏移一欄（insane = 0，真的神） */
+const MISTAKE_RATE: Record<Difficulty, number> = { easy: 0.20, normal: 0.10, hard: 0.04, insane: 0 };
 
 /**
  * AI 控制器：每塊先「思考」THINK_MS，再一口氣執行決策序列

--- a/tests/e2e/games-tetris-ai.spec.ts
+++ b/tests/e2e/games-tetris-ai.spec.ts
@@ -31,4 +31,22 @@ test.describe('Dungeon Arcade — vs AI', () => {
       )
       .toBeGreaterThan(0);
   });
+
+  test('deep link ?diff=insane starts the god-mode AI (80ms think delay)', async ({ page, browserName }) => {
+    test.skip(browserName !== 'chromium', 'WebGL Pixi game smoke runs on chromium only');
+
+    await page.goto('/games/tetris?mode=ai&diff=insane');
+    await expect(page.locator('#main-menu')).toHaveCount(0);
+    await expect(page.locator('#tetris-hint')).toContainText('INSANE');
+    await page.waitForFunction(
+      () => Boolean((window as unknown as { __tetrisDebug?: { match?: unknown } }).__tetrisDebug?.match),
+      undefined,
+      { timeout: 20000 },
+    );
+    // insane = 原 hard 神級參數（80ms 思考延遲、零失誤）
+    const interval = await page.evaluate(
+      () => ((window as unknown as { __tetrisDebug: { ai: unknown } }).__tetrisDebug.ai as { intervalMs: number }).intervalMs,
+    );
+    expect(interval).toBe(80);
+  });
 });

--- a/tests/e2e/games-tetris-menu.spec.ts
+++ b/tests/e2e/games-tetris-menu.spec.ts
@@ -6,6 +6,9 @@ test.describe('Tetris 主選單三分頁', () => {
     await page.goto('/games/tetris');
     await expect(page.locator('.mm-tab', { hasText: 'PLAY' })).toHaveClass(/is-active/);
     await expect(page.locator('[data-mode="solo"]')).toBeVisible();
+    // AI 難度四級：INSANE 超級模式按鈕（紫紅警示）也要在選單上
+    await expect(page.locator('[data-mode="ai"][data-diff="insane"]')).toBeVisible();
+    await expect(page.locator('[data-mode="ai"][data-diff="insane"]')).toContainText('INSANE');
   });
 
   test('切到 LEADERBOARD 顯示清單容器（空狀態或資料）', async ({ page }) => {


### PR DESCRIPTION
## 背景

玩家回饋：新 AI hard（80ms 思考延遲＋零失誤）太強太快，25 秒消 77 行，正常人不可能贏；但建議把神級保留成「超級模式」。

## 變更

- `AiController` 難度改四級，原 hard 神級參數（80ms／零失誤）整組搬到新的 **INSANE**
- 選單新增「vs AI · INSANE」紫紅警示按鈕（副標＋title 提示「人類無法戰勝」，沿用 ms-btn 體系、無 inline style／!important）
- `?mode=ai&diff=insane` 深連結支援（型別鏈 AiController → aiMain → tetris.astro 全通）
- 新增速率探針測試：各難度純重力自打 30 秒模擬時間（16ms 固定步進、seeded rng，非牆鐘），斷言消行速率落在設計帶
- 防自滅回歸基準（600 塊不 topout、≥150 行）改由 insane 承接

## 實測消行速率（30 秒模擬時間 × 3 seeds 平均）

| 難度 | 思考延遲 | 失誤率 | 消行速率 | 目標帶 |
|---|---|---|---|---|
| easy | 900ms | 0.20 | **0.30 行/秒** | < 0.4 ✅ |
| normal | 650ms | 0.10 | **0.46 行/秒** | 0.2–0.8 ✅ |
| hard | 480ms | 0.04 | **0.72 行/秒** | 0.4–1.0（目標 0.5–0.8）✅ |
| insane（NEW） | 80ms | 0 | **4.96 行/秒** | > 2 ✅（＝原 hard，不降速） |

註：hard 表定 420ms 實測 0.89 行/秒超出 0.5–0.8 目標帶，微調至 480ms 落點 0.72。

## 驗證

- `npx vitest run`：**775 passed**（67 檔，含新增 9 個 AI 測試）
- `npx playwright test games-tetris-ai/menu/hall/items --project=chromium`：**23 passed**（含新增 insane 深連結＋INSANE 按鈕可見性）
- `npm run build` EXIT=0；tsc 無新增錯誤
- 選單截圖自查：INSANE 鈕紫紅警示風格正常顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)