### PR TITLE
feat(games): Dungeon Bomber 2-4 人連線對戰 + 排行榜

### DIFF
--- a/src/pages/api/_bomber-match.test.ts
+++ b/src/pages/api/_bomber-match.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Wallet, type HDNodeWallet } from 'ethers';
+import { BomberLockstep, LoopbackBomberHub } from '@scripts/games/bomber/net/bomberLockstep';
+import { liveStandings } from '@scripts/games/bomber/net/versusReplay';
+import { buildFfaResultMessage } from '@scripts/games/tetris/net/auth';
+import type { CharacterId } from '@scripts/games/bomber/engine/types';
+
+/**
+ * Bomber 結算端點測試（copy-adapt 自 _ffa-match.test.ts）。
+ * 端點與 bomber rankStore 共用同一單例（無 Upstash env → MemoryRankStore，bomber: 前綴）。
+ * 每個 case 先 vi.resetModules() 再 import 端點。
+ */
+async function loadPost() {
+  const mod = await import('./bomber-match');
+  return mod.POST;
+}
+
+/** 建一個 Astro APIContext 風格的呼叫物件（只用到 request / clientAddress）。 */
+function ctx(body: unknown, method = 'POST') {
+  const request = new Request('http://localhost/api/bomber-match', {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: method === 'POST' ? JSON.stringify(body) : undefined,
+  });
+  return { request, clientAddress: '127.0.0.1' } as never;
+}
+
+const CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
+
+/** 把全端推進到同一 confirmedFrame（消除 loopback 末輪一幀偏移）。 */
+function settle(nodes: BomberLockstep[], hub?: LoopbackBomberHub): void {
+  for (let r = 0; r < 200; r++) {
+    const max = Math.max(...nodes.map((n) => n.confirmedFrame));
+    const laggards = nodes.filter((n) => n.confirmedFrame < max);
+    if (laggards.length === 0) break;
+    for (const n of laggards) n.tick();
+    hub?.flush();
+  }
+}
+
+/**
+ * 用 N 個 wallet 跑一場可重現的 versus 局到分出勝負（P0 自爆先死）。
+ * matchId 第二段以 seed 的 base36 編碼（與 ffa-match / match.ts 的 seed 綁定一致）。
+ * 回傳每位 wallet 對應的 playerId（= wallet.address），含 replay / standings / matchId。
+ */
+function buildScenario(seed: number, n: number) {
+  const wallets = Array.from({ length: n }, () => Wallet.createRandom());
+  const playerIds = wallets.map((w) => w.address);
+  const characters: Record<string, CharacterId> = {};
+  playerIds.forEach((id, i) => (characters[id] = CHARS[i % CHARS.length]));
+
+  const hub = new LoopbackBomberHub();
+  const nodes = playerIds.map(
+    (localId) =>
+      new BomberLockstep({
+        playerIds,
+        localId,
+        seed,
+        arenaId: 0,
+        characters,
+        transport: hub.transportFor(localId),
+      }),
+  );
+  // P0 原地放彈自爆先死，其餘不動 → 必分出勝負。
+  nodes[0].queueLocal({ t: 'bomb' });
+
+  let p0Dead = false;
+  for (let f = 0; f < 6000 && nodes[0].match.getState().status === 'playing'; f++) {
+    for (const node of nodes) {
+      if (node.localId === playerIds[0] && p0Dead) continue;
+      node.tick();
+    }
+    const p0 = nodes[0].match.getState().players.find((p) => p.id === playerIds[0]);
+    if (p0 && !p0.alive) p0Dead = true;
+  }
+  settle(nodes, hub);
+
+  const node = nodes[0];
+  const replay = node.getReplay();
+  const standings = liveStandings(node.match, playerIds);
+  const stateHash = node.match.stateHash();
+  const matchId = `bomber-${seed.toString(36)}-room1`;
+  return { wallets, playerIds, standings, stateHash, replay, matchId };
+}
+
+/** 為某 wallet 對 (matchId, standings) 產生合法簽章（沿用 buildFfaResultMessage）。 */
+async function sign(wallet: Wallet | HDNodeWallet, matchId: string, standings: string[]) {
+  const placements = standings.map((_, i) => i + 1);
+  const msg = buildFfaResultMessage(matchId, standings, placements);
+  return wallet.signMessage(msg);
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('POST /api/bomber-match — 基本參數防護', () => {
+  it('非 POST → 400', async () => {
+    const POST = await loadPost();
+    const res = await POST(ctx(undefined, 'GET'));
+    expect(res.status).toBe(400);
+  });
+
+  it('壞 JSON → 400', async () => {
+    const POST = await loadPost();
+    const request = new Request('http://localhost/api/bomber-match', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{ not json',
+    });
+    const res = await POST({ request, clientAddress: '127.0.0.1' } as never);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('bad json');
+  });
+
+  it('缺必要欄位 → 400', async () => {
+    const POST = await loadPost();
+    const res = await POST(ctx({ matchId: 'bomber-1-x' }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/bomber-match — seed 綁定與 replay 抽驗', () => {
+  it('replay.seed 與 matchId 內嵌 seed 不符 → 400', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay } = buildScenario(42, 2);
+    const matchId = `bomber-${(99).toString(36)}-room1`; // seed 段刻意與 replay.seed 不同
+    const sig = await sign(wallets[0], matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: wallets[0].address, standings, stateHash, signature: sig, replay }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain('seed');
+  });
+
+  it('replay 與宣稱 standings 不符（竄改名次）→ 400', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(42, 2);
+    const tampered = [...standings].reverse(); // 竄改名次
+    const sig = await sign(wallets[0], matchId, tampered);
+    const res = await POST(
+      ctx({ matchId, reporterId: wallets[0].address, standings: tampered, stateHash, signature: sig, replay }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('stateHash 與 replay 重模擬不符（竄改最終盤面）→ 400', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, replay, matchId } = buildScenario(42, 2);
+    const sig = await sign(wallets[0], matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: wallets[0].address, standings, stateHash: '0xdeadbeef', signature: sig, replay }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('缺 replay → 400', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, matchId } = buildScenario(42, 2);
+    const sig = await sign(wallets[0], matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: wallets[0].address, standings, stateHash, signature: sig }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/bomber-match — 簽章驗證', () => {
+  it('壞簽章 / reporterId 與還原地址不符 → 401', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(42, 2);
+    // 用 wallet[0] 簽，但宣稱 reporterId 是 wallet[1] → 還原地址不符
+    const sig = await sign(wallets[0], matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: wallets[1].address, standings, stateHash, signature: sig, replay }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/bomber-match — 共識結算（2 人，門檻 ceil(2/2)=1）', () => {
+  it('回報者不在 standings 內（非參與者）→ 403', async () => {
+    const POST = await loadPost();
+    const { standings, stateHash, replay, matchId } = buildScenario(42, 2);
+    const outsider = Wallet.createRandom(); // 簽章有效，但非對局參與者
+    const sig = await sign(outsider, matchId, standings);
+    const res = await POST(
+      ctx({ matchId, reporterId: outsider.address, standings, stateHash, signature: sig, replay }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('2 人場：首位回報達門檻 → applied，含每位玩家結算欄位；再回報 → already', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(42, 2); // 門檻 1
+
+    const r1 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+      }),
+    );
+    expect(r1.status).toBe(200);
+    const body1 = await r1.json();
+    expect(body1.outcome).toBe('applied');
+    // 回應含每位玩家 { ratingBefore, ratingAfter, xpGained, level }
+    expect(Array.isArray(body1.results)).toBe(true);
+    expect(body1.results).toHaveLength(2);
+    const champ = body1.results.find((r: { id: string }) => r.id === standings[0].toLowerCase());
+    expect(champ).toBeTruthy();
+    expect(champ.ratingBefore).toBe(1000); // 新玩家基底
+    expect(champ.ratingAfter).toBeGreaterThan(1000); // 冠軍漲分
+    expect(champ.ratingAfter).toBeLessThan(1100); // 但絕非偽造大數
+    expect(champ.xpGained).toBeGreaterThan(0);
+    expect(champ.level).toBeGreaterThanOrEqual(1);
+    const last = body1.results.find((r: { id: string }) => r.id === standings[1].toLowerCase());
+    expect(last.ratingAfter).toBeLessThan(1000); // 敗方掉分
+
+    // 再次回報（已結算）→ already
+    const r2 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[1].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[1], matchId, standings),
+        replay,
+      }),
+    );
+    expect(r2.status).toBe(200);
+    expect((await r2.json()).outcome).toBe('already');
+  });
+});
+
+describe('POST /api/bomber-match — 共識結算（3-4 人，N-way ELO）', () => {
+  it('3 人場：首位回報 → pending（門檻 ceil(3/2)=2 未達），第二位達門檻 → applied', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(7, 3); // 門檻 2
+
+    const r1 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+      }),
+    );
+    expect(r1.status).toBe(200);
+    expect((await r1.json()).outcome).toBe('pending');
+
+    const r2 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[1].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[1], matchId, standings),
+        replay,
+      }),
+    );
+    expect(r2.status).toBe(200);
+    const body2 = await r2.json();
+    expect(body2.outcome).toBe('applied');
+    expect(body2.results).toHaveLength(3);
+  });
+
+  it('衝突：兩位回報不同名次且並列最高票 → conflict（409）', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(7, 3); // 門檻 2
+    // wallet[0] 回報真實 standings；wallet[1] 回報反轉名次（簽章/抽驗都過不了反轉，
+    // 故此處用「相同 replay 但宣稱不同 standings」會被 replay 抽驗擋下 → 改測同票分歧。
+    // 為觸發 conflict（並列最高），兩位各報一種不同但都通過抽驗的名次是不可能的
+    // （只有一種名次能通過 replay 抽驗）。故 conflict 由「非一致回報」自然被 replay 抽驗擋掉，
+    // 此處驗證：偽造名次的第二票會在 replay 抽驗前被擋（400），不會污染共識。
+    const r1 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+      }),
+    );
+    expect((await r1.json()).outcome).toBe('pending');
+
+    const tampered = [...standings].reverse();
+    const r2 = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[1].address,
+        standings: tampered,
+        stateHash,
+        signature: await sign(wallets[1], matchId, tampered),
+        replay,
+      }),
+    );
+    // 竄改名次過不了 replay 抽驗 → 400，且不入帳
+    expect(r2.status).toBe(400);
+  });
+
+  it('client 提供的 ratings 被忽略（防偽造基底分數）：結算後分數由後端基底算出', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(77, 2); // 門檻 1
+    const forged: Record<string, number> = {};
+    for (const id of standings) forged[id.toLowerCase()] = 9000;
+    const res = await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+        ratings: forged,
+      }),
+    );
+    const body = await res.json();
+    expect(body.outcome).toBe('applied');
+    const champ = body.results.find((r: { id: string }) => r.id === standings[0].toLowerCase());
+    expect(champ.ratingBefore).toBe(1000); // 偽造的 9000 不得生效
+    expect(champ.ratingAfter).toBeLessThan(1100);
+  });
+});
+
+describe('POST /api/bomber-match — ladder 隔離（bomber: 前綴，不污染 tetris）', () => {
+  it('bomber 結算後，tetris rankStore 對同一玩家仍為空（完全隔離）', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId } = buildScenario(99, 2);
+    await POST(
+      ctx({
+        matchId,
+        reporterId: wallets[0].address,
+        standings,
+        stateHash,
+        signature: await sign(wallets[0], matchId, standings),
+        replay,
+      }),
+    );
+    // bomber store 有該玩家
+    const { getBomberRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    const bomberRec = await getBomberRankStore().getPlayer(standings[0].toLowerCase());
+    expect(bomberRec).not.toBeNull();
+
+    // tetris store 對同一玩家為 null（隔離成功）
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    const tetrisRec = await getRankStore().getPlayer(standings[0].toLowerCase());
+    expect(tetrisRec).toBeNull();
+  });
+});

--- a/src/pages/api/_leaderboard.test.ts
+++ b/src/pages/api/_leaderboard.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { PlayerRecord } from '@scripts/games/tetris/net/rankStore';
+
+/**
+ * GET /api/leaderboard 端點測試（copy-adapt 自 _queue.test.ts / _bomber-match.test.ts）。
+ *
+ * 檔名以底線開頭（_leaderboard.test.ts）防止 Astro 把測試檔當路由打包。
+ * 每個 case 先 vi.resetModules() 取乾淨單例：無 Upstash env →
+ *   getRankStore()        = MemoryRankStore（tetris，ns=''）
+ *   getBomberRankStore()  = 另一個 MemoryRankStore 實例（bomber，ns='bomber:'）
+ * 端點與測試共用同一單例，故可直接 seed store 再驗 GET 路由結果。
+ *
+ * 核心驗證：
+ *   - game 參數路由（缺省/tetris → tetris store；bomber → bomber store）
+ *   - tetris 回應 byte-identical（缺省 與 ?game=tetris 完全相同）
+ *   - 兩個 ladder 完全隔離（互不污染）
+ *   - 未知 game 值 → 寬鬆退回 tetris（不回 400）
+ */
+
+async function loadGet() {
+  const mod = await import('./leaderboard');
+  return mod.GET;
+}
+
+type Get = Awaited<ReturnType<typeof loadGet>>;
+
+/** 建一個 Astro APIContext 風格的呼叫物件（GET 只用到 url）。 */
+function ctx(query = '') {
+  const url = new URL(`http://localhost/api/leaderboard${query}`);
+  return { url } as never;
+}
+
+async function call(GET: Get, query = ''): Promise<{ status: number; raw: string; rows: Array<Record<string, unknown>> }> {
+  const res = await GET(ctx(query));
+  const raw = await res.text();
+  return { status: res.status, raw, rows: (JSON.parse(raw) as { rows: Array<Record<string, unknown>> }).rows };
+}
+
+function rec(rating: number, name: string): PlayerRecord {
+  return { name, rating, wins: 3, losses: 1, xp: 120, level: 2, games: 4, top3: 2 };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('GET /api/leaderboard — game 參數路由', () => {
+  it('缺省 game → 讀 tetris ladder（getRankStore）', async () => {
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    await getRankStore().setPlayer('0xTETRIS', rec(1500, 'TETRIS-ACE'));
+
+    const GET = await loadGet();
+    const { status, rows } = await call(GET);
+    expect(status).toBe(200);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('0xTETRIS');
+    expect(rows[0].name).toBe('TETRIS-ACE');
+    expect(rows[0].rating).toBe(1500);
+    // 回應 shape：含 tier / level / wins / losses 等欄位
+    expect(rows[0]).toHaveProperty('tier');
+    expect(rows[0]).toHaveProperty('level');
+    expect(rows[0]).toHaveProperty('wins');
+    expect(rows[0]).toHaveProperty('losses');
+  });
+
+  it('?game=tetris → 與缺省 byte-identical（tetris 零回歸）', async () => {
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    await getRankStore().setPlayer('0xA', rec(1400, 'A'));
+    await getRankStore().setPlayer('0xB', rec(1600, 'B'));
+
+    const GET = await loadGet();
+    const def = await call(GET, '');
+    const explicit = await call(GET, '?game=tetris');
+    expect(def.status).toBe(200);
+    expect(explicit.status).toBe(200);
+    // 原始 JSON 字串完全相同 → byte-identical
+    expect(explicit.raw).toBe(def.raw);
+  });
+
+  it('?game=bomber → 讀 bomber ladder（getBomberRankStore），不是 tetris', async () => {
+    const { getRankStore, getBomberRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    await getRankStore().setPlayer('0xTETRIS', rec(1500, 'TETRIS-ACE'));
+    await getBomberRankStore().setPlayer('0xBOMBER', rec(1700, 'BOMBER-KING'));
+
+    const GET = await loadGet();
+    const { status, rows } = await call(GET, '?game=bomber');
+    expect(status).toBe(200);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('0xBOMBER');
+    expect(rows[0].name).toBe('BOMBER-KING');
+    expect(rows[0].rating).toBe(1700);
+  });
+
+  it('兩個 ladder 完全隔離：bomber 結果不含 tetris 玩家，反之亦然', async () => {
+    const { getRankStore, getBomberRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    await getRankStore().setPlayer('0xTETRIS', rec(1500, 'TETRIS-ACE'));
+    await getBomberRankStore().setPlayer('0xBOMBER', rec(1700, 'BOMBER-KING'));
+
+    const GET = await loadGet();
+    const tetris = await call(GET, '?game=tetris');
+    const bomber = await call(GET, '?game=bomber');
+
+    expect(tetris.rows.map((r) => r.id)).toEqual(['0xTETRIS']);
+    expect(bomber.rows.map((r) => r.id)).toEqual(['0xBOMBER']);
+  });
+
+  it('未知 game 值 → 寬鬆退回 tetris（不回 400）', async () => {
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    await getRankStore().setPlayer('0xTETRIS', rec(1500, 'TETRIS-ACE'));
+
+    const GET = await loadGet();
+    const { status, rows } = await call(GET, '?game=pacman');
+    expect(status).toBe(200);
+    expect(rows.map((r) => r.id)).toEqual(['0xTETRIS']);
+  });
+});
+
+describe('GET /api/leaderboard — n 參數仍照舊夾擠（回歸保護）', () => {
+  it('n 超過上限 100 → 夾到 100；非數字 → 預設 20（不影響少量資料回傳）', async () => {
+    const { getRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    // seed 3 名，驗 n 參數不會破壞回傳
+    await getRankStore().setPlayer('0xA', rec(1400, 'A'));
+    await getRankStore().setPlayer('0xB', rec(1600, 'B'));
+    await getRankStore().setPlayer('0xC', rec(1500, 'C'));
+
+    const GET = await loadGet();
+    const big = await call(GET, '?n=9999');
+    const bad = await call(GET, '?n=abc');
+    expect(big.status).toBe(200);
+    expect(bad.status).toBe(200);
+    // 高→低排序仍正確
+    expect(big.rows.map((r) => r.id)).toEqual(['0xB', '0xC', '0xA']);
+    expect(bad.rows.map((r) => r.id)).toEqual(['0xB', '0xC', '0xA']);
+  });
+});

--- a/src/pages/api/bomber-match.ts
+++ b/src/pages/api/bomber-match.ts
@@ -1,0 +1,212 @@
+import type { APIRoute } from 'astro';
+import { getBomberRankStore } from '@scripts/games/tetris/net/rankStore';
+import type { PlayerRecord, RankStore } from '@scripts/games/tetris/net/rankStore';
+import { verifySignature, buildFfaResultMessage } from '@scripts/games/tetris/net/auth';
+import { updateRatings, DEFAULT_RATING } from '@scripts/games/tetris/net/elo';
+import { updateRatingsNWay } from '@scripts/games/tetris/net/ffaElo';
+import { xpForMatch, levelForXp } from '@scripts/games/tetris/net/progression';
+import { verifyVersusReplay, type VersusReplay } from '@scripts/games/bomber/net/versusReplay';
+
+export const prerender = false;
+
+// 共識 / 結算暫存 TTL（比照 tetris ranking.ts 的 FFA 設定）
+const REPORT_TTL = 600; // 名次回報暫存 10 分鐘
+const SETTLED_TTL = 86_400; // 已結算標記 1 天（防重複計分）
+
+const json = (obj: unknown, status = 200): Response =>
+  new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' } });
+
+// 簡易 per-instance rate limit（搭配 Upstash 免費硬上限做雙保險）
+const hits = new Map<string, { n: number; reset: number }>();
+function limited(ip: string): boolean {
+  const now = Date.now();
+  const e = hits.get(ip);
+  if (!e || e.reset < now) {
+    hits.set(ip, { n: 1, reset: now + 60_000 });
+    return false;
+  }
+  e.n++;
+  return e.n > 30; // 30 次/分鐘/實例
+}
+
+function fresh(): PlayerRecord {
+  return { rating: DEFAULT_RATING, wins: 0, losses: 0, xp: 0, level: 1, games: 0, top3: 0 };
+}
+
+/** 單位玩家的結算結果（供 Task 15 結算畫面顯示）。 */
+export interface BomberSettleResult {
+  id: string;
+  placement: number;
+  ratingBefore: number;
+  ratingAfter: number;
+  xpGained: number;
+  level: number;
+}
+
+/**
+ * 套用一場 bomber versus 結算（標準名次制 ELO + XP），回傳每位玩家 before/after。
+ * - 2 人場走 elo.ts updateRatings；3-4 人場走 ffaElo.ts updateRatingsNWay。
+ *   （數學上 updateRatingsNWay 在 N=2 退化為 updateRatings，但 2 人仍顯式走
+ *    updateRatings 以符合 Task 規格「2 人場走 updateRatings」。）
+ * - XP 由 progression.ts xpForMatch/levelForXp 累加回推等級。
+ * ratings 為各玩家當前基底（後端讀取，client 傳入一律不可信，故此處只吃後端讀到的值）。
+ */
+async function applyBomberResult(
+  store: RankStore,
+  standings: string[],
+  ratings: Record<string, number>,
+): Promise<BomberSettleResult[]> {
+  const players = standings.length;
+
+  // 1) 算新 ELO（before 用 ratings；2 人顯式 updateRatings，其餘 N-way）
+  let newRatings: Record<string, number>;
+  if (players === 2) {
+    const [a, b] = standings; // index0 = 冠軍 = 勝方
+    const ra = Number(ratings[a] ?? DEFAULT_RATING);
+    const rb = Number(ratings[b] ?? DEFAULT_RATING);
+    const upd = updateRatings(ra, rb, 'a'); // a = 冠軍 = winner
+    newRatings = { [a]: upd.a, [b]: upd.b };
+  } else {
+    const ratingInput = standings.map((id, i) => ({
+      id,
+      rating: Number(ratings[id] ?? DEFAULT_RATING),
+      placement: i + 1,
+    }));
+    newRatings = updateRatingsNWay(ratingInput);
+  }
+
+  // 2) 逐位玩家更新紀錄並記錄 before/after 供回應
+  const out: BomberSettleResult[] = [];
+  for (let i = 0; i < standings.length; i++) {
+    const id = standings[i];
+    const placement = i + 1;
+    const isWinner = placement === 1;
+    const rec = (await store.getPlayer(id)) ?? fresh();
+    const ratingBefore = rec.rating;
+    const xpGained = xpForMatch(players, placement, isWinner);
+
+    rec.rating = newRatings[id];
+    rec.xp += xpGained;
+    rec.level = levelForXp(rec.xp);
+    rec.games += 1;
+    if (isWinner) rec.wins += 1; else rec.losses += 1;
+    if (placement <= 3) rec.top3 += 1;
+    await store.setPlayer(id, rec);
+
+    out.push({ id, placement, ratingBefore, ratingAfter: rec.rating, xpGained, level: rec.level });
+  }
+  return out;
+}
+
+/**
+ * POST /api/bomber-match — 回報 bomber versus 名次（需回報者錢包簽章）。
+ * body: { matchId, reporterId, standings, stateHash, signature, replay, ratings? }
+ *   standings: 名次順序，index0=冠軍。
+ *   stateHash: replay 重模擬的決定性盤面雜湊（與 standings 一起被抽驗）。
+ *   signature: 對 buildFfaResultMessage(matchId, standings, [1..N]) 的簽章。
+ *   replay:    供抽驗的可重播紀錄；seed 必須與 matchId 內嵌 seed 相符。
+ *   ratings:   忽略（一律由後端讀基底，防偽造灌分）。
+ *
+ * 共識（過半一致才入帳）/ conflict / duplicate(already) / 簽章 / replay seed 與 matchId 相符。
+ * rankStore key 一律 bomber: 前綴（getBomberRankStore），與 tetris 紀錄完全隔離。
+ */
+export const POST: APIRoute = async ({ request, clientAddress }) => {
+  let ip = 'unknown';
+  try { ip = clientAddress; } catch { /* 某些環境不提供 */ }
+  if (limited(ip)) return json({ error: 'rate limited' }, 429);
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: 'bad json' }, 400);
+  }
+
+  const { matchId, reporterId, standings, stateHash, signature } = body;
+  if (
+    typeof matchId !== 'string' ||
+    typeof reporterId !== 'string' ||
+    typeof stateHash !== 'string' ||
+    typeof signature !== 'string' ||
+    !Array.isArray(standings) ||
+    !standings.every((x) => typeof x === 'string')
+  ) {
+    return json({ error: 'bad params' }, 400);
+  }
+  // bomber versus：2..4 人（單機/熱座不入帳；4 人為對局上限）。
+  if (standings.length < 2 || standings.length > 4) {
+    return json({ error: 'player count out of range (2..4)' }, 400);
+  }
+  const m = matchId;
+  const reporter = reporterId.toLowerCase();
+  const order = standings as string[];
+  const lowerStandings = order.map((id) => id.toLowerCase());
+
+  // 回報者必須是對局參與者：非參與者的簽章不得計入共識
+  if (!lowerStandings.includes(reporter)) {
+    return json({ error: 'reporter not a participant' }, 403);
+  }
+
+  // ── replay 抽驗：名次與 stateHash 必須由 seed + 各玩家輸入重現 ──
+  const replay = body.replay as VersusReplay | undefined;
+  if (!replay || typeof replay !== 'object') {
+    return json({ error: 'missing replay' }, 400);
+  }
+  // seed 必須與 matchId 內嵌的 seed 相符（matchId 已被簽章 → 綁定 replay）
+  const seedFromMatch = parseInt(m.split('-')[1] ?? '', 36);
+  if (!Number.isFinite(seedFromMatch) || replay.seed !== seedFromMatch) {
+    return json({ error: 'replay seed mismatch' }, 400);
+  }
+  // 宣稱的 standings + stateHash 必須等於 replay 重模擬出的結果（竄改被抓）
+  if (!verifyVersusReplay(replay, { standings: order, stateHash })) {
+    return json({ error: 'replay does not support standings' }, 400);
+  }
+
+  // ── 簽章驗證：由 standings 推 placements 重建訊息（沿用 FFA 結果訊息格式） ──
+  const placements = order.map((_, i) => i + 1);
+  const message = buildFfaResultMessage(m, order, placements);
+  if (!verifySignature(message, signature, reporter)) {
+    return json({ error: 'bad signature' }, 401);
+  }
+
+  // ── 共識結算（過半一致）。每位玩家各回報一份 standings；達門檻 ceil(N/2) 且唯一多數才入帳 ──
+  const store = getBomberRankStore();
+  const n = lowerStandings.length;
+  const threshold = Math.ceil(n / 2);
+
+  // 1) 記下本次回報（以共識的 lowerStandings 為投票內容）
+  await store.setBRReport(m, reporter, lowerStandings, REPORT_TTL);
+
+  // 2) 統計「完全相同」的 standings 票數（JSON 字串當 key）
+  const reports = await store.getBRReportsForMatch(m);
+  const tally = new Map<string, number>();
+  for (const s of Object.values(reports)) {
+    tally.set(JSON.stringify(s), (tally.get(JSON.stringify(s)) ?? 0) + 1);
+  }
+
+  // 3) 最高票
+  let maxVotes = 0;
+  for (const v of tally.values()) if (v > maxVotes) maxVotes = v;
+
+  // 4) 未達門檻 → pending
+  if (maxVotes < threshold) return json({ outcome: 'pending' });
+
+  // 5) 並列最高（>=2 種 standings 同為最高票）→ 無單一多數 → conflict（409）
+  const leaders = [...tally.entries()].filter(([, v]) => v === maxVotes);
+  if (leaders.length > 1) return json({ outcome: 'conflict' }, 409);
+
+  // 6) 唯一多數達門檻 → 原子閘確保只結算一次 → 計分
+  const consensus = JSON.parse(leaders[0][0]) as string[];
+  const first = await store.markSettledBR(m, SETTLED_TTL);
+  if (!first) return json({ outcome: 'already' });
+
+  // ratings：一律由後端讀各玩家現有分數（client 傳入的 ratings 不可信，忽略）
+  const ratings: Record<string, number> = {};
+  for (const id of consensus) {
+    const rec = await store.getPlayer(id);
+    ratings[id] = rec?.rating ?? DEFAULT_RATING;
+  }
+
+  const results = await applyBomberResult(store, consensus, ratings);
+  return json({ outcome: 'applied', results });
+};

--- a/src/pages/api/leaderboard.ts
+++ b/src/pages/api/leaderboard.ts
@@ -1,14 +1,23 @@
 import type { APIRoute } from 'astro';
-import { getRankStore } from '@scripts/games/tetris/net/rankStore';
+import { getRankStore, getBomberRankStore } from '@scripts/games/tetris/net/rankStore';
 import { leaderboard } from '@scripts/games/tetris/net/ranking';
 
 export const prerender = false;
 
-/** GET /api/leaderboard?n=20 — 取前 n 名（上限 100）。 */
+/**
+ * GET /api/leaderboard?n=20&game=tetris — 取前 n 名（上限 100）。
+ *
+ * game 參數選 ladder（皆回傳相同 response shape，頁面以同一方式渲染）：
+ *   - 缺省 / 'tetris' → 預設 tetris ladder（getRankStore，與原本 byte-identical）
+ *   - 'bomber'        → 隔離的 bomber ladder（getBomberRankStore，bomber: 前綴）
+ * 未知 game 值 → 退回 tetris（與站內 ?n 等容錯參數一致的寬鬆處理；不回 400）。
+ */
 export const GET: APIRoute = async ({ url }) => {
   const raw = Number(url.searchParams.get('n') ?? 20);
   const n = Math.min(Math.max(Number.isFinite(raw) ? raw : 20, 1), 100);
-  const rows = await leaderboard(getRankStore(), n);
+  const game = url.searchParams.get('game');
+  const store = game === 'bomber' ? getBomberRankStore() : getRankStore();
+  const rows = await leaderboard(store, n);
   return new Response(JSON.stringify({ rows }), {
     status: 200,
     headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },

--- a/src/pages/games/bomber.astro
+++ b/src/pages/games/bomber.astro
@@ -327,6 +327,15 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     <div class="bomber-over" id="bomber-over" hidden>
       <h2 class="ms-title">GAME OVER</h2>
       <p id="bomber-over-stats" class="over-stats"></p>
+      <!-- Online result: standings table (rank / player / character / Elo±) -->
+      <div id="bomber-over-standings" class="over-standings"></div>
+      <!-- Online result: local XP gained + level + progress bar -->
+      <div id="bomber-over-xp" class="over-xp"></div>
+      <!-- Online result: REMATCH / LOBBY (shown only online; hotseat uses RETRY) -->
+      <div id="bomber-over-actions" class="over-actions" hidden>
+        <button class="ms-btn ms-online" id="bomber-rematch" type="button" hidden>REMATCH</button>
+        <button class="ms-btn ms-back" id="bomber-lobby" type="button" hidden>LOBBY</button>
+      </div>
       <button class="ms-btn ms-solo" id="bomber-restart">RETRY</button>
     </div>
   </main>
@@ -1523,6 +1532,108 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     text-align: center;
     line-height: 1.8;
   }
+  .over-stats:empty {
+    display: none;
+  }
+
+  /* ─── Online result: standings table ────────────────────── */
+  .over-standings {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: min(560px, 88vw);
+    font-size: clamp(8px, 1vw, 11px);
+  }
+  .over-standings:empty {
+    display: none;
+  }
+  .res-row {
+    display: grid;
+    grid-template-columns: 2.5em 1fr auto auto;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border: 1px solid rgba(255, 157, 60, 0.28);
+    background: rgba(255, 157, 60, 0.05);
+    color: #e8e2d4;
+  }
+  .res-row.is-local {
+    border-color: rgba(255, 210, 63, 0.85);
+    background: rgba(255, 210, 63, 0.1);
+  }
+  .res-rank {
+    color: #ffd23f;
+    letter-spacing: 1px;
+  }
+  .res-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .res-char {
+    color: #ff9d3c;
+    letter-spacing: 1px;
+  }
+  .res-elo {
+    letter-spacing: 1px;
+    white-space: nowrap;
+  }
+  .res-elo.is-up {
+    color: #6bffb0;
+  }
+  .res-elo.is-down {
+    color: #ff7a6a;
+  }
+  .res-elo.is-flat {
+    color: #c7c2b6;
+  }
+  .res-elo.is-pending {
+    color: #8a857a;
+  }
+
+  /* ─── Online result: local XP block + progress bar ──────── */
+  .over-xp {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: min(560px, 88vw);
+    font-size: clamp(8px, 0.95vw, 11px);
+  }
+  .over-xp:empty {
+    display: none;
+  }
+  .res-xp-head {
+    display: flex;
+    justify-content: space-between;
+    color: #ffd23f;
+    letter-spacing: 1px;
+  }
+  .res-xp-gain {
+    color: #6bffb0;
+  }
+  .res-xp-bar {
+    position: relative;
+    height: 12px;
+    border: 1px solid rgba(255, 210, 63, 0.6);
+    background: rgba(0, 0, 0, 0.5);
+    overflow: hidden;
+  }
+  .res-xp-fill {
+    display: block;
+    height: 100%;
+    width: var(--res-xp-ratio, 0%);
+    background: linear-gradient(90deg, #ff9d3c, #ffd23f);
+    transition: width 0.5s ease-out;
+  }
+
+  /* ─── Online result: REMATCH / LOBBY actions ────────────── */
+  .over-actions {
+    display: flex;
+    gap: 16px;
+  }
+  .over-actions[hidden] {
+    display: none;
+  }
 
   /* ─── Accessibility: honour reduced-motion ──────────────── */
   /* Overrides rely on equal specificity + later source order (no !important,
@@ -1540,6 +1651,7 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     .ms-btn { transition: none; }
     .roster-start { transition: none; }
     .lobby-status.pending { animation: none; }
+    .res-xp-fill { transition: none; }
     .arena-nav { transition: none; }
   }
 </style>
@@ -1663,6 +1775,30 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   let arenaIdx = 0;                // host 選的 arena（0..7）
   let connectedGuests = 0;         // host 端：已連上的 guest 數（來自 onStatus）
   let resolveStart: (() => void) | null = null; // host START → resolve waitStart
+
+  // 本端身分（ranked：錢包地址 + 簽章函式；casual：匿名 id、無簽章 → 不回報名次）。
+  // 進入 online 流程時解析一次：id 即是各端共享的 playerId（後端以此驗證簽章 reporter）。
+  let localPlayerId: string | null = null;
+  let localSignMessage: ((msg: string) => Promise<string>) | null = null;
+
+  /**
+   * 解析本端身分：嘗試連錢包（ranked，id = 地址、可簽章）；失敗/無錢包退回匿名（casual）。
+   * 只解析一次（冪等）。casual 仍可正常對戰，只是結算不回報（bomberRanking 收到無 signMessage → no-op）。
+   */
+  async function resolveIdentity(prefix: 'Host' | 'Guest'): Promise<string> {
+    if (localPlayerId) return localPlayerId;
+    try {
+      const { connectWallet } = await import('@scripts/games/tetris/net/netMain');
+      const w = await connectWallet();
+      if (w) {
+        localPlayerId = w.address;
+        localSignMessage = w.signMessage;
+        return localPlayerId;
+      }
+    } catch { /* 使用者拒絕 / 無錢包 → casual */ }
+    localPlayerId = `${prefix}-${Math.floor(Math.random() * 9000 + 1000)}`;
+    return localPlayerId;
+  }
 
   function setLobbyStatus(text: string, kind?: 'pending' | 'error'): void {
     if (!lobbyStatusEl) return;
@@ -1810,7 +1946,26 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
       hint.textContent = 'MOVE WASD/←↑→↓  ·  BOMB SPACE/ENTER  ·  SKILL E/SHIFT  ·  MUTE M';
       hint.style.display = 'block';
     }
-    await startVersusOnline(canvas, { lockstep, localId: ready.localId, arenaId: ready.arenaId });
+
+    // 結算回報接線：matchId = bomber-<seed36>-<room>；reporterId = 本端身分；
+    // signMessage 有則 ranked（回報名次），無則 casual（只顯示名次，不回報）。
+    const roomId = ready.room;
+    await startVersusOnline(canvas, {
+      lockstep,
+      localId: ready.localId,
+      arenaId: ready.arenaId,
+      ranked: {
+        seed: ready.seed,
+        roomId,
+        reporterId: ready.localId,
+        signMessage: localSignMessage ?? undefined,
+      },
+      // REMATCH：同房同設定、新 seed 重開。完整握手（host 重廣播 init 沿用既有 RTC 連線）
+      // 需改動 netMain；此處採最小可靠路徑＝重新進入 online 流程（host 重建房 / guest 重連同房號）。
+      onRematch: () => { location.href = `/games/bomber?online=1&room=${encodeURIComponent(roomId)}`; },
+      // LOBBY：返回 online 大廳入口。
+      onLobby: () => { location.href = '/games/bomber?online=1'; },
+    });
   }
 
   // ── onStatus → lobby UI ──────────────────────────────────
@@ -1853,8 +2008,10 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     const startSignal = new Promise<void>((res) => { resolveStart = res; });
     // 決定性 seed：host 單一來源（不影響任何模擬內部 RNG，僅作為各端共享的初始 seed）。
     const seed = Math.floor(Math.random() * 0x1_0000_0000) >>> 0;
+    // 身分：ranked（錢包地址，可簽章 → 回報名次）或 casual（匿名，不回報）。
+    const id = await resolveIdentity('Host');
     hostBomberGame({
-      identity: { id: hostIdentityId(), character: selected },
+      identity: { id, character: selected },
       arenaId: arenaIdx,
       maxGuests: 3, // 2-4 人：host + 最多 3 guest
       seed,
@@ -1874,20 +2031,14 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     if (lobbyCodeEl) lobbyCodeEl.textContent = room;
     setLobbyStatus('Connecting…', 'pending');
     const { joinBomberGame } = await import('@scripts/games/bomber/net/bomberNetMain');
+    // 身分：ranked（錢包地址，可簽章 → 回報名次）或 casual（匿名，不回報）。
+    const id = await resolveIdentity('Guest');
     joinBomberGame({
       room,
-      identity: { id: guestIdentityId(), character: selected },
+      identity: { id, character: selected },
       onStatus: (s) => onNetStatus(s, false),
       onReady: (r) => { void bootOnline(r); },
     }).catch((err: unknown) => onNetStatus({ phase: 'error', message: String(err) }, false));
-  }
-
-  /** 身分 id：訪客匿名（id 不影響模擬，只用於 roster 順序與 transport 路由）。 */
-  function hostIdentityId(): string {
-    return `Host-${Math.floor(Math.random() * 9000 + 1000)}`;
-  }
-  function guestIdentityId(): string {
-    return `Guest-${Math.floor(Math.random() * 9000 + 1000)}`;
   }
 
   // ── Wire ONLINE controls ─────────────────────────────────
@@ -1966,6 +2117,19 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   const charParam = params.get('char') as CharacterId | null;
   if (charParam && (VALID_CHARS as string[]).includes(charParam)) {
     start(charParam);
+  }
+
+  // ── Online deep-link: ?online=1[&room=CODE] ───────────────
+  //  REMATCH/LOBBY 結算按鈕導回此頁帶 ?online=1（&room= 給 REMATCH 同房重連）。
+  //  REMATCH 限制：未沿用既有 RTC 連線（完整握手需改 netMain）——以「同房號重新協商」近似
+  //  「同房同設定、新 seed」：guest 重連同房號，host 端會以新 seed 重開一局。
+  if (!started && params.get('online') === '1') {
+    openOnline();
+    const rejoinRoom = params.get('room');
+    if (rejoinRoom && roomInput) {
+      roomInput.value = rejoinRoom.toUpperCase();
+      void beginJoin(); // 直接重連該房（REMATCH 路徑）
+    }
   }
 
   // ── Autostart: ?mode=solo → lena (backward compat for e2e) ──

--- a/src/pages/games/bomber.astro
+++ b/src/pages/games/bomber.astro
@@ -1254,6 +1254,27 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   const modeSelect = document.getElementById('mode-select');
   let started = false;
 
+  // ── VERSUS hotseat debug entry: ?mode=hotseat ────────────
+  // 本機雙人同鍵盤（P1 WASD+Space+E、P2 方向鍵+Enter+Shift）。
+  // 可選 ?arena=0-7（越界回退 0）、?seed=<int>。網路對戰留待後續 Task。
+  if (params.get('mode') === 'hotseat' && canvas) {
+    started = true;
+    modeSelect?.remove();
+    const hint = document.querySelector('.bomber-hint') as HTMLElement | null;
+    if (hint) {
+      hint.textContent = 'P1 WASD+SPACE+E  ·  P2 ←↑→↓+ENTER+SHIFT  ·  MUTE M';
+      hint.style.display = 'block';
+    }
+    const arenaParam = Number(params.get('arena'));
+    const seedParam = Number(params.get('seed'));
+    void import('@scripts/games/bomber/render/versusMain').then(({ startVersus }) => {
+      startVersus(canvas, {
+        arenaId: Number.isFinite(arenaParam) ? arenaParam : 0,
+        seed: Number.isFinite(seedParam) && params.has('seed') ? seedParam : undefined,
+      }).catch((err: unknown) => console.error('[bomber] versus start failed', err));
+    }).catch((err: unknown) => console.error('[bomber] versus load failed', err));
+  }
+
   // ── Selection state ──────────────────────────────────────
   let selected: CharacterId = 'lena';
 

--- a/src/pages/games/bomber.astro
+++ b/src/pages/games/bomber.astro
@@ -1762,10 +1762,14 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     });
 
     // ── 斷線 → 決定性強制淘汰 ──────────────────────────────
+    // 離場幀的決定性來源：離場玩家「最後輸入幀 + 1」（lockstep.lastInputFrame(p)+1）。
+    //   此值各端一致（星狀中繼下各端對同一玩家收到的廣播集合相同），與各端 simFrame
+    //   偏移無關，且正是該玩家停送後鎖步的共同停滯前緣——絕不可改用本端 confirmedFrame
+    //   （各端 confirmedFrame 可能不同步，會在不同 simFrame 套用 forfeit → 分歧 → desync）。
     // host：transport.onChannelClose(idx) → guestIds[idx] 對映 playerId。
-    //   host 廣播 bomber-leave{p,f}（f＝本端排程幀，與一般輸入同步），全端在同一幀 forfeit。
-    // guest：transport.onClose() → host 斷線。guest 無權廣播，僅本端把 host 標記離場
-    //   （host 走了，這局對 guest 而言實質結束；以本端 confirmedFrame 當離場幀）。
+    //   host 算 f = lastInputFrame(pid)+1 並廣播 bomber-leave{p,f}，全端在同一幀 forfeit。
+    // guest：transport.onControl 收 host 廣播的 leave → 套用 host 給的同一幀；
+    //   transport.onClose() → host 斷線，guest 本端把 host 標記離場（同樣以 lastInputFrame+1）。
     const transport = ready.transport;
     if (ready.role === 'host' && 'onChannelClose' in transport) {
       const guestIds = ready.guestIds ?? [];
@@ -1773,7 +1777,8 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
         .onChannelClose((idx: number) => {
           const pid = guestIds[idx];
           if (!pid) return;
-          const f = lockstep.confirmedFrame + 1;
+          // 共享前緣：離場玩家最後一筆輸入幀 + 1（各端一致，不受 simFrame 偏移影響）。
+          const f = lockstep.lastInputFrame(pid) + 1;
           // 廣播給其餘 guest：同一玩家、同一幀離場（決定性）。
           (transport as import('@scripts/games/bomber/net/bomberTransport').BomberHubTransport)
             .sendControl({ t: 'bomber-leave', p: pid, f });
@@ -1781,16 +1786,18 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
         });
     } else if (ready.role === 'guest' && 'onClose' in transport) {
       const spoke = transport as import('@scripts/games/bomber/net/bomberTransport').BomberSpokeTransport;
-      // guest 收到 host 廣播的 bomber-leave（某 guest 離場）→ 在 host 指定幀 forfeit（決定性）。
+      // guest 收到 host 廣播的 bomber-leave（某 guest 離場）→ 在 host 指定幀 forfeit。
+      // host 的 f 由其 lastInputFrame(p)+1 算出，因各端共享 p 的輸入記錄，等同本端自算 → 決定性。
       spoke.onControl((msg: Record<string, unknown>) => {
         if (msg.t === 'bomber-leave' && typeof msg.p === 'string' && typeof msg.f === 'number') {
           lockstep.forfeit(msg.p, msg.f);
         }
       });
       // host 頻道關閉：host 離場。guest 端把 host 標記離場（forfeit），對局收斂結束。
+      // 同樣以「host 最後輸入幀 + 1」當離場幀，與其他端推導方式一致（即使此時只剩本 guest）。
       spoke.onClose(() => {
         const hostId = ready.playerIds[0];
-        lockstep.forfeit(hostId, lockstep.confirmedFrame + 1);
+        lockstep.forfeit(hostId, lockstep.lastInputFrame(hostId) + 1);
       });
     }
 

--- a/src/pages/games/bomber.astro
+++ b/src/pages/games/bomber.astro
@@ -256,6 +256,9 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
             <button class="ms-btn ms-solo roster-start" data-action="start" type="button">
               <span class="roster-start-text">▶ START</span>
             </button>
+            <button class="ms-btn ms-online roster-online" data-action="online" type="button">
+              ⚔ ONLINE
+            </button>
           </div>
         </div>
 
@@ -267,6 +270,59 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
       </button>
 
     </div><!-- /mode-select -->
+
+    <!-- ── ONLINE lobby (create / join → roster → ready → start) ── -->
+    <div class="online-screen" id="online-screen" hidden>
+      <div class="crt-overlay" aria-hidden="true"></div>
+      <div class="ms-header">
+        <h2 class="ms-title">ONLINE VERSUS</h2>
+      </div>
+
+      <div class="online-body">
+        <!-- Entry: pick CREATE or JOIN -->
+        <div class="online-entry" id="online-entry">
+          <button class="ms-btn ms-online" id="online-create" type="button">CREATE ROOM</button>
+          <div class="online-join-row">
+            <input
+              class="online-input"
+              id="online-room-input"
+              maxlength="5"
+              placeholder="ROOM CODE"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button class="ms-btn" id="online-join-btn" type="button">JOIN</button>
+          </div>
+          <button class="ms-btn ms-back" id="online-back" type="button">← BACK</button>
+        </div>
+
+        <!-- Lobby: shown once host creates / guest joins -->
+        <div class="online-lobby" id="online-lobby" hidden>
+          <p class="lobby-label">ROOM</p>
+          <div class="lobby-code-row">
+            <span class="lobby-code" id="lobby-code">·····</span>
+            <button class="ms-btn lobby-copy" id="lobby-copy" type="button">COPY</button>
+          </div>
+
+          <ul class="lobby-roster" id="lobby-roster" aria-label="Players"></ul>
+
+          <!-- Host-only arena picker (guests see read-only label) -->
+          <div class="lobby-arena" id="lobby-arena">
+            <button class="arena-nav" id="arena-prev" type="button" aria-label="Previous map">◀</button>
+            <span class="arena-name" id="arena-name">STONE PLAZA</span>
+            <button class="arena-nav" id="arena-next" type="button" aria-label="Next map">▶</button>
+          </div>
+
+          <p class="lobby-status" id="lobby-status">Waiting for players…</p>
+
+          <div class="lobby-actions">
+            <button class="ms-btn ms-solo lobby-ready" id="lobby-ready" type="button">READY</button>
+            <button class="ms-btn ms-online lobby-start" id="lobby-start" type="button" hidden>START</button>
+          </div>
+          <button class="ms-btn ms-back lobby-cancel" id="lobby-cancel" type="button">← LEAVE</button>
+        </div>
+      </div>
+    </div><!-- /online-screen -->
 
     <div class="bomber-over" id="bomber-over" hidden>
       <h2 class="ms-title">GAME OVER</h2>
@@ -1200,6 +1256,249 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     50%, 100% { opacity: 0.2; }
   }
 
+  /* ─── ONLINE roster button (sits under START) ────────── */
+  .roster-online {
+    flex-shrink: 0;
+    margin-top: clamp(6px, 1vh, 10px);
+    width: 100%;
+  }
+  .ms-online {
+    border-color: rgba(255, 90, 77, 0.85);
+    color: #ffd7c2;
+  }
+  .ms-online:hover {
+    border-color: #ff5a4d;
+    background: rgba(255, 90, 40, 0.2);
+  }
+
+  /* ─── ONLINE screen (lobby) ───────────────────────────── */
+  .online-screen {
+    position: absolute;
+    inset: 0;
+    z-index: 22;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    font-family: 'Press Start 2P', Consolas, monospace;
+    background: #0a0c14;
+    overflow: hidden;
+  }
+  .online-screen[hidden] {
+    display: none;
+  }
+  .online-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(14px, 2.4vh, 24px);
+    padding: clamp(16px, 3vh, 36px);
+    position: relative;
+    z-index: 5;
+    overflow-y: auto;
+  }
+
+  /* Entry: create / join */
+  .online-entry {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: clamp(10px, 1.8vh, 16px);
+    width: clamp(240px, 40vw, 360px);
+  }
+  .online-entry[hidden] { display: none; }
+  .online-join-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+  }
+  .online-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-family: 'Press Start 2P', Consolas, monospace;
+    font-size: clamp(10px, 1.2vw, 13px);
+    letter-spacing: 3px;
+    text-align: center;
+    text-transform: uppercase;
+    color: #ffe9d6;
+    background: rgba(8, 12, 22, 0.9);
+    border: 2px solid rgba(255, 157, 60, 0.5);
+    padding: clamp(9px, 1.4vh, 13px) 10px;
+    box-sizing: border-box;
+  }
+  .online-input::placeholder { color: #6e5440; letter-spacing: 2px; }
+  .online-input:focus-visible {
+    outline: none;
+    border-color: #ffd23f;
+    box-shadow: 0 0 0 2px rgba(255, 210, 63, 0.35);
+  }
+  .ms-back {
+    border-color: rgba(255, 157, 60, 0.45);
+    color: #c98f6a;
+    font-size: clamp(8px, 0.95vw, 11px);
+  }
+  .ms-back:hover { color: #ff9d3c; border-color: rgba(255, 157, 60, 0.8); }
+
+  /* Lobby (after create/join) */
+  .online-lobby {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(10px, 1.8vh, 18px);
+    width: clamp(260px, 46vw, 440px);
+  }
+  .online-lobby[hidden] { display: none; }
+  .lobby-label {
+    margin: 0;
+    font-size: clamp(8px, 0.9vw, 10px);
+    letter-spacing: 4px;
+    color: #c98f6a;
+  }
+  .lobby-code-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+  .lobby-code {
+    font-size: clamp(28px, 6vw, 46px);
+    letter-spacing: 10px;
+    color: #ff9d3c;
+    text-shadow:
+      2px 2px 0 #0a0c14,
+      0 0 14px rgba(255, 157, 60, 0.8),
+      0 0 30px rgba(255, 90, 77, 0.4);
+    padding-left: 10px;
+  }
+  .lobby-copy { font-size: clamp(8px, 0.9vw, 10px); padding: 9px 13px; width: auto; }
+
+  /* Roster: one row per player (character + ready light) */
+  .lobby-roster {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(4px, 0.7vh, 8px);
+  }
+  .lobby-roster-item {
+    display: flex;
+    align-items: center;
+    gap: clamp(8px, 1.1vw, 13px);
+    padding: clamp(6px, 0.9vh, 10px) clamp(10px, 1.2vw, 14px);
+    background: linear-gradient(
+      100deg,
+      rgba(22, 15, 12, 0.82) 0%,
+      rgba(10, 7, 16, 0.66) 100%
+    );
+    border: 1px solid rgba(255, 157, 60, 0.18);
+    border-left: 3px solid rgba(255, 157, 60, 0.5);
+    box-sizing: border-box;
+  }
+  .lobby-roster-item.is-local {
+    border-left-color: #ffd23f;
+    background: linear-gradient(
+      100deg,
+      rgba(52, 32, 18, 0.8) 0%,
+      rgba(18, 11, 18, 0.74) 100%
+    );
+  }
+  .lri-char {
+    font-size: clamp(9px, 1vw, 12px);
+    letter-spacing: 1.5px;
+    color: #ffe8cf;
+    text-shadow: 1px 1px 0 #0a0c14;
+    text-transform: uppercase;
+  }
+  .lri-host {
+    font-size: clamp(6px, 0.7vw, 8px);
+    letter-spacing: 1px;
+    color: #ffce6b;
+    margin-left: 4px;
+  }
+  .lri-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: clamp(6px, 0.7vw, 8px);
+    letter-spacing: 1px;
+    color: #b2835f;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .lri-light {
+    flex-shrink: 0;
+    width: clamp(9px, 1vw, 12px);
+    height: clamp(9px, 1vw, 12px);
+    border-radius: 50%;
+    background: #3a2a10;
+    border: 1px solid rgba(255, 157, 60, 0.4);
+  }
+  .lri-light.is-ready {
+    background: #4dff88;
+    border-color: #4dff88;
+    box-shadow: 0 0 8px rgba(77, 255, 136, 0.8);
+  }
+
+  /* Arena picker (host) */
+  .lobby-arena {
+    display: flex;
+    align-items: center;
+    gap: clamp(8px, 1.2vw, 16px);
+    padding: clamp(8px, 1.2vh, 12px) clamp(10px, 1.4vw, 18px);
+    border: 1px solid rgba(255, 157, 60, 0.3);
+    background: rgba(8, 6, 18, 0.7);
+  }
+  .lobby-arena.is-readonly .arena-nav { display: none; }
+  .arena-nav {
+    font-family: 'Press Start 2P', Consolas, monospace;
+    font-size: clamp(10px, 1.2vw, 14px);
+    color: #ff9d3c;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 4px 6px;
+    transition: color 0.14s ease, transform 0.14s ease;
+  }
+  .arena-nav:hover { color: #ffd23f; transform: scale(1.2); }
+  .arena-name {
+    min-width: clamp(120px, 18vw, 180px);
+    text-align: center;
+    font-size: clamp(9px, 1.1vw, 13px);
+    letter-spacing: 2px;
+    color: #ffd7a8;
+    text-shadow: 1px 1px 0 #0a0c14, 0 0 8px rgba(255, 157, 60, 0.5);
+  }
+
+  .lobby-status {
+    margin: 0;
+    font-size: clamp(8px, 0.95vw, 11px);
+    letter-spacing: 1px;
+    color: #cfe9ff;
+    text-align: center;
+    min-height: 1.4em;
+  }
+  .lobby-status.pending { animation: lobbyPulse 1.4s ease-in-out infinite; }
+  .lobby-status.error { color: #ff7a6a; }
+  @keyframes lobbyPulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
+
+  .lobby-actions {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+  }
+  .lobby-ready, .lobby-start { flex: 1 1 auto; }
+  .lobby-ready.is-ready {
+    border-color: #4dff88;
+    color: #4dff88;
+    background: rgba(77, 255, 136, 0.1);
+  }
+  .lobby-start[hidden] { display: none; }
+  .lobby-start[disabled] { opacity: 0.4; cursor: not-allowed; }
+  .lobby-cancel { width: 100%; font-size: clamp(8px, 0.95vw, 11px); }
+
   /* ─── Game Over overlay ──────────────────────────────── */
   .bomber-over {
     position: absolute;
@@ -1240,12 +1539,15 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     .roster-item { transition: none; }
     .ms-btn { transition: none; }
     .roster-start { transition: none; }
+    .lobby-status.pending { animation: none; }
+    .arena-nav { transition: none; }
   }
 </style>
 
 <script>
   import { startBomber } from '@scripts/games/bomber/render/main';
   import type { CharacterId } from '@scripts/games/bomber/engine/types';
+  import { ARENAS } from '@scripts/games/bomber/versus/arenas';
 
   const VALID_CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
 
@@ -1253,6 +1555,7 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   const canvas = document.getElementById('bomber-canvas') as HTMLCanvasElement | null;
   const modeSelect = document.getElementById('mode-select');
   let started = false;
+  let onlineOpen = false; // ONLINE 大廳開啟中（攔截選角鍵盤導覽）
 
   // ── VERSUS hotseat debug entry: ?mode=hotseat ────────────
   // 本機雙人同鍵盤（P1 WASD+Space+E、P2 方向鍵+Enter+Shift）。
@@ -1337,9 +1640,305 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     });
   });
 
+  // ═══════════════════════════════════════════════════════════
+  //  ONLINE VERSUS — lobby + handshake wiring (Task 11b)
+  //  hotseat/solo 路徑完全不受影響：online 走獨立的 startVersusOnline。
+  // ═══════════════════════════════════════════════════════════
+  const onlineScreen = document.getElementById('online-screen');
+  const onlineEntry = document.getElementById('online-entry');
+  const onlineLobby = document.getElementById('online-lobby');
+  const lobbyCodeEl = document.getElementById('lobby-code');
+  const lobbyRosterEl = document.getElementById('lobby-roster');
+  const lobbyArenaEl = document.getElementById('lobby-arena');
+  const arenaNameEl = document.getElementById('arena-name');
+  const lobbyStatusEl = document.getElementById('lobby-status');
+  const lobbyReadyBtn = document.getElementById('lobby-ready') as HTMLButtonElement | null;
+  const lobbyStartBtn = document.getElementById('lobby-start') as HTMLButtonElement | null;
+  const roomInput = document.getElementById('online-room-input') as HTMLInputElement | null;
+
+  // 大廳本地狀態（host 權威：seed/arena/順序由 host 廣播）。
+  let netRole: 'host' | 'guest' | null = null;
+  let netStarted = false;          // 已觸發 host/join 連線編排（避免重複點）
+  let localReady = false;          // 本端就緒（host START 需自身就緒 + ≥1 guest）
+  let arenaIdx = 0;                // host 選的 arena（0..7）
+  let connectedGuests = 0;         // host 端：已連上的 guest 數（來自 onStatus）
+  let resolveStart: (() => void) | null = null; // host START → resolve waitStart
+
+  function setLobbyStatus(text: string, kind?: 'pending' | 'error'): void {
+    if (!lobbyStatusEl) return;
+    lobbyStatusEl.textContent = text;
+    lobbyStatusEl.classList.toggle('pending', kind === 'pending');
+    lobbyStatusEl.classList.toggle('error', kind === 'error');
+  }
+
+  function renderArenaName(): void {
+    if (arenaNameEl) arenaNameEl.textContent = ARENAS[arenaIdx]?.name ?? `ARENA ${arenaIdx}`;
+  }
+
+  /** 重繪大廳名單：host 在前，再依「已連上 guest 數」補占位列。 */
+  function renderRoster(): void {
+    if (!lobbyRosterEl) return;
+    lobbyRosterEl.innerHTML = '';
+    const rows: { char: string; host: boolean; local: boolean; name: string; ready: boolean }[] = [];
+    // 本端＋（host：占位 guest 列 / guest：host 占位列）
+    if (netRole === 'host') {
+      rows.push({ char: selected, host: true, local: true, name: 'YOU', ready: localReady });
+      for (let i = 0; i < connectedGuests; i++) {
+        rows.push({ char: '?', host: false, local: false, name: `GUEST ${i + 1}`, ready: true });
+      }
+    } else {
+      rows.push({ char: '?', host: true, local: false, name: 'HOST', ready: true });
+      rows.push({ char: selected, host: false, local: true, name: 'YOU', ready: localReady });
+    }
+    for (const r of rows) {
+      const li = document.createElement('li');
+      li.className = 'lobby-roster-item' + (r.local ? ' is-local' : '');
+      const charSpan = document.createElement('span');
+      charSpan.className = 'lri-char';
+      charSpan.textContent = r.char.toUpperCase();
+      if (r.host) {
+        const hostTag = document.createElement('span');
+        hostTag.className = 'lri-host';
+        hostTag.textContent = 'HOST';
+        charSpan.appendChild(hostTag);
+      }
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'lri-name';
+      nameSpan.textContent = r.name;
+      const light = document.createElement('span');
+      light.className = 'lri-light' + (r.ready ? ' is-ready' : '');
+      li.append(charSpan, nameSpan, light);
+      lobbyRosterEl.appendChild(li);
+    }
+  }
+
+  /** host：依「自身就緒 + ≥1 guest」決定 START 是否可按。 */
+  function refreshHostStart(): void {
+    if (netRole !== 'host' || !lobbyStartBtn) return;
+    lobbyStartBtn.hidden = false;
+    lobbyStartBtn.disabled = !(localReady && connectedGuests >= 1);
+  }
+
+  function openOnline(): void {
+    if (started || onlineOpen) return;
+    onlineOpen = true;
+    if (modeSelect) (modeSelect as HTMLElement).hidden = true;
+    if (onlineScreen) onlineScreen.hidden = false;
+    if (onlineEntry) onlineEntry.hidden = false;
+    if (onlineLobby) onlineLobby.hidden = true;
+    renderArenaName();
+  }
+
+  function leaveOnline(): void {
+    // 回選角畫面（未連線時）：最簡單可靠＝reload（清掉任何半開的 RTC/輪詢）。
+    location.href = '/games/bomber';
+  }
+
+  function showLobbyPanel(role: 'host' | 'guest'): void {
+    netRole = role;
+    if (onlineEntry) onlineEntry.hidden = true;
+    if (onlineLobby) onlineLobby.hidden = false;
+    if (lobbyArenaEl) lobbyArenaEl.classList.toggle('is-readonly', role !== 'host');
+    if (lobbyStartBtn) lobbyStartBtn.hidden = role !== 'host';
+    renderArenaName();
+    renderRoster();
+    refreshHostStart();
+  }
+
+  /** 由 BomberReady 建鎖步、接斷線→淘汰，啟動線上渲染。 */
+  async function bootOnline(ready: import('@scripts/games/bomber/net/bomberNetMain').BomberReady): Promise<void> {
+    if (!canvas) return;
+    const [{ BomberLockstep }, { startVersusOnline }] = await Promise.all([
+      import('@scripts/games/bomber/net/bomberLockstep'),
+      import('@scripts/games/bomber/render/versusMain'),
+    ]);
+    const lockstep = new BomberLockstep({
+      playerIds: ready.playerIds,
+      localId: ready.localId,
+      seed: ready.seed,
+      arenaId: ready.arenaId,
+      characters: ready.characters,
+      transport: ready.transport,
+    });
+
+    // ── 斷線 → 決定性強制淘汰 ──────────────────────────────
+    // host：transport.onChannelClose(idx) → guestIds[idx] 對映 playerId。
+    //   host 廣播 bomber-leave{p,f}（f＝本端排程幀，與一般輸入同步），全端在同一幀 forfeit。
+    // guest：transport.onClose() → host 斷線。guest 無權廣播，僅本端把 host 標記離場
+    //   （host 走了，這局對 guest 而言實質結束；以本端 confirmedFrame 當離場幀）。
+    const transport = ready.transport;
+    if (ready.role === 'host' && 'onChannelClose' in transport) {
+      const guestIds = ready.guestIds ?? [];
+      (transport as import('@scripts/games/bomber/net/bomberTransport').BomberHubTransport)
+        .onChannelClose((idx: number) => {
+          const pid = guestIds[idx];
+          if (!pid) return;
+          const f = lockstep.confirmedFrame + 1;
+          // 廣播給其餘 guest：同一玩家、同一幀離場（決定性）。
+          (transport as import('@scripts/games/bomber/net/bomberTransport').BomberHubTransport)
+            .sendControl({ t: 'bomber-leave', p: pid, f });
+          lockstep.forfeit(pid, f);
+        });
+    } else if (ready.role === 'guest' && 'onClose' in transport) {
+      const spoke = transport as import('@scripts/games/bomber/net/bomberTransport').BomberSpokeTransport;
+      // guest 收到 host 廣播的 bomber-leave（某 guest 離場）→ 在 host 指定幀 forfeit（決定性）。
+      spoke.onControl((msg: Record<string, unknown>) => {
+        if (msg.t === 'bomber-leave' && typeof msg.p === 'string' && typeof msg.f === 'number') {
+          lockstep.forfeit(msg.p, msg.f);
+        }
+      });
+      // host 頻道關閉：host 離場。guest 端把 host 標記離場（forfeit），對局收斂結束。
+      spoke.onClose(() => {
+        const hostId = ready.playerIds[0];
+        lockstep.forfeit(hostId, lockstep.confirmedFrame + 1);
+      });
+    }
+
+    started = true;
+    onlineOpen = false;
+    if (onlineScreen) onlineScreen.remove();
+    if (modeSelect) modeSelect.remove();
+    const hint = document.querySelector('.bomber-hint') as HTMLElement | null;
+    if (hint) {
+      hint.textContent = 'MOVE WASD/←↑→↓  ·  BOMB SPACE/ENTER  ·  SKILL E/SHIFT  ·  MUTE M';
+      hint.style.display = 'block';
+    }
+    await startVersusOnline(canvas, { lockstep, localId: ready.localId, arenaId: ready.arenaId });
+  }
+
+  // ── onStatus → lobby UI ──────────────────────────────────
+  function onNetStatus(
+    s: import('@scripts/games/bomber/net/bomberNetMain').BomberNetStatus,
+    isHost: boolean,
+  ): void {
+    if (s.phase === 'creating') {
+      setLobbyStatus('Creating room…', 'pending');
+    } else if (s.phase === 'lobby') {
+      if (s.room && lobbyCodeEl) lobbyCodeEl.textContent = s.room;
+      if (isHost) {
+        connectedGuests = s.connected ?? 0;
+        renderRoster();
+        refreshHostStart();
+        setLobbyStatus(
+          connectedGuests >= 1 ? 'Players joined — set ready & START' : 'Waiting for players…',
+          'pending',
+        );
+      } else {
+        setLobbyStatus('Connected · waiting for host…', 'pending');
+      }
+    } else if (s.phase === 'connecting') {
+      setLobbyStatus('Connecting…', 'pending');
+    } else if (s.phase === 'connected') {
+      setLobbyStatus('Connected — starting…');
+    } else if (s.phase === 'error') {
+      netStarted = false; // 允許重試
+      setLobbyStatus(`Error: ${s.message ?? 'connection failed'} (leave & retry)`, 'error');
+    }
+  }
+
+  // ── CREATE ROOM (host) ───────────────────────────────────
+  async function beginHost(): Promise<void> {
+    if (netStarted || !canvas) return;
+    netStarted = true;
+    showLobbyPanel('host');
+    setLobbyStatus('Creating room…', 'pending');
+    const { hostBomberGame } = await import('@scripts/games/bomber/net/bomberNetMain');
+    const startSignal = new Promise<void>((res) => { resolveStart = res; });
+    // 決定性 seed：host 單一來源（不影響任何模擬內部 RNG，僅作為各端共享的初始 seed）。
+    const seed = Math.floor(Math.random() * 0x1_0000_0000) >>> 0;
+    hostBomberGame({
+      identity: { id: hostIdentityId(), character: selected },
+      arenaId: arenaIdx,
+      maxGuests: 3, // 2-4 人：host + 最多 3 guest
+      seed,
+      waitStart: () => startSignal,
+      onStatus: (s) => onNetStatus(s, true),
+      onReady: (r) => { void bootOnline(r); },
+    }).catch((err: unknown) => onNetStatus({ phase: 'error', message: String(err) }, true));
+  }
+
+  // ── JOIN (guest) ─────────────────────────────────────────
+  async function beginJoin(): Promise<void> {
+    const room = (roomInput?.value ?? '').trim().toUpperCase();
+    if (!room) { setLobbyStatus('Enter a room code', 'error'); return; }
+    if (netStarted || !canvas) return;
+    netStarted = true;
+    showLobbyPanel('guest');
+    if (lobbyCodeEl) lobbyCodeEl.textContent = room;
+    setLobbyStatus('Connecting…', 'pending');
+    const { joinBomberGame } = await import('@scripts/games/bomber/net/bomberNetMain');
+    joinBomberGame({
+      room,
+      identity: { id: guestIdentityId(), character: selected },
+      onStatus: (s) => onNetStatus(s, false),
+      onReady: (r) => { void bootOnline(r); },
+    }).catch((err: unknown) => onNetStatus({ phase: 'error', message: String(err) }, false));
+  }
+
+  /** 身分 id：訪客匿名（id 不影響模擬，只用於 roster 順序與 transport 路由）。 */
+  function hostIdentityId(): string {
+    return `Host-${Math.floor(Math.random() * 9000 + 1000)}`;
+  }
+  function guestIdentityId(): string {
+    return `Guest-${Math.floor(Math.random() * 9000 + 1000)}`;
+  }
+
+  // ── Wire ONLINE controls ─────────────────────────────────
+  modeSelect?.querySelectorAll<HTMLButtonElement>('[data-action="online"]').forEach((btn) => {
+    btn.addEventListener('click', openOnline);
+  });
+  document.getElementById('online-back')?.addEventListener('click', leaveOnline);
+  document.getElementById('online-create')?.addEventListener('click', () => void beginHost());
+  document.getElementById('online-join-btn')?.addEventListener('click', () => void beginJoin());
+  document.getElementById('lobby-cancel')?.addEventListener('click', leaveOnline);
+  roomInput?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); void beginJoin(); }
+  });
+
+  document.getElementById('lobby-copy')?.addEventListener('click', () => {
+    const code = lobbyCodeEl?.textContent ?? '';
+    if (code && navigator.clipboard) {
+      void navigator.clipboard.writeText(code).then(() => {
+        const btn = document.getElementById('lobby-copy');
+        if (btn) { const t = btn.textContent; btn.textContent = 'COPIED'; setTimeout(() => { if (btn) btn.textContent = t; }, 1200); }
+      });
+    }
+  });
+
+  // Host arena picker (◀ ▶)
+  document.getElementById('arena-prev')?.addEventListener('click', () => {
+    if (netRole !== 'host') return;
+    arenaIdx = (arenaIdx + ARENAS.length - 1) % ARENAS.length;
+    renderArenaName();
+  });
+  document.getElementById('arena-next')?.addEventListener('click', () => {
+    if (netRole !== 'host') return;
+    arenaIdx = (arenaIdx + 1) % ARENAS.length;
+    renderArenaName();
+  });
+
+  // READY toggle (local)
+  lobbyReadyBtn?.addEventListener('click', () => {
+    localReady = !localReady;
+    lobbyReadyBtn.classList.toggle('is-ready', localReady);
+    lobbyReadyBtn.textContent = localReady ? 'READY ✓' : 'READY';
+    renderRoster();
+    refreshHostStart();
+  });
+
+  // START (host only): resolve waitStart → orchestration assembles roster & broadcasts init.
+  lobbyStartBtn?.addEventListener('click', () => {
+    if (netRole !== 'host' || !resolveStart) return;
+    if (!(localReady && connectedGuests >= 1)) return;
+    lobbyStartBtn.disabled = true;
+    setLobbyStatus('Starting match…', 'pending');
+    resolveStart();
+    resolveStart = null;
+  });
+
   // ── Keyboard navigation ──────────────────────────────────
   document.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (started) return;
+    if (started || onlineOpen) return;
     const idx = VALID_CHARS.indexOf(selected);
     if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
       e.preventDefault();

--- a/src/pages/games/leaderboard.astro
+++ b/src/pages/games/leaderboard.astro
@@ -17,6 +17,10 @@ const lang: Language = defaultLang;
   <main class="lb">
     <a class="lb-home" href="/games">← ARCADE</a>
     <h1 class="lb-title">LEADERBOARD</h1>
+    <div class="lb-tabs" id="lb-tabs" role="tablist" aria-label="Leaderboard game">
+      <button class="lb-tab is-active" id="lb-tab-tetris" type="button" role="tab" aria-selected="true" data-game="tetris">TETRIS</button>
+      <button class="lb-tab" id="lb-tab-bomber" type="button" role="tab" aria-selected="false" data-game="bomber">BOMBER</button>
+    </div>
     <div class="lb-board" id="lb-board">
       <p class="lb-empty" id="lb-status">載入中…</p>
     </div>
@@ -57,6 +61,31 @@ const lang: Language = defaultLang;
     color: #eafdff;
     text-shadow: 0 0 12px rgba(54, 230, 255, 0.9), 0 0 30px rgba(54, 230, 255, 0.5);
   }
+  .lb-tabs {
+    display: flex;
+    gap: 10px;
+    width: min(760px, 94vw);
+    justify-content: center;
+  }
+  .lb-tab {
+    flex: 0 0 auto;
+    padding: 10px 22px;
+    font-family: inherit;
+    font-size: 11px;
+    letter-spacing: 2px;
+    color: #6fa8d8;
+    background: rgba(8, 12, 22, 0.72);
+    border: 1px solid rgba(54, 230, 255, 0.22);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, box-shadow 0.15s;
+  }
+  .lb-tab:hover { color: #36e6ff; }
+  .lb-tab.is-active {
+    color: #eafdff;
+    border-color: rgba(54, 230, 255, 0.6);
+    box-shadow: 0 0 14px rgba(54, 230, 255, 0.25);
+  }
   .lb-board {
     width: min(760px, 94vw);
     display: flex;
@@ -93,15 +122,24 @@ const lang: Language = defaultLang;
 <script>
   type Row = { id: string; rating: number; tier: string; wins: number; losses: number; name?: string };
 
+  type Game = 'tetris' | 'bomber';
+
   const board = document.getElementById('lb-board');
+  const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>('.lb-tab'));
   const short = (id: string) => (id.startsWith('0x') && id.length > 12 ? `${id.slice(0, 6)}…${id.slice(-4)}` : id);
   const esc = (s: string) => s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
 
-  async function load(): Promise<void> {
+  let active: Game = 'tetris';
+  let reqToken = 0; // 防止慢回應覆蓋後選的分頁
+
+  async function load(game: Game): Promise<void> {
     if (!board) return;
+    const token = ++reqToken;
+    board.innerHTML = '<p class="lb-empty">載入中…</p>';
     try {
-      const res = await fetch('/api/leaderboard?n=50');
+      const res = await fetch(`/api/leaderboard?n=50&game=${game}`);
       const { rows } = (await res.json()) as { rows: Row[] };
+      if (token !== reqToken) return; // 已切換分頁，丟棄過期回應
       if (!rows || rows.length === 0) {
         board.innerHTML = '<p class="lb-empty">尚無對戰紀錄<br/>到遊戲室開一場線上對戰來上榜！</p>';
         return;
@@ -116,9 +154,25 @@ const lang: Language = defaultLang;
         .join('');
       board.innerHTML = head + body;
     } catch {
+      if (token !== reqToken) return;
       board.innerHTML = '<p class="lb-empty">排行榜載入失敗</p>';
     }
   }
 
-  void load();
+  function selectGame(game: Game): void {
+    if (game === active) return;
+    active = game;
+    for (const tab of tabs) {
+      const on = tab.dataset.game === game;
+      tab.classList.toggle('is-active', on);
+      tab.setAttribute('aria-selected', String(on));
+    }
+    void load(game);
+  }
+
+  for (const tab of tabs) {
+    tab.addEventListener('click', () => selectGame((tab.dataset.game as Game) ?? 'tetris'));
+  }
+
+  void load(active);
 </script>

--- a/src/scripts/games/bomber/engine/types.ts
+++ b/src/scripts/games/bomber/engine/types.ts
@@ -11,7 +11,7 @@ export interface AbilityDef { id: AbilityId; name: string; desc: string; cooldow
 export interface CharacterProfile { id: CharacterId; name: string; start: CharacterStats; caps: CharacterStats; ability: AbilityDef; }
 export type EnemyKind = 'wander' | 'chaser' | 'ghost' | 'dasher' | 'mimic' | 'tank' | 'sapper' | 'splitter' | 'mini';
 
-export interface Bomb { x: number; y: number; fuseMs: number; range: number; owner?: 'enemy'; }
+export interface Bomb { x: number; y: number; fuseMs: number; range: number; owner?: string; }
 export interface BlastCell { x: number; y: number; ttlMs: number; }
 export interface PowerUp { x: number; y: number; kind: PowerUpKind; }
 export interface Enemy {

--- a/src/scripts/games/bomber/net/bomberLockstep.test.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from 'vitest';
+import { BomberLockstep, LoopbackBomberHub, INPUT_DELAY } from './bomberLockstep';
+import type { BomberFrameMsg, VersusAction } from './bomberLockstep';
+import type { CharacterId, Dir } from '../engine/types';
+
+const CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
+const DIRS: Dir[] = ['up', 'down', 'left', 'right'];
+
+/** 建 N 個接同一 LoopbackBomberHub 的 BomberLockstep 節點，同 seed/arenaId/characters。 */
+function buildNodes(
+  playerIds: string[],
+  seed: number,
+  arenaId = 0,
+): { nodes: BomberLockstep[]; hub: LoopbackBomberHub } {
+  const hub = new LoopbackBomberHub();
+  const characters: Record<string, CharacterId> = {};
+  playerIds.forEach((id, i) => (characters[id] = CHARS[i % CHARS.length]));
+  const nodes = playerIds.map(
+    (localId) =>
+      new BomberLockstep({
+        playerIds,
+        localId,
+        seed,
+        arenaId,
+        characters,
+        transport: hub.transportFor(localId),
+      }),
+  );
+  return { nodes, hub };
+}
+
+/**
+ * 把全端推進到同一個 confirmedFrame，以便在共同幀上比對 stateHash。
+ *
+ * 同步 loopback 下，每輪最後 tick 的節點會「結構性領先」一幀（它擁有當輪最新廣播，
+ * 又因已淘汰玩家被自動補空輸入而不需等其真訊息）——這在 lockstep 是良性的瞬時偏移：
+ * 鐵則只保證「全端皆已確認的幀，狀態必相同」。本 helper 只 tick 落後端（凍結領先端，
+ * 保證收斂終止），直到全端 confirmedFrame 追平領先端，方可在同一幀比對指紋。
+ */
+function settle(nodes: BomberLockstep[], hub?: LoopbackBomberHub): void {
+  for (let r = 0; r < 50; r++) {
+    const max = Math.max(...nodes.map((n) => n.confirmedFrame));
+    const laggards = nodes.filter((n) => n.confirmedFrame < max);
+    if (laggards.length === 0) break;
+    for (const n of laggards) n.tick();
+    hub?.flush();
+  }
+}
+
+describe('BomberLockstep N 人鎖步', () => {
+  it('4 端 loopback 跑 600 幀：全端 stateHash 一致', () => {
+    const playerIds = ['P0', 'P1', 'P2', 'P3'];
+    const { nodes } = buildNodes(playerIds, 12345);
+
+    // 每端各自的輸入排程（依本端 localId 給不同序列；含 held 切換、bomb、ability）
+    const localActionsAt = (id: string, f: number): VersusAction[] => {
+      const out: VersusAction[] = [];
+      if (id === 'P0') {
+        if (f % 5 === 0) out.push({ t: 'held', d: 'right', v: true });
+        if (f % 5 === 3) out.push({ t: 'held', d: 'right', v: false });
+        if (f % 23 === 0) out.push({ t: 'bomb' });
+      } else if (id === 'P1') {
+        if (f % 7 === 0) out.push({ t: 'held', d: 'left', v: true });
+        if (f % 7 === 4) out.push({ t: 'held', d: 'left', v: false });
+        if (f % 31 === 0) out.push({ t: 'ability' });
+      } else if (id === 'P2') {
+        if (f % 11 === 0) out.push({ t: 'held', d: 'up', v: true });
+        if (f % 11 === 6) out.push({ t: 'held', d: 'up', v: false });
+        if (f % 29 === 0) out.push({ t: 'bomb' });
+      } else if (id === 'P3') {
+        if (f % 13 === 0) out.push({ t: 'held', d: 'down', v: true });
+        if (f % 13 === 8) out.push({ t: 'held', d: 'down', v: false });
+        if (f % 37 === 0) out.push({ t: 'ability' });
+      }
+      return out;
+    };
+
+    for (let f = 0; f < 600; f++) {
+      for (const node of nodes) {
+        node.queueLocal(...localActionsAt(node.localId, f));
+        node.tick();
+      }
+    }
+    // 收斂到共同幀（消除同步 loopback 末輪的良性一幀偏移）
+    settle(nodes);
+
+    // 各端推進的幀數必須相等且 > 0
+    const cf = nodes[0].confirmedFrame;
+    expect(cf).toBeGreaterThan(0);
+    for (const node of nodes) expect(node.confirmedFrame).toBe(cf);
+
+    // 各端 stateHash 必須與 nodes[0] 完全一致（鎖步驗收門檻）
+    const ref = nodes[0].match.stateHash();
+    for (const node of nodes) {
+      expect(node.match.stateHash()).toBe(ref);
+    }
+  });
+
+  it('各端 confirmedFrame 相等（混合輸入 200 幀）', () => {
+    const playerIds = ['A', 'B', 'C', 'D'];
+    const { nodes } = buildNodes(playerIds, 555);
+    for (let f = 0; f < 200; f++) {
+      for (const node of nodes) {
+        if (f % 3 === 0) node.queueLocal({ t: 'bomb' });
+        node.tick();
+      }
+    }
+    settle(nodes);
+    const ref = nodes[0].confirmedFrame;
+    expect(ref).toBeGreaterThan(0);
+    for (const node of nodes) expect(node.confirmedFrame).toBe(ref);
+    const hash = nodes[0].match.stateHash();
+    for (const node of nodes) expect(node.match.stateHash()).toBe(hash);
+  });
+
+  it('亂序/延遲投遞：訊息延後且打亂順序送達 → 最終全端 stateHash 仍一致', () => {
+    const playerIds = ['P0', 'P1', 'P2', 'P3'];
+    const hub = new LoopbackBomberHub({ jitter: true });
+    const characters: Record<string, CharacterId> = {};
+    playerIds.forEach((id, i) => (characters[id] = CHARS[i]));
+    const nodes = playerIds.map(
+      (localId) =>
+        new BomberLockstep({ playerIds, localId, seed: 909, arenaId: 1, characters, transport: hub.transportFor(localId) }),
+    );
+
+    const localActionsAt = (id: string, f: number): VersusAction[] => {
+      const out: VersusAction[] = [];
+      const k = playerIds.indexOf(id);
+      if (f % (5 + k) === 0) out.push({ t: 'held', d: DIRS[k], v: true });
+      if (f % (5 + k) === 2) out.push({ t: 'held', d: DIRS[k], v: false });
+      if (f % (17 + k) === 0) out.push(k % 2 === 0 ? { t: 'bomb' } : { t: 'ability' });
+      return out;
+    };
+
+    // 多輪：每輪先全員 queue+send，再 flush 亂序遞送，確保最終全員追上
+    for (let f = 0; f < 400; f++) {
+      for (const node of nodes) {
+        node.queueLocal(...localActionsAt(node.localId, f));
+        node.tick();
+      }
+      hub.flush(); // 把暫存的亂序/延遲訊息送達
+    }
+    // 收尾：清空所有在途訊息，再讓落後端追平領先端（亂序投遞下偏移可能 >1 幀）
+    for (let i = 0; i < INPUT_DELAY + 8; i++) {
+      for (const node of nodes) node.tick();
+      hub.flush();
+    }
+    settle(nodes, hub);
+
+    const cf = nodes[0].confirmedFrame;
+    expect(cf).toBeGreaterThan(0);
+    for (const node of nodes) expect(node.confirmedFrame).toBe(cf);
+    const ref = nodes[0].match.stateHash();
+    for (const node of nodes) expect(node.match.stateHash()).toBe(ref);
+  });
+
+  it('某端 frame 缺輸入時其他端等待（不推進）；補上後恢復', () => {
+    const playerIds = ['P0', 'P1', 'P2', 'P3'];
+    const seed = 99;
+    const { nodes } = buildNodes(playerIds, seed);
+
+    // 只讓 P0/P1/P2 tick（P3 不送任何幀）
+    for (let f = 0; f < 20; f++) {
+      nodes[0].tick();
+      nodes[1].tick();
+      nodes[2].tick();
+    }
+    const stuck = nodes[0].confirmedFrame;
+    // P3 從未送輸入 → 缺其輸入的幀全部卡住（confirmedFrame 遠小於 20）
+    expect(stuck).toBeLessThan(20);
+
+    // 補上 P3 的輸入後應恢復推進
+    for (let f = 0; f < 30; f++) {
+      for (const node of nodes) node.tick();
+    }
+    expect(nodes[0].confirmedFrame).toBeGreaterThan(stuck);
+    // 收斂到共同幀後，全端仍一致
+    settle(nodes);
+    const ref = nodes[0].match.stateHash();
+    for (const node of nodes) expect(node.match.stateHash()).toBe(ref);
+  });
+
+  it('淘汰玩家停止送輸入後其餘端仍可推進（淘汰者自動補空輸入、不死鎖）', () => {
+    // 2 人局：P0 走進自己的爆風自殺，P0 端隨後停 tick，P1 端必須能繼續推進直到 finished。
+    const playerIds = ['P0', 'P1'];
+    const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira' };
+    const hub = new LoopbackBomberHub();
+    const nodes = playerIds.map(
+      (localId) =>
+        new BomberLockstep({ playerIds, localId, seed: 3, arenaId: 0, characters, transport: hub.transportFor(localId) }),
+    );
+
+    // P0 放彈後原地不動 → 引信到期自爆淘汰
+    nodes[0].queueLocal({ t: 'bomb' });
+
+    let p0Dead = false;
+    let f = 0;
+    for (; f < 6000 && nodes[1].match.getState().status === 'playing'; f++) {
+      for (const node of nodes) {
+        // 一旦 P0 死亡，P0 端就停止 tick（模擬淘汰者離場不再送輸入）
+        if (node.localId === 'P0' && p0Dead) continue;
+        node.tick();
+      }
+      const p0 = nodes[1].match.getState().players.find((p) => p.id === 'P0');
+      if (p0 && !p0.alive) p0Dead = true;
+    }
+
+    expect(p0Dead).toBe(true);
+    expect(nodes[1].match.getState().status).toBe('finished');
+    // 倖存的 P1 端推進到結束（沒因 P0 停送而死鎖）
+    expect(nodes[1].match.getState().winnerId).toBe('P1');
+  });
+
+  it('畸形網路訊息被忽略不丟例外、不污染狀態', () => {
+    const playerIds = ['P0', 'P1'];
+    let cap: ((d: unknown) => void) | null = null;
+    const transport = {
+      send(): void {},
+      onMessage(cb: (m: unknown) => void): void {
+        cap = cb as (d: unknown) => void;
+      },
+    };
+    const ls = new BomberLockstep({
+      playerIds,
+      localId: 'P0',
+      seed: 1,
+      arenaId: 0,
+      characters: { P0: 'lena', P1: 'mira' },
+      transport: transport as never,
+    });
+    expect(cap).not.toBeNull();
+
+    const before = ls.match.stateHash();
+
+    expect(() => cap!('not json{')).not.toThrow(); // 畸形 JSON 字串
+    expect(() => cap!(JSON.stringify({ junk: 1 }))).not.toThrow(); // 缺欄位
+    expect(() => cap!({ f: 'x', p: 'P1', a: [] })).not.toThrow(); // f 非數字
+    expect(() => cap!({ f: 0, p: 'ZZ', a: [] })).not.toThrow(); // p 不在名單
+    expect(() => cap!({ f: 0, p: 'P1', a: 'nope' })).not.toThrow(); // a 非陣列
+    expect(() => cap!({ f: 0, p: 'P1', a: [{ t: 'fly' }] })).not.toThrow(); // 未知 action t
+    expect(() => cap!({ f: 0, p: 'P1', a: [{ t: 'held', d: 'sideways', v: true }] })).not.toThrow(); // 非法 dir
+    expect(() => cap!({ f: 0, p: 'P1', a: [{ t: 'held', d: 'up', v: 'yes' }] })).not.toThrow(); // v 非 boolean
+    expect(() => cap!({ f: 0, p: 'P1', a: [{ d: 'up', v: true }] })).not.toThrow(); // 缺 t
+    expect(() => cap!({ f: 0, p: 'P1', a: ['bomb'] })).not.toThrow(); // action 非物件
+    expect(() => cap!(null)).not.toThrow();
+    expect(() => cap!(undefined)).not.toThrow();
+
+    // 推進若干幀：預填的空幀 0..INPUT_DELAY-1 可被消化（全員齊備），
+    // 但 frame INPUT_DELAY 起缺 P1 合法輸入 → 一律卡住、絕不丟例外。
+    void before;
+    for (let f = 0; f < 5; f++) expect(() => ls.tick()).not.toThrow();
+    // 畸形訊息未被當成 P1 的輸入記錄 → confirmedFrame 恰好卡在 INPUT_DELAY
+    // （僅消化預填的 0..INPUT_DELAY-1，之後永遠缺 P1）。
+    expect(ls.confirmedFrame).toBe(INPUT_DELAY);
+  });
+
+  it('合法 held/bomb/ability 訊息可被處理（部分畸形混入仍只取合法）', () => {
+    const playerIds = ['P0', 'P1'];
+    const { nodes } = buildNodes(playerIds, 7);
+    // 對照組：完全不送任何遠端動作的另一局，跑相同幀數 → 與本局 hash 不同
+    const ctrl = buildNodes(playerIds, 7).nodes;
+
+    for (let f = 0; f < 40; f++) {
+      // 本局：P0 持續往右、間歇放彈
+      if (f % 4 === 0) nodes[0].queueLocal({ t: 'held', d: 'right', v: true });
+      if (f % 4 === 2) nodes[0].queueLocal({ t: 'held', d: 'right', v: false });
+      if (f % 9 === 0) nodes[0].queueLocal({ t: 'bomb' });
+      for (const node of nodes) node.tick();
+      // 對照組：完全不動
+      for (const node of ctrl) node.tick();
+    }
+    settle(nodes);
+    settle(ctrl);
+
+    // 合法輸入確實生效 → 兩局 hash 不同
+    expect(nodes[0].match.stateHash()).not.toBe(ctrl[0].match.stateHash());
+    // 本局兩端一致
+    expect(nodes[1].match.stateHash()).toBe(nodes[0].match.stateHash());
+  });
+});
+
+describe('BomberFrameMsg 型別契約', () => {
+  it('queueLocal 過濾非法本地動作（防呆，與 onMessage 同一道驗證）', () => {
+    const playerIds = ['P0', 'P1'];
+    const { nodes } = buildNodes(playerIds, 5);
+    const clean = buildNodes(playerIds, 5).nodes;
+
+    for (let f = 0; f < 20; f++) {
+      // 摻入畸形本地動作 → 應被過濾，效果等同只送合法動作（這裡無合法動作）
+      nodes[0].queueLocal({ t: 'fly' } as unknown as VersusAction);
+      nodes[0].queueLocal({ t: 'held', d: 'nowhere', v: true } as unknown as VersusAction);
+      for (const node of nodes) node.tick();
+      for (const node of clean) node.tick();
+    }
+    // 摻入畸形動作的一局 hash 應與「完全沒送動作」的乾淨局相同（畸形被丟棄）
+    expect(nodes[0].match.stateHash()).toBe(clean[0].match.stateHash());
+  });
+
+  it('BomberFrameMsg 形狀：tick 送出的訊息含 f/p/a', () => {
+    const sent: BomberFrameMsg[] = [];
+    const ls = new BomberLockstep({
+      playerIds: ['P0', 'P1'],
+      localId: 'P0',
+      seed: 1,
+      arenaId: 0,
+      characters: { P0: 'lena', P1: 'mira' },
+      transport: { send: (m: BomberFrameMsg) => sent.push(m), onMessage: () => {} },
+    });
+    ls.queueLocal({ t: 'bomb' });
+    ls.tick();
+    expect(sent.length).toBe(1);
+    expect(sent[0].p).toBe('P0');
+    expect(sent[0].f).toBe(INPUT_DELAY); // 第一幀排程到 sendFrame(0)+INPUT_DELAY
+    expect(sent[0].a).toEqual([{ t: 'bomb' }]);
+  });
+});

--- a/src/scripts/games/bomber/net/bomberLockstep.test.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.test.ts
@@ -319,7 +319,6 @@ describe('BomberLockstep forfeit（斷線→決定性強制淘汰）', () => {
     );
 
     // 先正常跑數幀（全員都送輸入），確保大家都有共同已確認幀界。
-    const LEAVE_FRAME = INPUT_DELAY + 5;
     for (let f = 0; f < 12; f++) {
       for (const node of nodes) {
         if (f % 4 === 0) node.queueLocal({ t: 'held', d: 'right', v: true });
@@ -329,9 +328,12 @@ describe('BomberLockstep forfeit（斷線→決定性強制淘汰）', () => {
     }
     settle(nodes);
 
-    // P2 「斷線」：存活端 P0/P1 各自在「同一幀」對 P2 forfeit。
+    // P2 「斷線」：存活端 P0/P1 以決定性推導離場幀＝P2 最後輸入幀 + 1（各端一致），
+    // 各自對 P2 forfeit。此推導使離場幀必 >= 各端 simFrame，不觸發防禦性夾鉗。
+    const leaveFrame = nodes[0].lastInputFrame('P2') + 1;
+    expect(leaveFrame).toBe(nodes[1].lastInputFrame('P2') + 1); // 跨端推導一致
     for (const node of nodes) {
-      if (node.localId !== 'P2') node.forfeit('P2', LEAVE_FRAME);
+      if (node.localId !== 'P2') node.forfeit('P2', leaveFrame);
     }
     // P2 端停止 tick（離場）；P0/P1 繼續直到追平。
     const survivors = nodes.filter((n) => n.localId !== 'P2');
@@ -343,6 +345,78 @@ describe('BomberLockstep forfeit（斷線→決定性強制淘汰）', () => {
     expect(survivors[0].match.stateHash()).toBe(survivors[1].match.stateHash());
     const p2 = survivors[0].match.getState().players.find((p) => p.id === 'P2')!;
     expect(p2.alive).toBe(false);
+  });
+
+  it('跨端 simFrame 偏移下離場：以 lastInputFrame+1 推導 → 全端 stateHash 一致；用 confirmedFrame+1 會分歧', () => {
+    // 回歸測試：code review 指出舊 `confirmedFrame+1` 推導在「存活端 simFrame 不同步」時
+    // 各端會在不同 simFrame 套用 forfeit → match.forfeit 跑在不同幀 → stateHash 分歧 → desync。
+    //
+    // 本測試刻意「不 settle」，而是讓存活端跑出 simFrame 偏移（P0 領先 P1 一幀），
+    // 然後在偏移狀態下觸發離場。可切換離場幀推導：
+    //  - confirmedFrame+1（舊）：P0/P1 算出不同幀 → 應分歧（hashes 不相等）。
+    //  - lastInputFrame(p)+1（修正後）：各端算出相同幀（不受 simFrame 偏移影響）→ 一致。
+    const setup = (): { nodes: BomberLockstep[] } => {
+      const playerIds = ['P0', 'P1', 'P2'];
+      const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira', P2: 'aya' };
+      const hub = new LoopbackBomberHub();
+      const nodes = playerIds.map(
+        (localId) =>
+          new BomberLockstep({ playerIds, localId, seed: 77, arenaId: 2, characters, transport: hub.transportFor(localId) }),
+      );
+      // 正常跑數幀（全員送輸入），建立共同已確認前緣。
+      for (let f = 0; f < 8; f++) for (const node of nodes) node.tick();
+      // P2 此後斷線（停止送輸入）。刻意對 P0 多 tick 數次（P1 凍結）→ 製造存活端 simFrame 偏移：
+      // P0 領先、P1 落後（兩者皆停在缺 P2 輸入的前緣，但 P0 多消化了一幀已抵達的輸入）。
+      for (let i = 0; i < 6; i++) nodes[0].tick();
+      return { nodes };
+    };
+
+    // 把存活端各自推進到對局結束（或極限），消化後比對。不能用 settle() 把偏移先抹平——
+    // 偏移正是本測試要保留的條件。落後端優先 tick，但允許領先端在落後端追上後續推進。
+    const drive = (survivors: BomberLockstep[]): void => {
+      for (let r = 0; r < 4000; r++) {
+        if (survivors.every((n) => n.match.getState().status !== 'playing')) break;
+        const max = Math.max(...survivors.map((n) => n.confirmedFrame));
+        const laggards = survivors.filter((n) => n.confirmedFrame < max);
+        const toTick = laggards.length ? laggards : survivors;
+        for (const n of toTick) n.tick();
+      }
+    };
+
+    // 先確認偏移確實存在（前提條件成立，否則測試沒測到 skew）。
+    {
+      const { nodes } = setup();
+      expect(nodes[0].confirmedFrame).not.toBe(nodes[1].confirmedFrame);
+      // 各端對 P2 的 lastInputFrame 必須一致（修正後推導的決定性基礎）。
+      expect(nodes[0].lastInputFrame('P2')).toBe(nodes[1].lastInputFrame('P2'));
+    }
+
+    // 舊推導（confirmedFrame+1）：存活端在偏移下算出不同離場幀 → 套用於不同 simFrame → 分歧。
+    {
+      const { nodes } = setup();
+      const survivors = [nodes[0], nodes[1]];
+      for (const n of survivors) n.forfeit('P2', n.confirmedFrame + 1);
+      drive(survivors);
+      // 這正是 bug：兩端最終 stateHash 不相等（desync）。
+      expect(survivors[0].match.stateHash()).not.toBe(survivors[1].match.stateHash());
+    }
+
+    // 修正後推導（lastInputFrame(p)+1）：各端算出相同離場幀 → 套用於相同 simFrame → 一致。
+    {
+      const { nodes } = setup();
+      const survivors = [nodes[0], nodes[1]];
+      // host 會算 f=lastInputFrame(P2)+1 並廣播；各端套用相同值。此處兩端皆以本端記錄推導，
+      // 因各端 P2 的輸入記錄相同，算出的 f 也相同。
+      const f0 = nodes[0].lastInputFrame('P2') + 1;
+      const f1 = nodes[1].lastInputFrame('P2') + 1;
+      expect(f0).toBe(f1); // 跨端推導一致（不受 simFrame 偏移影響）
+      survivors[0].forfeit('P2', f0);
+      survivors[1].forfeit('P2', f1);
+      drive(survivors);
+      expect(survivors[0].match.stateHash()).toBe(survivors[1].match.stateHash());
+      const p2 = survivors[0].match.getState().players.find((p) => p.id === 'P2')!;
+      expect(p2.alive).toBe(false);
+    }
   });
 });
 

--- a/src/scripts/games/bomber/net/bomberLockstep.test.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.test.ts
@@ -279,6 +279,73 @@ describe('BomberLockstep N 人鎖步', () => {
   });
 });
 
+describe('BomberLockstep forfeit（斷線→決定性強制淘汰）', () => {
+  it('forfeit 指定玩家於指定幀：該玩家停止送輸入也不死鎖、最終被淘汰', () => {
+    // 2 人局：P1 「斷線」（從不送輸入）。P0 端在某幀對 P1 forfeit →
+    // P1 被自動補空輸入（不死鎖）+ 在 leave 幀強制淘汰 → P0 勝出。
+    const playerIds = ['P0', 'P1'];
+    const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira' };
+    let cap: ((m: BomberFrameMsg) => void) | null = null;
+    const ls = new BomberLockstep({
+      playerIds, localId: 'P0', seed: 3, arenaId: 0, characters,
+      transport: { send: () => {}, onMessage: (cb) => { cap = cb; } },
+    });
+    void cap;
+
+    // 推進到 confirmedFrame 卡住（缺 P1）。
+    for (let f = 0; f < 10; f++) ls.tick();
+    const stuck = ls.confirmedFrame;
+    expect(stuck).toBe(INPUT_DELAY); // 只消化預填空幀
+
+    // 在「目前 confirmedFrame」這幀 forfeit P1 → 之後 P1 被補空輸入、不再卡。
+    ls.forfeit('P1', ls.confirmedFrame);
+    for (let f = 0; f < 30; f++) ls.tick();
+
+    expect(ls.confirmedFrame).toBeGreaterThan(stuck);
+    const s = ls.match.getState();
+    const p1 = s.players.find((p) => p.id === 'P1')!;
+    expect(p1.alive).toBe(false);
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('P0');
+  });
+
+  it('兩端對同一玩家、同一幀 forfeit → stateHash 仍一致（決定性）', () => {
+    const playerIds = ['P0', 'P1', 'P2'];
+    const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira', P2: 'aya' };
+    const hub = new LoopbackBomberHub();
+    const nodes = playerIds.map(
+      (localId) =>
+        new BomberLockstep({ playerIds, localId, seed: 77, arenaId: 2, characters, transport: hub.transportFor(localId) }),
+    );
+
+    // 先正常跑數幀（全員都送輸入），確保大家都有共同已確認幀界。
+    const LEAVE_FRAME = INPUT_DELAY + 5;
+    for (let f = 0; f < 12; f++) {
+      for (const node of nodes) {
+        if (f % 4 === 0) node.queueLocal({ t: 'held', d: 'right', v: true });
+        if (f % 4 === 2) node.queueLocal({ t: 'held', d: 'right', v: false });
+        node.tick();
+      }
+    }
+    settle(nodes);
+
+    // P2 「斷線」：存活端 P0/P1 各自在「同一幀」對 P2 forfeit。
+    for (const node of nodes) {
+      if (node.localId !== 'P2') node.forfeit('P2', LEAVE_FRAME);
+    }
+    // P2 端停止 tick（離場）；P0/P1 繼續直到追平。
+    const survivors = nodes.filter((n) => n.localId !== 'P2');
+    for (let f = 0; f < 40; f++) for (const node of survivors) node.tick();
+    settle(survivors);
+
+    // 兩存活端推進到相同幀、stateHash 一致，且 P2 已淘汰。
+    expect(survivors[0].confirmedFrame).toBe(survivors[1].confirmedFrame);
+    expect(survivors[0].match.stateHash()).toBe(survivors[1].match.stateHash());
+    const p2 = survivors[0].match.getState().players.find((p) => p.id === 'P2')!;
+    expect(p2.alive).toBe(false);
+  });
+});
+
 describe('BomberFrameMsg 型別契約', () => {
   it('queueLocal 過濾非法本地動作（防呆，與 onMessage 同一道驗證）', () => {
     const playerIds = ['P0', 'P1'];

--- a/src/scripts/games/bomber/net/bomberLockstep.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.ts
@@ -1,5 +1,6 @@
 import { VersusMatch } from '../versus/versusMatch';
 import type { CharacterId, Dir } from '../engine/types';
+import type { VersusReplay } from './versusReplay';
 
 const SIM_DT = 1000 / 60;
 
@@ -88,12 +89,27 @@ export class BomberLockstep {
   /** 已經實際套用過 match.forfeit 的離場玩家（冪等，避免重複淘汰）。 */
   private leaveApplied: Set<string> = new Set();
 
+  private readonly arenaId: number;
+  private readonly characters: Record<string, CharacterId>;
+  /**
+   * 重播捕捉緩衝。inbox 在 advance() 消化後即刪除（line 292），故無法事後重建稀疏 log——
+   * 必須在「真正套用某幀」的當下記錄下來：
+   *  - replayInputs：稀疏逐幀輸入，只收「非空」的 (frame, player, actions)，
+   *    且記錄的順序與 advance() 套用順序一致（同幀依固定 playerIds 序）。
+   *  - replayForfeits：advance() 在哪一幀對哪位玩家套用了 match.forfeit。
+   * 兩者足以讓 simulateVersusReplay 1:1 重現本局（含 forfeit 結束的局）。
+   */
+  private replayInputs: Array<{ f: number; p: string; a: VersusAction[] }> = [];
+  private replayForfeits: Array<{ f: number; p: string }> = [];
+
   constructor(opts: BomberLockstepOptions) {
     this.playerIds = [...opts.playerIds];
     this.localId = opts.localId;
     this.seed = opts.seed;
     this.inputDelay = opts.inputDelay ?? INPUT_DELAY;
     this.transport = opts.transport;
+    this.arenaId = opts.arenaId;
+    this.characters = { ...opts.characters };
     this.match = new VersusMatch({
       seed: this.seed,
       arenaId: opts.arenaId,
@@ -229,6 +245,29 @@ export class BomberLockstep {
   }
 
   /**
+   * 輸出本局的可重播紀錄（比照 tetris ffaReplay）。
+   *  - seed / arenaId / characters / playerIds：重建 VersusMatch 的全部不可變參數。
+   *  - frameCount：已套用（step 過）的總幀數 == confirmedFrame。
+   *  - inputs：稀疏逐幀「某玩家」輸入（只含非空，順序 == advance() 的套用順序）。
+   *  - forfeits：advance() 在哪一幀對哪位玩家套用了 forfeit（足以重現斷線結束的局）。
+   *
+   * simulateVersusReplay(getReplay()) 會 1:1 重跑出相同的最終名次與 stateHash。
+   * 注意：本紀錄只涵蓋「已確認推進」的幀（confirmedFrame 之前）——尚未全員齊備、
+   * 還沒 step 的前緣輸入不在內（它們也尚未影響 match 狀態），故 stateHash 對得上。
+   */
+  getReplay(): VersusReplay {
+    return {
+      seed: this.seed,
+      arenaId: this.arenaId,
+      characters: { ...this.characters },
+      playerIds: [...this.playerIds],
+      frameCount: this.simFrame,
+      inputs: this.replayInputs.map((e) => ({ f: e.f, p: e.p, a: e.a.slice() })),
+      forfeits: this.replayForfeits.map((e) => ({ f: e.f, p: e.p })),
+    };
+  }
+
+  /**
    * 盡量推進所有「全員齊備」的幀。
    * 已淘汰玩家（player.alive === false）不會送輸入 → 在此自動補空輸入，避免死鎖。
    */
@@ -271,6 +310,9 @@ export class BomberLockstep {
         if (at !== undefined && this.simFrame === at) {
           this.match.forfeit(id);
           this.leaveApplied.add(id);
+          // 捕捉：replay 必須在同一 simFrame、同一 playerIds 序套用相同 forfeit，
+          // 否則 forfeit 結束的局重模擬不會收斂到相同名次/stateHash。
+          this.replayForfeits.push({ f: this.simFrame, p: id });
         }
       }
 
@@ -278,6 +320,11 @@ export class BomberLockstep {
       // 確保各端逐位元一致）。
       for (const id of this.playerIds) {
         const actions = this.inbox.get(id)!.get(this.simFrame)!;
+        // 捕捉：只收非空輸入（稀疏 log），且記錄順序與此處套用順序一致
+        //（同幀依 playerIds 固定序），simulateVersusReplay 依此序重播即逐位元一致。
+        if (actions.length > 0) {
+          this.replayInputs.push({ f: this.simFrame, p: id, a: actions.slice() });
+        }
         for (const act of actions) {
           if (act.t === 'held') this.match.setHeld(id, act.d, act.v);
         }

--- a/src/scripts/games/bomber/net/bomberLockstep.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.ts
@@ -72,6 +72,12 @@ export class BomberLockstep {
 
   /** 每玩家每幀輸入：inbox.get(playerId).get(frame) = VersusAction[]。 */
   private inbox: Map<string, Map<number, VersusAction[]>> = new Map();
+  /**
+   * 每玩家「曾經收到過的最大輸入幀」（單調遞增，不隨 advance() 消化/刪除 inbox 而回退）。
+   * 各端對同一玩家收到的廣播集合相同（inbox 寫入冪等、星狀中繼全員同收），故此值在各端一致，
+   * 與各端的 simFrame 偏移無關——這正是 forfeit leave 幀「跨端決定性」的依據。
+   */
+  private lastInput: Map<string, number> = new Map();
   private simFrame = 0; // 下一個要模擬的幀（== confirmedFrame）
   private sendFrame = 0; // 下一個要送出的本地輸入幀
   /** 本地累積、尚未隨 tick 送出的動作。 */
@@ -94,11 +100,14 @@ export class BomberLockstep {
       players: this.playerIds.map((id) => ({ id, character: opts.characters[id] })),
     });
 
-    for (const id of this.playerIds) this.inbox.set(id, new Map());
+    for (const id of this.playerIds) {
+      this.inbox.set(id, new Map());
+      this.lastInput.set(id, -1);
+    }
 
     // 預填 frame 0..inputDelay-1 為空陣列（全員），否則開局永遠卡在 simFrame 0。
     for (let f = 0; f < this.inputDelay; f++) {
-      for (const id of this.playerIds) this.inbox.get(id)!.set(f, []);
+      for (const id of this.playerIds) this.recordInput(id, f, []);
     }
 
     this.transport.onMessage((raw) => this.handleMessage(raw));
@@ -121,16 +130,32 @@ export class BomberLockstep {
    *  1. advance() 為其自動補「空輸入」→ 不再因缺其輸入而死鎖（木桶效應）。
    *  2. 在 simFrame === frame 當幀對 match 套用一次 forfeit（強制淘汰）。
    *
-   * 決定性鐵則：各端必須以「同一個 frame」呼叫本方法（host 計算 leave 幀並透過
-   * 控制訊息廣播；全端皆套用相同幀），如此各端在相同 simFrame 套用相同 forfeit，
-   * stateHash 不分歧。frame 取 max(目前 confirmedFrame, frame) 夾住——不允許追溯到
-   * 已模擬過的歷史幀（否則該端無法在「正確幀」套用 forfeit，會與他端分歧）。
-   * 同一玩家重複呼叫採「最早的有效幀」（冪等，避免不同來源覆蓋造成偏移）。
+   * 決定性鐵則：各端必須以「同一個 frame」呼叫本方法，如此各端在相同 simFrame 套用
+   * 相同 forfeit，stateHash 不分歧。**正確的 frame 來源＝該離場玩家的
+   * `lastInputFrame(p) + 1`**（見 lastInputFrame）：此值各端一致、與各端 simFrame 偏移
+   * 無關，且恰是對局原本會卡住的前緣。呼叫端（bomber.astro）應以此推導 frame，
+   * host 計算後廣播、全端套用相同值。
+   *
+   * 注意：下方 `Math.max(this.simFrame, frame)` 只是**防禦性安全網**，正確性來自上述
+   * 「共享前緣」推導、而非此夾鉗。若以 lastInputFrame(p)+1 推導，理論上 frame 永遠 >=
+   * 各端 simFrame（沒人能模擬超過尚缺輸入的前緣），故此夾鉗應**永不觸發**。一旦真的
+   * 觸發（frame 已是過去式），代表推導出了問題（例如誤用 confirmedFrame）——此時於
+   * 較晚的 simFrame 套用會造成端間分歧，寧可記錄警告而不要悄悄在分歧幀套用。
+   * 同一玩家重複呼叫採「最早排定的有效幀」（冪等，避免不同來源覆蓋造成偏移）。
    */
   forfeit(playerId: string, frame: number): void {
     if (!this.inbox.has(playerId)) return; // 未知玩家忽略
     if (!Number.isFinite(frame)) return;
-    const at = Math.max(this.simFrame, Math.floor(frame));
+    const requested = Math.floor(frame);
+    const at = Math.max(this.simFrame, requested);
+    if (at !== requested && typeof console !== 'undefined') {
+      // 防禦性安全網被觸發＝推導出了 bug（要求的離場幀已被本端模擬過）。記錄以利偵錯，
+      // 仍夾到 simFrame 避免追溯歷史幀，但這代表端間可能分歧——不應在正常運作下發生。
+      console.warn(
+        `[BomberLockstep] forfeit(${playerId}) requested frame ${requested} < simFrame ${this.simFrame}; ` +
+          `clamping to ${at}. This indicates a non-deterministic leave-frame derivation.`,
+      );
+    }
     const existing = this.leaveAt.get(playerId);
     if (existing !== undefined && existing <= at) return; // 已排定更早/同幀：保留首次
     this.leaveAt.set(playerId, at);
@@ -184,6 +209,23 @@ export class BomberLockstep {
     if (!map) return;
     if (map.has(frame)) return; // 冪等：保留首次確認的輸入
     map.set(frame, actions);
+    // 單調記錄「曾收到的最大輸入幀」——advance() 之後會刪掉已消化的幀，但此值不回退，
+    // 故 lastInputFrame() 在各端一致（不受 simFrame 偏移影響）。
+    const prev = this.lastInput.get(id);
+    if (prev === undefined || frame > prev) this.lastInput.set(id, frame);
+  }
+
+  /**
+   * 某玩家「曾經收到過的最大輸入幀」（無任何輸入則回傳 -1）。
+   *
+   * 決定性關鍵：星狀中繼下各端對同一玩家收到的廣播集合相同（inbox 寫入冪等），故此值
+   * 在各端完全一致，與各端 simFrame 偏移無關。用於推導離場幀：一旦玩家 p 停送，
+   * 全端的鎖步都會停在 p 的「最後輸入幀 + 1」（木桶效應的共同停滯點），所以
+   * `lastInputFrame(p) + 1` 是各端算出皆相同、且正是對局原本會卡住的前緣——
+   * 在該幀套用 forfeit 不會與任何端的 simFrame 相衝。
+   */
+  lastInputFrame(playerId: string): number {
+    return this.lastInput.get(playerId) ?? -1;
   }
 
   /**

--- a/src/scripts/games/bomber/net/bomberLockstep.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.ts
@@ -77,6 +77,11 @@ export class BomberLockstep {
   /** 本地累積、尚未隨 tick 送出的動作。 */
   private pending: VersusAction[] = [];
 
+  /** 斷線/離場玩家 → 其「離場生效幀」。自該幀起：補空輸入（免死鎖）+ 於該幀強制淘汰一次。 */
+  private leaveAt: Map<string, number> = new Map();
+  /** 已經實際套用過 match.forfeit 的離場玩家（冪等，避免重複淘汰）。 */
+  private leaveApplied: Set<string> = new Set();
+
   constructor(opts: BomberLockstepOptions) {
     this.playerIds = [...opts.playerIds];
     this.localId = opts.localId;
@@ -109,6 +114,26 @@ export class BomberLockstep {
     for (const a of actions) {
       if (isValidAction(a)) this.pending.push(a);
     }
+  }
+
+  /**
+   * 標記某玩家自 `frame` 起離場（斷線/退出）。自該幀起：
+   *  1. advance() 為其自動補「空輸入」→ 不再因缺其輸入而死鎖（木桶效應）。
+   *  2. 在 simFrame === frame 當幀對 match 套用一次 forfeit（強制淘汰）。
+   *
+   * 決定性鐵則：各端必須以「同一個 frame」呼叫本方法（host 計算 leave 幀並透過
+   * 控制訊息廣播；全端皆套用相同幀），如此各端在相同 simFrame 套用相同 forfeit，
+   * stateHash 不分歧。frame 取 max(目前 confirmedFrame, frame) 夾住——不允許追溯到
+   * 已模擬過的歷史幀（否則該端無法在「正確幀」套用 forfeit，會與他端分歧）。
+   * 同一玩家重複呼叫採「最早的有效幀」（冪等，避免不同來源覆蓋造成偏移）。
+   */
+  forfeit(playerId: string, frame: number): void {
+    if (!this.inbox.has(playerId)) return; // 未知玩家忽略
+    if (!Number.isFinite(frame)) return;
+    const at = Math.max(this.simFrame, Math.floor(frame));
+    const existing = this.leaveAt.get(playerId);
+    if (existing !== undefined && existing <= at) return; // 已排定更早/同幀：保留首次
+    this.leaveAt.set(playerId, at);
   }
 
   /**
@@ -172,12 +197,15 @@ export class BomberLockstep {
       const state = this.match.getState();
       if (state.status !== 'playing') break;
 
-      // 為已淘汰玩家補上 simFrame 的空輸入（其端不再送 → 否則永遠缺幀死鎖）。
+      // 為已淘汰／已離場玩家補上 simFrame 的空輸入（其端不再送 → 否則永遠缺幀死鎖）。
       // 依 playerIds 固定順序迭代以保確定性。
+      // - 已淘汰：player.alive === false。
+      // - 已離場（斷線 forfeit）：simFrame >= 該玩家的 leaveAt（自離場幀起不再送）。
       const dead = new Set<string>();
       for (const p of state.players) if (!p.alive) dead.add(p.id);
       for (const id of this.playerIds) {
-        if (dead.has(id) && !this.inbox.get(id)!.has(this.simFrame)) {
+        const left = this.leaveAt.has(id) && this.simFrame >= this.leaveAt.get(id)!;
+        if ((dead.has(id) || left) && !this.inbox.get(id)!.has(this.simFrame)) {
           this.inbox.get(id)!.set(this.simFrame, []);
         }
       }
@@ -191,6 +219,18 @@ export class BomberLockstep {
         }
       }
       if (!ready) break;
+
+      // 離場強制淘汰：在套用本幀輸入「之前」對所有「leaveAt === simFrame」的玩家套用一次
+      // forfeit（依 playerIds 固定順序，確保多人同幀離場時各端淘汰順序一致）。
+      // 各端皆以 host 廣播的同一 leave 幀呼叫 forfeit → 在相同 simFrame 套用 → stateHash 一致。
+      for (const id of this.playerIds) {
+        if (this.leaveApplied.has(id)) continue;
+        const at = this.leaveAt.get(id);
+        if (at !== undefined && this.simFrame === at) {
+          this.match.forfeit(id);
+          this.leaveApplied.add(id);
+        }
+      }
 
       // 套用該幀全員輸入（依 playerIds 固定順序；同一玩家內 held 先於 bomb/ability，
       // 確保各端逐位元一致）。

--- a/src/scripts/games/bomber/net/bomberLockstep.ts
+++ b/src/scripts/games/bomber/net/bomberLockstep.ts
@@ -1,0 +1,277 @@
+import { VersusMatch } from '../versus/versusMatch';
+import type { CharacterId, Dir } from '../engine/types';
+
+const SIM_DT = 1000 / 60;
+
+/** 輸入延遲幀數（沿用 tetris ffaLockstep）。預填 0..INPUT_DELAY-1 為空輸入，
+ * 故「從未送幀的玩家」的全員停滯點 = INPUT_DELAY。 */
+export const INPUT_DELAY = 3;
+
+/** 合法方向集合，用於 onMessage / queueLocal 的 shape 驗證（網路訊息不可信）。 */
+const VALID_DIRS: ReadonlySet<string> = new Set<Dir>(['up', 'down', 'left', 'right']);
+
+/**
+ * 單一玩家「某一幀」的 versus 動作。
+ *  - held：方向鍵按住/放開（對應 VersusMatch.setHeld）。
+ *  - bomb / ability：單次動作（對應 VersusMatch.input）。
+ */
+export type VersusAction =
+  | { t: 'held'; d: Dir; v: boolean }
+  | { t: 'bomb' }
+  | { t: 'ability' };
+
+/** 單一玩家某幀的輸入。p = playerId。 */
+export interface BomberFrameMsg {
+  f: number;
+  p: string;
+  a: VersusAction[];
+}
+
+/**
+ * N 人鎖步的傳輸抽象（比照 tetris FfaLockstepTransport 精神）。
+ * 本端把自己的 BomberFrameMsg 丟給 send；transport 會把「所有玩家的該幀輸入」
+ * 透過 onMessage 回灌回來（星狀中繼，含或不含自己皆可，inbox 寫入需冪等）。
+ * 實際傳輸由 T10 提供，這裡只依賴介面。
+ */
+export interface BomberLockstepTransport {
+  send(msg: BomberFrameMsg): void;
+  onMessage(cb: (msg: BomberFrameMsg) => void): void;
+}
+
+export interface BomberLockstepOptions {
+  playerIds: string[];
+  localId: string;
+  seed: number;
+  arenaId: number;
+  characters: Record<string, CharacterId>;
+  transport: BomberLockstepTransport;
+  inputDelay?: number;
+}
+
+/**
+ * N 人確定性鎖步（星狀中繼），驅動 VersusMatch。
+ *
+ * 鐵則（1:1 仿 tetris ffaLockstep）：
+ *  1. 前進條件＝「全部 playerIds 在 frame F 都有輸入」才 step F（木桶效應）。
+ *  2. 已淘汰玩家（VersusMatch 中 player.alive === false）不再送輸入 →
+ *     推進邏輯自動為其補空輸入 []，避免死鎖。
+ *     （tetris ffaLockstep 用 getPlacement().has(id) 判定；VersusMatch 無該 API，
+ *      改以 alive===false 對應「已定名次/離場、不會再送輸入」的玩家。）
+ *  3. onMessage 對網路訊息做 JSON 容錯 + shape 驗證，畸形訊息一律忽略、不丟例外、不污染狀態。
+ *  4. 套用某幀全員輸入時依固定 playerIds 順序、且同一玩家內 held 先於 bomb/ability，
+ *     確保各端算出相同 stateHash()。
+ */
+export class BomberLockstep {
+  readonly playerIds: string[];
+  readonly localId: string;
+  readonly match: VersusMatch;
+
+  private transport: BomberLockstepTransport;
+  private readonly seed: number;
+  private readonly inputDelay: number;
+
+  /** 每玩家每幀輸入：inbox.get(playerId).get(frame) = VersusAction[]。 */
+  private inbox: Map<string, Map<number, VersusAction[]>> = new Map();
+  private simFrame = 0; // 下一個要模擬的幀（== confirmedFrame）
+  private sendFrame = 0; // 下一個要送出的本地輸入幀
+  /** 本地累積、尚未隨 tick 送出的動作。 */
+  private pending: VersusAction[] = [];
+
+  constructor(opts: BomberLockstepOptions) {
+    this.playerIds = [...opts.playerIds];
+    this.localId = opts.localId;
+    this.seed = opts.seed;
+    this.inputDelay = opts.inputDelay ?? INPUT_DELAY;
+    this.transport = opts.transport;
+    this.match = new VersusMatch({
+      seed: this.seed,
+      arenaId: opts.arenaId,
+      players: this.playerIds.map((id) => ({ id, character: opts.characters[id] })),
+    });
+
+    for (const id of this.playerIds) this.inbox.set(id, new Map());
+
+    // 預填 frame 0..inputDelay-1 為空陣列（全員），否則開局永遠卡在 simFrame 0。
+    for (let f = 0; f < this.inputDelay; f++) {
+      for (const id of this.playerIds) this.inbox.get(id)!.set(f, []);
+    }
+
+    this.transport.onMessage((raw) => this.handleMessage(raw));
+  }
+
+  /** == 下一個要模擬的幀；亦即「已全員確認並推進」的幀界線。 */
+  get confirmedFrame(): number {
+    return this.simFrame;
+  }
+
+  /** 累積本地輸入（會在下一次 tick 隨 sendFrame 送出）；過濾掉非法動作。 */
+  queueLocal(...actions: VersusAction[]): void {
+    for (const a of actions) {
+      if (isValidAction(a)) this.pending.push(a);
+    }
+  }
+
+  /**
+   * 每模擬幀呼叫一次：先消化已到達的輸入推進，再送本地這一幀的輸入。
+   * drain-before-send 與 tetris 一致，避免 loopback 同步傳遞造成端間 confirmedFrame 偏移。
+   */
+  tick(): void {
+    // 1) 盡量前進：唯有全員對 simFrame 都有輸入才 step（淘汰者自動補空輸入）
+    this.advance();
+
+    // 2) 送出本地這一幀輸入（排程到 sendFrame + inputDelay）
+    const targetFrame = this.sendFrame + this.inputDelay;
+    const actions = this.pending;
+    this.pending = [];
+    this.recordInput(this.localId, targetFrame, actions);
+    this.transport.send({ f: targetFrame, p: this.localId, a: actions });
+    this.sendFrame++;
+
+    // 送出後可能又湊齊（自身輸入），再推進一次
+    this.advance();
+  }
+
+  // ── 內部 ──────────────────────────────────────────────────────────────
+
+  /** 收遠端 BomberFrameMsg：JSON 容錯 + shape 驗證 → 寫入 inbox。畸形一律忽略。 */
+  private handleMessage(raw: unknown): void {
+    let m: unknown = raw;
+    if (typeof raw === 'string') {
+      try {
+        m = JSON.parse(raw);
+      } catch {
+        return;
+      }
+    }
+    if (!m || typeof m !== 'object') return;
+    const msg = m as Record<string, unknown>;
+    if (typeof msg.f !== 'number' || !Number.isFinite(msg.f)) return;
+    if (typeof msg.p !== 'string' || !this.inbox.has(msg.p)) return;
+    if (!Array.isArray(msg.a)) return;
+    if (!msg.a.every(isValidAction)) return;
+    this.recordInput(msg.p, msg.f, msg.a as VersusAction[]);
+  }
+
+  /** 寫入某玩家某幀輸入（冪等：已存在則不覆蓋，避免重複廣播造成不一致）。 */
+  private recordInput(id: string, frame: number, actions: VersusAction[]): void {
+    if (frame < this.simFrame) return; // 已模擬過的幀＝死歷史（遲到重播）→ 不寫，免汙染 inbox
+    const map = this.inbox.get(id);
+    if (!map) return;
+    if (map.has(frame)) return; // 冪等：保留首次確認的輸入
+    map.set(frame, actions);
+  }
+
+  /**
+   * 盡量推進所有「全員齊備」的幀。
+   * 已淘汰玩家（player.alive === false）不會送輸入 → 在此自動補空輸入，避免死鎖。
+   */
+  private advance(): void {
+    for (;;) {
+      // 對局已分出勝負就停止推進（否則下方「為已淘汰者補空輸入」會把全員每幀補滿 →
+      // ready 恆真 → 無窮遞增 simFrame）。
+      const state = this.match.getState();
+      if (state.status !== 'playing') break;
+
+      // 為已淘汰玩家補上 simFrame 的空輸入（其端不再送 → 否則永遠缺幀死鎖）。
+      // 依 playerIds 固定順序迭代以保確定性。
+      const dead = new Set<string>();
+      for (const p of state.players) if (!p.alive) dead.add(p.id);
+      for (const id of this.playerIds) {
+        if (dead.has(id) && !this.inbox.get(id)!.has(this.simFrame)) {
+          this.inbox.get(id)!.set(this.simFrame, []);
+        }
+      }
+
+      // 前進條件：全員都有 simFrame 的輸入
+      let ready = true;
+      for (const id of this.playerIds) {
+        if (!this.inbox.get(id)!.has(this.simFrame)) {
+          ready = false;
+          break;
+        }
+      }
+      if (!ready) break;
+
+      // 套用該幀全員輸入（依 playerIds 固定順序；同一玩家內 held 先於 bomb/ability，
+      // 確保各端逐位元一致）。
+      for (const id of this.playerIds) {
+        const actions = this.inbox.get(id)!.get(this.simFrame)!;
+        for (const act of actions) {
+          if (act.t === 'held') this.match.setHeld(id, act.d, act.v);
+        }
+        for (const act of actions) {
+          if (act.t === 'bomb') this.match.input(id, 'bomb');
+          else if (act.t === 'ability') this.match.input(id, 'ability');
+        }
+      }
+      this.match.step(SIM_DT);
+
+      // 清理該幀，前進
+      for (const id of this.playerIds) this.inbox.get(id)!.delete(this.simFrame);
+      this.simFrame++;
+    }
+  }
+}
+
+/** 驗證單一 VersusAction 形狀（網路 / 本地皆走同一道閘）。 */
+function isValidAction(a: unknown): a is VersusAction {
+  if (!a || typeof a !== 'object') return false;
+  const o = a as Record<string, unknown>;
+  if (o.t === 'bomb' || o.t === 'ability') return true;
+  if (o.t === 'held') {
+    return typeof o.d === 'string' && VALID_DIRS.has(o.d) && typeof o.v === 'boolean';
+  }
+  return false;
+}
+
+/**
+ * 記憶體 mock Hub（測試用）：建多個 BomberLockstepTransport，彼此互聯。
+ * 某 transport.send → 廣播給「所有」節點的 onMessage（含自己）。inbox 寫入冪等
+ * → 含自己重複寫入不影響一致性。
+ *
+ * 預設同步、無延遲、確定性。傳入 { jitter:true } 則進入「暫存」模式：
+ * send 不立即投遞，而是壓入佇列；呼叫 flush() 時以確定性的打亂順序一次投遞
+ * （模擬亂序/延遲投遞，仍 100% 確定性——以固定演算法重排，無 Math.random）。
+ */
+export class LoopbackBomberHub {
+  private callbacks: Map<string, (msg: BomberFrameMsg) => void> = new Map();
+  private readonly jitter: boolean;
+  private queue: BomberFrameMsg[] = [];
+  private seq = 0; // 確定性重排用的單調計數器
+
+  constructor(opts?: { jitter?: boolean }) {
+    this.jitter = opts?.jitter ?? false;
+  }
+
+  /** 為某 playerId 取得一條接上本 Hub 的 transport。 */
+  transportFor(playerId: string): BomberLockstepTransport {
+    const broadcast = (msg: BomberFrameMsg): void => {
+      if (this.jitter) {
+        this.queue.push(msg);
+      } else {
+        for (const cb of this.callbacks.values()) cb(msg);
+      }
+    };
+    return {
+      send: broadcast,
+      onMessage: (cb: (msg: BomberFrameMsg) => void): void => {
+        this.callbacks.set(playerId, cb);
+      },
+    };
+  }
+
+  /**
+   * jitter 模式：把暫存訊息以「確定性打亂順序」一次投遞給全節點。
+   * 重排鍵 = (seq * 2654435761) >>> 0 的位元雜湊（無 Math.random / Date.now），
+   * 每次 flush 都會打亂與送達順序無關的次序，模擬亂序但保確定性。
+   */
+  flush(): void {
+    if (this.queue.length === 0) return;
+    const tagged = this.queue.map((msg) => ({ msg, k: (this.seq++ * 2654435761) >>> 0 }));
+    tagged.sort((a, b) => a.k - b.k || a.msg.f - b.msg.f);
+    this.queue = [];
+    for (const { msg } of tagged) {
+      for (const cb of this.callbacks.values()) cb(msg);
+    }
+  }
+}

--- a/src/scripts/games/bomber/net/bomberNetMain.test.ts
+++ b/src/scripts/games/bomber/net/bomberNetMain.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  buildBomberInit,
+  parseBomberInit,
+  claimBomberGuestSlot,
+  negotiateHostBomberGuestInit,
+  negotiateJoinBomberGuestInit,
+  wrapChannel,
+  withTimeout,
+  hostBomberGame,
+  joinBomberGame,
+  BOMBER_NS,
+  type BomberSignalClient,
+  type BomberHostAnswerPeer,
+  type BomberGuestOfferPeer,
+} from './bomberNetMain';
+import { BomberHubTransport, BomberSpokeTransport } from './bomberTransport';
+import { BomberLockstep, type BomberFrameMsg } from './bomberLockstep';
+
+afterEach(() => vi.restoreAllMocks());
+
+/**
+ * Mock signal store：用 Map 模擬 /api/signal 的 room/slot 鍵值，並記錄每次 putSlot 的
+ * room 參數（驗證 bomber: namespace 沒傳就會在這露餡——但本 mock 接的是 netMain 內已
+ * 包好的 BomberSignalClient.putSlot(room, slot)，故另用 nsCalls 追蹤 ns 是否套用）。
+ */
+function makeMockSignal(): BomberSignalClient & {
+  store: Map<string, string>;
+  rooms: string[];
+} {
+  const store = new Map<string, string>();
+  const rooms: string[] = [];
+  const key = (room: string, slot: string) => `${room}:${slot}`;
+  let roomSeq = 0;
+  return {
+    store,
+    rooms,
+    async createRoom() {
+      const room = `ROOM${roomSeq++}`;
+      rooms.push(room);
+      return room;
+    },
+    async putSlot(room, slot, data) {
+      store.set(key(room, slot), data);
+    },
+    async getSlot(room, slot) {
+      return store.get(key(room, slot)) ?? null;
+    },
+    async pollSlot(room, slot) {
+      const v = store.get(key(room, slot));
+      if (v) return v;
+      throw new Error(`timeout waiting for ${slot}`);
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. bomber-init：seed + arenaId + players(id+character) + yourIndex
+// ─────────────────────────────────────────────────────────────────────────
+describe('bomber-init（buildBomberInit / parseBomberInit）', () => {
+  it('round-trip 後 seed/arenaId/players/yourIndex 不變', () => {
+    const raw = buildBomberInit({
+      seed: 0xC0FFEE,
+      arenaId: 5,
+      players: [
+        { id: 'host', character: 'lena' },
+        { id: 'g1', character: 'mira' },
+        { id: 'g2', character: 'aya' },
+      ],
+      yourIndex: 2,
+    });
+    const parsed = parseBomberInit(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.seed).toBe(0xC0FFEE);
+    expect(parsed!.arenaId).toBe(5);
+    expect(parsed!.players).toEqual([
+      { id: 'host', character: 'lena' },
+      { id: 'g1', character: 'mira' },
+      { id: 'g2', character: 'aya' },
+    ]);
+    expect(parsed!.yourIndex).toBe(2);
+  });
+
+  it('控制前綴為 bomber-（t 欄位以 bomber- 開頭，與 tetris ffa-* 不衝突）', () => {
+    const raw = buildBomberInit({ seed: 1, arenaId: 0, players: [{ id: 'h', character: 'lena' }], yourIndex: 0 });
+    const obj = JSON.parse(raw) as { t: string };
+    expect(obj.t.startsWith('bomber-')).toBe(true);
+  });
+
+  it('畸形輸入回 null（不丟例外）', () => {
+    expect(parseBomberInit('not-json')).toBeNull();
+    expect(parseBomberInit(JSON.stringify({ t: 'nope' }))).toBeNull();
+    expect(parseBomberInit(JSON.stringify({ t: 'bomber-init', seed: 'x', arenaId: 0, players: [], yourIndex: 0 }))).toBeNull();
+    // arenaId 非數字
+    expect(parseBomberInit(JSON.stringify({ t: 'bomber-init', seed: 1, arenaId: 'z', players: [], yourIndex: 0 }))).toBeNull();
+    // players 內缺 character
+    expect(parseBomberInit(JSON.stringify({ t: 'bomber-init', seed: 1, arenaId: 0, players: [{ id: 'h' }], yourIndex: 0 }))).toBeNull();
+    // yourIndex 缺
+    expect(parseBomberInit(JSON.stringify({ t: 'bomber-init', seed: 1, arenaId: 0, players: [{ id: 'h', character: 'lena' }] }))).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. claimBomberGuestSlot：選最低空 slot；滿則拋錯
+// ─────────────────────────────────────────────────────────────────────────
+describe('claimBomberGuestSlot', () => {
+  it('選最低未占用 slot（已占用者跳過）', async () => {
+    const signal = makeMockSignal();
+    const room = 'R';
+    await signal.putSlot(room, 'guest-0-offer', JSON.stringify({ id: 'x', offer: 'o' }));
+    const idx = await claimBomberGuestSlot(signal, room, 'alice', 'OFFER-A', 3);
+    expect(idx).toBe(1);
+    const off = JSON.parse(signal.store.get(`${room}:guest-1-offer`)!) as { id: string };
+    expect(off.id).toBe('alice');
+  });
+
+  it('上限 3 個 guest slot 占滿（2-4 人對戰）→ 拋明確錯誤', async () => {
+    const signal = makeMockSignal();
+    const room = 'R';
+    for (let i = 0; i < 3; i++) {
+      await signal.putSlot(room, `guest-${i}-offer`, JSON.stringify({ id: `x${i}`, offer: 'o' }));
+    }
+    await expect(claimBomberGuestSlot(signal, room, 'alice', 'OFFER-A', 3)).rejects.toThrow(/full|滿|slot/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. guest-initiated 握手（host 收 offer 回 answer；組裝 playerIds host 在前）
+// ─────────────────────────────────────────────────────────────────────────
+function makeHostPeer(): BomberHostAnswerPeer {
+  let onmsg: ((r: string) => void) | null = null;
+  return {
+    createAnswer: async (_offer: string) => 'ANSWER-SDP',
+    waitOpen: async () => {},
+    get channel() {
+      return {
+        send: () => {},
+        get open() { return true; },
+        set onmessage(fn: ((r: string) => void) | null) { onmsg = fn; },
+        get onmessage() { return onmsg; },
+      };
+    },
+  } as unknown as BomberHostAnswerPeer;
+}
+
+describe('guest-initiated 握手（negotiate*BomberGuestInit）', () => {
+  it('host 輪詢 guest-{i}-offer → createAnswer → 寫 host-ack-{i}；playerIds host 在前、依 index 升序', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOM0';
+    await signal.putSlot(room, 'guest-0-offer', JSON.stringify({ id: 'alice', offer: 'OFF0' }));
+    await signal.putSlot(room, 'guest-1-offer', JSON.stringify({ id: 'bob', offer: 'OFF1' }));
+
+    const result = await negotiateHostBomberGuestInit({
+      hostId: 'HOST',
+      maxGuests: 3,
+      expectedGuests: 2,
+      room,
+      signal,
+      peerFactory: makeHostPeer,
+      pollOpts: { timeoutMs: 50, intervalMs: 0 },
+    });
+
+    expect(result.playerIds).toEqual(['HOST', 'alice', 'bob']);
+    expect(result.guestPeers.length).toBe(2);
+    expect(signal.store.get(`${room}:host-ack-0`)).toBe('ANSWER-SDP');
+    expect(signal.store.get(`${room}:host-ack-1`)).toBe('ANSWER-SDP');
+  });
+
+  it('guest：claim 最低空 slot → 寫 guest-{idx}-offer → 等 host-ack-{idx} answer → acceptAnswer', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOMX';
+    await signal.putSlot(room, 'host-ack-0', 'ANSWER-FROM-HOST');
+
+    let acceptedAnswer: string | null = null;
+    const peerFactory = (): BomberGuestOfferPeer => {
+      let onmsg: ((r: string) => void) | null = null;
+      return {
+        createOffer: async () => 'OFFER-FROM-GUEST',
+        acceptAnswer: async (a: string) => { acceptedAnswer = a; },
+        waitOpen: async () => {},
+        channel: {
+          send: () => {},
+          get open() { return true; },
+          set onmessage(fn: ((r: string) => void) | null) { onmsg = fn; },
+          get onmessage() { return onmsg; },
+        },
+      } as unknown as BomberGuestOfferPeer;
+    };
+
+    const result = await negotiateJoinBomberGuestInit({
+      room,
+      guestId: 'alice',
+      signal,
+      peerFactory,
+      maxGuests: 3,
+      pollOpts: { timeoutMs: 50, intervalMs: 0 },
+    });
+
+    expect(result.slotIndex).toBe(0);
+    expect(result.localId).toBe('alice');
+    const off = JSON.parse(signal.store.get(`${room}:guest-0-offer`)!) as { id: string; offer: string };
+    expect(off.id).toBe('alice');
+    expect(off.offer).toBe('OFFER-FROM-GUEST');
+    expect(acceptedAnswer).toBe('ANSWER-FROM-HOST');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. wrapChannel：把 WebRtcTransport 風格物件包成 RelayChannel
+// ─────────────────────────────────────────────────────────────────────────
+describe('wrapChannel', () => {
+  it('send 透傳、open 反映底層、onmessage 設定前到達的訊息會回放（保序）', () => {
+    const sent: string[] = [];
+    let opened = false;
+    let msgCb: ((d: string) => void) | null = null;
+    const fakeTransport = {
+      send: (d: string) => sent.push(d),
+      onMessage: (cb: (d: string) => void) => { msgCb = cb; },
+      get isOpen() { return opened; },
+    };
+    const ch = wrapChannel(fakeTransport);
+    expect(ch.open).toBe(false);
+    opened = true;
+    expect(ch.open).toBe(true);
+    ch.send('hello');
+    expect(sent).toEqual(['hello']);
+
+    // onmessage 設定前先到 2 筆 → 暫存
+    msgCb!('early-1');
+    msgCb!('early-2');
+    const got: string[] = [];
+    ch.onmessage = (r) => got.push(r);
+    // 設定當下回放暫存（保序），之後即時轉發
+    expect(got).toEqual(['early-1', 'early-2']);
+    msgCb!('live');
+    expect(got).toEqual(['early-1', 'early-2', 'live']);
+  });
+
+  it('底層 onClose → 觸發包裝後的 onclose', () => {
+    let closeCb: (() => void) | null = null;
+    const fakeTransport = {
+      send: (_d: string) => {},
+      onMessage: (_cb: (d: string) => void) => {},
+      get isOpen() { return true; },
+      onClose: (cb: () => void) => { closeCb = cb; },
+    };
+    const ch = wrapChannel(fakeTransport);
+    expect('onclose' in ch).toBe(true);
+    let closed = 0;
+    ch.onclose = () => { closed++; };
+    closeCb!();
+    expect(closed).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. withTimeout：逾時 reject
+// ─────────────────────────────────────────────────────────────────────────
+describe('withTimeout', () => {
+  it('在期限內 resolve → 透傳值', async () => {
+    await expect(withTimeout(Promise.resolve(42), 1000, 'x')).resolves.toBe(42);
+  });
+  it('逾時 → reject 含 label', async () => {
+    await expect(withTimeout(new Promise(() => {}), 10, 'my-label')).rejects.toThrow(/my-label/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 6. hostBomberGame：建房 → 收 guest → 廣播 bomber-init → 回傳 ready-to-run 結果
+//    （含 transport / playerIds / seed / arenaId / characters / localId / guestIds）
+// ─────────────────────────────────────────────────────────────────────────
+
+/** 雙端互送的同步 loopback channel pair（host 端 / guest 端各一）。 */
+function pair() {
+  const a = {
+    open: true,
+    onmessage: null as ((r: string) => void) | null,
+    onclose: null as (() => void) | null,
+    send: (raw: string) => { b.onmessage?.(raw); },
+  };
+  const b = {
+    open: true,
+    onmessage: null as ((r: string) => void) | null,
+    onclose: null as (() => void) | null,
+    send: (raw: string) => { a.onmessage?.(raw); },
+  };
+  return { hostEnd: a, guestEnd: b };
+}
+
+describe('hostBomberGame（room-code 主機端組裝）', () => {
+  it('建房→收 2 guest→廣播 bomber-init→onReady 拿到 transport/roster/seed/arenaId/characters/guestIds', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOM0';
+
+    // 兩個 guest 預先 claim slot 0/1 寫 offer（夾帶各自 character）
+    await signal.putSlot(room, 'guest-0-offer', JSON.stringify({ id: 'g1', offer: 'OFF0', character: 'mira' }));
+    await signal.putSlot(room, 'guest-1-offer', JSON.stringify({ id: 'g2', offer: 'OFF1', character: 'aya' }));
+
+    // 每個 host peer 的 channel 記錄收到的廣播訊息
+    const broadcasts: string[][] = [];
+    const peerFactory = (): BomberHostAnswerPeer => {
+      const sent: string[] = [];
+      broadcasts.push(sent);
+      let onmsg: ((r: string) => void) | null = null;
+      return {
+        createAnswer: async () => 'ANS',
+        waitOpen: async () => {},
+        channel: {
+          send: (raw: string) => sent.push(raw),
+          get open() { return true; },
+          set onmessage(fn: ((r: string) => void) | null) { onmsg = fn; },
+          get onmessage() { return onmsg; },
+          onclose: null as (() => void) | null,
+        },
+      } as unknown as BomberHostAnswerPeer;
+    };
+
+    const statuses: string[] = [];
+    let ready: Parameters<NonNullable<Parameters<typeof hostBomberGame>[0]['onReady']>>[0] | null = null;
+
+    await hostBomberGame({
+      identity: { id: 'host', character: 'lena' },
+      arenaId: 3,
+      maxGuests: 2,
+      seed: 0xABCDE, // 注入固定 seed（決定性）
+      room,
+      signal,
+      peerFactory,
+      onStatus: (s) => statuses.push(s.phase),
+      onReady: (r) => { ready = r; },
+      pollOpts: { timeoutMs: 200, intervalMs: 0 },
+    });
+
+    expect(ready).not.toBeNull();
+    const r = ready!;
+    expect(r.playerIds).toEqual(['host', 'g1', 'g2']);
+    expect(r.localId).toBe('host');
+    expect(r.seed).toBe(0xABCDE);
+    expect(r.arenaId).toBe(3);
+    expect(r.characters).toEqual({ host: 'lena', g1: 'mira', g2: 'aya' });
+    expect(r.guestIds).toEqual(['g1', 'g2']);
+    expect(r.transport).toBeInstanceOf(BomberHubTransport);
+    expect(statuses).toContain('connected');
+
+    // 每個 guest channel 都收到 bomber-init（yourIndex 對應其在 playerIds 的位置）
+    expect(broadcasts.length).toBe(2);
+    const init0 = parseBomberInit(broadcasts[0][0])!;
+    const init1 = parseBomberInit(broadcasts[1][0])!;
+    expect(init0.seed).toBe(0xABCDE);
+    expect(init0.arenaId).toBe(3);
+    expect(init0.yourIndex).toBe(1); // g1
+    expect(init1.yourIndex).toBe(2); // g2
+    expect(init0.players).toEqual(init1.players);
+  });
+
+  it('每個 guest 的 character 取自其 guest-{i}-offer（host 不臆測來賓角色）', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOM0';
+    await signal.putSlot(room, 'guest-0-offer', JSON.stringify({ id: 'g1', offer: 'OFF0', character: 'rosa' }));
+
+    const peerFactory = (): BomberHostAnswerPeer => ({
+      createAnswer: async () => 'ANS',
+      waitOpen: async () => {},
+      channel: { send: () => {}, open: true, onmessage: null, onclose: null },
+    } as unknown as BomberHostAnswerPeer);
+
+    let ready: { characters: Record<string, string> } | null = null;
+    await hostBomberGame({
+      identity: { id: 'host', character: 'lena' },
+      arenaId: 0,
+      maxGuests: 1,
+      seed: 1,
+      room,
+      signal,
+      peerFactory,
+      onStatus: () => {},
+      onReady: (r) => { ready = r as unknown as { characters: Record<string, string> }; },
+      pollOpts: { timeoutMs: 200, intervalMs: 0 },
+    });
+    expect(ready!.characters).toEqual({ host: 'lena', g1: 'rosa' });
+  });
+
+  it('沒有任何 guest 連上 → onStatus error，不呼叫 onReady', async () => {
+    const signal = makeMockSignal();
+    const peerFactory = (): BomberHostAnswerPeer => makeHostPeer();
+    const statuses: string[] = [];
+    let readyCalled = false;
+    await hostBomberGame({
+      identity: { id: 'host', character: 'lena' },
+      arenaId: 0,
+      maxGuests: 2,
+      seed: 1,
+      room: 'EMPTY',
+      signal,
+      peerFactory,
+      onStatus: (s) => statuses.push(s.phase),
+      onReady: () => { readyCalled = true; },
+      pollOpts: { timeoutMs: 30, intervalMs: 0 },
+    });
+    expect(readyCalled).toBe(false);
+    expect(statuses).toContain('error');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 7. joinBomberGame：claim slot → 收 bomber-init → 建 SpokeTransport → onReady
+// ─────────────────────────────────────────────────────────────────────────
+describe('joinBomberGame（room-code 來賓端組裝）', () => {
+  it('claim slot → 等 answer → 收 bomber-init → onReady 拿 transport/roster/seed/arenaId/characters', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOMJ';
+    await signal.putSlot(room, 'host-ack-0', 'ANSWER-FROM-HOST');
+
+    // 用 wrapChannel 包一個 backing（如真實 WebRtcTransport）：onmessage 設定前到達的訊息
+    // 進暫存佇列、設定當下回放——故 host 提前廣播 bomber-init 也不會丟（不需精準對齊微任務時序）。
+    let backingCb: ((d: string) => void) | null = null;
+    const backing = {
+      send: (_d: string) => {},
+      onMessage: (cb: (d: string) => void) => { backingCb = cb; },
+      get isOpen() { return true; },
+    };
+    const wrapped = wrapChannel(backing);
+    const peerFactory = (): BomberGuestOfferPeer => ({
+      createOffer: async () => 'OFFER',
+      acceptAnswer: async () => {},
+      waitOpen: async () => {},
+      channel: wrapped,
+    } as unknown as BomberGuestOfferPeer);
+
+    const statuses: string[] = [];
+    let ready: { playerIds: string[]; seed: number; arenaId: number; characters: Record<string, string>; localId: string } | null = null;
+
+    const joinPromise = joinBomberGame({
+      room,
+      identity: { id: 'g1', character: 'mira' },
+      signal,
+      peerFactory,
+      maxGuests: 3,
+      onStatus: (s) => statuses.push(s.phase),
+      onReady: (r) => { ready = r as unknown as typeof ready; },
+      pollOpts: { timeoutMs: 200, intervalMs: 0 },
+      initTimeoutMs: 500,
+    });
+
+    // host 透過 backing 廣播 bomber-init（即使在 join 掛上 onmessage 前到達，wrapChannel 會回放）。
+    const init = buildBomberInit({
+      seed: 0x1234,
+      arenaId: 6,
+      players: [
+        { id: 'host', character: 'lena' },
+        { id: 'g1', character: 'mira' },
+      ],
+      yourIndex: 1,
+    });
+    // backing 收訊處理在 wrapChannel 建構時即綁定；此時送入會進佇列，待 join 設 onmessage 後回放。
+    backingCb!(init);
+
+    await joinPromise;
+
+    expect(ready).not.toBeNull();
+    const r = ready!;
+    expect(r.playerIds).toEqual(['host', 'g1']);
+    expect(r.seed).toBe(0x1234);
+    expect(r.arenaId).toBe(6);
+    expect(r.characters).toEqual({ host: 'lena', g1: 'mira' });
+    expect(r.localId).toBe('g1');
+    expect(statuses).toContain('connected');
+  });
+
+  it('bomber-init 逾時（host 從不廣播）→ onStatus error，不呼叫 onReady', async () => {
+    const signal = makeMockSignal();
+    const room = 'ROOMT';
+    await signal.putSlot(room, 'host-ack-0', 'ANSWER');
+
+    const p = pair();
+    const peerFactory = (): BomberGuestOfferPeer => ({
+      createOffer: async () => 'OFFER',
+      acceptAnswer: async () => {},
+      waitOpen: async () => {},
+      channel: p.guestEnd,
+    } as unknown as BomberGuestOfferPeer);
+
+    const statuses: string[] = [];
+    let readyCalled = false;
+    await joinBomberGame({
+      room,
+      identity: { id: 'g1', character: 'mira' },
+      signal,
+      peerFactory,
+      maxGuests: 3,
+      onStatus: (s) => statuses.push(s.phase),
+      onReady: () => { readyCalled = true; },
+      pollOpts: { timeoutMs: 200, intervalMs: 0 },
+      initTimeoutMs: 20, // 很短 → 必逾時
+    });
+    expect(readyCalled).toBe(false);
+    expect(statuses).toContain('error');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 8. namespace：所有 signalClient 呼叫帶 bomber: ns（房號不與 tetris 相撞）
+// ─────────────────────────────────────────────────────────────────────────
+describe('bomber: namespace 隔離', () => {
+  it('BOMBER_NS 常數為 "bomber:"（傳給 signalClient 用）', () => {
+    expect(BOMBER_NS).toBe('bomber:');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// 9. 端到端（mock channel）：host + 2 guest 各自用 netMain 結果建 BomberLockstep，
+//    跑數十幀仍 stateHash 一致（確定性接線驗證，不碰真 WebRTC）
+// ─────────────────────────────────────────────────────────────────────────
+describe('整合：netMain 結果建 BomberLockstep → 三端確定性一致', () => {
+  it('host hub + 2 guest spoke：相同 seed/arenaId/players → 各端 step 後 stateHash 一致', () => {
+    const p1 = pair();
+    const p2 = pair();
+    const hub = new BomberHubTransport([p1.hostEnd, p2.hostEnd]);
+    const spoke1 = new BomberSpokeTransport(p1.guestEnd);
+    const spoke2 = new BomberSpokeTransport(p2.guestEnd);
+
+    const seed = 0xBADF00D;
+    const arenaId = 2;
+    const playerIds = ['host', 'g1', 'g2'];
+    const characters = { host: 'lena', g1: 'mira', g2: 'aya' } as const;
+
+    const hostLs = new BomberLockstep({ playerIds, localId: 'host', seed, arenaId, characters: { ...characters }, transport: hub });
+    const g1Ls = new BomberLockstep({ playerIds, localId: 'g1', seed, arenaId, characters: { ...characters }, transport: spoke1 });
+    const g2Ls = new BomberLockstep({ playerIds, localId: 'g2', seed, arenaId, characters: { ...characters }, transport: spoke2 });
+
+    const nodes = [hostLs, g1Ls, g2Ls];
+    for (let i = 0; i < 40; i++) {
+      for (const n of nodes) n.tick();
+    }
+    // 同步 loopback 末輪會有良性的一幀偏移（最後 tick 的節點結構性領先一幀）；
+    // 只 tick 落後端直到全端 confirmedFrame 追平，才在共同幀上比對指紋（鐵則：全端皆確認的幀必相同）。
+    for (let r = 0; r < 50; r++) {
+      const max = Math.max(...nodes.map((n) => n.confirmedFrame));
+      const laggards = nodes.filter((n) => n.confirmedFrame < max);
+      if (laggards.length === 0) break;
+      for (const n of laggards) n.tick();
+    }
+
+    const h1 = hostLs.match.stateHash();
+    const h2 = g1Ls.match.stateHash();
+    const h3 = g2Ls.match.stateHash();
+    expect(h2).toBe(h1);
+    expect(h3).toBe(h1);
+    // 三端推進到相同 confirmedFrame
+    expect(g1Ls.confirmedFrame).toBe(hostLs.confirmedFrame);
+    expect(g2Ls.confirmedFrame).toBe(hostLs.confirmedFrame);
+  });
+});
+
+// 確保未使用 import 不被 tree-shake 警告（型別檢查用）
+const _unusedFrame: BomberFrameMsg = { f: 0, p: 'x', a: [] };
+void _unusedFrame;

--- a/src/scripts/games/bomber/net/bomberNetMain.ts
+++ b/src/scripts/games/bomber/net/bomberNetMain.ts
@@ -1,0 +1,654 @@
+import type { CharacterId } from '../engine/types';
+import {
+  createRoom as realCreateRoom,
+  putSlot as realPutSlot,
+  getSlot as realGetSlot,
+  pollSlot as realPollSlot,
+} from '../../tetris/net/signalClient';
+import { WebRtcTransport } from '../../tetris/net/webrtcTransport';
+import {
+  BomberHubTransport,
+  BomberSpokeTransport,
+  type RelayChannel,
+} from './bomberTransport';
+
+/**
+ * Bomber room-code 連線編排（copy-adapt 自 tetris/net/ffaNetMain.ts 的 room-code 路徑）。
+ *
+ * 拓樸：星狀（host 為 hub，guest 為 spoke），guest-initiated 握手——
+ *   guest：createOffer → claim 最低空 guest-{idx}-offer（夾帶自己的 character）→
+ *          等 host-ack-{idx}(=answer) → acceptAnswer → waitOpen → 透過 data channel 收 bomber-init。
+ *   host ：輪詢 guest-{0..maxGuests-1}-offer → createAnswer → 寫 host-ack-{idx} → waitOpen
+ *          → 收齊（或房主按開始）後組裝 playerIds + characters，透過各 channel 廣播 bomber-init。
+ *
+ * 與 ffaNetMain 的主要差異：
+ *  1. bomber-init 多帶 `arenaId` 與「每人 character」（players:[{id,character}]）——
+ *     bomber 的 VersusMatch 需要每位玩家的角色與場地，且兩者皆 host 單一來源、廣播給全員（決定性）。
+ *  2. 所有 signalClient 呼叫帶 `bomber:` namespace（房號不與 tetris 相撞）。
+ *  3. 控制前綴 `bomber-`（與 bomberTransport 一致）。
+ *  4. 不在此跑 Pixi 主迴圈——而是回傳「ready-to-run」結果（transport + roster + seed + arenaId
+ *     + characters + localId + guestIds），由 Task 11b 自行建構並擁有 BomberLockstep。
+ *
+ * 刻意排除（v1 out of scope，未從 ffa 移植）：
+ *  - 快速配對 / 隊列（queueClient）。
+ *  - Host migration（ffaMigration）。本版策略：斷線者即視為死亡——由 game-loop 層處理
+ *    （BomberLockstep 已對已淘汰玩家自動補空輸入；transport 的 `bomber-leave` / channel close
+ *     會觸發 onChannelClose / onClose，game 層據此把該玩家標記淘汰）。
+ *    下方「MIGRATION SEAM」註解標出未來若要做 host 遷移的接點。
+ */
+
+// ─────────────────────────────────────────────────────────────────────────
+// 常數 / 工具
+// ─────────────────────────────────────────────────────────────────────────
+
+/** signalClient namespace 前綴：bomber 房號加此前綴，與 tetris 房號隔離（不相撞）。 */
+export const BOMBER_NS = 'bomber:';
+
+// 控制/init 訊息前綴沿用 bomberTransport 的 'bomber-'（buildBomberInit 的 t 即 'bomber-init'，
+// 故會被 BomberHub/Spoke 的 parseControl 視為控制訊息而非幀；解析時改走 onControl 路徑）。
+
+const HANDSHAKE_TIMEOUT_MS = 30_000;
+/** lobby 等待房主開始可較久（房主可慢慢等人）。 */
+const LOBBY_DEADLINE_MS = HANDSHAKE_TIMEOUT_MS * 4;
+
+/** bomber 對戰人數：2-4 人 → host 之外最多 3 名 guest。 */
+const MAX_GUEST_SLOTS = 3;
+
+/** 為 Promise 加上逾時，避免對手在連線後崩潰導致永久卡住（沿用 ffaNetMain.withTimeout）。 */
+export function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timeout`)), ms);
+    p.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 依賴注入：signal client + RTC peer 抽象（測試傳 mock，預設真實 signalClient / WebRTC）
+// ─────────────────────────────────────────────────────────────────────────
+
+/** 與 /api/signal 互動的最小客戶端（可注入 mock 測握手序列；真實環境包 bomber: ns）。 */
+export interface BomberSignalClient {
+  createRoom(): Promise<string>;
+  putSlot(room: string, slot: string, data: string): Promise<void>;
+  getSlot(room: string, slot: string): Promise<string | null>;
+  pollSlot(room: string, slot: string, opts?: { timeoutMs?: number; intervalMs?: number }): Promise<string>;
+}
+
+/**
+ * 預設真實 signal client：對每個呼叫帶入 `bomber:` namespace（房號不與 tetris 相撞）。
+ * 顯示給使用者的房號仍是 createRoom() 回傳的乾淨 5 碼；前綴只作用在 store key 層。
+ */
+export const realSignalClient: BomberSignalClient = {
+  createRoom: realCreateRoom,
+  putSlot: (room, slot, data) => realPutSlot(room, slot, data, BOMBER_NS),
+  getSlot: (room, slot) => realGetSlot(room, slot, BOMBER_NS),
+  pollSlot: (room, slot, opts) => realPollSlot(room, slot, opts ?? {}, BOMBER_NS),
+};
+
+/** Host 端對某 guest 的 RTC peer（guest-initiated：host 收 offer 回 answer）。 */
+export interface BomberHostAnswerPeer {
+  createAnswer(offer: string): Promise<string>;
+  waitOpen(): Promise<void>;
+  channel: RelayChannel & { onmessage?: ((raw: string) => void) | null };
+}
+
+/** Guest 端對 host 的 RTC peer（guest-initiated：guest 建 offer 收 answer）。 */
+export interface BomberGuestOfferPeer {
+  createOffer(): Promise<string>;
+  acceptAnswer(answer: string): Promise<void>;
+  waitOpen(): Promise<void>;
+  channel: RelayChannel & { onmessage?: ((raw: string) => void) | null };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// bomber-init 訊息（host 廣播給各 guest：seed + arenaId + 最終 players(id+character) + yourIndex）
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface BomberInitMsg {
+  t: 'bomber-init';
+  seed: number;
+  arenaId: number;
+  /** host 在前、guest 依 slot index 升序。index 即 BomberLockstep playerIds 的順序。 */
+  players: Array<{ id: string; character: CharacterId }>;
+  yourIndex: number;
+}
+
+/** 把 bomber-init 內容序列化為字串（透過 data channel 廣播）。 */
+export function buildBomberInit(opts: {
+  seed: number;
+  arenaId: number;
+  players: Array<{ id: string; character: CharacterId }>;
+  yourIndex: number;
+}): string {
+  const msg: BomberInitMsg = {
+    t: 'bomber-init',
+    seed: opts.seed,
+    arenaId: opts.arenaId,
+    players: opts.players.map((p) => ({ id: p.id, character: p.character })),
+    yourIndex: opts.yourIndex,
+  };
+  return JSON.stringify(msg);
+}
+
+/** 解析 bomber-init；JSON 容錯 + shape 驗證，畸形回 null（不丟例外）。 */
+export function parseBomberInit(raw: string): BomberInitMsg | null {
+  let m: unknown;
+  try {
+    m = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!m || typeof m !== 'object') return null;
+  const o = m as Record<string, unknown>;
+  if (o.t !== 'bomber-init') return null;
+  if (typeof o.seed !== 'number' || !Number.isFinite(o.seed)) return null;
+  if (typeof o.arenaId !== 'number' || !Number.isFinite(o.arenaId)) return null;
+  if (typeof o.yourIndex !== 'number' || !Number.isFinite(o.yourIndex)) return null;
+  if (!Array.isArray(o.players)) return null;
+  const players: Array<{ id: string; character: CharacterId }> = [];
+  for (const p of o.players) {
+    if (!p || typeof p !== 'object') return null;
+    const pp = p as Record<string, unknown>;
+    if (typeof pp.id !== 'string') return null;
+    if (typeof pp.character !== 'string') return null;
+    players.push({ id: pp.id, character: pp.character as CharacterId });
+  }
+  return { t: 'bomber-init', seed: o.seed, arenaId: o.arenaId, players, yourIndex: o.yourIndex };
+}
+
+/** guest 寫進 guest-{idx}-offer 的內容：自己的 id + RTC offer + 選擇的 character。 */
+interface GuestOfferMsg { id: string; offer: string; character?: CharacterId }
+
+function parseGuestOffer(raw: string): GuestOfferMsg | null {
+  try {
+    const m = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof m.id === 'string' && typeof m.offer === 'string') {
+      const character = typeof m.character === 'string' ? (m.character as CharacterId) : undefined;
+      return { id: m.id, offer: m.offer, character };
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 握手協調（可測：不依賴真實 WebRTC / DOM）
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Guest 認領最低未占用的 guest-{idx}-offer 槽位（寫入自己的 id+offer+character）。
+ *
+ * 已知限制（誠實揭露，沿用 ffaNetMain.claimGuestSlot）：claim 為「讀-改-寫」非原子操作，
+ * 兩名 guest 幾乎同時 claim 同一空槽時可能 race（後者覆蓋前者）。e2e 以「依序加入」規避；
+ * 生產環境可接受小機率重連。回傳認領到的 slot index。
+ */
+export async function claimBomberGuestSlot(
+  signal: BomberSignalClient,
+  room: string,
+  guestId: string,
+  offer: string,
+  maxGuests: number,
+  character?: CharacterId,
+): Promise<number> {
+  const slots = Math.min(Math.max(maxGuests, 1), MAX_GUEST_SLOTS);
+  for (let idx = 0; idx < slots; idx++) {
+    const existing = await signal.getSlot(room, `guest-${idx}-offer`);
+    if (existing) continue; // 已被占用，試下一個
+    const payload: GuestOfferMsg = { id: guestId, offer, character };
+    await signal.putSlot(room, `guest-${idx}-offer`, JSON.stringify(payload));
+    return idx;
+  }
+  throw new Error('lobby full: no free guest slot');
+}
+
+export interface NegotiateHostResult {
+  /** host 在前、連上的 guest 依 slot index 升序。 */
+  playerIds: string[];
+  /** 每位玩家的角色（playerId → CharacterId）；host 的角色由呼叫端帶入。 */
+  characters: Record<string, CharacterId>;
+  /** 每位連上 guest 的 host 端 peer（依 playerIds 中該 guest 的順序）。 */
+  guestPeers: BomberHostAnswerPeer[];
+  room: string;
+}
+
+/**
+ * Host 牽線（guest-initiated）：輪詢 guest-{i}-offer → 對每個 offer createAnswer 並寫
+ * host-ack-{i} → waitOpen → 收齊 expectedGuests（或取消）→ 組裝 playerIds + characters。
+ *
+ * isCancelled 可選：每輪檢查，外部按「開始」或逾時時提早結束（回已連上的）。
+ * onGuest 可選：每連上一名 guest 回呼一次（UI 更新 lobby 人數）。
+ * hostCharacter：host 自己的角色（寫進 characters[hostId]）。
+ */
+export async function negotiateHostBomberGuestInit(opts: {
+  hostId: string;
+  hostCharacter?: CharacterId;
+  maxGuests: number;
+  expectedGuests: number;
+  room: string;
+  signal: BomberSignalClient;
+  peerFactory: () => BomberHostAnswerPeer;
+  pollOpts?: { timeoutMs?: number; intervalMs?: number };
+  isCancelled?: () => boolean;
+  onGuest?: (connectedCount: number) => void;
+}): Promise<NegotiateHostResult> {
+  const { hostId, maxGuests, expectedGuests, room, signal, peerFactory } = opts;
+  if (expectedGuests < 1) {
+    throw new Error('bomber versus requires at least 2 players (host needs >= 1 guest)');
+  }
+  const slots = Math.min(Math.max(maxGuests, expectedGuests), MAX_GUEST_SLOTS);
+
+  const connected = new Array<{ id: string; peer: BomberHostAnswerPeer; character?: CharacterId } | undefined>(slots);
+  let count = 0;
+  const timeoutMs = opts.pollOpts?.timeoutMs ?? HANDSHAKE_TIMEOUT_MS;
+  const intervalMs = opts.pollOpts?.intervalMs ?? 600;
+  const deadline = Date.now() + timeoutMs;
+
+  // 反覆掃所有 slot，發現未處理的 offer 就回 answer 並連線，直到收齊或逾時/取消。
+  while (count < expectedGuests && Date.now() < deadline) {
+    if (opts.isCancelled?.()) break;
+    let progressed = false;
+    for (let idx = 0; idx < slots; idx++) {
+      if (connected[idx]) continue;
+      const raw = await signal.getSlot(room, `guest-${idx}-offer`);
+      if (!raw) continue;
+      const parsed = parseGuestOffer(raw);
+      if (!parsed) continue;
+
+      const peer = peerFactory();
+      const answer = await peer.createAnswer(parsed.offer);
+      await signal.putSlot(room, `host-ack-${idx}`, answer);
+      await peer.waitOpen();
+      connected[idx] = { id: parsed.id, peer, character: parsed.character };
+      count++;
+      progressed = true;
+      opts.onGuest?.(count);
+      if (count >= expectedGuests) break;
+    }
+    if (count >= expectedGuests) break;
+    if (!progressed) {
+      if (intervalMs === 0) break; // 測試模式：不忙等
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+
+  if (count < 1) {
+    throw new Error('no guests connected');
+  }
+
+  const playerIds: string[] = [hostId];
+  const characters: Record<string, CharacterId> = {};
+  if (opts.hostCharacter) characters[hostId] = opts.hostCharacter;
+  const guestPeers: BomberHostAnswerPeer[] = [];
+  for (let idx = 0; idx < slots; idx++) {
+    const c = connected[idx];
+    if (!c) continue;
+    playerIds.push(c.id);
+    if (c.character) characters[c.id] = c.character;
+    guestPeers.push(c.peer);
+  }
+
+  return { playerIds, characters, guestPeers, room };
+}
+
+export interface NegotiateJoinResult {
+  localId: string;
+  slotIndex: number;
+  peer: BomberGuestOfferPeer;
+  room: string;
+}
+
+/**
+ * Guest 牽線（guest-initiated）：createOffer → claim 最低空 guest-{idx}-offer（夾帶 character）→
+ * 等 host-ack-{idx}(=answer) → acceptAnswer → waitOpen。
+ * seed/arenaId/players 不在此取得——由 host 開局後透過 data channel 廣播 bomber-init。
+ */
+export async function negotiateJoinBomberGuestInit(opts: {
+  room: string;
+  guestId: string;
+  character?: CharacterId;
+  signal: BomberSignalClient;
+  peerFactory: () => BomberGuestOfferPeer;
+  maxGuests?: number;
+  /** 指定槽位（免並發 claim race）；未給則掃最低空槽。 */
+  fixedSlot?: number;
+  pollOpts?: { timeoutMs?: number; intervalMs?: number };
+}): Promise<NegotiateJoinResult> {
+  const { room, guestId, signal, peerFactory } = opts;
+  const peer = peerFactory();
+  const offer = await peer.createOffer();
+  let slotIndex: number;
+  if (opts.fixedSlot !== undefined) {
+    slotIndex = opts.fixedSlot;
+    const payload: GuestOfferMsg = { id: guestId, offer, character: opts.character };
+    await signal.putSlot(room, `guest-${slotIndex}-offer`, JSON.stringify(payload));
+  } else {
+    slotIndex = await claimBomberGuestSlot(signal, room, guestId, offer, opts.maxGuests ?? MAX_GUEST_SLOTS, opts.character);
+  }
+
+  const answer = await signal.pollSlot(room, `host-ack-${slotIndex}`, opts.pollOpts);
+  await peer.acceptAnswer(answer);
+  await peer.waitOpen();
+
+  return { localId: guestId, slotIndex, peer, room };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// RelayChannel 卡接：把 WebRtcTransport（send/onMessage/isOpen[/onClose]）包成 RelayChannel
+// （沿用 ffaNetMain.wrapChannel：onmessage 設定前到達的訊息進暫存佇列，設定當下回放保序）
+// ─────────────────────────────────────────────────────────────────────────
+
+/** WebRtcTransport 對外需要的最小形狀（供 wrapChannel；真實環境傳 WebRtcTransport 實例）。 */
+export interface ChannelBacking {
+  send(data: string): void;
+  onMessage(cb: (data: string) => void): void;
+  readonly isOpen: boolean;
+  /** 可選：底層 channel 關閉通知（→ 中離 close 快速路徑）。 */
+  onClose?(cb: () => void): void;
+}
+
+/**
+ * 把一個 ChannelBacking（如 WebRtcTransport）包成 RelayChannel：
+ *  - send(raw) → backing.send(raw)
+ *  - open → backing.isOpen
+ *  - onmessage setter → 掛到 backing.onMessage（Hub/Spoke 會設定此 setter）
+ *  - onclose 可賦值屬性 → 由 backing.onClose 觸發
+ *
+ * 鐵則：onmessage 設定前到達的訊息進暫存佇列，設定當下立刻回放（保序）——
+ * 避免 channel 開啟與設定 onmessage 之間的空檔丟失早到的 bomber-init / 對手幀。
+ */
+export function wrapChannel(
+  backing: ChannelBacking,
+): RelayChannel & { onmessage: ((raw: string) => void) | null; onclose: (() => void) | null } {
+  let cb: ((raw: string) => void) | null = null;
+  const queue: string[] = [];
+  backing.onMessage((d) => {
+    if (cb) cb(d);
+    else queue.push(d);
+  });
+  const wrapped = {
+    send: (raw: string) => backing.send(raw),
+    get open() { return backing.isOpen; },
+    get onmessage() { return cb; },
+    set onmessage(fn: ((raw: string) => void) | null) {
+      cb = fn;
+      if (fn) while (queue.length) fn(queue.shift()!);
+    },
+    onclose: null as (() => void) | null,
+  };
+  backing.onClose?.(() => wrapped.onclose?.());
+  return wrapped;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 真實環境 RTC peer 工廠（包 WebRtcTransport；測試注入 stub 取代）
+// ─────────────────────────────────────────────────────────────────────────
+
+/** 真實環境的 host 端 peer 工廠：每 guest 一條 WebRtcTransport，包成 BomberHostAnswerPeer。 */
+export function realHostAnswerPeerFactory(): BomberHostAnswerPeer {
+  const transport = new WebRtcTransport();
+  const channel = wrapChannel(transport);
+  return {
+    createAnswer: (offer: string) => transport.createAnswer(offer),
+    waitOpen: () => transport.waitOpen(),
+    channel,
+  };
+}
+
+/** 真實環境的 guest 端 peer 工廠：一條對 host 的 WebRtcTransport，包成 BomberGuestOfferPeer。 */
+export function realGuestOfferPeerFactory(): BomberGuestOfferPeer {
+  const transport = new WebRtcTransport();
+  const channel = wrapChannel(transport);
+  return {
+    createOffer: () => transport.createOffer(),
+    acceptAnswer: (answer: string) => transport.acceptAnswer(answer),
+    waitOpen: () => transport.waitOpen(),
+    channel,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 高階入口：hostBomberGame / joinBomberGame
+// （回傳「ready-to-run」結果，由 Task 11b 自行建構並擁有 BomberLockstep）
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface BomberNetStatus {
+  phase: 'creating' | 'lobby' | 'connecting' | 'connected' | 'error';
+  room?: string;
+  message?: string;
+  /** 目前已連上的 guest 數（host lobby 顯示「已加入 / 目標」）。 */
+  connected?: number;
+}
+export type BomberStatusCb = (s: BomberNetStatus) => void;
+
+export interface BomberIdentity {
+  id: string;
+  character: CharacterId;
+}
+
+/**
+ * 連線完成、可開跑的結果。Task 11b 用此建構 BomberLockstep：
+ *   new BomberLockstep({ playerIds, localId, seed, arenaId, characters, transport })
+ * 並接上 transport 的 onChannelClose（host）/ onClose（guest）把斷線玩家標記淘汰。
+ */
+export interface BomberReady {
+  /** 星狀 transport：host 為 BomberHubTransport、guest 為 BomberSpokeTransport。 */
+  transport: BomberHubTransport | BomberSpokeTransport;
+  /** host 在前、guest 依 slot index 升序。 */
+  playerIds: string[];
+  /** 每位玩家的角色（playerId → CharacterId）。 */
+  characters: Record<string, CharacterId>;
+  seed: number;
+  arenaId: number;
+  localId: string;
+  /** host 端：channels[i] ↔ guestIds[i]（playerIds 去掉 host）；guest 端為 undefined。 */
+  guestIds?: string[];
+  /** 房號（顯示用 / 後續清理）。 */
+  room: string;
+  /** 本端角色（host 才有 guestIds）。 */
+  role: 'host' | 'guest';
+}
+
+/**
+ * Host（guest-initiated 真實 WebRTC）：
+ *  1. 建房（或用指定 room），回報 room（lobby 顯示房號）。
+ *  2. 背景接受 guest（輪詢 guest-{i}-offer → answer → waitOpen），每連上一名回報人數。
+ *  3. 等 waitStart()（lobby「開始」按鈕）resolve；或滿員（autoStart 不適用 v1，預留）。
+ *  4. 組裝 playerIds + characters，透過各 channel 廣播 bomber-init，建 BomberHubTransport。
+ *  5. 呼叫 onReady(BomberReady)——不在此跑遊戲迴圈（交給 Task 11b）。
+ *
+ * peerFactory 預設真實 WebRtcTransport；signal 預設帶 bomber: ns 的 realSignalClient；測試可注入。
+ */
+export async function hostBomberGame(opts: {
+  identity: BomberIdentity;
+  arenaId: number;
+  /** 開放的 guest 槽位數（1..3 → 2..4 人）。 */
+  maxGuests: number;
+  /** 對局 seed（host 單一來源；Task 11b 通常從 BomberLobby.buildStartPayload 取得後傳入）。 */
+  seed: number;
+  /** lobby「開始」訊號：resolve 後 host 停止收人並開局。未傳＝收滿 maxGuests 即開。 */
+  waitStart?: () => Promise<void>;
+  /** 指定房號；未給則 signal.createRoom()（lobby 顯示此房號）。 */
+  room?: string;
+  onStatus: BomberStatusCb;
+  /** 連線完成回呼：交付 ready-to-run 結果（Task 11b 建 BomberLockstep）。 */
+  onReady?: (r: BomberReady) => void;
+  peerFactory?: () => BomberHostAnswerPeer;
+  signal?: BomberSignalClient;
+  pollOpts?: { timeoutMs?: number; intervalMs?: number };
+}): Promise<void> {
+  const signal = opts.signal ?? realSignalClient;
+  const peerFactory = opts.peerFactory ?? realHostAnswerPeerFactory;
+  const slots = Math.min(Math.max(opts.maxGuests, 1), MAX_GUEST_SLOTS);
+  try {
+    opts.onStatus({ phase: 'creating' });
+    const room = opts.room ?? (await signal.createRoom());
+    opts.onStatus({ phase: 'lobby', room, connected: 0 });
+
+    // 背景持續接受 guest，直到 start 訊號或收滿（未傳 waitStart 則收滿即開）。
+    const connected = new Array<{ id: string; peer: BomberHostAnswerPeer; character?: CharacterId } | undefined>(slots);
+    let count = 0;
+    let started = false;
+    if (opts.waitStart) void opts.waitStart().then(() => { started = true; });
+
+    const intervalMs = opts.pollOpts?.intervalMs ?? 500;
+    const deadline = Date.now() + (opts.pollOpts?.timeoutMs ?? LOBBY_DEADLINE_MS);
+    while (!started && Date.now() < deadline) {
+      let progressed = false;
+      for (let idx = 0; idx < slots; idx++) {
+        if (connected[idx]) continue;
+        const raw = await signal.getSlot(room, `guest-${idx}-offer`);
+        if (!raw) continue;
+        const parsed = parseGuestOffer(raw);
+        if (!parsed) continue;
+        const peer = peerFactory();
+        const answer = await peer.createAnswer(parsed.offer);
+        await signal.putSlot(room, `host-ack-${idx}`, answer);
+        await peer.waitOpen();
+        connected[idx] = { id: parsed.id, peer, character: parsed.character };
+        count++;
+        progressed = true;
+        opts.onStatus({ phase: 'lobby', room, connected: count });
+        // 未提供 waitStart：收滿 maxGuests 即自動開局。
+        if (!opts.waitStart && count >= slots) started = true;
+        if (started || count >= slots) break;
+      }
+      if (started) break;
+      if (count >= slots) break;
+      if (!progressed) {
+        if (intervalMs === 0) break; // 測試模式：不忙等
+        await new Promise((r) => setTimeout(r, intervalMs));
+      }
+    }
+
+    if (count < 1) throw new Error('no guests connected');
+
+    // 組裝 playerIds（host 在前、guest 依 slot index 升序）+ characters + channels。
+    const playerIds: string[] = [opts.identity.id];
+    const characters: Record<string, CharacterId> = { [opts.identity.id]: opts.identity.character };
+    const channels: Array<RelayChannel & { onmessage?: ((raw: string) => void) | null }> = [];
+    for (let idx = 0; idx < slots; idx++) {
+      const c = connected[idx];
+      if (!c) continue;
+      playerIds.push(c.id);
+      // guest 若夾帶 character 用之；否則退回 host identity 的預設（誠實：host 不臆測，但需 fallback）。
+      characters[c.id] = c.character ?? opts.identity.character;
+      channels.push(c.peer.channel);
+    }
+
+    // 透過各 channel 廣播 bomber-init（seed + arenaId + 最終 players(id+character) + 該 guest 的 index）。
+    // channels[i] 對應 playerIds[i+1]（host 在 index 0），故 yourIndex = i+1。
+    const players = playerIds.map((id) => ({ id, character: characters[id] }));
+    for (let i = 0; i < channels.length; i++) {
+      channels[i].send(buildBomberInit({ seed: opts.seed, arenaId: opts.arenaId, players, yourIndex: i + 1 }));
+    }
+
+    opts.onStatus({ phase: 'connected', room, connected: count });
+
+    const transport = new BomberHubTransport(channels);
+    // MIGRATION SEAM：v1 不做 host migration。若日後支援，這裡是「把 transport 包進
+    // MigratingTransport facade、並在 host-down 時 swap 內層」的接點（參照 ffaNetMain.runFfaGame）。
+    opts.onReady?.({
+      transport,
+      playerIds,
+      characters,
+      seed: opts.seed,
+      arenaId: opts.arenaId,
+      localId: opts.identity.id,
+      // channels[i] ↔ playerIds[i+1]（host 在 0）→ guestIds 供 Task 11b 啟動斷線→淘汰偵測。
+      guestIds: playerIds.slice(1),
+      room,
+      role: 'host',
+    });
+  } catch (e) {
+    opts.onStatus({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+  }
+}
+
+/**
+ * Guest（guest-initiated 真實 WebRTC）：
+ *  1. createOffer → claim guest-{idx}-offer（夾帶 character）→ 等 host-ack-{idx}(=answer)
+ *     → acceptAnswer → waitOpen。
+ *  2. 透過 data channel 等 host 廣播的 bomber-init（取 seed/arenaId/players/yourIndex）。
+ *  3. 建 BomberSpokeTransport → 呼叫 onReady（Task 11b 建 BomberLockstep）。
+ */
+export async function joinBomberGame(opts: {
+  room: string;
+  identity: BomberIdentity;
+  onStatus: BomberStatusCb;
+  onReady?: (r: BomberReady) => void;
+  maxGuests?: number;
+  /** 指定槽位（免並發 claim race）。 */
+  fixedSlot?: number;
+  peerFactory?: () => BomberGuestOfferPeer;
+  signal?: BomberSignalClient;
+  pollOpts?: { timeoutMs?: number; intervalMs?: number };
+  /** bomber-init 等待逾時（預設沿用握手逾時）。 */
+  initTimeoutMs?: number;
+}): Promise<void> {
+  const signal = opts.signal ?? realSignalClient;
+  const peerFactory = opts.peerFactory ?? realGuestOfferPeerFactory;
+  try {
+    opts.onStatus({ phase: 'connecting', room: opts.room });
+    const result = await negotiateJoinBomberGuestInit({
+      room: opts.room,
+      guestId: opts.identity.id,
+      character: opts.identity.character,
+      signal,
+      peerFactory,
+      maxGuests: opts.maxGuests ?? MAX_GUEST_SLOTS,
+      fixedSlot: opts.fixedSlot,
+      pollOpts: opts.pollOpts,
+    });
+    opts.onStatus({ phase: 'lobby', room: opts.room });
+
+    // channel 開後，先攔截 bomber-init（host 開局時第一筆廣播）。
+    // bomber-init 之後到達的對手幀先暫存，交給 BomberSpokeTransport 前回放，避免開局丟幀。
+    const ch = result.peer.channel;
+    const earlyFrames: string[] = [];
+    const initRaw = await withTimeout(
+      new Promise<string>((resolve) => {
+        let gotInit = false;
+        ch.onmessage = (raw: string) => {
+          if (!gotInit) {
+            const init = parseBomberInit(raw);
+            if (init) { gotInit = true; resolve(raw); return; }
+            return; // bomber-init 前的雜訊忽略（理論上不會有）
+          }
+          earlyFrames.push(raw); // bomber-init 後、接管前的對手幀先暫存
+        };
+      }),
+      opts.initTimeoutMs ?? HANDSHAKE_TIMEOUT_MS,
+      'bomber-init',
+    );
+    const init = parseBomberInit(initRaw)!;
+
+    const playerIds = init.players.map((p) => p.id);
+    const characters: Record<string, CharacterId> = {};
+    for (const p of init.players) characters[p.id] = p.character;
+
+    opts.onStatus({ phase: 'connected', room: opts.room });
+
+    // BomberSpokeTransport 建構時會覆寫 ch.onmessage（接管收幀）；此後幀進 lockstep。
+    const transport = new BomberSpokeTransport(ch);
+    // 回放 bomber-init 之後、接管之前暫存的對手幀（保序）。
+    for (const raw of earlyFrames) ch.onmessage?.(raw);
+
+    // MIGRATION SEAM：v1 guest 端不做 host migration。host 斷線 → BomberSpokeTransport.onClose
+    // 觸發，由 Task 11b 把對局判為中止（或將 host 標記淘汰）。日後若支援遷移，這裡是
+    // 「傳入 migration 依賴（同 room 的 mig{g}- 槽位）」的接點（參照 ffaNetMain.joinFfaGame）。
+    opts.onReady?.({
+      transport,
+      playerIds,
+      characters,
+      seed: init.seed,
+      arenaId: init.arenaId,
+      localId: opts.identity.id,
+      room: opts.room,
+      role: 'guest',
+    });
+  } catch (e) {
+    opts.onStatus({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/src/scripts/games/bomber/net/bomberRanking.test.ts
+++ b/src/scripts/games/bomber/net/bomberRanking.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildBomberMatchId,
+  reportBomberRanked,
+  type BomberRankReport,
+} from './bomberRanking';
+import { buildFfaResultMessage } from '@scripts/games/tetris/net/auth';
+import type { VersusReplay } from './versusReplay';
+import { BomberLockstep, LoopbackBomberHub } from './bomberLockstep';
+import type { CharacterId } from '../engine/types';
+
+// ── 共用：跑一場決定性的 2 人 loopback 局，得到真實 replay/standings ──────────
+const CHARS: Record<string, CharacterId> = { A: 'lena' as CharacterId, B: 'mira' as CharacterId };
+
+/** 建一個 host 端 lockstep，把它推進到分出勝負，回傳 { lockstep, replay, standings }。 */
+function playToFinish(seed: number): { lockstep: BomberLockstep; replay: VersusReplay } {
+  const hub = new LoopbackBomberHub();
+  const a = new BomberLockstep({
+    playerIds: ['A', 'B'], localId: 'A', seed, arenaId: 0, characters: CHARS, transport: hub.transportFor('A'),
+  });
+  const b = new BomberLockstep({
+    playerIds: ['A', 'B'], localId: 'B', seed, arenaId: 0, characters: CHARS, transport: hub.transportFor('B'),
+  });
+  // 直接讓 B 自爆：B 放炸彈站著不動，A 走開 → B 先死 → A 冠軍。
+  // 為了測試只要「局會結束」即可（用 forfeit 收斂，最穩定、與 seed 無關）。
+  // 推進若干幀以累積一些已確認幀，再 forfeit B（各端同一幀）。
+  for (let i = 0; i < 20; i++) { a.tick(); b.tick(); }
+  const f = a.lastInputFrame('B') + 1;
+  a.forfeit('B', f); b.forfeit('B', f);
+  for (let i = 0; i < 30; i++) { a.tick(); b.tick(); }
+  return { lockstep: a, replay: a.getReplay() };
+}
+
+describe('buildBomberMatchId', () => {
+  it('格式為 bomber-<seed.toString(36)>-<roomId>（與 Task 14 endpoint 解析相符）', () => {
+    expect(buildBomberMatchId(0, 'ABCDE')).toBe('bomber-0-ABCDE');
+    expect(buildBomberMatchId(35, 'R1')).toBe('bomber-z-R1');
+    expect(buildBomberMatchId(1296, 'XY')).toBe('bomber-100-XY'); // 36^2
+  });
+
+  it('endpoint 由 matchId.split("-")[1] 以 base36 解析出的 seed 必須等於原 seed', () => {
+    const seed = 1234567;
+    const matchId = buildBomberMatchId(seed, 'ROOM7');
+    const parsed = parseInt(matchId.split('-')[1] ?? '', 36);
+    expect(parsed).toBe(seed);
+  });
+});
+
+describe('reportBomberRanked — claim 組裝 / 簽章訊息 / POST', () => {
+  it('無 signMessage（casual）→ 不送、回 outcome:null', async () => {
+    const { replay } = playToFinish(0x1111);
+    const fetchFn = vi.fn();
+    const r = await reportBomberRanked({
+      seed: replay.seed, roomId: 'RM', reporterId: 'A', replay, fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(r.outcome).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('有 signMessage → POST /api/bomber-match，body 含正確 matchId/standings/stateHash/signature/replay/reporterId', async () => {
+    const { replay } = playToFinish(0x2222);
+    const signMessage = vi.fn(async (m: string) => `sig(${m})`);
+    const fetchFn = vi.fn(async () =>
+      new Response(JSON.stringify({ outcome: 'pending' }), { status: 200 }),
+    );
+    await reportBomberRanked({
+      seed: replay.seed, roomId: 'RM5', reporterId: 'A', replay, signMessage,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/bomber-match');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    const matchId = buildBomberMatchId(replay.seed, 'RM5');
+    expect(body.matchId).toBe(matchId);
+    expect(body.reporterId).toBe('A');
+    // standings：冠軍在前，這場 A 勝 B 敗
+    expect(body.standings).toEqual(['A', 'B']);
+    expect(typeof body.stateHash).toBe('string');
+    expect((body.stateHash as string).length).toBeGreaterThan(0);
+    expect(body.replay).toBeTruthy();
+    // 簽章訊息：buildFfaResultMessage(matchId, standings, [1..N])
+    const expectedMsg = buildFfaResultMessage(matchId, ['A', 'B'], [1, 2]);
+    expect(signMessage).toHaveBeenCalledWith(expectedMsg);
+    expect(body.signature).toBe(`sig(${expectedMsg})`);
+  });
+
+  it('seed 內嵌進 matchId 後，endpoint 的 split("-")[1] base36 解析 == replay.seed', async () => {
+    const { replay } = playToFinish(0xfeed);
+    const signMessage = vi.fn(async (m: string) => `sig(${m})`);
+    const fetchFn = vi.fn(async () =>
+      new Response(JSON.stringify({ outcome: 'pending' }), { status: 200 }),
+    );
+    await reportBomberRanked({
+      seed: replay.seed, roomId: 'ZZ', reporterId: 'A', replay, signMessage,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    const body = JSON.parse((fetchFn.mock.calls[0] as unknown as [string, RequestInit])[1].body as string) as { matchId: string };
+    const seedFromMatch = parseInt(body.matchId.split('-')[1] ?? '', 36);
+    expect(seedFromMatch).toBe(replay.seed);
+  });
+});
+
+describe('reportBomberRanked — 回應解析', () => {
+  const mkReply = () => playToFinish(0x3333);
+
+  async function runWith(json: unknown, status = 200): Promise<BomberRankReport> {
+    const { replay } = mkReply();
+    const signMessage = async (m: string) => `sig(${m})`;
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify(json), { status }));
+    return reportBomberRanked({
+      seed: replay.seed, roomId: 'RM', reporterId: 'A', replay, signMessage,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+  }
+
+  it('applied → 回傳 outcome:applied + results 陣列', async () => {
+    const results = [
+      { id: 'A', placement: 1, ratingBefore: 1200, ratingAfter: 1216, xpGained: 35, level: 1 },
+      { id: 'B', placement: 2, ratingBefore: 1200, ratingAfter: 1184, xpGained: 10, level: 1 },
+    ];
+    const r = await runWith({ outcome: 'applied', results });
+    expect(r.outcome).toBe('applied');
+    expect(r.results).toEqual(results);
+  });
+
+  it('pending → outcome:pending、無 results', async () => {
+    const r = await runWith({ outcome: 'pending' });
+    expect(r.outcome).toBe('pending');
+    expect(r.results).toBeUndefined();
+  });
+
+  it('already → outcome:already', async () => {
+    const r = await runWith({ outcome: 'already' });
+    expect(r.outcome).toBe('already');
+  });
+
+  it('conflict（409）→ outcome:conflict', async () => {
+    const r = await runWith({ outcome: 'conflict' }, 409);
+    expect(r.outcome).toBe('conflict');
+  });
+
+  it('fetch 失敗（reject）→ outcome:null（不丟例外）', async () => {
+    const { replay } = mkReply();
+    const fetchFn = vi.fn(async () => { throw new Error('network'); });
+    const r = await reportBomberRanked({
+      seed: replay.seed, roomId: 'RM', reporterId: 'A', replay,
+      signMessage: async (m) => `sig(${m})`,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(r.outcome).toBeNull();
+  });
+
+  it('壞 JSON 回應 → outcome:null', async () => {
+    const { replay } = mkReply();
+    const fetchFn = vi.fn(async () => new Response('not json', { status: 200 }));
+    const r = await reportBomberRanked({
+      seed: replay.seed, roomId: 'RM', reporterId: 'A', replay,
+      signMessage: async (m) => `sig(${m})`,
+      fetchFn: fetchFn as unknown as typeof fetch,
+    });
+    expect(r.outcome).toBeNull();
+  });
+});

--- a/src/scripts/games/bomber/net/bomberRanking.ts
+++ b/src/scripts/games/bomber/net/bomberRanking.ts
@@ -1,0 +1,128 @@
+import { buildFfaResultMessage } from '@scripts/games/tetris/net/auth';
+import { simulateVersusReplay, type VersusReplay } from './versusReplay';
+
+/** 結果回報逾時（沿用 tetris ffaNetMain 的 8s）。 */
+const REPORT_TIMEOUT_MS = 8_000;
+
+/**
+ * 結算端點（/api/bomber-match）回報結果。client 端負責「組 claim → 簽章 → POST → 解析」，
+ * 真正的計分/共識/防作弊全由後端（Task 14）負責。
+ *
+ * - applied   ：共識達成且本次請求為首位結算者 → results 含每位玩家 before/after。
+ * - pending   ：尚未達共識門檻（其他端還沒回報相同 standings）。
+ * - already   ：本場已被結算過（重複回報，不重複計分）。
+ * - conflict  ：並列最高票（無單一多數）→ 名次有爭議。
+ * - null      ：casual（無 signMessage）不回報；或網路/解析失敗（不丟例外）。
+ */
+export type BomberRankOutcome = 'applied' | 'pending' | 'already' | 'conflict' | null;
+
+/** 單位玩家結算結果（鏡像 endpoint 的 BomberSettleResult，供結算畫面顯示 Elo±/XP/等級）。 */
+export interface BomberRankResult {
+  id: string;
+  placement: number; // 1 = 冠軍
+  ratingBefore: number;
+  ratingAfter: number;
+  xpGained: number;
+  level: number;
+}
+
+/** reportBomberRanked 的回傳：本次結果 + 達共識時每位玩家的 before/after。 */
+export interface BomberRankReport {
+  outcome: BomberRankOutcome;
+  results?: BomberRankResult[];
+}
+
+/**
+ * 組出對局 id：**bomber-<seed.toString(36)>-<roomId>**。
+ *
+ * 鐵則（與 Task 14 endpoint 對齊）：endpoint 以 `matchId.split('-')[1]` 取出中段、
+ * 以 base36 parseInt，要求 == replay.seed。故 seed 必須是中段、且以 36 進位編碼。
+ * roomId 放最後一段（可含字母，不被當作 seed 解析）。
+ */
+export function buildBomberMatchId(seed: number, roomId: string): string {
+  return `bomber-${seed.toString(36)}-${roomId}`;
+}
+
+/** 為 Promise 加逾時（避免對手結算後崩潰導致 UI 永久等待）。 */
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timeout`)), ms);
+    p.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+/** 把任意回應正規化成已知 outcome；未知值 → null。 */
+function normalizeOutcome(v: unknown): BomberRankOutcome {
+  return v === 'applied' || v === 'pending' || v === 'already' || v === 'conflict' ? v : null;
+}
+
+/**
+ * 對局結束後本機簽章並 POST /api/bomber-match。
+ *
+ * 決定性鐵則：standings 與 stateHash **不**讀 live match 狀態，而是由 replay 經
+ * simulateVersusReplay 重模擬得到——這正是 endpoint 抽驗時重建的同一份結果，
+ * 保證 client 宣稱值與 server 重模擬「逐位元相同」（否則 verifyVersusReplay 會 400）。
+ *
+ * - 無 signMessage（casual / 未連錢包）→ 不送、回 { outcome: null }（仍可顯示本機名次）。
+ * - 各端各自呼叫一次（mirror tetris FFA：consensus 過半 + SETTLED 原子閘去重；
+ *   不需要選「誰送」——全送，後端只結算一次）。
+ * - 逾時 / 網路 / 壞 JSON → { outcome: null }，絕不丟未捕捉例外（不影響對局收尾）。
+ */
+export async function reportBomberRanked(opts: {
+  /** host 廣播的對局 seed（== replay.seed）。 */
+  seed: number;
+  /** 房號（BomberReady.room）。 */
+  roomId: string;
+  /** 本端玩家 id（== 簽章地址；ranked 時為錢包地址）。 */
+  reporterId: string;
+  /** 本局可重播紀錄（lockstep.getReplay()）。 */
+  replay: VersusReplay;
+  /** 錢包簽章函式；casual（無）→ 不回報。 */
+  signMessage?: (msg: string) => Promise<string>;
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<BomberRankReport> {
+  const { seed, roomId, reporterId, replay, signMessage } = opts;
+  if (!signMessage) return { outcome: null }; // casual：不回報
+
+  const fetchFn = opts.fetchFn ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? REPORT_TIMEOUT_MS;
+
+  try {
+    // standings + stateHash 由 replay 重模擬（與 endpoint 抽驗同源 → 必相符）。
+    const { standings, stateHash } = simulateVersusReplay(replay);
+    const matchId = buildBomberMatchId(seed, roomId);
+
+    // 簽章訊息：buildFfaResultMessage(matchId, standings, [1..N])（與 endpoint 重建一致）。
+    const placements = standings.map((_, i) => i + 1);
+    const message = buildFfaResultMessage(matchId, standings, placements);
+    const signature = await signMessage(message);
+
+    const body: Record<string, unknown> = {
+      matchId,
+      reporterId,
+      standings,
+      stateHash,
+      signature,
+      replay,
+    };
+
+    const res = await withTimeout(
+      fetchFn('/api/bomber-match', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+      timeoutMs,
+      'bomber-report',
+    );
+    const json = (await res.json()) as { outcome?: unknown; results?: BomberRankResult[] };
+    const outcome = normalizeOutcome(json.outcome);
+    return outcome === 'applied' ? { outcome, results: json.results } : { outcome };
+  } catch {
+    return { outcome: null }; // 回報失敗不影響對局收尾
+  }
+}

--- a/src/scripts/games/bomber/net/bomberTransport.test.ts
+++ b/src/scripts/games/bomber/net/bomberTransport.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect } from 'vitest';
+import {
+  routeFrame,
+  BomberHubTransport,
+  BomberSpokeTransport,
+  type RelayChannel,
+} from './bomberTransport';
+import { BomberLockstep, type BomberFrameMsg } from './bomberLockstep';
+import type { CharacterId } from '../engine/types';
+
+/** 測試用 mock channel：記錄送出的原始字串、可切 open、含 onclose 掛點。 */
+function mockChannel(open = true): RelayChannel & {
+  sent: string[];
+  open: boolean;
+  onmessage: ((raw: string) => void) | null;
+  onclose: (() => void) | null;
+} {
+  return {
+    sent: [] as string[],
+    open,
+    onmessage: null as ((raw: string) => void) | null,
+    onclose: null as (() => void) | null,
+    send(raw: string): void {
+      this.sent.push(raw);
+    },
+  };
+}
+
+describe('routeFrame（純函式 relay）', () => {
+  it('來自 channel 1 → 轉發給其餘 0/2/3、自己不收，回傳 [0,2,3]', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel(), mockChannel()];
+    const raw = JSON.stringify({ f: 5, p: 'g1', a: [] });
+    const routed = routeFrame(1, raw, channels);
+    expect(routed).toEqual([0, 2, 3]);
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([]); // 來源不回灌
+    expect(channels[2].sent).toEqual([raw]);
+    expect(channels[3].sent).toEqual([raw]);
+  });
+
+  it('fromIdx=null（host 自己的幀）→ 全部 channel 都收到，回傳全部 index', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel()];
+    const raw = JSON.stringify({ f: 0, p: 'host', a: [{ t: 'bomb' }] });
+    const routed = routeFrame(null, raw, channels);
+    expect(routed).toEqual([0, 1, 2]);
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([raw]);
+    expect(channels[2].sent).toEqual([raw]);
+  });
+
+  it('channel 未開（open=false）跳過、不丟例外、不在回傳陣列', () => {
+    const channels = [mockChannel(true), mockChannel(false), mockChannel(true)];
+    const raw = JSON.stringify({ f: 1, p: 'g0', a: [] });
+    const routed = routeFrame(null, raw, channels);
+    expect(routed).toEqual([0, 2]);
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([]); // 未開不送
+    expect(channels[2].sent).toEqual([raw]);
+  });
+});
+
+describe('BomberHubTransport（Host 端 relay）', () => {
+  it('某 guest channel 觸發 onmessage → 其餘 guest 收到該 raw、host 上層收到 parse 後 msg', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const got: BomberFrameMsg[] = [];
+    hub.onMessage((m) => got.push(m));
+
+    const msg: BomberFrameMsg = { f: 2, p: 'g1', a: [{ t: 'held', d: 'right', v: true }] };
+    const raw = JSON.stringify(msg);
+    // 模擬 guest 1 的 channel 收到訊息
+    channels[1].onmessage!(raw);
+
+    // 其餘 guest channel（0、2）都收到原始 raw、來源 channel 1 不回灌
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([]);
+    expect(channels[2].sent).toEqual([raw]);
+    // host 上層也看到該幀
+    expect(got).toEqual([msg]);
+  });
+
+  it('send（host 自己的幀）→ 所有 guest channel 收到、host 上層 cb 也收到（自身可見）', () => {
+    const channels = [mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const got: BomberFrameMsg[] = [];
+    hub.onMessage((m) => got.push(m));
+
+    const msg: BomberFrameMsg = { f: 0, p: 'host', a: [{ t: 'bomb' }] };
+    hub.send(msg);
+
+    const raw = JSON.stringify(msg);
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([raw]);
+    expect(got).toEqual([msg]); // host lockstep 也要看到自己的幀
+  });
+});
+
+describe('BomberSpokeTransport（Guest 端）', () => {
+  it('send → 對 host 的 channel.send 被呼叫且內容為該 msg 的 JSON', () => {
+    const ch = mockChannel();
+    const spoke = new BomberSpokeTransport(ch);
+    const msg: BomberFrameMsg = { f: 3, p: 'g0', a: [{ t: 'ability' }] };
+    spoke.send(msg);
+    expect(ch.sent).toEqual([JSON.stringify(msg)]);
+  });
+
+  it('channel.open=false 時 send 不丟例外、不送出', () => {
+    const ch = mockChannel(false);
+    const spoke = new BomberSpokeTransport(ch);
+    expect(() => spoke.send({ f: 1, p: 'g0', a: [] })).not.toThrow();
+    expect(ch.sent).toEqual([]);
+  });
+
+  it('channel.onmessage(raw) → 上層 cb 收到 parse 後 msg', () => {
+    const ch = mockChannel();
+    const spoke = new BomberSpokeTransport(ch);
+    const got: BomberFrameMsg[] = [];
+    spoke.onMessage((m) => got.push(m));
+    const msg: BomberFrameMsg = { f: 4, p: 'host', a: [{ t: 'held', d: 'left', v: false }] };
+    ch.onmessage!(JSON.stringify(msg));
+    expect(got).toEqual([msg]);
+  });
+});
+
+describe('控制訊息通道 + channel-close 掛點（Hub）', () => {
+  it('guest 送 bomber-leave → onChannelClose(該 idx)、不 relay、不上拋（onMessage/onControl 都沒收到）', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const closed: number[] = [];
+    const frames: BomberFrameMsg[] = [];
+    const controls: Array<Record<string, unknown>> = [];
+    hub.onChannelClose((idx) => closed.push(idx));
+    hub.onMessage((m) => frames.push(m));
+    hub.onControl((m) => controls.push(m));
+
+    channels[1].onmessage!(JSON.stringify({ t: 'bomber-leave' }));
+
+    expect(closed).toEqual([1]);
+    expect(channels[0].sent).toEqual([]); // 不 relay
+    expect(channels[2].sent).toEqual([]);
+    expect(frames).toEqual([]); // 不上拋幀
+    expect(controls).toEqual([]); // 也不當一般控制訊息
+  });
+
+  it('guest 送 bomber-forfeit → relay 給其餘 channel、hub onControl 收到 parse 後物件、onMessage 沒收到', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const frames: BomberFrameMsg[] = [];
+    const controls: Array<Record<string, unknown>> = [];
+    hub.onMessage((m) => frames.push(m));
+    hub.onControl((m) => controls.push(m));
+
+    const msg = { t: 'bomber-forfeit', p: 'x', f: 5 };
+    const raw = JSON.stringify(msg);
+    channels[0].onmessage!(raw);
+
+    expect(channels[1].sent).toEqual([raw]); // 其餘 channel 收到
+    expect(channels[2].sent).toEqual([raw]);
+    expect(channels[0].sent).toEqual([]); // 來源不回灌
+    expect(controls).toEqual([msg]); // hub 自身 onControl 收到
+    expect(frames).toEqual([]); // 幀路徑沒收到
+  });
+
+  it('hub sendControl → 全部 channel 收到、自身 onControl 回灌', () => {
+    const channels = [mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const controls: Array<Record<string, unknown>> = [];
+    hub.onControl((m) => controls.push(m));
+
+    const msg = { t: 'bomber-forfeit', p: 'x', f: 9 };
+    hub.sendControl(msg);
+
+    const raw = JSON.stringify(msg);
+    expect(channels[0].sent).toEqual([raw]);
+    expect(channels[1].sent).toEqual([raw]);
+    expect(controls).toEqual([msg]); // 回灌自身
+  });
+
+  it('mock channel 觸發 onclose → hub onChannelClose(該 idx)', () => {
+    const channels = [mockChannel(), mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const closed: number[] = [];
+    hub.onChannelClose((idx) => closed.push(idx));
+
+    channels[2].onclose?.();
+    channels[0].onclose?.();
+
+    expect(closed).toEqual([2, 0]);
+  });
+
+  it('畸形 JSON / t 非字串 → 走幀訊息既有容錯路徑、不丟例外、不觸發控制回呼', () => {
+    const channels = [mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const controls: Array<Record<string, unknown>> = [];
+    const closed: number[] = [];
+    hub.onControl((m) => controls.push(m));
+    hub.onChannelClose((idx) => closed.push(idx));
+
+    // 畸形 JSON：不丟例外、照幀路徑 relay（既有行為）
+    expect(() => channels[0].onmessage!('not-json{{')).not.toThrow();
+    expect(channels[1].sent).toEqual(['not-json{{']);
+
+    // t 非字串：不是控制訊息 → 照幀路徑 relay
+    const raw = JSON.stringify({ t: 5, f: 1, p: 'g0', a: [] });
+    expect(() => channels[0].onmessage!(raw)).not.toThrow();
+    expect(channels[1].sent).toEqual(['not-json{{', raw]);
+
+    expect(controls).toEqual([]);
+    expect(closed).toEqual([]);
+  });
+
+  it('tetris 命名空間的控制訊息（ffa-*）不被當作 bomber 控制訊息 → 走幀路徑 relay', () => {
+    const channels = [mockChannel(), mockChannel()];
+    const hub = new BomberHubTransport(channels);
+    const controls: Array<Record<string, unknown>> = [];
+    const closed: number[] = [];
+    hub.onControl((m) => controls.push(m));
+    hub.onChannelClose((idx) => closed.push(idx));
+
+    const raw = JSON.stringify({ t: 'ffa-leave' });
+    expect(() => channels[0].onmessage!(raw)).not.toThrow();
+    // bomber 前綴不符 → 不觸發 control/close，照幀路徑 relay
+    expect(controls).toEqual([]);
+    expect(closed).toEqual([]);
+    expect(channels[1].sent).toEqual([raw]);
+  });
+});
+
+describe('控制訊息通道 + onClose 掛點（Spoke）', () => {
+  it('收 bomber-forfeit → onControl 收到、onMessage 沒收到；收幀 → onMessage 收到、onControl 沒收到', () => {
+    const ch = mockChannel();
+    const spoke = new BomberSpokeTransport(ch);
+    const frames: BomberFrameMsg[] = [];
+    const controls: Array<Record<string, unknown>> = [];
+    spoke.onMessage((m) => frames.push(m));
+    spoke.onControl((m) => controls.push(m));
+
+    const ctrl = { t: 'bomber-forfeit', p: 'x', f: 5 };
+    ch.onmessage!(JSON.stringify(ctrl));
+    expect(controls).toEqual([ctrl]);
+    expect(frames).toEqual([]);
+
+    const frame: BomberFrameMsg = { f: 7, p: 'host', a: [{ t: 'held', d: 'up', v: true }] };
+    ch.onmessage!(JSON.stringify(frame));
+    expect(frames).toEqual([frame]);
+    expect(controls).toEqual([ctrl]); // 控制回呼沒再被觸發
+  });
+
+  it('sendControl：open=true 送出 JSON；open=false 不丟例外、不送出', () => {
+    const chOpen = mockChannel();
+    const spokeOpen = new BomberSpokeTransport(chOpen);
+    const msg = { t: 'bomber-leave' };
+    spokeOpen.sendControl(msg);
+    expect(chOpen.sent).toEqual([JSON.stringify(msg)]);
+
+    const chClosed = mockChannel(false);
+    const spokeClosed = new BomberSpokeTransport(chClosed);
+    expect(() => spokeClosed.sendControl(msg)).not.toThrow();
+    expect(chClosed.sent).toEqual([]);
+  });
+
+  it('channel 觸發 onclose → spoke onClose 回呼', () => {
+    const ch = mockChannel();
+    const spoke = new BomberSpokeTransport(ch);
+    let closed = 0;
+    spoke.onClose(() => closed++);
+
+    ch.onclose?.();
+    expect(closed).toBe(1);
+  });
+});
+
+describe('整合：1 Hub + 3 Spoke 串接撐起 BomberLockstep', () => {
+  it('4 端跑 ~60 幀 → stateHash 位元級一致', () => {
+    const playerIds = ['host', 'g0', 'g1', 'g2'];
+    const seed = 0xc0ffee;
+    const arenaId = 0;
+    const CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
+    const characters: Record<string, CharacterId> = {};
+    playerIds.forEach((id, i) => (characters[id] = CHARS[i % CHARS.length]));
+
+    // Host 有 3 條 channel（對應 g0/g1/g2）。
+    const hubChannels = [mockChannel(), mockChannel(), mockChannel()];
+    // 各 spoke 對 host 的 channel。
+    const spokeChannels = [mockChannel(), mockChannel(), mockChannel()];
+
+    const hub = new BomberHubTransport(hubChannels);
+    const spokes = spokeChannels.map((ch) => new BomberSpokeTransport(ch));
+
+    // 手動接線：
+    //  spoke i 的 send → 走 spokeChannels[i].send → 應觸發 hub 對應 channel 的 onmessage。
+    //  hub 對 guest i 廣播（hubChannels[i].send）→ 應觸發 spoke i 的 channel.onmessage。
+    for (let i = 0; i < 3; i++) {
+      // guest → host：spoke 送出的 raw 直接餵給 hub 對應 channel 的 onmessage
+      spokeChannels[i].send = (raw: string) => {
+        hubChannels[i].onmessage!(raw);
+      };
+      // host → guest：hub 對該 channel 廣播的 raw 直接餵給 spoke 的 channel onmessage
+      hubChannels[i].send = (raw: string) => {
+        spokeChannels[i].onmessage!(raw);
+      };
+    }
+
+    const transports = [hub, ...spokes];
+    const locksteps = playerIds.map(
+      (localId, i) =>
+        new BomberLockstep({
+          playerIds,
+          localId,
+          seed,
+          arenaId,
+          characters,
+          transport: transports[i],
+        }),
+    );
+
+    // 跑 60 幀，每端都不送輸入（確定性，所有端同序推進）。
+    for (let f = 0; f < 60; f++) {
+      for (const ls of locksteps) ls.tick();
+    }
+
+    // 同步 loopback 下末輪最後 tick 的節點會「結構性領先」一幀（良性瞬時偏移）：
+    // 只 tick 落後端（凍結領先端，保證收斂終止），直到全端 confirmedFrame 追平領先端，
+    // 方可在同一幀比對指紋。
+    for (let r = 0; r < 50; r++) {
+      const max = Math.max(...locksteps.map((n) => n.confirmedFrame));
+      const laggards = locksteps.filter((n) => n.confirmedFrame < max);
+      if (laggards.length === 0) break;
+      for (const n of laggards) n.tick();
+    }
+
+    // 各端推進的幀數必須相等且 > 0（證明這層星狀中繼撐起確定性鎖步）。
+    const cf = locksteps[0].confirmedFrame;
+    expect(cf).toBeGreaterThan(0);
+    for (const ls of locksteps) expect(ls.confirmedFrame).toBe(cf);
+
+    // 各端 stateHash 必須位元級一致。
+    const ref = locksteps[0].match.stateHash();
+    for (const ls of locksteps) expect(ls.match.stateHash()).toBe(ref);
+  });
+});

--- a/src/scripts/games/bomber/net/bomberTransport.ts
+++ b/src/scripts/games/bomber/net/bomberTransport.ts
@@ -1,0 +1,225 @@
+import type { BomberLockstepTransport, BomberFrameMsg } from './bomberLockstep';
+
+/**
+ * Bomber 多人傳輸層（copy-adapt 自 tetris/net/ffaTransport.ts）。
+ *
+ * 差異：
+ *  - 幀訊息型別 → `BomberFrameMsg`（{f,p,a}，a 為 VersusAction[]）。
+ *  - 控制訊息前綴 → `'bomber-'`（與 tetris 的 `'ffa-'` 互不干擾，避免跨遊戲誤判）。
+ *  - 對外介面相容 `BomberLockstepTransport`（send / onMessage），故 BomberLockstep 可直用；
+ *    額外保留 sendControl / onControl / onChannelClose / onClose 等強健性掛點供 T11 lobby/握手使用。
+ *
+ * 拓樸沿用 ffaTransport：Hub = 房主中繼（星狀中心），Spoke = 來賓（星狀輻條）。
+ */
+
+/** 控制訊息前綴：JSON parse 後物件的字串欄位 `t` 以此開頭 → 視為控制訊息。 */
+const CONTROL_PREFIX = 'bomber-';
+
+/**
+ * 一個 channel 的最小抽象（mock 或真 RTCDataChannel 包裝）。
+ * 對應一條「Host ↔ 某 Guest」的單向送出能力 + 開啟狀態。
+ */
+export interface RelayChannel {
+  send(raw: string): void;
+  readonly open: boolean;
+  /**
+   * 可選 close 掛點（模仿 RTCDataChannel.onclose 的可賦值屬性）。
+   * Hub/Spoke 建構時若 channel 支援此屬性會掛上處理器；mock 物件可直接設。
+   */
+  onclose?: (() => void) | null;
+}
+
+/**
+ * Host 收到「來自 channel fromIdx」的一筆原始訊息 raw 後，轉發給「其餘所有 channel」。
+ * fromIdx === null 代表訊息源自 Host 自己（host 的 BomberLockstep send）→ 轉發給全部 channel。
+ * channel 未開（open=false）跳過、不丟例外。
+ * 純函式：只對傳入 channels 做 send，回傳實際轉發到的 index 陣列。
+ */
+export function routeFrame(
+  fromIdx: number | null,
+  raw: string,
+  channels: RelayChannel[],
+): number[] {
+  const routed: number[] = [];
+  for (let i = 0; i < channels.length; i++) {
+    if (i === fromIdx) continue; // 不回灌來源
+    const ch = channels[i];
+    if (!ch.open) continue; // 未開跳過、不丟例外
+    ch.send(raw);
+    routed.push(i);
+  }
+  return routed;
+}
+
+/**
+ * 把任意原始訊息解析為 BomberFrameMsg（JSON 字串或已是物件皆容錯）。
+ * 解析失敗回傳 null（呼叫端忽略，與 BomberLockstep handleMessage 的字串容錯相容）。
+ */
+function parseFrame(raw: unknown): BomberFrameMsg | null {
+  let m: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      m = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!m || typeof m !== 'object') return null;
+  return m as BomberFrameMsg;
+}
+
+/**
+ * 控制訊息判別：JSON parse 後物件有字串欄位 `t` 且以 'bomber-' 開頭 → 控制訊息
+ * （BomberFrameMsg 是 {f,p,a} 無 t，不會誤判；tetris 的 'ffa-*' 控制訊息前綴不符，亦不誤判）。
+ * parse 失敗 / 無 t / t 非字串 / 前綴不符 → 回傳 null（呼叫端走幀訊息既有容錯路徑）。
+ */
+function parseControl(raw: unknown): Record<string, unknown> | null {
+  let m: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      m = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!m || typeof m !== 'object') return null;
+  const t = (m as Record<string, unknown>).t;
+  if (typeof t !== 'string' || !t.startsWith(CONTROL_PREFIX)) return null;
+  return m as Record<string, unknown>;
+}
+
+/**
+ * Host 端 relay transport（星狀中心）。
+ *
+ * 拓樸：Host 對每個 Guest 各持一條 channel（channels[i] 對應 guest i）。
+ *  - 收到某 guest channel 的訊息：轉發給「其餘所有 guest」（routeFrame），
+ *    並把 parse 後的 msg 丟給本端上層 onMessage cb（host 的 BomberLockstep 也要看到全員的幀）。
+ *  - send（host 自己的幀）：routeFrame(null, ...) 廣播給全部 guest，
+ *    並回灌自己上層 cb（讓 host lockstep 收到自己的幀；inbox 寫入冪等故安全）。
+ *
+ * Host 只是純 relay，不是遊戲權威；路由邏輯抽在 routeFrame 純函式中。
+ */
+export class BomberHubTransport implements BomberLockstepTransport {
+  private readonly channels: RelayChannel[];
+  private cb: ((msg: BomberFrameMsg) => void) | null = null;
+  private controlCb: ((msg: Record<string, unknown>) => void) | null = null;
+  private channelCloseCb: ((idx: number) => void) | null = null;
+
+  /**
+   * @param channels N-1 條 channel（對應各 guest）。
+   *   每條若帶 `onmessage` setter（mock 或 RTCDataChannel 包裝），會被掛上收訊轉發邏輯；
+   *   若支援 `onclose` 也會掛上 close 處理（觸發 onChannelClose 回呼帶 idx）。
+   */
+  constructor(channels: Array<RelayChannel & { onmessage?: ((raw: string) => void) | null }>) {
+    this.channels = channels;
+    channels.forEach((ch, idx) => {
+      // 為每條 guest channel 安裝收訊處理：轉發其餘 guest + 回灌本端上層
+      ch.onmessage = (raw: string) => this.handleGuestMessage(idx, raw);
+      // channel 關閉 → 觸發 channelClose 回呼（帶該 idx）
+      if ('onclose' in ch) ch.onclose = () => this.channelCloseCb?.(idx);
+    });
+  }
+
+  /**
+   * 收到 guest idx 的一筆原始訊息：
+   *  - 控制訊息 'bomber-leave' → 觸發 channelClose 回呼（快速路徑），不 relay 不上拋。
+   *  - 其他 'bomber-*' 控制訊息 → relay 給其餘 guest + 觸發自身 onControl。
+   *  - 幀訊息 → relay 給其餘 guest，再丟給本端上層（既有行為）。
+   */
+  private handleGuestMessage(fromIdx: number, raw: string): void {
+    const ctrl = parseControl(raw);
+    if (ctrl) {
+      if (ctrl.t === 'bomber-leave') {
+        this.channelCloseCb?.(fromIdx);
+        return; // 不 relay、不上拋
+      }
+      routeFrame(fromIdx, raw, this.channels);
+      this.controlCb?.(ctrl);
+      return;
+    }
+    routeFrame(fromIdx, raw, this.channels);
+    const msg = parseFrame(raw);
+    if (msg) this.cb?.(msg);
+  }
+
+  /** host 自己的幀：廣播給全部 guest，並回灌自己上層（自身可見）。 */
+  send(msg: BomberFrameMsg): void {
+    routeFrame(null, JSON.stringify(msg), this.channels);
+    this.cb?.(msg);
+  }
+
+  /** host 自己的控制訊息：廣播給全部 guest，並回灌自身 onControl（自身可見）。 */
+  sendControl(msg: Record<string, unknown>): void {
+    routeFrame(null, JSON.stringify(msg), this.channels);
+    this.controlCb?.(msg);
+  }
+
+  onMessage(cb: (msg: BomberFrameMsg) => void): void {
+    this.cb = cb;
+  }
+
+  onControl(cb: (msg: Record<string, unknown>) => void): void {
+    this.controlCb = cb;
+  }
+
+  /** 登記 channel 關閉回呼（來源：channel onclose 或 guest 的 bomber-leave 快速路徑）。 */
+  onChannelClose(cb: (idx: number) => void): void {
+    this.channelCloseCb = cb;
+  }
+}
+
+/**
+ * Guest 端 transport（星狀輻條）。
+ *
+ * 只連 Host 一條 channel：
+ *  - send：JSON 編碼後送給 host（host 會 relay 給其餘）；channel 未開不丟例外。
+ *  - 收訊（channel.onmessage）：parse 後丟給上層 onMessage cb。
+ */
+export class BomberSpokeTransport implements BomberLockstepTransport {
+  private readonly channel: RelayChannel;
+  private cb: ((msg: BomberFrameMsg) => void) | null = null;
+  private controlCb: ((msg: Record<string, unknown>) => void) | null = null;
+  private closeCb: (() => void) | null = null;
+
+  /**
+   * @param channel 對 Host 的單一 channel；若帶 `onmessage` setter 會被掛上收訊處理
+   *   （控制訊息 → onControl、幀 → onMessage）；若支援 `onclose` 也會掛上 close 處理。
+   */
+  constructor(channel: RelayChannel & { onmessage?: ((raw: string) => void) | null }) {
+    this.channel = channel;
+    channel.onmessage = (raw: string) => {
+      const ctrl = parseControl(raw);
+      if (ctrl) {
+        this.controlCb?.(ctrl);
+        return;
+      }
+      const msg = parseFrame(raw);
+      if (msg) this.cb?.(msg);
+    };
+    if ('onclose' in channel) channel.onclose = () => this.closeCb?.();
+  }
+
+  send(msg: BomberFrameMsg): void {
+    if (!this.channel.open) return; // 未開不送、不丟例外
+    this.channel.send(JSON.stringify(msg));
+  }
+
+  /** 控制訊息送給 host（host 會分流處理/relay）；channel 未開不送、不丟例外。 */
+  sendControl(msg: Record<string, unknown>): void {
+    if (!this.channel.open) return;
+    this.channel.send(JSON.stringify(msg));
+  }
+
+  onMessage(cb: (msg: BomberFrameMsg) => void): void {
+    this.cb = cb;
+  }
+
+  onControl(cb: (msg: Record<string, unknown>) => void): void {
+    this.controlCb = cb;
+  }
+
+  /** 登記 host 頻道關閉回呼。 */
+  onClose(cb: () => void): void {
+    this.closeCb = cb;
+  }
+}

--- a/src/scripts/games/bomber/net/lobby.test.ts
+++ b/src/scripts/games/bomber/net/lobby.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { BomberLobby, type BomberStartPayload } from './lobby';
+import type { CharacterId } from '../engine/types';
+
+/** 確定性 rng（注入用）：每次回傳遞增的固定值，避免 Math.random 破壞可重播。 */
+function makeSeqRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+describe('BomberLobby — 角色與初始狀態', () => {
+  it('host 建立 lobby：自己先入座（index 0）、狀態 waiting、role=host', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    expect(lobby.role).toBe('host');
+    expect(lobby.state).toBe('waiting');
+    expect(lobby.players).toEqual([{ id: 'host', character: 'lena', ready: false }]);
+    expect(lobby.isHost).toBe(true);
+  });
+
+  it('guest 建立 lobby：自己入座、role=guest、isHost=false、預設 arenaId=0', () => {
+    const lobby = new BomberLobby({ role: 'guest', localId: 'g1', character: 'mira' });
+    expect(lobby.role).toBe('guest');
+    expect(lobby.isHost).toBe(false);
+    expect(lobby.players).toEqual([{ id: 'g1', character: 'mira', ready: false }]);
+    expect(lobby.arenaId).toBe(0);
+  });
+
+  it('可指定初始 arenaId', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena', arenaId: 5 });
+    expect(lobby.arenaId).toBe(5);
+  });
+});
+
+describe('BomberLobby — 加入 / 人數上限（2-4）', () => {
+  function host(): BomberLobby {
+    return new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+  }
+
+  it('加入第 2~4 名玩家成功；第 5 名被拒（回 false，名單不變）', () => {
+    const lobby = host();
+    expect(lobby.addPlayer({ id: 'g1', character: 'mira' })).toBe(true);
+    expect(lobby.addPlayer({ id: 'g2', character: 'aya' })).toBe(true);
+    expect(lobby.addPlayer({ id: 'g3', character: 'rosa' })).toBe(true);
+    expect(lobby.players.length).toBe(4);
+    // 第 5 名 → 拒絕
+    expect(lobby.addPlayer({ id: 'g4', character: 'lena' })).toBe(false);
+    expect(lobby.players.length).toBe(4);
+  });
+
+  it('重複 id 加入 → 拒絕（不重複入座）', () => {
+    const lobby = host();
+    expect(lobby.addPlayer({ id: 'g1', character: 'mira' })).toBe(true);
+    expect(lobby.addPlayer({ id: 'g1', character: 'aya' })).toBe(false);
+    expect(lobby.players.length).toBe(2);
+  });
+
+  it('新加入玩家預設 ready=false', () => {
+    const lobby = host();
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    expect(lobby.players.find((p) => p.id === 'g1')!.ready).toBe(false);
+  });
+});
+
+describe('BomberLobby — ready 狀態與開局 gating', () => {
+  function full2(): BomberLobby {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    return lobby;
+  }
+
+  it('未全員 ready → state 維持 waiting、canStart=false', () => {
+    const lobby = full2();
+    lobby.setReady('host', true);
+    expect(lobby.state).toBe('waiting');
+    expect(lobby.canStart()).toBe(false);
+  });
+
+  it('全員 ready 且 >=2 人 → state 轉 ready、canStart=true', () => {
+    const lobby = full2();
+    lobby.setReady('host', true);
+    lobby.setReady('g1', true);
+    expect(lobby.state).toBe('ready');
+    expect(lobby.canStart()).toBe(true);
+  });
+
+  it('僅 1 人（host 自己）即使 ready 也不能開局（至少 2 人）', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    lobby.setReady('host', true);
+    expect(lobby.canStart()).toBe(false);
+    expect(lobby.state).toBe('waiting');
+  });
+
+  it('某玩家取消 ready → state 退回 waiting、canStart=false', () => {
+    const lobby = full2();
+    lobby.setReady('host', true);
+    lobby.setReady('g1', true);
+    expect(lobby.state).toBe('ready');
+    lobby.setReady('g1', false);
+    expect(lobby.state).toBe('waiting');
+    expect(lobby.canStart()).toBe(false);
+  });
+
+  it('setReady 未知 id → 忽略（不丟例外、名單不變）', () => {
+    const lobby = full2();
+    expect(() => lobby.setReady('nobody', true)).not.toThrow();
+    expect(lobby.players.every((p) => !p.ready)).toBe(true);
+  });
+
+  it('guest 不能 canStart（只有 host 能開局）即使全員 ready', () => {
+    const lobby = new BomberLobby({ role: 'guest', localId: 'g1', character: 'mira' });
+    lobby.addPlayer({ id: 'host', character: 'lena' });
+    lobby.setReady('g1', true);
+    lobby.setReady('host', true);
+    expect(lobby.state).toBe('ready');
+    expect(lobby.canStart()).toBe(false); // guest 端不主導開局
+  });
+});
+
+describe('BomberLobby — arena 選擇（host，0-7）', () => {
+  it('host 設定 arenaId 0..7 成功', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    expect(lobby.setArena(7)).toBe(true);
+    expect(lobby.arenaId).toBe(7);
+    expect(lobby.setArena(0)).toBe(true);
+    expect(lobby.arenaId).toBe(0);
+  });
+
+  it('arenaId 超界（負數 / >=8 / 非整數）→ 拒絕、值不變', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena', arenaId: 3 });
+    expect(lobby.setArena(8)).toBe(false);
+    expect(lobby.setArena(-1)).toBe(false);
+    expect(lobby.setArena(2.5)).toBe(false);
+    expect(lobby.arenaId).toBe(3);
+  });
+
+  it('guest 不能改 arena（只有 host 決定）→ 拒絕、值不變', () => {
+    const lobby = new BomberLobby({ role: 'guest', localId: 'g1', character: 'mira', arenaId: 1 });
+    expect(lobby.setArena(4)).toBe(false);
+    expect(lobby.arenaId).toBe(1);
+  });
+});
+
+describe('BomberLobby — leave 處理', () => {
+  function ready3(): BomberLobby {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    lobby.addPlayer({ id: 'g2', character: 'aya' });
+    lobby.setReady('host', true);
+    lobby.setReady('g1', true);
+    lobby.setReady('g2', true);
+    return lobby;
+  }
+
+  it('一名 guest 離開 → 從名單移除、state 退回 waiting', () => {
+    const lobby = ready3();
+    expect(lobby.state).toBe('ready');
+    lobby.removePlayer('g2');
+    expect(lobby.players.map((p) => p.id)).toEqual(['host', 'g1']);
+    expect(lobby.state).toBe('waiting'); // 有人離開 → 回 waiting，需重新確認
+  });
+
+  it('leave 後其餘玩家的 ready 被清空（需重新就緒）', () => {
+    const lobby = ready3();
+    lobby.removePlayer('g2');
+    expect(lobby.players.every((p) => !p.ready)).toBe(true);
+  });
+
+  it('移除 host 自己 / 未知 id → 安全（不丟例外）', () => {
+    const lobby = ready3();
+    expect(() => lobby.removePlayer('nobody')).not.toThrow();
+    expect(lobby.players.length).toBe(3);
+  });
+
+  it('leave 至剩 1 人 → canStart=false', () => {
+    const lobby = ready3();
+    lobby.removePlayer('g1');
+    lobby.removePlayer('g2');
+    expect(lobby.players.length).toBe(1);
+    expect(lobby.canStart()).toBe(false);
+  });
+});
+
+describe('BomberLobby — host 建立 start payload（決定性 seed）', () => {
+  function full3(): BomberLobby {
+    const lobby = new BomberLobby({
+      role: 'host',
+      localId: 'host',
+      character: 'lena',
+      arenaId: 4,
+      rng: makeSeqRng([0.5]),
+    });
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    lobby.addPlayer({ id: 'g2', character: 'aya' });
+    lobby.setReady('host', true);
+    lobby.setReady('g1', true);
+    lobby.setReady('g2', true);
+    return lobby;
+  }
+
+  it('buildStartPayload：含 seed/arenaId/players（id+character，順序＝入座順序，host 在前）', () => {
+    const lobby = full3();
+    const payload = lobby.buildStartPayload();
+    expect(payload).not.toBeNull();
+    const p = payload as BomberStartPayload;
+    expect(typeof p.seed).toBe('number');
+    expect(Number.isFinite(p.seed)).toBe(true);
+    expect(p.arenaId).toBe(4);
+    expect(p.players).toEqual([
+      { id: 'host', character: 'lena' },
+      { id: 'g1', character: 'mira' },
+      { id: 'g2', character: 'aya' },
+    ]);
+  });
+
+  it('seed 由注入的 rng 決定（確定性可重播，非 Math.random 直用）', () => {
+    const a = new BomberLobby({ role: 'host', localId: 'host', character: 'lena', rng: () => 0.123456789 });
+    a.addPlayer({ id: 'g1', character: 'mira' });
+    a.setReady('host', true);
+    a.setReady('g1', true);
+    const b = new BomberLobby({ role: 'host', localId: 'host', character: 'lena', rng: () => 0.123456789 });
+    b.addPlayer({ id: 'g1', character: 'mira' });
+    b.setReady('host', true);
+    b.setReady('g1', true);
+    // 相同 rng → 相同 seed（決定性）
+    expect(a.buildStartPayload()!.seed).toBe(b.buildStartPayload()!.seed);
+  });
+
+  it('可接受外部指定 seed（覆蓋 rng）', () => {
+    const lobby = full3();
+    const payload = lobby.buildStartPayload({ seed: 987654 });
+    expect(payload!.seed).toBe(987654);
+  });
+
+  it('未達開局條件（未全 ready / <2 人）→ buildStartPayload 回 null', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    // 未全 ready
+    expect(lobby.buildStartPayload()).toBeNull();
+  });
+
+  it('guest 角色 → buildStartPayload 回 null（只有 host 出 payload）', () => {
+    const lobby = new BomberLobby({ role: 'guest', localId: 'g1', character: 'mira' });
+    lobby.addPlayer({ id: 'host', character: 'lena' });
+    lobby.setReady('g1', true);
+    lobby.setReady('host', true);
+    expect(lobby.buildStartPayload()).toBeNull();
+  });
+
+  it('seed 落在 32-bit 無號整數範圍內（適合當 arena/RNG 種子）', () => {
+    const lobby = full3();
+    const seed = lobby.buildStartPayload()!.seed;
+    expect(Number.isInteger(seed)).toBe(true);
+    expect(seed).toBeGreaterThanOrEqual(0);
+    expect(seed).toBeLessThan(2 ** 32);
+  });
+
+  it('start payload 的 characters 可直接組成 BomberLockstep 的 Record<string,CharacterId>', () => {
+    const lobby = full3();
+    const p = lobby.buildStartPayload()!;
+    const characters: Record<string, CharacterId> = {};
+    for (const pl of p.players) characters[pl.id] = pl.character;
+    expect(characters).toEqual({ host: 'lena', g1: 'mira', g2: 'aya' });
+  });
+});
+
+describe('BomberLobby — markStarting（開局後鎖定）', () => {
+  it('canStart 時 markStarting → state=starting；之後 addPlayer/setReady 被忽略', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    lobby.addPlayer({ id: 'g1', character: 'mira' });
+    lobby.setReady('host', true);
+    lobby.setReady('g1', true);
+    expect(lobby.markStarting()).toBe(true);
+    expect(lobby.state).toBe('starting');
+    // 鎖定後不再變動
+    expect(lobby.addPlayer({ id: 'g2', character: 'aya' })).toBe(false);
+    expect(lobby.players.length).toBe(2);
+  });
+
+  it('未達開局條件 markStarting → false、state 不變', () => {
+    const lobby = new BomberLobby({ role: 'host', localId: 'host', character: 'lena' });
+    expect(lobby.markStarting()).toBe(false);
+    expect(lobby.state).toBe('waiting');
+  });
+});

--- a/src/scripts/games/bomber/net/lobby.ts
+++ b/src/scripts/games/bomber/net/lobby.ts
@@ -1,0 +1,197 @@
+import type { CharacterId } from '../engine/types';
+
+/**
+ * Bomber 對戰 Lobby 純狀態機（無 DOM、無網路）。
+ *
+ * 職責（plan Task 11 Step 1）：
+ *  - host / guest 角色。
+ *  - 玩家名單（每人 {id, character, ready}）。
+ *  - 房狀態轉移 waiting → ready → starting。
+ *  - host 選 arena（0-7）。
+ *  - 2-4 人上限（拒絕第 5 名）。
+ *  - 全員到齊且 ready 才可開局（>=2 人）。
+ *  - 一名 guest 離開 → 退回 waiting（並清空 ready，需重新就緒）。
+ *  - host 組裝 start payload {seed, arenaId, players:[{id,character}]}。
+ *
+ * 決定性鐵則：seed 是 host 的責任，且必須可重播——lobby 不直接用 Math.random，
+ * 而是接受注入的 rng（測試/重播傳固定值），或 buildStartPayload 時外部直接指定 seed。
+ * （對齊 ffaNetMain 由 host randInt 產 seed 並廣播給全員的精神：seed 單一來源、決定性。）
+ */
+
+export const MIN_PLAYERS = 2;
+export const MAX_PLAYERS = 4;
+export const ARENA_COUNT = 8; // arenaId 合法範圍 0..7（與 versus/arenas.ts ARENAS.length 一致）
+
+export type LobbyRole = 'host' | 'guest';
+export type LobbyState = 'waiting' | 'ready' | 'starting';
+
+export interface LobbyPlayer {
+  id: string;
+  character: CharacterId;
+  ready: boolean;
+}
+
+/** host 開局時廣播給全員的 start payload（seed/arenaId 單一來源＝host）。 */
+export interface BomberStartPayload {
+  seed: number;
+  arenaId: number;
+  /** 入座順序（host 在前）；index 即 BomberLockstep playerIds 的順序。 */
+  players: Array<{ id: string; character: CharacterId }>;
+}
+
+export interface BomberLobbyOptions {
+  role: LobbyRole;
+  localId: string;
+  character: CharacterId;
+  /** 初始 arena（host 預設值；guest 端僅作顯示，最終以 host 廣播為準）。 */
+  arenaId?: number;
+  /**
+   * 注入的隨機源（決定性測試/重播用）。預設 Math.random。
+   * 僅用於「未指定 seed 時」產生 host 的對局 seed；不影響任何模擬內部 RNG。
+   */
+  rng?: () => number;
+}
+
+export class BomberLobby {
+  readonly role: LobbyRole;
+  readonly localId: string;
+
+  private _players: LobbyPlayer[] = [];
+  private _arenaId: number;
+  private _state: LobbyState = 'waiting';
+  private readonly rng: () => number;
+
+  constructor(opts: BomberLobbyOptions) {
+    this.role = opts.role;
+    this.localId = opts.localId;
+    this._arenaId = clampArena(opts.arenaId ?? 0) ?? 0;
+    this.rng = opts.rng ?? Math.random;
+    // 本機玩家先入座（host 在前的順序由「host 先建 lobby」自然保證）。
+    this._players.push({ id: opts.localId, character: opts.character, ready: false });
+  }
+
+  get isHost(): boolean {
+    return this.role === 'host';
+  }
+
+  get arenaId(): number {
+    return this._arenaId;
+  }
+
+  get state(): LobbyState {
+    return this._state;
+  }
+
+  /** 名單快照（外部不可變更內部陣列）。 */
+  get players(): LobbyPlayer[] {
+    return this._players.map((p) => ({ ...p }));
+  }
+
+  /**
+   * 加入一名玩家（入座順序＝呼叫順序）。
+   * 拒絕條件：已 starting / 已達上限（>MAX_PLAYERS）/ id 重複。回傳是否成功。
+   */
+  addPlayer(p: { id: string; character: CharacterId }): boolean {
+    if (this._state === 'starting') return false;
+    if (this._players.length >= MAX_PLAYERS) return false;
+    if (this._players.some((x) => x.id === p.id)) return false;
+    this._players.push({ id: p.id, character: p.character, ready: false });
+    this.recompute();
+    return true;
+  }
+
+  /**
+   * 移除一名玩家（離開）。
+   * 鐵則：有人離開 → 退回 waiting 並清空所有人的 ready（需重新確認後才能再開局）。
+   * 未知 id 安全忽略。
+   */
+  removePlayer(id: string): void {
+    if (this._state === 'starting') return;
+    const before = this._players.length;
+    this._players = this._players.filter((p) => p.id !== id);
+    if (this._players.length === before) return; // 未知 id：無變化
+    // 名單異動 → 重置就緒，回 waiting（避免「人換了但已就緒」的不一致）。
+    for (const p of this._players) p.ready = false;
+    this.recompute();
+  }
+
+  /** 設定某玩家 ready；未知 id 忽略。設定後重算 state。 */
+  setReady(id: string, ready: boolean): void {
+    if (this._state === 'starting') return;
+    const p = this._players.find((x) => x.id === id);
+    if (!p) return;
+    p.ready = ready;
+    this.recompute();
+  }
+
+  /**
+   * host 選 arena（0..7）。guest 端無權（回 false）。
+   * 超界 / 非整數 → 拒絕、值不變。
+   */
+  setArena(arenaId: number): boolean {
+    if (!this.isHost) return false;
+    if (this._state === 'starting') return false;
+    const clamped = clampArena(arenaId);
+    if (clamped === null) return false;
+    this._arenaId = clamped;
+    return true;
+  }
+
+  /**
+   * 是否可開局：host 角色 + 人數達標（>=2, <=4）+ 全員 ready。
+   * guest 端恆 false（開局由 host 主導，guest 收 host 的 start 廣播）。
+   */
+  canStart(): boolean {
+    if (!this.isHost) return false;
+    if (this._players.length < MIN_PLAYERS || this._players.length > MAX_PLAYERS) return false;
+    return this._players.every((p) => p.ready);
+  }
+
+  /**
+   * host 組裝 start payload。未達開局條件（含非 host）→ 回 null。
+   * seed 來源優先序：明確指定 opts.seed > rng()（決定性可注入）。
+   */
+  buildStartPayload(opts?: { seed?: number }): BomberStartPayload | null {
+    if (!this.canStart()) return null;
+    const seed = opts?.seed !== undefined ? (opts.seed >>> 0) : this.genSeed();
+    return {
+      seed,
+      arenaId: this._arenaId,
+      players: this._players.map((p) => ({ id: p.id, character: p.character })),
+    };
+  }
+
+  /**
+   * 鎖定 lobby 進入 starting（開局後不再接受加入/就緒變動）。
+   * 僅在 canStart() 時成功；回傳是否成功。
+   */
+  markStarting(): boolean {
+    if (!this.canStart()) return false;
+    this._state = 'starting';
+    return true;
+  }
+
+  // ── 內部 ──────────────────────────────────────────────────────────────
+
+  /** 由 rng 產生 32-bit 無號整數 seed（決定性：rng 可注入）。 */
+  private genSeed(): number {
+    return Math.floor(this.rng() * 0x1_0000_0000) >>> 0;
+  }
+
+  /** 依名單/ready 重算 state（starting 為終態，不被此覆蓋）。 */
+  private recompute(): void {
+    if (this._state === 'starting') return;
+    const allReady =
+      this._players.length >= MIN_PLAYERS &&
+      this._players.length <= MAX_PLAYERS &&
+      this._players.every((p) => p.ready);
+    this._state = allReady ? 'ready' : 'waiting';
+  }
+}
+
+/** 驗證並回傳合法 arenaId（0..7 整數），否則 null。 */
+function clampArena(arenaId: number): number | null {
+  if (!Number.isInteger(arenaId)) return null;
+  if (arenaId < 0 || arenaId >= ARENA_COUNT) return null;
+  return arenaId;
+}

--- a/src/scripts/games/bomber/net/versusReplay.test.ts
+++ b/src/scripts/games/bomber/net/versusReplay.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { BomberLockstep, LoopbackBomberHub, type VersusAction } from './bomberLockstep';
+import {
+  simulateVersusReplay,
+  liveStandings,
+  type VersusReplay,
+} from './versusReplay';
+import type { CharacterId } from '../engine/types';
+import { VersusMatch } from '../versus/versusMatch';
+
+const CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
+
+/** 建 N 個接同一 LoopbackBomberHub 的 BomberLockstep 節點。 */
+function buildNodes(
+  playerIds: string[],
+  seed: number,
+  arenaId = 0,
+): { nodes: BomberLockstep[]; hub: LoopbackBomberHub; characters: Record<string, CharacterId> } {
+  const hub = new LoopbackBomberHub();
+  const characters: Record<string, CharacterId> = {};
+  playerIds.forEach((id, i) => (characters[id] = CHARS[i % CHARS.length]));
+  const nodes = playerIds.map(
+    (localId) =>
+      new BomberLockstep({
+        playerIds,
+        localId,
+        seed,
+        arenaId,
+        characters,
+        transport: hub.transportFor(localId),
+      }),
+  );
+  return { nodes, hub };
+}
+
+/**
+ * 把全端推進到同一個 confirmedFrame（消除同步 loopback 末輪的良性一幀偏移），
+ * 比照 bomberLockstep.test 的 settle。
+ */
+function settle(nodes: BomberLockstep[], hub?: LoopbackBomberHub): void {
+  for (let r = 0; r < 200; r++) {
+    const max = Math.max(...nodes.map((n) => n.confirmedFrame));
+    const laggards = nodes.filter((n) => n.confirmedFrame < max);
+    if (laggards.length === 0) break;
+    for (const n of laggards) n.tick();
+    hub?.flush();
+  }
+}
+
+/**
+ * 跑一場 2 人局到 P0 自爆淘汰、P1 奪冠。P0 放彈原地不動，P1 也不動。
+ * 回傳 nodes[1]（倖存端，已 finished）。
+ */
+function runSelfBombMatch(seed: number): { node: BomberLockstep; nodes: BomberLockstep[] } {
+  const playerIds = ['P0', 'P1'];
+  const { nodes } = buildNodes(playerIds, seed, 0);
+  nodes[0].queueLocal({ t: 'bomb' });
+
+  let p0Dead = false;
+  for (let f = 0; f < 6000 && nodes[1].match.getState().status === 'playing'; f++) {
+    for (const node of nodes) {
+      if (node.localId === 'P0' && p0Dead) continue;
+      node.tick();
+    }
+    const p0 = nodes[1].match.getState().players.find((p) => p.id === 'P0');
+    if (p0 && !p0.alive) p0Dead = true;
+  }
+  settle(nodes);
+  return { node: nodes[1], nodes };
+}
+
+describe('liveStandings — 由 placement 推導名次（winner first）', () => {
+  it('已結束局：名次依 placement 升冪、平手以 playerIds 序穩定排列', () => {
+    const { node } = runSelfBombMatch(3);
+    const st = node.match.getState();
+    expect(st.status).toBe('finished');
+    const standings = liveStandings(node.match, ['P0', 'P1']);
+    // P1 奪冠（placement 1）在前、P0 自爆（placement 2）殿後
+    expect(standings).toEqual(['P1', 'P0']);
+  });
+});
+
+describe('BomberLockstep.getReplay — 捕捉稀疏輸入log', () => {
+  it('輸出 seed/arenaId/characters/playerIds/frameCount/inputs', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    expect(replay.seed).toBe(3);
+    expect(replay.arenaId).toBe(0);
+    expect(replay.playerIds).toEqual(['P0', 'P1']);
+    expect(replay.characters).toMatchObject({ P0: 'lena', P1: 'mira' });
+    expect(replay.frameCount).toBeGreaterThan(0);
+    expect(Array.isArray(replay.inputs)).toBe(true);
+    // 稀疏：空輸入幀不應出現在 inputs（log 只記非空）
+    for (const e of replay.inputs) {
+      expect(e.a.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('simulateVersusReplay — 重模擬還原名次與 stateHash', () => {
+  it('2 人局（自爆）：模擬名次與 stateHash == 原局', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    const live = {
+      standings: liveStandings(node.match, replay.playerIds),
+      stateHash: node.match.stateHash(),
+    };
+    const sim = simulateVersusReplay(replay);
+    expect(sim.standings).toEqual(live.standings);
+    expect(sim.stateHash).toBe(live.stateHash);
+  });
+
+  it('4 人混合輸入跑完一段：模擬 stateHash 與名次 == 原局', () => {
+    const playerIds = ['P0', 'P1', 'P2', 'P3'];
+    const { nodes } = buildNodes(playerIds, 12345, 1);
+    const localActionsAt = (id: string, f: number): VersusAction[] => {
+      const out: VersusAction[] = [];
+      const k = playerIds.indexOf(id);
+      if (f % (5 + k) === 0) out.push({ t: 'held', d: (['up', 'down', 'left', 'right'] as const)[k], v: true });
+      if (f % (5 + k) === 2) out.push({ t: 'held', d: (['up', 'down', 'left', 'right'] as const)[k], v: false });
+      if (f % (17 + k) === 0) out.push(k % 2 === 0 ? { t: 'bomb' } : { t: 'ability' });
+      return out;
+    };
+    for (let f = 0; f < 800; f++) {
+      for (const node of nodes) {
+        node.queueLocal(...localActionsAt(node.localId, f));
+        node.tick();
+      }
+    }
+    settle(nodes);
+
+    const node = nodes[0];
+    const replay = node.getReplay();
+    const live = {
+      standings: liveStandings(node.match, replay.playerIds),
+      stateHash: node.match.stateHash(),
+    };
+    const sim = simulateVersusReplay(replay);
+    expect(sim.stateHash).toBe(live.stateHash);
+    expect(sim.standings).toEqual(live.standings);
+  });
+
+  it('determinism：同 replay 模擬兩次完全相同', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    const a = simulateVersusReplay(replay);
+    const b = simulateVersusReplay(replay);
+    expect(a.standings).toEqual(b.standings);
+    expect(a.stateHash).toBe(b.stateHash);
+  });
+});
+
+describe('simulateVersusReplay — forfeit 結束的局也能重現', () => {
+  it('P1 斷線（不送輸入）+ host forfeit → 模擬名次與 stateHash == 原局', () => {
+    const playerIds = ['P0', 'P1'];
+    const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira' };
+    const hub = new LoopbackBomberHub();
+    // 只建 P0 端（P1 從不送輸入＝斷線）
+    const ls = new BomberLockstep({
+      playerIds,
+      localId: 'P0',
+      seed: 3,
+      arenaId: 0,
+      characters,
+      transport: hub.transportFor('P0'),
+    });
+
+    // 推進到卡住（缺 P1）。
+    for (let f = 0; f < 10; f++) ls.tick();
+    // 以 lastInputFrame(P1)+1 推導離場幀（決定性），對 P1 forfeit。
+    ls.forfeit('P1', ls.lastInputFrame('P1') + 1);
+    for (let f = 0; f < 60 && ls.match.getState().status === 'playing'; f++) ls.tick();
+
+    const s = ls.match.getState();
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('P0');
+
+    const replay = ls.getReplay();
+    // replay 必須捕捉到 forfeit（否則重模擬永遠不會結束）
+    expect(Array.isArray(replay.forfeits)).toBe(true);
+    expect(replay.forfeits!.some((ff) => ff.p === 'P1')).toBe(true);
+
+    const live = {
+      standings: liveStandings(ls.match, replay.playerIds),
+      stateHash: ls.match.stateHash(),
+    };
+    const sim = simulateVersusReplay(replay);
+    expect(sim.standings).toEqual(live.standings);
+    expect(sim.stateHash).toBe(live.stateHash);
+    expect(sim.standings).toEqual(['P0', 'P1']);
+  });
+
+  it('forfeit 局 determinism：模擬兩次相同', () => {
+    const playerIds = ['P0', 'P1'];
+    const characters: Record<string, CharacterId> = { P0: 'lena', P1: 'mira' };
+    const hub = new LoopbackBomberHub();
+    const ls = new BomberLockstep({
+      playerIds, localId: 'P0', seed: 5, arenaId: 0, characters,
+      transport: hub.transportFor('P0'),
+    });
+    for (let f = 0; f < 10; f++) ls.tick();
+    ls.forfeit('P1', ls.lastInputFrame('P1') + 1);
+    for (let f = 0; f < 60 && ls.match.getState().status === 'playing'; f++) ls.tick();
+    const replay = ls.getReplay();
+    const a = simulateVersusReplay(replay);
+    const b = simulateVersusReplay(replay);
+    expect(a.stateHash).toBe(b.stateHash);
+    expect(a.standings).toEqual(b.standings);
+  });
+});
+
+describe('simulateVersusReplay — 未結束局回傳的 status', () => {
+  it('frameCount 裁短到必不結束：standings 含全員、stateHash 仍可計算（不丟例外）', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    const partial: VersusReplay = { ...replay, frameCount: 2 };
+    expect(() => simulateVersusReplay(partial)).not.toThrow();
+    const sim = simulateVersusReplay(partial);
+    expect(typeof sim.stateHash).toBe('string');
+    expect(sim.standings.length).toBe(replay.playerIds.length);
+  });
+});
+
+describe('simulateVersusReplay — 竄改輸入被抓（stateHash 變動）', () => {
+  it('插入額外 bomb 輸入 → stateHash != 原局', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    const liveHash = node.match.stateHash();
+    const tampered: VersusReplay = {
+      ...replay,
+      inputs: [{ f: 0, p: 'P1', a: [{ t: 'bomb' }] }, ...replay.inputs],
+      // 給足夠幀讓竄改有機會改變局面
+      frameCount: replay.frameCount,
+    };
+    const sim = simulateVersusReplay(tampered);
+    // 竄改後 hash 幾乎必然不同（P1 多放一顆彈改變局面）
+    expect(sim.stateHash).not.toBe(liveHash);
+  });
+});
+
+describe('VersusReplay 結構 — 可直接餵 VersusMatch 重建（無需 lockstep）', () => {
+  it('用 replay 的 seed/arenaId/characters/playerIds 建 VersusMatch 不丟例外', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    expect(
+      () =>
+        new VersusMatch({
+          seed: replay.seed,
+          arenaId: replay.arenaId,
+          players: replay.playerIds.map((id) => ({ id, character: replay.characters[id] })),
+        }),
+    ).not.toThrow();
+  });
+});

--- a/src/scripts/games/bomber/net/versusReplay.ts
+++ b/src/scripts/games/bomber/net/versusReplay.ts
@@ -1,0 +1,186 @@
+import { VersusMatch } from '../versus/versusMatch';
+import type { CharacterId } from '../engine/types';
+import type { VersusAction } from './bomberLockstep';
+
+const SIM_DT = 1000 / 60;
+
+/** 重播上限（防 DoS / 損壞紀錄無窮迴圈）。bomber 局含 sudden death，最長約 3 分鐘。 */
+const MAX_FRAMES = 60 * 60 * 5; // 5 分鐘 frame 上限（遠超實際 sudden-death 終局）
+const MAX_INPUTS = 200_000;
+
+/**
+ * 一場 versus 的可重播紀錄（比照 tetris FfaReplay）：
+ *  - 不可變參數（seed/arenaId/characters/playerIds）足以重建 VersusMatch。
+ *  - frameCount：已 step 的總幀數。
+ *  - inputs：稀疏逐幀「某玩家」輸入（只含非空；順序 == BomberLockstep.advance() 套用序，
+ *    即同幀依固定 playerIds 序、同玩家內 held 先於 bomb/ability 由 VersusAction 陣列保證）。
+ *  - forfeits：哪一幀對哪位玩家套用 forfeit（重現斷線結束的局；套用在該幀輸入之前）。
+ */
+export interface VersusReplay {
+  seed: number;
+  arenaId: number;
+  characters: Record<string, CharacterId>;
+  playerIds: string[];
+  frameCount: number;
+  inputs: Array<{ f: number; p: string; a: VersusAction[] }>;
+  /** 中離事件（可選，向後相容）：幀 f 時玩家 p 被 forfeit；套用順序在該幀輸入之前。 */
+  forfeits?: Array<{ f: number; p: string }>;
+}
+
+/** simulateVersusReplay 的回傳：最終名次（冠軍在前）+ 決定性 stateHash。 */
+export interface VersusReplayResult {
+  standings: string[];
+  stateHash: string;
+}
+
+/**
+ * 由 VersusMatch 的 placement 推導最終名次（冠軍在前）。
+ *
+ * 鐵則（與 BomberLockstep / FfaMatch.getStandings 對齊）：
+ *  - placement 升冪（1 = 冠軍在最前；存活中 placement=0 會排在最前，僅在未結束局出現）。
+ *  - 平手（同 placement，如同幀死亡共享名次、或全滅平局全員 placement=1）以
+ *    `playerIds` 的固定順序穩定排列——這是各端一致、與 simFrame 偏移無關的決定性 tie-break，
+ *    對應 FfaMatch 以 placements Map 插入序（淘汰序）穩定排列的精神。
+ *
+ * 實作：對 playerIds 的副本做穩定排序（依 placement 升冪；相等者保留 playerIds 原序）。
+ */
+export function liveStandings(match: VersusMatch, playerIds: string[]): string[] {
+  const state = match.getState();
+  const placementOf = new Map<string, number>();
+  for (const p of state.players) placementOf.set(p.id, p.placement);
+  // 以 playerIds 固定順序為基底，標上原序索引做穩定 tie-break（避免依賴 sort 穩定性）。
+  return playerIds
+    .map((id, i) => ({ id, placement: placementOf.get(id) ?? 0, i }))
+    .sort((a, b) => a.placement - b.placement || a.i - b.i)
+    .map((e) => e.id);
+}
+
+/**
+ * 以確定性 VersusMatch 重跑該局，逐幀套用紀錄的輸入/forfeit，回傳最終名次與 stateHash。
+ *
+ * 套用順序「逐位元」對齊 BomberLockstep.advance()：
+ *  每幀 f（status 仍 playing 時）：
+ *   1. 先套用該幀所有 forfeit（依 forfeits 陣列出現序）。
+ *   2. 再套用該幀所有輸入：同幀多筆 entry 依 inputs 陣列出現序（錄製端已是固定 playerIds 序），
+ *      每筆 entry 內 held 先於 bomb/ability（與 advance() 同）。
+ *   3. match.step(1000/60)。
+ *  對局結束（status !== 'playing'）後即停止套用（forfeit/input 對 finished 局為 no-op，
+ *  但提早停可避免無謂運算，且與 advance() 的「分出勝負就停止推進」一致）。
+ *
+ * 決定性鐵則：純整數/紀錄重放，無 Math.random / Date.now。
+ */
+export function simulateVersusReplay(replay: VersusReplay): VersusReplayResult {
+  const match = new VersusMatch({
+    seed: replay.seed,
+    arenaId: replay.arenaId,
+    players: replay.playerIds.map((id) => ({ id, character: replay.characters[id] })),
+  });
+
+  // 依 frame 分組輸入（保留陣列出現序＝錄製端的固定 playerIds 套用序）。
+  const inputsByFrame = new Map<number, Array<{ p: string; a: VersusAction[] }>>();
+  for (const e of replay.inputs) {
+    let list = inputsByFrame.get(e.f);
+    if (!list) {
+      list = [];
+      inputsByFrame.set(e.f, list);
+    }
+    list.push({ p: e.p, a: e.a });
+  }
+
+  // 依 frame 分組 forfeits（同幀多筆依陣列出現序套用）。
+  const forfeitsByFrame = new Map<number, string[]>();
+  if (Array.isArray(replay.forfeits)) {
+    for (const ff of replay.forfeits) {
+      let list = forfeitsByFrame.get(ff.f);
+      if (!list) {
+        list = [];
+        forfeitsByFrame.set(ff.f, list);
+      }
+      list.push(ff.p);
+    }
+  }
+
+  const n = Math.min(replay.frameCount, MAX_FRAMES);
+  for (let f = 0; f < n && match.getState().status === 'playing'; f++) {
+    // 1) 該幀 forfeit 先於輸入（與 advance() 約定一致）。
+    const frameForfeits = forfeitsByFrame.get(f);
+    if (frameForfeits) {
+      for (const p of frameForfeits) match.forfeit(p);
+    }
+    // 2) 該幀輸入：依 entry 出現序；entry 內 held 先於 bomb/ability。
+    const frameInputs = inputsByFrame.get(f);
+    if (frameInputs) {
+      for (const entry of frameInputs) {
+        for (const act of entry.a) {
+          if (act.t === 'held') match.setHeld(entry.p, act.d, act.v);
+        }
+        for (const act of entry.a) {
+          if (act.t === 'bomb') match.input(entry.p, 'bomb');
+          else if (act.t === 'ability') match.input(entry.p, 'ability');
+        }
+      }
+    }
+    // 3) 推進一幀。
+    match.step(SIM_DT);
+  }
+
+  return {
+    standings: liveStandings(match, replay.playerIds),
+    stateHash: match.stateHash(),
+  };
+}
+
+/**
+ * 驗證 replay 結構合理且重模擬名次/stateHash == 宣稱值（伺服器端結算共識用，比照 verifyFfaReplay）。
+ * 任何結構不合法或重模擬不符 → false；絕不丟例外（不可信輸入）。
+ */
+export function verifyVersusReplay(
+  replay: VersusReplay,
+  claimed: { standings: string[]; stateHash: string },
+): boolean {
+  if (!replay || typeof replay !== 'object') return false;
+  if (typeof replay.seed !== 'number' || !Number.isFinite(replay.seed)) return false;
+  if (typeof replay.arenaId !== 'number' || !Number.isFinite(replay.arenaId)) return false;
+  if (!replay.characters || typeof replay.characters !== 'object') return false;
+  if (!Array.isArray(replay.playerIds)) return false;
+  if (!Number.isFinite(replay.frameCount)) return false;
+  if (replay.frameCount < 0 || replay.frameCount > MAX_FRAMES) return false;
+  if (!Array.isArray(replay.inputs)) return false;
+  if (replay.inputs.length > MAX_INPUTS) return false;
+
+  // 每位玩家都要有角色設定（否則 VersusMatch 取不到 profile）。
+  for (const id of replay.playerIds) {
+    if (typeof replay.characters[id] !== 'string') return false;
+  }
+
+  // inputs 逐筆 shape：f 有限且在範圍內、p 在名單、a 為陣列。
+  for (const e of replay.inputs) {
+    if (!e || typeof e !== 'object') return false;
+    if (!Number.isFinite(e.f) || e.f < 0 || e.f > replay.frameCount) return false;
+    if (typeof e.p !== 'string' || !replay.playerIds.includes(e.p)) return false;
+    if (!Array.isArray(e.a)) return false;
+  }
+
+  // forfeits 檢查（欄位不存在＝合法，向後相容）。
+  if (replay.forfeits !== undefined) {
+    if (!Array.isArray(replay.forfeits)) return false;
+    if (replay.forfeits.length > replay.playerIds.length) return false;
+    for (const ff of replay.forfeits) {
+      if (!ff || typeof ff !== 'object') return false;
+      if (!Number.isFinite(ff.f) || ff.f < 0 || ff.f > replay.frameCount) return false;
+      if (typeof ff.p !== 'string' || !replay.playerIds.includes(ff.p)) return false;
+    }
+  }
+
+  if (!claimed || !Array.isArray(claimed.standings) || typeof claimed.stateHash !== 'string') {
+    return false;
+  }
+
+  const sim = simulateVersusReplay(replay);
+  if (sim.stateHash !== claimed.stateHash) return false;
+  if (sim.standings.length !== claimed.standings.length) return false;
+  for (let i = 0; i < sim.standings.length; i++) {
+    if (sim.standings[i] !== claimed.standings[i]) return false;
+  }
+  return true;
+}

--- a/src/scripts/games/bomber/render/GridView.ts
+++ b/src/scripts/games/bomber/render/GridView.ts
@@ -1,8 +1,18 @@
 import { Container, Sprite } from 'pixi.js';
-import type { BomberState, Grid, Tile } from '../engine/types';
+import type { Grid, Tile } from '../engine/types';
 import { GRID_COLS, GRID_ROWS } from '../engine/constants';
 import type { BomberTextures } from './assets';
 import type { Layout } from './layout';
+
+/**
+ * GridView 只讀取盤面與（單機用的）樓層編號——結構型別讓單機 BomberState 與
+ * versus VersusState 皆可傳入；versus 不含 floor（以 themeOverride 指定磚組）。
+ */
+interface GridRenderState {
+  grid: Grid;
+  /** 單機樓層（決定 biome 與裝飾 hash）；versus 省略，magic 0 即可（hash 仍穩定）。 */
+  floor?: number;
+}
 
 /**
  * 依 BomberState.grid 以 Sprite 繪製地板/牆/箱子。
@@ -43,14 +53,29 @@ export class GridView {
     return Math.min(4, Math.floor((floor - 1) / 3));
   }
 
-  private _tileTexture(tile: Tile, biome: number) {
-    const set = this.textures.tileSets[biome] ?? this.textures.tileSets[0];
+  /**
+   * 解析有效的磚組索引。
+   * versus 競技場以 arena.theme 為主（0-7）；單機則以樓層 biome（0-4）。
+   * TODO(Task 7): real tiles for themes 5-7 — 目前 tileSets 只有 0-4，
+   * theme 5/6/7 暫以 (theme % length) 回退到既有磚組（佔位、不崩潰）。
+   */
+  private _resolveTileSet(theme: number) {
+    const sets = this.textures.tileSets;
+    return sets[theme] ?? sets[theme % sets.length] ?? sets[0];
+  }
+
+  private _tileTexture(tile: Tile, theme: number) {
+    const set = this._resolveTileSet(theme);
     if (tile === 'wall')  return set.wall;
     if (tile === 'crate') return set.crate;
     return set.floor;
   }
 
-  render(state: BomberState, layout: Layout): void {
+  /**
+   * 繪製地板/牆/箱子。
+   * @param themeOverride versus 模式傳入 arena.theme（0-7）；省略時退回單機樓層 biome。
+   */
+  render(state: GridRenderState, layout: Layout, themeOverride?: number): void {
     const { cell, ox, oy } = layout;
     const gridChanged  = state.grid !== this.lastGrid;
     const layoutChanged = cell !== this.lastCell;
@@ -60,7 +85,8 @@ export class GridView {
     this.lastGrid = state.grid;
     this.lastCell = cell;
 
-    const biome = this._biomeIndex(state.floor);
+    const floor = state.floor ?? 0;
+    const biome = themeOverride ?? this._biomeIndex(floor);
     const grid = state.grid;
     for (let row = 0; row < GRID_ROWS; row++) {
       for (let col = 0; col < GRID_COLS; col++) {
@@ -81,14 +107,17 @@ export class GridView {
     }
 
     // 地面裝飾：~12% 的 floor 格放生態區專屬小物件（決定性 hash，重繪穩定）
+    // decorFrames 只有 10 幀（biome 0-4 × 2）；theme 5-7 暫夾到既有範圍（佔位）。
+    // TODO(Task 7): real decor for themes 5-7
+    const decorBiome = biome % 5;
     let di = 0;
     for (let row = 1; row < GRID_ROWS - 1; row++) {
       for (let col = 1; col < GRID_COLS - 1; col++) {
         if ((grid[row]?.[col] ?? 'floor') !== 'floor') continue;
-        const h = this._hash(state.floor, col, row);
+        const h = this._hash(floor, col, row);
         if (h >= 0.12) continue;
         const variant = h < 0.06 ? 0 : 1;
-        const tex = this.textures.decorFrames[biome * 2 + variant];
+        const tex = this.textures.decorFrames[decorBiome * 2 + variant];
         let sp = this.decorPool[di];
         if (!sp) {
           sp = new Sprite(tex);

--- a/src/scripts/games/bomber/render/VersusEntityView.ts
+++ b/src/scripts/games/bomber/render/VersusEntityView.ts
@@ -1,0 +1,361 @@
+import { Container, Sprite, Texture, Rectangle, Graphics } from 'pixi.js';
+import { speedMs } from '../engine/player';
+import { BLAST_TTL_MS, GRID_COLS, GRID_ROWS } from '../engine/constants';
+import { lerp, type Layout } from './layout';
+import type { BomberTextures } from './assets';
+import type { VersusState, VPlayer } from '../versus/types';
+import type { AbilityId, CharacterId } from '../engine/types';
+
+/**
+ * Versus 多玩家渲染層——比照 EntityView 的玩家段，但對 N 個玩家各畫一份。
+ * 繪製：
+ * - 道具（小 bob）
+ * - 炸彈（脈動 scale；造型依持有者角色）
+ * - 爆風（方向性件型，additive blend，black drops out，alpha from ttlMs）
+ * - 所有存活玩家（walk sheet：列依朝向、幀依移動 walk-cycle；淘汰者隱藏）
+ * - 護盾泡（持盾玩家）、無敵閃爍
+ * - 技能環形震波（drainEvents → triggerAbility）
+ * - Sudden death 警告：collapsedRings 變化後 3 秒內，下一圈（d === collapsedRings+1）
+ *   格子以脈動紅色半透明覆層提示即將塌縮
+ *
+ * 策略：沿用 EntityView 的 recreate-per-frame pool（多的隱藏、不足時新增）。
+ */
+
+/** Walk-cycle step sequence for ping-pong: A → stand → B → stand */
+const WALK_STEPS = [0, 1, 2, 1] as const;
+
+/** Map direction string to walk-sheet row index (row 0=down, 1=left, 2=right, 3=up). */
+function dirToRow(dir: string): number {
+  switch (dir) {
+    case 'left':  return 1;
+    case 'right': return 2;
+    case 'up':    return 3;
+    default:      return 0; // 'down' and any unknown default to down
+  }
+}
+
+/** Per-player tint accents (P1 warm / P2 cool / P3 / P4) — 助辨識，疊在 walk sprite 上。 */
+const PLAYER_TINTS = [0xffffff, 0x9fd8ff, 0xffd6a0, 0xc0ffc0];
+
+/** Per-ability accent colours (match the select-screen auras). */
+const ABILITY_COLOR: Record<AbilityId, number> = {
+  detonate: 0xffb347,
+  inferno: 0xff5a3c,
+  blink:   0x36e0c0,
+  bulwark: 0x6b9fd0,
+};
+
+/** Expanding ring shockwave effect (grid coords; radii in cell units). */
+interface RingFx {
+  gx: number; gy: number;
+  ageMs: number; ttlMs: number;
+  fromR: number; toR: number;
+  color: number;
+}
+
+const CHAR_FALLBACK: CharacterId = 'lena';
+function asCharacter(c: string): CharacterId {
+  return (c === 'lena' || c === 'mira' || c === 'aya' || c === 'rosa') ? c : CHAR_FALLBACK;
+}
+
+export class VersusEntityView {
+  private pulsePhase    = 0;
+  private blinkPhase    = 0;
+  /** 各玩家 walk-cycle 時基（id → ms），移動時累加、靜止保持站立幀。 */
+  private playerWalkMs   = new Map<string, number>();
+  /** Sudden death 警告剩餘顯示時間（ms）；collapsedRings 變化時重設為 3000。 */
+  private warnMs = 0;
+  private lastCollapsedRings = 0;
+
+  private textures: BomberTextures;
+  private walkFrameCache = new Map<string, Texture>();
+
+  // --- sprite pools ---
+  private playerPool: Sprite[] = [];
+  private bombPool:   Sprite[] = [];
+  private blastPool:  Sprite[] = [];
+  private puPool:     Sprite[] = [];
+
+  // --- ability fx ---
+  private rings: RingFx[] = [];
+  private fxG: Graphics;
+  /** Sudden death 警告覆層（fxLayer 上，每幀重畫）。 */
+  private warnG: Graphics;
+
+  constructor(private layer: Container, private fxLayer: Container, textures: BomberTextures) {
+    this.textures = textures;
+    this.warnG = new Graphics();
+    this.fxLayer.addChild(this.warnG);
+    this.fxG = new Graphics();
+    this.fxLayer.addChild(this.fxG);
+  }
+
+  /** 技能視覺特效（versusMain 在 drainEvents 收到 ability 事件時呼叫）。 */
+  triggerAbility(id: AbilityId, player: VPlayer): void {
+    const color = ABILITY_COLOR[id];
+    if (id === 'inferno') {
+      this.rings.push({ gx: player.x, gy: player.y, ageMs: 0, ttlMs: 520, fromR: 0.3, toR: 4.4, color });
+      this.rings.push({ gx: player.x, gy: player.y, ageMs: 0, ttlMs: 640, fromR: 0.1, toR: 3.2, color: 0xffb347 });
+    } else {
+      // detonate / blink / bulwark：以玩家位置一圈警示環即可
+      this.rings.push({ gx: player.x, gy: player.y, ageMs: 0, ttlMs: 420, fromR: 0.15, toR: 1.1, color });
+    }
+  }
+
+  // ─── pool helpers ────────────────────────────────────────────────────────────
+
+  private _newSprite(texture: Texture): Sprite {
+    const sp = new Sprite(texture);
+    sp.anchor.set(0.5);
+    this.layer.addChild(sp);
+    return sp;
+  }
+
+  private _newBlastSprite(texture: Texture): Sprite {
+    const sp = new Sprite(texture);
+    sp.anchor.set(0.5);
+    sp.blendMode = 'add';
+    this.fxLayer.addChild(sp);
+    return sp;
+  }
+
+  private _poolGet(pool: Sprite[], idx: number, texture: Texture): Sprite {
+    if (idx < pool.length) {
+      pool[idx].texture = texture;
+      pool[idx].visible = true;
+      pool[idx].tint = 0xffffff;
+      return pool[idx];
+    }
+    const sp = this._newSprite(texture);
+    pool.push(sp);
+    return sp;
+  }
+
+  private _blastPoolGet(idx: number, texture: Texture): Sprite {
+    if (idx < this.blastPool.length) {
+      this.blastPool[idx].texture = texture;
+      this.blastPool[idx].visible = true;
+      return this.blastPool[idx];
+    }
+    const sp = this._newBlastSprite(texture);
+    this.blastPool.push(sp);
+    return sp;
+  }
+
+  private _poolHideFrom(pool: Sprite[], from: number): void {
+    for (let i = from; i < pool.length; i++) pool[i].visible = false;
+  }
+
+  // ─── render ──────────────────────────────────────────────────────────────────
+
+  render(state: VersusState, layout: Layout, dtMs: number): void {
+    this.pulsePhase = (this.pulsePhase + dtMs * 0.005) % (Math.PI * 2);
+    this.blinkPhase = (this.blinkPhase + dtMs * 0.008) % (Math.PI * 2);
+
+    const { cell, ox, oy } = layout;
+
+    // 1. 爆風 — 方向性件型 × 3 階段漸弱（比照 EntityView）
+    const bKey = (x: number, y: number): number => y * 64 + x;
+    const blastSet = new Set(state.blasts.map((b) => bKey(b.x, b.y)));
+    let bi = 0;
+    for (const blast of state.blasts) {
+      const L = blastSet.has(bKey(blast.x - 1, blast.y));
+      const R = blastSet.has(bKey(blast.x + 1, blast.y));
+      const U = blastSet.has(bKey(blast.x, blast.y - 1));
+      const D = blastSet.has(bKey(blast.x, blast.y + 1));
+      const horiz = L || R, vert = U || D;
+      let piece: keyof BomberTextures['blastPieces'];
+      if ((horiz && vert) || (!horiz && !vert)) piece = 'center';
+      else if (horiz) piece = L && R ? 'armH' : L ? 'tipR' : 'tipL';
+      else            piece = U && D ? 'armV' : U ? 'tipD' : 'tipU';
+
+      const t = Math.min(1, Math.max(0, 1 - blast.ttlMs / BLAST_TTL_MS)); // 0→1
+      const stg = Math.min(2, Math.floor(t * 3));
+      const sp = this._blastPoolGet(bi++, this.textures.blastPieces[piece][stg]);
+      const bSize = cell + 1;
+      sp.width  = bSize;
+      sp.height = bSize;
+      sp.x = ox + blast.x * cell + cell / 2;
+      sp.y = oy + blast.y * cell + cell / 2;
+      sp.alpha = t < 0.85 ? 1 : 1 - (t - 0.85) / 0.15;
+    }
+    this._poolHideFrom(this.blastPool, bi);
+
+    // 2. 道具（小 bob）
+    let pi = 0;
+    for (const pu of state.powerUps) {
+      const sp = this._poolGet(this.puPool, pi++, this._puTexture(pu.kind));
+      const bob = 1 + Math.sin(this.pulsePhase + pi * 0.7) * 0.06;
+      const size = cell * 0.7 * bob;
+      sp.width  = size;
+      sp.height = size;
+      sp.x = ox + pu.x * cell + cell / 2;
+      sp.y = oy + pu.y * cell + cell / 2;
+      sp.alpha = 1;
+    }
+    this._poolHideFrom(this.puPool, pi);
+
+    // 3. 炸彈（脈動 scale；造型依持有者角色）
+    const ownerChar = new Map<string, CharacterId>();
+    for (const p of state.players) ownerChar.set(p.id, asCharacter(p.character));
+    let bmi = 0;
+    for (const bomb of state.bombs) {
+      const ch = bomb.owner ? ownerChar.get(bomb.owner) : undefined;
+      const sp = this._poolGet(this.bombPool, bmi++, this._bombTexture(ch));
+      const pulseScale = 1 + Math.sin(this.pulsePhase) * 0.12;
+      const size = cell * 0.8 * pulseScale;
+      sp.width  = size;
+      sp.height = size;
+      sp.x = ox + bomb.x * cell + cell / 2;
+      sp.y = oy + bomb.y * cell + cell / 2;
+      sp.alpha = 1;
+    }
+    this._poolHideFrom(this.bombPool, bmi);
+
+    // 4. 玩家（walk-cycle；淘汰者隱藏）
+    let pli = 0;
+    for (let i = 0; i < state.players.length; i++) {
+      const p = state.players[i];
+      if (!p.alive) continue;
+
+      const progress = Math.min(1, Math.max(0, 1 - p.moveCooldownMs / speedMs(p.speedLevel)));
+      const rx = lerp(p.prevX, p.x, progress);
+      const ry = lerp(p.prevY, p.y, progress);
+
+      // walk-cycle：移動中持續累加相位；靜止顯示站立幀
+      const moving = p.moveCooldownMs > 0;
+      let walkMs = this.playerWalkMs.get(p.id) ?? 0;
+      if (moving) walkMs = (walkMs + dtMs) % (130 * 4);
+      this.playerWalkMs.set(p.id, walkMs);
+      const step = moving ? WALK_STEPS[Math.floor(walkMs / 130) % 4] : 1;
+
+      const character = asCharacter(p.character);
+      const dirRow = dirToRow(p.dir);
+
+      const sp = this._poolGet(this.playerPool, pli++, this._walkFrame(character, dirRow, step));
+      const pSize = cell * 0.95;
+      sp.width  = pSize;
+      sp.height = pSize;
+      sp.x = ox + rx * cell + cell / 2;
+      sp.y = oy + ry * cell + cell / 2;
+      sp.scale.x = Math.abs(sp.scale.x);
+
+      // 無敵閃爍 + 持盾微淡；以玩家序賦予辨識色調
+      const isInvuln = p.invulnMs > 0;
+      const blinkVisible = !isInvuln || Math.sin(this.blinkPhase) > 0;
+      sp.tint  = PLAYER_TINTS[i] ?? 0xffffff;
+      sp.alpha = blinkVisible ? (p.shield ? 0.95 : 1) : 0.3;
+    }
+    this._poolHideFrom(this.playerPool, pli);
+
+    // 5. 特效層：sudden-death 警告 + 護盾泡 + 技能環形震波
+    this._renderFx(state, layout, dtMs);
+  }
+
+  // ─── fx rendering ──────────────────────────────────────────────────────────────
+
+  private _renderFx(state: VersusState, layout: Layout, dtMs: number): void {
+    const { cell, ox, oy } = layout;
+
+    // -- Sudden death 警告覆層（下一圈格子脈動紅色半透明） --
+    if (state.collapsedRings !== this.lastCollapsedRings) {
+      this.warnMs = 3000; // 每次塌縮後警示下一圈 3 秒
+      this.lastCollapsedRings = state.collapsedRings;
+    }
+    const wg = this.warnG;
+    wg.clear();
+    if (this.warnMs > 0) {
+      this.warnMs = Math.max(0, this.warnMs - dtMs);
+      const nextRing = state.collapsedRings + 1;
+      // 圈半徑超出盤面中心則無下一圈可警示
+      const maxRing = Math.floor(Math.min(GRID_COLS, GRID_ROWS) / 2);
+      if (nextRing <= maxRing) {
+        const pulse = 0.18 + Math.abs(Math.sin(this.pulsePhase * 2.4)) * 0.32; // 0.18→0.5
+        for (let y = 0; y < GRID_ROWS; y++) {
+          for (let x = 0; x < GRID_COLS; x++) {
+            const d = Math.min(x, GRID_COLS - 1 - x, y, GRID_ROWS - 1 - y);
+            if (d !== nextRing) continue;
+            wg.rect(ox + x * cell, oy + y * cell, cell, cell)
+              .fill({ color: 0xff2a2a, alpha: pulse });
+          }
+        }
+      }
+    }
+
+    // -- 護盾泡 + 技能環形震波 --
+    const g = this.fxG;
+    g.clear();
+
+    // 護盾泡（持盾或無敵中的玩家）
+    for (const p of state.players) {
+      if (!p.alive) continue;
+      if (!p.shield && p.invulnMs <= 0) continue;
+      const progress = Math.min(1, Math.max(0, 1 - p.moveCooldownMs / speedMs(p.speedLevel)));
+      const rx = lerp(p.prevX, p.x, progress);
+      const ry = lerp(p.prevY, p.y, progress);
+      const px = ox + rx * cell + cell / 2;
+      const py = oy + ry * cell + cell / 2;
+      const ringPulse = 0.78 + Math.sin(this.pulsePhase * 2.2) * 0.12;
+      const radius = cell * 0.66 * ringPulse;
+      g.circle(px, py, radius).fill({ color: 0x6b9fd0, alpha: 0.1 });
+      g.circle(px, py, radius).stroke({ color: 0x9fd0ff, width: 2, alpha: 0.65 });
+    }
+
+    // 環形震波
+    for (const r of this.rings) r.ageMs += dtMs;
+    this.rings = this.rings.filter((r) => r.ageMs < r.ttlMs);
+    for (const r of this.rings) {
+      const t = r.ageMs / r.ttlMs;
+      const ease = 1 - (1 - t) * (1 - t);
+      const radius = (r.fromR + (r.toR - r.fromR) * ease) * cell;
+      const alpha = (1 - t) * 0.9;
+      const cx = ox + r.gx * cell + cell / 2;
+      const cy = oy + r.gy * cell + cell / 2;
+      g.circle(cx, cy, radius).stroke({ color: r.color, width: Math.max(2, cell * 0.07 * (1 - t)), alpha });
+      g.circle(cx, cy, radius * 0.7).stroke({ color: 0xffffff, width: 1, alpha: alpha * 0.35 });
+    }
+  }
+
+  // ─── walk-cycle helpers ───────────────────────────────────────────────────────
+
+  private _walkFrame(character: CharacterId, dirRow: number, step: number): Texture {
+    const key = `${character}-${dirRow}-${step}`;
+    const cached = this.walkFrameCache.get(key);
+    if (cached) return cached;
+
+    const walkTexMap = {
+      lena: this.textures.walkLena,
+      mira: this.textures.walkMira,
+      aya:  this.textures.walkAya,
+      rosa: this.textures.walkRosa,
+    };
+    const base = walkTexMap[character] ?? this.textures.walkLena;
+    const tex = new Texture({
+      source: base.source,
+      frame: new Rectangle(step * 64, dirRow * 64, 64, 64),
+    });
+    this.walkFrameCache.set(key, tex);
+    return tex;
+  }
+
+  private _bombTexture(character?: CharacterId): Texture {
+    switch (character) {
+      case 'lena': return this.textures.bombLena;
+      case 'mira': return this.textures.bombMira;
+      case 'aya':  return this.textures.bombAya;
+      case 'rosa': return this.textures.bombRosa;
+      default:     return this.textures.bomb;
+    }
+  }
+
+  private _puTexture(kind: string): Texture {
+    switch (kind) {
+      case 'fire':   return this.textures.puFire;
+      case 'bomb':   return this.textures.puBomb;
+      case 'speed':  return this.textures.puSpeed;
+      case 'shield': return this.textures.puShield;
+      case 'heart':  return this.textures.heart;
+      default:       return this.textures.puFire;
+    }
+  }
+}

--- a/src/scripts/games/bomber/render/versusMain.ts
+++ b/src/scripts/games/bomber/render/versusMain.ts
@@ -9,6 +9,8 @@ import { loadBomberTextures } from './assets';
 import type { Dir, CharacterId } from '../engine/types';
 import type { VersusInput } from '../versus/types';
 import type { BomberLockstep, VersusAction } from '../net/bomberLockstep';
+import { reportBomberRanked, type BomberRankResult } from '../net/bomberRanking';
+import { liveStandings } from '../net/versusReplay';
 
 export interface VersusHandle {
   match: VersusMatch;
@@ -33,6 +35,25 @@ export interface VersusOnlineBootOptions {
   localId: string;
   /** 競技場 id（決定 theme；與鎖步建構時一致，由 BomberReady.arenaId 傳入）。 */
   arenaId: number;
+  /**
+   * 排名結算接線（皆可選；缺 signMessage = casual，只顯示名次、不回報）。
+   * matchId 由 `bomber-<seed.toString(36)>-<roomId>` 組出（與 Task 14 endpoint 解析相符）。
+   */
+  ranked?: {
+    /** host 廣播的對局 seed（== lockstep replay seed）。 */
+    seed: number;
+    /** 房號（BomberReady.room）。 */
+    roomId: string;
+    /** 本端簽章地址（ranked 時為錢包地址，與 localId 一致）。 */
+    reporterId: string;
+    /** 錢包簽章函式；無 → casual（不回報，只顯示本機名次）。 */
+    signMessage?: (msg: string) => Promise<string>;
+    fetchFn?: typeof fetch;
+  };
+  /** REMATCH 按鈕（同房同設定、新 seed 重開）。未傳則該鈕隱藏。 */
+  onRematch?: () => void;
+  /** LOBBY 按鈕（返回大廳）。未傳則該鈕隱藏。 */
+  onLobby?: () => void;
 }
 
 /** 固定時間步長（與 lockstep SIM_DT 對齊；render 累積真實 dt、以此固定增量推進）。 */
@@ -77,6 +98,8 @@ async function mountVersusLoop(
   attachInput: (sound: SoundManager) => void,
   onDestroyExtra: () => void,
   lockstep?: BomberLockstep,
+  /** 線上模式覆寫：finish 時呼叫此 hook 顯示結算畫面（傳入後不顯示基本 overlay）。 */
+  onFinish?: (winnerId: string | null) => void,
 ): Promise<VersusHandle> {
   const stage = await PixiStage.create(canvas);
   const theme = ARENAS[arenaId]?.theme ?? 0;
@@ -94,18 +117,23 @@ async function mountVersusLoop(
   }
   stage.app.renderer.on('resize', relayout);
 
-  // ---- 結束 overlay（簡單版：VICTORY: <id> / DRAW） ----
+  // ---- 結束 overlay（基本版：VICTORY: <id> / DRAW；online 改走 onFinish 結算畫面） ----
   const overEl = document.getElementById('bomber-over') as HTMLElement | null;
   const overStatsEl = document.getElementById('bomber-over-stats') as HTMLElement | null;
   const titleEl = overEl?.querySelector('.ms-title') as HTMLElement | null;
   const retryBtn = document.getElementById('bomber-restart') as HTMLElement | null;
   const onRetry = () => location.reload();
-  retryBtn?.addEventListener('click', onRetry);
+  // online 模式以結算畫面（onFinish）的 LOBBY/REMATCH 取代單機 RETRY。
+  if (onFinish) { if (retryBtn) retryBtn.hidden = true; }
+  else { retryBtn?.addEventListener('click', onRetry); }
 
   let finishShown = false;
   function showFinish(winnerId: string | null): void {
     if (finishShown) return;
     finishShown = true;
+    // 線上：交給結算畫面 hook（standings/Elo/XP/REMATCH/LOBBY）。
+    if (onFinish) { onFinish(winnerId); return; }
+    // 單機/熱座：基本 VICTORY/DRAW。
     if (titleEl) titleEl.textContent = winnerId ? 'VICTORY' : 'DRAW';
     if (overStatsEl) overStatsEl.textContent = winnerId ? `WINNER: ${winnerId}` : 'DRAW';
     if (overEl) overEl.removeAttribute('hidden');
@@ -329,6 +357,48 @@ export async function startVersusOnline(
 
   void localId; // 本端玩家身分已由 lockstep（localId）持有；輸入即視為該玩家的動作
 
+  // ── 線上結算畫面：finish → 顯示名次 → 簽章回報 → 收到 results 後補 Elo±/XP ──
+  const onFinish = (winnerId: string | null): void => {
+    // 1) 先以本機名次即時顯示（不等網路；標題用本端視角 VICTORY/DEFEAT/DRAW）。
+    //    liveStandings 與 endpoint 重建名次同源（playerIds 固定序 tie-break）→ 與回報一致。
+    const standings = liveStandings(lockstep.match, lockstep.playerIds);
+    renderResultOverlay({
+      localId,
+      winnerId,
+      standings,
+      characters: charactersOf(match),
+      results: null, // ratings/xp 待回報結果回來再補
+      onRematch: opts.onRematch,
+      onLobby: opts.onLobby,
+    });
+
+    // 2) 簽章回報（各端各自送；後端共識 + SETTLED 去重）。casual 無 signMessage → 不送。
+    const rk = opts.ranked;
+    if (rk) {
+      void reportBomberRanked({
+        seed: rk.seed,
+        roomId: rk.roomId,
+        reporterId: rk.reporterId,
+        replay: lockstep.getReplay(),
+        signMessage: rk.signMessage,
+        fetchFn: rk.fetchFn,
+      }).then((report) => {
+        if (report.outcome === 'applied' && report.results) {
+          // 重繪：補上每位玩家 Elo before→after 與本端 XP/等級進度。
+          renderResultOverlay({
+            localId,
+            winnerId,
+            standings,
+            characters: charactersOf(match),
+            results: report.results,
+            onRematch: opts.onRematch,
+            onLobby: opts.onLobby,
+          });
+        }
+      });
+    }
+  };
+
   return mountVersusLoop(
     canvas,
     match,
@@ -340,5 +410,140 @@ export async function startVersusOnline(
       window.removeEventListener('keyup', onKeyUp);
     },
     lockstep,
+    onFinish,
   );
+}
+
+/** playerId → CharacterId（供結算表顯示角色）。 */
+function charactersOf(match: VersusMatch): Record<string, CharacterId> {
+  const out: Record<string, CharacterId> = {};
+  for (const p of match.getState().players) out[p.id] = p.character;
+  return out;
+}
+
+/**
+ * 繪製線上結算畫面（標準名次表 + Elo± + XP 進度條 + REMATCH/LOBBY）。
+ * 全英文、無行內樣式（樣式類別在 bomber.astro）。results 為 null 時只顯示名次（待回報）。
+ */
+function renderResultOverlay(o: {
+  localId: string;
+  winnerId: string | null;
+  standings: string[];
+  characters: Record<string, CharacterId>;
+  results: BomberRankResult[] | null;
+  onRematch?: () => void;
+  onLobby?: () => void;
+}): void {
+  const overEl = document.getElementById('bomber-over') as HTMLElement | null;
+  if (!overEl) return;
+  const titleEl = overEl.querySelector('.ms-title') as HTMLElement | null;
+  const statsEl = document.getElementById('bomber-over-stats') as HTMLElement | null;
+  const tableEl = document.getElementById('bomber-over-standings') as HTMLElement | null;
+  const xpEl = document.getElementById('bomber-over-xp') as HTMLElement | null;
+  const actionsEl = document.getElementById('bomber-over-actions') as HTMLElement | null;
+  const rematchBtn = document.getElementById('bomber-rematch') as HTMLButtonElement | null;
+  const lobbyBtn = document.getElementById('bomber-lobby') as HTMLButtonElement | null;
+
+  // 標題（本端視角）：本端冠軍→VICTORY、平局→DRAW、其餘→DEFEAT。
+  if (titleEl) {
+    titleEl.textContent = o.winnerId === null
+      ? 'DRAW'
+      : o.standings[0] === o.localId ? 'VICTORY' : 'DEFEAT';
+  }
+  if (statsEl) statsEl.textContent = '';
+
+  const resultById = new Map<string, BomberRankResult>();
+  if (o.results) for (const r of o.results) resultById.set(r.id, r);
+
+  // ── 名次表（rank / player / character / Elo±） ──
+  if (tableEl) {
+    tableEl.replaceChildren();
+    o.standings.forEach((id, i) => {
+      const row = document.createElement('div');
+      row.className = 'res-row' + (id === o.localId ? ' is-local' : '');
+
+      const rank = document.createElement('span');
+      rank.className = 'res-rank';
+      rank.textContent = `#${i + 1}`;
+
+      const name = document.createElement('span');
+      name.className = 'res-name';
+      name.textContent = id;
+
+      const char = document.createElement('span');
+      char.className = 'res-char';
+      char.textContent = (o.characters[id] ?? '?').toUpperCase();
+
+      const elo = document.createElement('span');
+      elo.className = 'res-elo';
+      const r = resultById.get(id);
+      if (r) {
+        const delta = r.ratingAfter - r.ratingBefore;
+        const sign = delta > 0 ? '+' : '';
+        elo.classList.add(delta > 0 ? 'is-up' : delta < 0 ? 'is-down' : 'is-flat');
+        elo.textContent = `${r.ratingBefore}→${r.ratingAfter} (${sign}${delta})`;
+      } else {
+        elo.classList.add('is-pending');
+        elo.textContent = o.results ? '—' : '…';
+      }
+
+      row.append(rank, name, char, elo);
+      tableEl.appendChild(row);
+    });
+  }
+
+  // ── XP：本端獲得 XP + 等級 + 進度條 ──
+  if (xpEl) {
+    xpEl.replaceChildren();
+    const mine = resultById.get(o.localId);
+    if (mine) {
+      const head = document.createElement('div');
+      head.className = 'res-xp-head';
+      const gain = document.createElement('span');
+      gain.className = 'res-xp-gain';
+      gain.textContent = `+${mine.xpGained} XP`;
+      const lvl = document.createElement('span');
+      lvl.className = 'res-xp-level';
+      lvl.textContent = `LV ${mine.level}`;
+      head.append(gain, lvl);
+
+      // 進度條：本場 xpGained 占「目前等級跨距」的比例（近似視覺）。
+      // 限制：endpoint 只回 level + xpGained（不回總 XP），無法精算本級已累積進度；
+      // 故以「本場獲得 XP / 本級門檻跨距」呈現本場貢獻量，clamp 至 [0,100]%。
+      const span = Math.max(1, xpAtLeastForLevel(mine.level + 1) - xpAtLeastForLevel(mine.level));
+      const pct = Math.max(0, Math.min(100, Math.round((mine.xpGained / span) * 100)));
+      const bar = document.createElement('div');
+      bar.className = 'res-xp-bar';
+      const fill = document.createElement('span');
+      fill.className = 'res-xp-fill';
+      // 進度以 CSS 自訂屬性驅動寬度（CSS 端 width: var(--res-xp-ratio)）——避免靜態行內樣式。
+      fill.style.setProperty('--res-xp-ratio', `${pct}%`);
+      bar.appendChild(fill);
+
+      xpEl.append(head, bar);
+    } else if (o.results === null) {
+      const wait = document.createElement('div');
+      wait.className = 'res-xp-head';
+      wait.textContent = 'Reporting result…';
+      xpEl.appendChild(wait);
+    }
+  }
+
+  // ── REMATCH / LOBBY 按鈕（只在 online 顯示；缺 handler 則隱藏該鈕） ──
+  if (actionsEl) actionsEl.hidden = !(o.onRematch || o.onLobby);
+  if (rematchBtn) {
+    rematchBtn.hidden = !o.onRematch;
+    if (o.onRematch) { rematchBtn.onclick = () => o.onRematch?.(); }
+  }
+  if (lobbyBtn) {
+    lobbyBtn.hidden = !o.onLobby;
+    if (o.onLobby) { lobbyBtn.onclick = () => o.onLobby?.(); }
+  }
+
+  overEl.removeAttribute('hidden');
+}
+
+/** 本級門檻 XP（與 progression.xpForLevel 對齊：50*L*(L-1)）。用於 XP 進度條近似填充。 */
+function xpAtLeastForLevel(level: number): number {
+  return 50 * level * (level - 1);
 }

--- a/src/scripts/games/bomber/render/versusMain.ts
+++ b/src/scripts/games/bomber/render/versusMain.ts
@@ -1,0 +1,208 @@
+import { VersusMatch } from '../versus/versusMatch';
+import { ARENAS } from '../versus/arenas';
+import { SoundManager } from '../audio/SoundManager';
+import { PixiStage } from './PixiStage';
+import { GridView } from './GridView';
+import { VersusEntityView } from './VersusEntityView';
+import { computeLayout } from './layout';
+import { loadBomberTextures } from './assets';
+import type { Dir, CharacterId } from '../engine/types';
+import type { VersusInput } from '../versus/types';
+
+export interface VersusHandle {
+  match: VersusMatch;
+  destroy(): void;
+}
+
+export interface VersusBootOptions {
+  /** 競技場 id（0-7）。超出有材質範圍仍會載入，磚組以 GridView 回退繪製。 */
+  arenaId?: number;
+  /** 固定亂數種子（決定性）。 */
+  seed?: number;
+  /** 玩家設定（hotseat 預設 2 人 lena/mira）。 */
+  players?: { id: string; character: CharacterId }[];
+}
+
+/** 固定時間步長（與日後 lockstep 對齊；render 累積真實 dt、以此固定增量推進）。 */
+const FIXED_DT = 1000 / 60;
+
+/** P1：WASD + Space(bomb) + E(ability)；以 KeyboardEvent.code 對應。 */
+const P1_DIR: Record<string, Dir> = {
+  KeyW: 'up', KeyS: 'down', KeyA: 'left', KeyD: 'right',
+};
+const P1_ACTION: Record<string, VersusInput> = {
+  Space: 'bomb', KeyE: 'ability',
+};
+
+/** P2：方向鍵 + Enter(bomb) + Shift(ability)。 */
+const P2_DIR: Record<string, Dir> = {
+  ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right',
+};
+const P2_ACTION: Record<string, VersusInput> = {
+  Enter: 'bomb', ShiftLeft: 'ability', ShiftRight: 'ability',
+};
+
+/**
+ * 掛載並啟動 Dungeon Bomber VERSUS（本機熱座 debug 模式）。
+ * 純本機：兩位玩家共用同一鍵盤、同一 VersusMatch。網路同步留待後續 Task。
+ */
+export async function startVersus(
+  canvas: HTMLCanvasElement,
+  opts: VersusBootOptions = {},
+): Promise<VersusHandle> {
+  const stage = await PixiStage.create(canvas);
+
+  const players = opts.players ?? [
+    { id: 'P1', character: 'lena' as CharacterId },
+    { id: 'P2', character: 'mira' as CharacterId },
+  ];
+  // 預設 arena 0（有真實磚組）；arena 越界則夾回 0 但仍允許 5-7（以回退磚組）。
+  const rawArena = opts.arenaId ?? 0;
+  const arenaId = rawArena >= 0 && rawArena < ARENAS.length ? rawArena : 0;
+  const seed = opts.seed ?? 0x5eed1234;
+
+  const match = new VersusMatch({ seed, arenaId, players });
+  const theme = ARENAS[arenaId].theme;
+
+  const textures = await loadBomberTextures();
+  const grid = new GridView(stage.gridLayer, textures);
+  const entity = new VersusEntityView(stage.entityLayer, stage.fxLayer, textures);
+  const sound = new SoundManager();
+
+  let lay = computeLayout(stage.width, stage.height);
+
+  function relayout(): void {
+    lay = computeLayout(stage.width, stage.height);
+    grid.invalidate();
+  }
+  stage.app.renderer.on('resize', relayout);
+
+  // ---- 結束 overlay（簡單版：WINNER: <id> / DRAW） ----
+  const overEl = document.getElementById('bomber-over') as HTMLElement | null;
+  const overStatsEl = document.getElementById('bomber-over-stats') as HTMLElement | null;
+  const titleEl = overEl?.querySelector('.ms-title') as HTMLElement | null;
+  const retryBtn = document.getElementById('bomber-restart') as HTMLElement | null;
+  const onRetry = () => location.reload();
+  retryBtn?.addEventListener('click', onRetry);
+
+  let finishShown = false;
+  function showFinish(winnerId: string | null): void {
+    if (finishShown) return;
+    finishShown = true;
+    if (titleEl) titleEl.textContent = winnerId ? 'VICTORY' : 'DRAW';
+    if (overStatsEl) overStatsEl.textContent = winnerId ? `WINNER: ${winnerId}` : 'DRAW';
+    if (overEl) overEl.removeAttribute('hidden');
+  }
+
+  // ---- 鍵盤輸入（兩套 keymap，hotseat 共用同鍵盤） ----
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.code === 'KeyM') {
+      e.preventDefault();
+      sound.ensure();
+      sound.toggle();
+      return;
+    }
+
+    // P1
+    if (e.code in P1_DIR) {
+      e.preventDefault();
+      match.setHeld('P1', P1_DIR[e.code], true);
+      return;
+    }
+    if (e.code in P1_ACTION) {
+      e.preventDefault();
+      sound.ensure();
+      if (!e.repeat) {
+        match.input('P1', P1_ACTION[e.code]);
+        if (P1_ACTION[e.code] === 'bomb') sound.place();
+      }
+      return;
+    }
+
+    // P2
+    if (e.code in P2_DIR) {
+      e.preventDefault();
+      match.setHeld('P2', P2_DIR[e.code], true);
+      return;
+    }
+    if (e.code in P2_ACTION) {
+      e.preventDefault();
+      sound.ensure();
+      if (!e.repeat) {
+        match.input('P2', P2_ACTION[e.code]);
+        if (P2_ACTION[e.code] === 'bomb') sound.place();
+      }
+      return;
+    }
+  };
+
+  const onKeyUp = (e: KeyboardEvent) => {
+    if (e.code in P1_DIR) match.setHeld('P1', P1_DIR[e.code], false);
+    else if (e.code in P2_DIR) match.setHeld('P2', P2_DIR[e.code], false);
+  };
+
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+
+  // ---- 固定步長 ticker（累積真實 dt → 以 FIXED_DT 固定增量步進） ----
+  let acc = 0;
+  const MAX_CATCHUP = FIXED_DT * 5; // 防止分頁背景化後一次補太多步
+
+  const tick = (ticker: { deltaMS: number }) => {
+    const dt = ticker.deltaMS;
+    acc = Math.min(acc + dt, MAX_CATCHUP + FIXED_DT);
+    while (acc >= FIXED_DT) {
+      match.step(FIXED_DT);
+      acc -= FIXED_DT;
+
+      // 消費引擎事件 → fx + sound（每個固定步皆 drain，避免事件堆積）
+      for (const ev of match.drainEvents()) {
+        if (ev.kind === 'explode') {
+          stage.shake(8);
+          sound.explode();
+        } else if (ev.kind === 'crateBreak') {
+          stage.shake(3);
+        } else if (ev.kind === 'pickup') {
+          sound.pickup();
+        } else if (ev.kind === 'playerDead') {
+          stage.shake(10);
+          sound.hit();
+        } else if (ev.kind === 'ringCollapse') {
+          stage.shake(6);
+          sound.descend();
+          grid.invalidate(); // 塌縮改了地形：強制格子重繪
+        } else if (ev.kind === 'ability') {
+          stage.shake(6);
+          const p = match.getState().players.find((pl) => pl.id === ev.playerId);
+          if (p) entity.triggerAbility(ev.id, p);
+        } else if (ev.kind === 'finish') {
+          sound.gameover();
+          showFinish(ev.winnerId);
+        }
+      }
+    }
+
+    const s = match.getState();
+    grid.render(s, lay, theme);
+    entity.render(s, lay, dt);
+    stage.update(dt);
+  };
+  stage.app.ticker.add(tick);
+
+  const handle: VersusHandle = {
+    match,
+    destroy() {
+      stage.app.renderer.off('resize', relayout);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      retryBtn?.removeEventListener('click', onRetry);
+      stage.app.ticker.remove(tick);
+      stage.app.destroy();
+    },
+  };
+
+  // e2e / 除錯掛鉤
+  (window as unknown as { __bomberVersusDebug?: unknown }).__bomberVersusDebug = { match, handle, stage };
+
+  return handle;
+}

--- a/src/scripts/games/bomber/render/versusMain.ts
+++ b/src/scripts/games/bomber/render/versusMain.ts
@@ -8,9 +8,12 @@ import { computeLayout } from './layout';
 import { loadBomberTextures } from './assets';
 import type { Dir, CharacterId } from '../engine/types';
 import type { VersusInput } from '../versus/types';
+import type { BomberLockstep, VersusAction } from '../net/bomberLockstep';
 
 export interface VersusHandle {
   match: VersusMatch;
+  /** 線上模式：驅動該對局的鎖步（hotseat 為 undefined）。 */
+  lockstep?: BomberLockstep;
   destroy(): void;
 }
 
@@ -23,7 +26,16 @@ export interface VersusBootOptions {
   players?: { id: string; character: CharacterId }[];
 }
 
-/** 固定時間步長（與日後 lockstep 對齊；render 累積真實 dt、以此固定增量推進）。 */
+export interface VersusOnlineBootOptions {
+  /** 由 BomberReady 建好的鎖步（已含 VersusMatch、seed、arena、players、transport）。 */
+  lockstep: BomberLockstep;
+  /** 本端玩家 id（BomberReady.localId）；本機鍵盤輸入只送這位玩家。 */
+  localId: string;
+  /** 競技場 id（決定 theme；與鎖步建構時一致，由 BomberReady.arenaId 傳入）。 */
+  arenaId: number;
+}
+
+/** 固定時間步長（與 lockstep SIM_DT 對齊；render 累積真實 dt、以此固定增量推進）。 */
 const FIXED_DT = 1000 / 60;
 
 /** P1：WASD + Space(bomb) + E(ability)；以 KeyboardEvent.code 對應。 */
@@ -43,26 +55,31 @@ const P2_ACTION: Record<string, VersusInput> = {
 };
 
 /**
- * 掛載並啟動 Dungeon Bomber VERSUS（本機熱座 debug 模式）。
- * 純本機：兩位玩家共用同一鍵盤、同一 VersusMatch。網路同步留待後續 Task。
+ * 線上模式本端鍵盤：採 P1 風格（WASD + Space + E）+ 方向鍵備用，全部映射到「本端玩家」。
+ * 線上單機只控制自己一位玩家，故同時接受兩套方向鍵讓玩家用慣哪套都行。
  */
-export async function startVersus(
+const ONLINE_DIR: Record<string, Dir> = { ...P1_DIR, ...P2_DIR };
+const ONLINE_ACTION: Record<string, VersusInput> = {
+  Space: 'bomb', KeyE: 'ability', Enter: 'bomb', ShiftLeft: 'ability', ShiftRight: 'ability',
+};
+
+/** Pixi 舞台 + view + sound + 固定步長渲染/特效迴圈的共用骨架。
+ *  hotseat 與 online 共用此渲染骨架，差別只在「輸入如何進到引擎」與「每步如何推進」。
+ *
+ *  @param stepOnce  每個固定步長呼叫一次：負責推進模擬（hotseat: match.step；online: lockstep.tick）。
+ *  @param onDestroyExtra  destroy 時的額外清理（移除鍵盤監聽等）。
+ */
+async function mountVersusLoop(
   canvas: HTMLCanvasElement,
-  opts: VersusBootOptions = {},
+  match: VersusMatch,
+  arenaId: number,
+  stepOnce: () => void,
+  attachInput: (sound: SoundManager) => void,
+  onDestroyExtra: () => void,
+  lockstep?: BomberLockstep,
 ): Promise<VersusHandle> {
   const stage = await PixiStage.create(canvas);
-
-  const players = opts.players ?? [
-    { id: 'P1', character: 'lena' as CharacterId },
-    { id: 'P2', character: 'mira' as CharacterId },
-  ];
-  // 預設 arena 0（有真實磚組）；arena 越界則夾回 0 但仍允許 5-7（以回退磚組）。
-  const rawArena = opts.arenaId ?? 0;
-  const arenaId = rawArena >= 0 && rawArena < ARENAS.length ? rawArena : 0;
-  const seed = opts.seed ?? 0x5eed1234;
-
-  const match = new VersusMatch({ seed, arenaId, players });
-  const theme = ARENAS[arenaId].theme;
+  const theme = ARENAS[arenaId]?.theme ?? 0;
 
   const textures = await loadBomberTextures();
   const grid = new GridView(stage.gridLayer, textures);
@@ -77,7 +94,7 @@ export async function startVersus(
   }
   stage.app.renderer.on('resize', relayout);
 
-  // ---- 結束 overlay（簡單版：WINNER: <id> / DRAW） ----
+  // ---- 結束 overlay（簡單版：VICTORY: <id> / DRAW） ----
   const overEl = document.getElementById('bomber-over') as HTMLElement | null;
   const overStatsEl = document.getElementById('bomber-over-stats') as HTMLElement | null;
   const titleEl = overEl?.querySelector('.ms-title') as HTMLElement | null;
@@ -94,55 +111,7 @@ export async function startVersus(
     if (overEl) overEl.removeAttribute('hidden');
   }
 
-  // ---- 鍵盤輸入（兩套 keymap，hotseat 共用同鍵盤） ----
-  const onKeyDown = (e: KeyboardEvent) => {
-    if (e.code === 'KeyM') {
-      e.preventDefault();
-      sound.ensure();
-      sound.toggle();
-      return;
-    }
-
-    // P1
-    if (e.code in P1_DIR) {
-      e.preventDefault();
-      match.setHeld('P1', P1_DIR[e.code], true);
-      return;
-    }
-    if (e.code in P1_ACTION) {
-      e.preventDefault();
-      sound.ensure();
-      if (!e.repeat) {
-        match.input('P1', P1_ACTION[e.code]);
-        if (P1_ACTION[e.code] === 'bomb') sound.place();
-      }
-      return;
-    }
-
-    // P2
-    if (e.code in P2_DIR) {
-      e.preventDefault();
-      match.setHeld('P2', P2_DIR[e.code], true);
-      return;
-    }
-    if (e.code in P2_ACTION) {
-      e.preventDefault();
-      sound.ensure();
-      if (!e.repeat) {
-        match.input('P2', P2_ACTION[e.code]);
-        if (P2_ACTION[e.code] === 'bomb') sound.place();
-      }
-      return;
-    }
-  };
-
-  const onKeyUp = (e: KeyboardEvent) => {
-    if (e.code in P1_DIR) match.setHeld('P1', P1_DIR[e.code], false);
-    else if (e.code in P2_DIR) match.setHeld('P2', P2_DIR[e.code], false);
-  };
-
-  window.addEventListener('keydown', onKeyDown);
-  window.addEventListener('keyup', onKeyUp);
+  attachInput(sound);
 
   // ---- 固定步長 ticker（累積真實 dt → 以 FIXED_DT 固定增量步進） ----
   let acc = 0;
@@ -152,7 +121,7 @@ export async function startVersus(
     const dt = ticker.deltaMS;
     acc = Math.min(acc + dt, MAX_CATCHUP + FIXED_DT);
     while (acc >= FIXED_DT) {
-      match.step(FIXED_DT);
+      stepOnce();
       acc -= FIXED_DT;
 
       // 消費引擎事件 → fx + sound（每個固定步皆 drain，避免事件堆積）
@@ -191,18 +160,185 @@ export async function startVersus(
 
   const handle: VersusHandle = {
     match,
+    lockstep,
     destroy() {
       stage.app.renderer.off('resize', relayout);
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('keyup', onKeyUp);
       retryBtn?.removeEventListener('click', onRetry);
+      onDestroyExtra();
       stage.app.ticker.remove(tick);
       stage.app.destroy();
     },
   };
 
   // e2e / 除錯掛鉤
-  (window as unknown as { __bomberVersusDebug?: unknown }).__bomberVersusDebug = { match, handle, stage };
+  (window as unknown as { __bomberVersusDebug?: unknown }).__bomberVersusDebug = { match, lockstep, handle, stage };
 
   return handle;
+}
+
+/**
+ * 掛載並啟動 Dungeon Bomber VERSUS（本機熱座 debug 模式）。
+ * 純本機：兩位玩家共用同一鍵盤、同一 VersusMatch。
+ */
+export async function startVersus(
+  canvas: HTMLCanvasElement,
+  opts: VersusBootOptions = {},
+): Promise<VersusHandle> {
+  const players = opts.players ?? [
+    { id: 'P1', character: 'lena' as CharacterId },
+    { id: 'P2', character: 'mira' as CharacterId },
+  ];
+  // 預設 arena 0（有真實磚組）；arena 越界則夾回 0 但仍允許 5-7（以回退磚組）。
+  const rawArena = opts.arenaId ?? 0;
+  const arenaId = rawArena >= 0 && rawArena < ARENAS.length ? rawArena : 0;
+  const seed = opts.seed ?? 0x5eed1234;
+
+  const match = new VersusMatch({ seed, arenaId, players });
+
+  let onKeyDown: (e: KeyboardEvent) => void = () => {};
+  let onKeyUp: (e: KeyboardEvent) => void = () => {};
+
+  const attachInput = (sound: SoundManager): void => {
+    // ---- 鍵盤輸入（兩套 keymap，hotseat 共用同鍵盤） ----
+    onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'KeyM') {
+        e.preventDefault();
+        sound.ensure();
+        sound.toggle();
+        return;
+      }
+
+      // P1
+      if (e.code in P1_DIR) {
+        e.preventDefault();
+        match.setHeld('P1', P1_DIR[e.code], true);
+        return;
+      }
+      if (e.code in P1_ACTION) {
+        e.preventDefault();
+        sound.ensure();
+        if (!e.repeat) {
+          match.input('P1', P1_ACTION[e.code]);
+          if (P1_ACTION[e.code] === 'bomb') sound.place();
+        }
+        return;
+      }
+
+      // P2
+      if (e.code in P2_DIR) {
+        e.preventDefault();
+        match.setHeld('P2', P2_DIR[e.code], true);
+        return;
+      }
+      if (e.code in P2_ACTION) {
+        e.preventDefault();
+        sound.ensure();
+        if (!e.repeat) {
+          match.input('P2', P2_ACTION[e.code]);
+          if (P2_ACTION[e.code] === 'bomb') sound.place();
+        }
+        return;
+      }
+    };
+
+    onKeyUp = (e: KeyboardEvent) => {
+      if (e.code in P1_DIR) match.setHeld('P1', P1_DIR[e.code], false);
+      else if (e.code in P2_DIR) match.setHeld('P2', P2_DIR[e.code], false);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+  };
+
+  return mountVersusLoop(
+    canvas,
+    match,
+    arenaId,
+    () => match.step(FIXED_DT),
+    attachInput,
+    () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    },
+  );
+}
+
+/**
+ * 掛載並啟動 Dungeon Bomber VERSUS（線上鎖步模式）。
+ * 本機鍵盤只控制「本端玩家」（localId）→ 透過 lockstep.queueLocal 排入；
+ * 每個固定步呼叫 lockstep.tick()（推進＝全員齊備才 step，缺幀則自然等待）；
+ * 渲染讀 lockstep.match.getState()。
+ *
+ * 決定性：UI/render 絕不直接呼叫 match.step / match.input / match.setHeld——
+ * 一切輸入只經 lockstep.queueLocal（held 持平/放開、bomb、ability），
+ * seed/arena/順序全來自 host 廣播的 BomberReady。
+ */
+export async function startVersusOnline(
+  canvas: HTMLCanvasElement,
+  opts: VersusOnlineBootOptions,
+): Promise<VersusHandle> {
+  const { lockstep, localId, arenaId } = opts;
+  const match = lockstep.match;
+
+  // 本端目前按住的方向（避免重複 queue 同一個 held=true；放開時才送 held=false）。
+  const heldDirs = new Set<Dir>();
+
+  let onKeyDown: (e: KeyboardEvent) => void = () => {};
+  let onKeyUp: (e: KeyboardEvent) => void = () => {};
+
+  const attachInput = (sound: SoundManager): void => {
+    onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'KeyM') {
+        e.preventDefault();
+        sound.ensure();
+        sound.toggle();
+        return;
+      }
+      const dir = ONLINE_DIR[e.code];
+      if (dir) {
+        e.preventDefault();
+        if (!heldDirs.has(dir)) {
+          heldDirs.add(dir);
+          lockstep.queueLocal({ t: 'held', d: dir, v: true });
+        }
+        return;
+      }
+      const action = ONLINE_ACTION[e.code];
+      if (action) {
+        e.preventDefault();
+        sound.ensure();
+        if (!e.repeat) {
+          lockstep.queueLocal(action === 'bomb' ? { t: 'bomb' } : { t: 'ability' });
+          if (action === 'bomb') sound.place();
+        }
+        return;
+      }
+    };
+
+    onKeyUp = (e: KeyboardEvent) => {
+      const dir = ONLINE_DIR[e.code];
+      if (dir && heldDirs.has(dir)) {
+        heldDirs.delete(dir);
+        lockstep.queueLocal({ t: 'held', d: dir, v: false });
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+  };
+
+  void localId; // 本端玩家身分已由 lockstep（localId）持有；輸入即視為該玩家的動作
+
+  return mountVersusLoop(
+    canvas,
+    match,
+    arenaId,
+    () => lockstep.tick(),
+    attachInput,
+    () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    },
+    lockstep,
+  );
 }

--- a/src/scripts/games/bomber/versus/arenas.test.ts
+++ b/src/scripts/games/bomber/versus/arenas.test.ts
@@ -39,13 +39,31 @@ describe('arenas', () => {
     }
   });
 
-  it('出生點四周 1 格淨空（floor，可起步）', () => {
+  it('出生點淨空：所有 seed 下每個出生點都至少一個 floor 鄰格', () => {
     for (const a of ARENAS) {
-      const { grid, spawns } = parseArena(a, 4, 7);
-      for (const s of spawns) {
-        expect(grid[s.y][s.x]).toBe('floor');
-        const neighbors = [grid[s.y][s.x-1], grid[s.y][s.x+1], grid[s.y-1]?.[s.x], grid[s.y+1]?.[s.x]];
-        expect(neighbors.filter((t) => t === 'floor').length).toBeGreaterThanOrEqual(1);
+      // 模板層不變量：每個出生點至少一個字面 '.' 鄰格 → 任何 seed 都成立
+      for (let seed = 1; seed <= 50; seed++) {
+        const { grid, spawns } = parseArena(a, 4, seed);
+        for (const s of spawns) {
+          expect(grid[s.y][s.x]).toBe('floor');
+          const neighbors = [grid[s.y][s.x-1], grid[s.y][s.x+1], grid[s.y-1]?.[s.x], grid[s.y+1]?.[s.x]];
+          expect(
+            neighbors.filter((t) => t === 'floor').length,
+            `${a.name} spawn (${s.x},${s.y}) seed ${seed}`,
+          ).toBeGreaterThanOrEqual(1);
+        }
+      }
+    }
+  });
+
+  it('模板左右鏡像對稱（出生位公平）', () => {
+    const mirrorCh = (ch: string): string =>
+      ch === '1' ? '2' : ch === '2' ? '1' : ch === '3' ? '4' : ch === '4' ? '3' : ch;
+    for (const a of ARENAS) {
+      for (let y = 0; y < a.rows.length; y++) {
+        const row = a.rows[y];
+        const mirrored = [...row].reverse().map(mirrorCh).join('');
+        expect(mirrored, `${a.name} row ${y}`).toBe(row);
       }
     }
   });

--- a/src/scripts/games/bomber/versus/arenas.test.ts
+++ b/src/scripts/games/bomber/versus/arenas.test.ts
@@ -1,0 +1,77 @@
+// src/scripts/games/bomber/versus/arenas.test.ts
+import { describe, it, expect } from 'vitest';
+import { ARENAS, parseArena } from './arenas';
+import { GRID_COLS, GRID_ROWS } from '../engine/constants';
+
+describe('arenas', () => {
+  it('共 8 張，id 0-7，各有名稱與主題索引', () => {
+    expect(ARENAS).toHaveLength(8);
+    ARENAS.forEach((a, i) => {
+      expect(a.id).toBe(i);
+      expect(a.name.length).toBeGreaterThan(0);
+      expect(a.theme).toBeGreaterThanOrEqual(0);
+      expect(a.theme).toBeLessThanOrEqual(7);
+    });
+  });
+
+  it('模板尺寸正確且外框全牆', () => {
+    for (const a of ARENAS) {
+      const { grid } = parseArena(a, 2, 1);
+      expect(grid).toHaveLength(GRID_ROWS);
+      grid.forEach((row) => expect(row).toHaveLength(GRID_COLS));
+      for (let x = 0; x < GRID_COLS; x++) {
+        expect(grid[0][x]).toBe('wall');
+        expect(grid[GRID_ROWS - 1][x]).toBe('wall');
+      }
+    }
+  });
+
+  it('出生點：2 人場給 2 個、4 人場給 4 個，且彼此距離 >= 8（公平）', () => {
+    for (const a of ARENAS) {
+      for (const n of [2, 3, 4] as const) {
+        const { spawns } = parseArena(a, n, 1);
+        expect(spawns).toHaveLength(n);
+        for (let i = 0; i < n; i++) for (let j = i + 1; j < n; j++) {
+          const d = Math.abs(spawns[i].x - spawns[j].x) + Math.abs(spawns[i].y - spawns[j].y);
+          expect(d, `${a.name} spawns ${i},${j}`).toBeGreaterThanOrEqual(8);
+        }
+      }
+    }
+  });
+
+  it('出生點四周 1 格淨空（floor，可起步）', () => {
+    for (const a of ARENAS) {
+      const { grid, spawns } = parseArena(a, 4, 7);
+      for (const s of spawns) {
+        expect(grid[s.y][s.x]).toBe('floor');
+        const neighbors = [grid[s.y][s.x-1], grid[s.y][s.x+1], grid[s.y-1]?.[s.x], grid[s.y+1]?.[s.x]];
+        expect(neighbors.filter((t) => t === 'floor').length).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  it('連通性：任一出生點可達其他所有出生點（非牆 flood fill）', () => {
+    for (const a of ARENAS) {
+      const { grid, spawns } = parseArena(a, 4, 3);
+      const seen = new Set([`${spawns[0].x},${spawns[0].y}`]);
+      const q = [spawns[0]];
+      while (q.length) {
+        const c = q.pop()!;
+        for (const [dx, dy] of [[0,1],[0,-1],[1,0],[-1,0]]) {
+          const k = `${c.x+dx},${c.y+dy}`;
+          if (!seen.has(k) && grid[c.y+dy]?.[c.x+dx] && grid[c.y+dy][c.x+dx] !== 'wall') {
+            seen.add(k); q.push({ x: c.x+dx, y: c.y+dy });
+          }
+        }
+      }
+      for (const s of spawns) expect(seen.has(`${s.x},${s.y}`), a.name).toBe(true);
+    }
+  });
+
+  it('同 seed 同佈局；不同 seed 的 ? 箱可不同', () => {
+    const a = ARENAS[0];
+    const g1 = parseArena(a, 2, 42).grid.flat().join('');
+    const g2 = parseArena(a, 2, 42).grid.flat().join('');
+    expect(g1).toBe(g2);
+  });
+});

--- a/src/scripts/games/bomber/versus/arenas.test.ts
+++ b/src/scripts/games/bomber/versus/arenas.test.ts
@@ -92,4 +92,44 @@ describe('arenas', () => {
     const g2 = parseArena(a, 2, 42).grid.flat().join('');
     expect(g1).toBe(g2);
   });
+
+  it('解析後 grid 左右對稱（seeds 1-30 × 8 arenas）', () => {
+    for (const a of ARENAS) {
+      for (let seed = 1; seed <= 30; seed++) {
+        const { grid } = parseArena(a, 4, seed);
+        for (let y = 0; y < GRID_ROWS; y++) {
+          for (let x = 0; x < GRID_COLS; x++) {
+            expect(
+              grid[y][x],
+              `${a.name} seed=${seed} grid[${y}][${x}] vs grid[${y}][${GRID_COLS - 1 - x}]`,
+            ).toBe(grid[y][GRID_COLS - 1 - x]);
+          }
+        }
+      }
+    }
+  });
+
+  it('解析後 grid 上下對稱（seeds 1-30 × 8 arenas）', () => {
+    for (const a of ARENAS) {
+      for (let seed = 1; seed <= 30; seed++) {
+        const { grid } = parseArena(a, 4, seed);
+        for (let y = 0; y < GRID_ROWS; y++) {
+          for (let x = 0; x < GRID_COLS; x++) {
+            expect(
+              grid[y][x],
+              `${a.name} seed=${seed} grid[${y}][${x}] vs grid[${GRID_ROWS - 1 - y}][${x}]`,
+            ).toBe(grid[GRID_ROWS - 1 - y][x]);
+          }
+        }
+      }
+    }
+  });
+
+  it('name 唯一性（8 個不重複）', () => {
+    expect(new Set(ARENAS.map((a) => a.name)).size).toBe(8);
+  });
+
+  it('nameZh 唯一性（8 個不重複）', () => {
+    expect(new Set(ARENAS.map((a) => a.nameZh)).size).toBe(8);
+  });
 });

--- a/src/scripts/games/bomber/versus/arenas.ts
+++ b/src/scripts/games/bomber/versus/arenas.ts
@@ -1,0 +1,200 @@
+// src/scripts/games/bomber/versus/arenas.ts
+import type { Grid, Tile, Vec } from '../engine/types';
+import { GRID_COLS, GRID_ROWS } from '../engine/constants';
+import { createRng } from '../engine/rng';
+
+/** 模板字元：W 牆、C 必箱、? 50% 箱（seed 決定，沿水平中軸鏡像對稱）、. 地板、1-4 出生點。 */
+export interface ArenaDef {
+  id: number;
+  name: string;        // 英文（arcade UI 慣例）
+  nameZh: string;      // 選圖卡顯示用
+  theme: number;       // tileSets 索引 0-7
+  rows: string[];      // GRID_ROWS 行、每行 GRID_COLS 字
+}
+
+export interface ParsedArena { grid: Grid; spawns: Vec[]; }
+
+export const ARENAS: ArenaDef[] = [
+  {
+    // 0 STONE PLAZA 石牢廣場：經典柱陣、開闊中央
+    id: 0, name: 'STONE PLAZA', nameZh: '石牢廣場', theme: 0,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.?CCCCC?.2W',
+      'W.W?W?W?W?W.W',
+      'W??C?...?C??W',
+      'W?W.W.W.W.W?W',
+      'WC?...?...?CW',
+      'W?W.W.W.W.W?W',
+      'W??C?...?C??W',
+      'W.W?W?W?W?W.W',
+      'W3.?CCCCC?.4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 1 BONE GALLERY 白骨迴廊：房室隔牆、雙走廊
+    id: 1, name: 'BONE GALLERY', nameZh: '白骨迴廊', theme: 1,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.CC...CC.2W',
+      'W.WWW?W?WWW.W',
+      'W?C...?...C?W',
+      'W?W?WWWWW?W?W',
+      'W..?..C..?..W',
+      'W?W?WWWWW?W?W',
+      'W?C...?...C?W',
+      'W.WWW?W?WWW.W',
+      'W3.CC...CC.4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 2 MOLTEN WORKS 熔火工坊：中央十字熱通道
+    // 出生點鄰側一格保留 '.'，確保 seed 任意值下均有地板可起步
+    id: 2, name: 'MOLTEN WORKS', nameZh: '熔火工坊', theme: 2,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1?C..W..C.2W',
+      'W?W?W.W.W?W?W',
+      'WC?.......?CW',
+      'W.W?W...W?W.W',
+      'WW....W....WW',
+      'W.W?W...W?W.W',
+      'WC?.......?CW',
+      'W?W?W.W.W?W?W',
+      'W3?C..W..C.4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 3 FROST ATRIUM 寒冰天井：四象限、角落保險區
+    id: 3, name: 'FROST ATRIUM', nameZh: '寒冰天井', theme: 3,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.?C.W.C?.2W',
+      'W.W.W?W?W.W.W',
+      'W?CC.....CC?W',
+      'WCW?W?W?W?WCW',
+      'W..?.....?..W',
+      'WCW?W?W?W?WCW',
+      'W?CC.....CC?W',
+      'W.W.W?W?W.W.W',
+      'W3.?C.W.C?.4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 4 VOID ALTAR 虛空祭壇：環形祭壇、稀疏柱
+    id: 4, name: 'VOID ALTAR', nameZh: '虛空祭壇', theme: 4,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1..?CCC?..2W',
+      'W.?.......?.W',
+      'W?.WW...WW.?W',
+      'WC.W..?..W.CW',
+      'WC?..???..?CW',
+      'WC.W..?..W.CW',
+      'W?.WW...WW.?W',
+      'W.?.......?.W',
+      'W3..?CCC?..4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 5 TOXIC FEN 毒霧沼澤：蜿蜒泥路、密箱
+    // 出生點旁 x=2 / x=10 改為 '.' 保證起步淨空
+    id: 5, name: 'TOXIC FEN', nameZh: '毒霧沼澤', theme: 5,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.CC?.?CC?2W',
+      'W?W.WCWCW.W?W',
+      'WCC?..?..?CCW',
+      'W.WCW?W?WCW.W',
+      'W?..C?.?C..?W',
+      'W.WCW?W?WCW.W',
+      'WCC?..?..?CCW',
+      'W?W.WCWCW.W?W',
+      'W3.CC?.?CC?4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 6 GOLD VAULT 黃金寶庫：金磚陣、道具豐沛
+    id: 6, name: 'GOLD VAULT', nameZh: '黃金寶庫', theme: 6,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.C?...?C.2W',
+      'W.WWC?.?CWW.W',
+      'WCWC?CCC?CWCW',
+      'W?C?C???C?C?W',
+      'W..?C?C?C?..W',
+      'W?C?C???C?C?W',
+      'WCWC?CCC?CWCW',
+      'W.WWC?.?CWW.W',
+      'W3.C?...?C.4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+  {
+    // 7 MOONLIT GARDEN 月光庭園：對角花園、長直線對狙
+    id: 7, name: 'MOONLIT GARDEN', nameZh: '月光庭園', theme: 7,
+    rows: [
+      'WWWWWWWWWWWWW',
+      'W1.........2W',
+      'W.W?W?W?W?W.W',
+      'W?C??...??C?W',
+      'W.?WW?C?WW?.W',
+      'W..?C...C?..W',
+      'W.?WW?C?WW?.W',
+      'W?C??...??C?W',
+      'W.W?W?W?W?W.W',
+      'W3.........4W',
+      'WWWWWWWWWWWWW',
+    ],
+  },
+];
+
+/** 解析模板：playerCount 決定啟用幾個出生點（1..N）；? 箱由 seed 決定且沿水平中軸鏡像。 */
+export function parseArena(def: ArenaDef, playerCount: 2 | 3 | 4, seed: number): ParsedArena {
+  const rng = createRng((seed ^ (def.id * 0x9e3779b1)) >>> 0);
+  const maybe: boolean[][] = [];
+  for (let y = 0; y < GRID_ROWS; y++) {
+    maybe.push([]);
+    for (let x = 0; x < GRID_COLS; x++) {
+      if (def.rows[y][x] !== '?') { maybe[y].push(false); continue; }
+      if (y <= Math.floor((GRID_ROWS - 1) / 2)) maybe[y].push(rng() < 0.5);
+      else maybe[y].push(false);
+    }
+  }
+  for (let y = Math.floor((GRID_ROWS - 1) / 2) + 1; y < GRID_ROWS; y++) {
+    const my = GRID_ROWS - 1 - y;
+    for (let x = 0; x < GRID_COLS; x++) {
+      if (def.rows[y][x] === '?') maybe[y][x] = def.rows[my][x] === '?' ? maybe[my][x] : rng() < 0.5;
+    }
+  }
+
+  const grid: Grid = [];
+  const spawnAt: Record<string, Vec> = {};
+  for (let y = 0; y < GRID_ROWS; y++) {
+    const row: Tile[] = [];
+    for (let x = 0; x < GRID_COLS; x++) {
+      const ch = def.rows[y][x];
+      if (ch === 'W') row.push('wall');
+      else if (ch === 'C') row.push('crate');
+      else if (ch === '?') row.push(maybe[y][x] ? 'crate' : 'floor');
+      else {
+        row.push('floor');
+        if (ch >= '1' && ch <= '4') spawnAt[ch] = { x, y };
+      }
+    }
+    grid.push(row);
+  }
+  const spawns: Vec[] = [];
+  for (let i = 1; i <= playerCount; i++) {
+    const s = spawnAt[String(i)];
+    if (!s) throw new Error(`arena ${def.id} missing spawn ${i}`);
+    spawns.push(s);
+  }
+  return { grid, spawns };
+}

--- a/src/scripts/games/bomber/versus/arenas.ts
+++ b/src/scripts/games/bomber/versus/arenas.ts
@@ -51,11 +51,11 @@ export const ARENAS: ArenaDef[] = [
   },
   {
     // 2 MOLTEN WORKS 熔火工坊：中央十字熱通道
-    // 出生點鄰側一格保留 '.'，確保 seed 任意值下均有地板可起步
+    // 出生點右/左鄰格為字面 '.'，任意 seed 下均有地板可起步；左右鏡像對稱
     id: 2, name: 'MOLTEN WORKS', nameZh: '熔火工坊', theme: 2,
     rows: [
       'WWWWWWWWWWWWW',
-      'W1?C..W..C.2W',
+      'W1.C..W..C.2W',
       'W?W?W.W.W?W?W',
       'WC?.......?CW',
       'W.W?W...W?W.W',
@@ -63,7 +63,7 @@ export const ARENAS: ArenaDef[] = [
       'W.W?W...W?W.W',
       'WC?.......?CW',
       'W?W?W.W.W?W?W',
-      'W3?C..W..C.4W',
+      'W3.C..W..C.4W',
       'WWWWWWWWWWWWW',
     ],
   },
@@ -103,11 +103,11 @@ export const ARENAS: ArenaDef[] = [
   },
   {
     // 5 TOXIC FEN 毒霧沼澤：蜿蜒泥路、密箱
-    // 出生點旁 x=2 / x=10 改為 '.' 保證起步淨空
+    // 出生點左右鄰格均為字面 '.'，任意 seed 下均有地板可起步；左右鏡像對稱
     id: 5, name: 'TOXIC FEN', nameZh: '毒霧沼澤', theme: 5,
     rows: [
       'WWWWWWWWWWWWW',
-      'W1.CC?.?CC?2W',
+      'W1.CC?.?CC.2W',
       'W?W.WCWCW.W?W',
       'WCC?..?..?CCW',
       'W.WCW?W?WCW.W',
@@ -115,7 +115,7 @@ export const ARENAS: ArenaDef[] = [
       'W.WCW?W?WCW.W',
       'WCC?..?..?CCW',
       'W?W.WCWCW.W?W',
-      'W3.CC?.?CC?4W',
+      'W3.CC?.?CC.4W',
       'WWWWWWWWWWWWW',
     ],
   },

--- a/src/scripts/games/bomber/versus/arenas.ts
+++ b/src/scripts/games/bomber/versus/arenas.ts
@@ -3,7 +3,7 @@ import type { Grid, Tile, Vec } from '../engine/types';
 import { GRID_COLS, GRID_ROWS } from '../engine/constants';
 import { createRng } from '../engine/rng';
 
-/** 模板字元：W 牆、C 必箱、? 50% 箱（seed 決定，沿水平中軸鏡像對稱）、. 地板、1-4 出生點。 */
+/** 模板字元：W 牆、C 必箱、? 50% 箱（seed 決定，雙軸象限鏡像對稱）、. 地板、1-4 出生點。 */
 export interface ArenaDef {
   id: number;
   name: string;        // 英文（arcade UI 慣例）
@@ -155,22 +155,39 @@ export const ARENAS: ArenaDef[] = [
   },
 ];
 
-/** 解析模板：playerCount 決定啟用幾個出生點（1..N）；? 箱由 seed 決定且沿水平中軸鏡像。 */
+/** 解析模板：playerCount 決定啟用幾個出生點（1..N）；? 箱由 seed 決定，雙軸象限鏡像確保四方等價。 */
 export function parseArena(def: ArenaDef, playerCount: 2 | 3 | 4, seed: number): ParsedArena {
   const rng = createRng((seed ^ (def.id * 0x9e3779b1)) >>> 0);
-  const maybe: boolean[][] = [];
-  for (let y = 0; y < GRID_ROWS; y++) {
-    maybe.push([]);
-    for (let x = 0; x < GRID_COLS; x++) {
-      if (def.rows[y][x] !== '?') { maybe[y].push(false); continue; }
-      if (y <= Math.floor((GRID_ROWS - 1) / 2)) maybe[y].push(rng() < 0.5);
-      else maybe[y].push(false);
+  const midX = Math.floor((GRID_COLS - 1) / 2); // 6
+  const midY = Math.floor((GRID_ROWS - 1) / 2); // 5
+
+  // 第一步：只對左上象限（x <= midX, y <= midY）的 '?' 格擲骰
+  const maybe: boolean[][] = Array.from({ length: GRID_ROWS }, () => new Array(GRID_COLS).fill(false));
+  for (let y = 0; y <= midY; y++) {
+    for (let x = 0; x <= midX; x++) {
+      if (def.rows[y][x] === '?') maybe[y][x] = rng() < 0.5;
     }
   }
-  for (let y = Math.floor((GRID_ROWS - 1) / 2) + 1; y < GRID_ROWS; y++) {
+
+  // 第二步：右上象限（x > midX, y <= midY）← 鏡像左上
+  for (let y = 0; y <= midY; y++) {
+    for (let x = midX + 1; x < GRID_COLS; x++) {
+      if (def.rows[y][x] === '?') {
+        const mx = GRID_COLS - 1 - x;
+        if (def.rows[y][mx] !== '?') throw new Error(`arena ${def.id} template not LR-symmetric at (${x},${y})`);
+        maybe[y][x] = maybe[y][mx];
+      }
+    }
+  }
+
+  // 第三步：下半（y > midY）← 鏡像上半（已確保左右各自完整）
+  for (let y = midY + 1; y < GRID_ROWS; y++) {
     const my = GRID_ROWS - 1 - y;
     for (let x = 0; x < GRID_COLS; x++) {
-      if (def.rows[y][x] === '?') maybe[y][x] = def.rows[my][x] === '?' ? maybe[my][x] : rng() < 0.5;
+      if (def.rows[y][x] === '?') {
+        if (def.rows[my][x] !== '?') throw new Error(`arena ${def.id} template not TB-symmetric at (${x},${y})`);
+        maybe[y][x] = maybe[my][x];
+      }
     }
   }
 

--- a/src/scripts/games/bomber/versus/determinism.test.ts
+++ b/src/scripts/games/bomber/versus/determinism.test.ts
@@ -1,0 +1,56 @@
+// src/scripts/games/bomber/versus/determinism.test.ts
+import { describe, it, expect } from 'vitest';
+import { VersusMatch } from './versusMatch';
+import { createRng } from '../engine/rng';
+
+const P = [
+  { id: 'a', character: 'lena' as const }, { id: 'b', character: 'mira' as const },
+  { id: 'c', character: 'aya' as const },  { id: 'd', character: 'rosa' as const },
+];
+const DIRS = ['up', 'down', 'left', 'right'] as const;
+
+/** 以固定 seed 衍生一條決定性輸入腳本，逐幀餵給全新的 VersusMatch，
+ *  回傳跑完 frames 幀後的 stateHash。模擬「某一端從頭重放輸入流」。 */
+function runScripted(seed: number, frames: number): string {
+  const m = new VersusMatch({ seed, arenaId: 3, players: P });
+  const script = createRng(seed ^ 0xabcdef); // 決定性輸入腳本
+  for (let f = 0; f < frames; f++) {
+    for (const p of P) {
+      const r = script();
+      if (r < 0.3) m.setHeld(p.id, DIRS[Math.floor(script() * 4)], script() < 0.5);
+      else if (r < 0.35) m.input(p.id, 'bomb');
+      else if (r < 0.38) m.input(p.id, 'ability');
+    }
+    m.step(1000 / 60);
+  }
+  return m.stateHash();
+}
+
+describe('determinism', () => {
+  it('同 seed＋同輸入流 → 每端 stateHash 一致（模擬 4 端各自重放）', () => {
+    const h1 = runScripted(777, 3600); // 60s
+    const h2 = runScripted(777, 3600);
+    const h3 = runScripted(777, 3600);
+    expect(h2).toBe(h1);
+    expect(h3).toBe(h1);
+  });
+
+  it('不同 seed → hash 不同', () => {
+    expect(runScripted(777, 600)).not.toBe(runScripted(778, 600));
+  });
+
+  it('getState() 為深拷貝：外部變更 state 不影響後續 stateHash', () => {
+    const m = new VersusMatch({ seed: 99, arenaId: 3, players: P });
+    for (let f = 0; f < 30; f++) m.step(1000 / 60);
+    const before = m.stateHash();
+    const snapshot = m.getState();
+    // 惡意/意外地修改取出的快照——絕不能反向污染引擎內部狀態。
+    snapshot.players[0].x = 999;
+    snapshot.players[0].alive = false;
+    snapshot.grid[0][0] = 'crate';
+    snapshot.bombs.push({ x: 1, y: 1, fuseMs: 1, range: 9, owner: 'a' });
+    snapshot.blasts.push({ x: 2, y: 2, ttlMs: 9 });
+    snapshot.powerUps.push({ x: 3, y: 3, kind: 'fire' });
+    expect(m.stateHash()).toBe(before);
+  });
+});

--- a/src/scripts/games/bomber/versus/determinism.test.ts
+++ b/src/scripts/games/bomber/versus/determinism.test.ts
@@ -1,6 +1,6 @@
 // src/scripts/games/bomber/versus/determinism.test.ts
 import { describe, it, expect } from 'vitest';
-import { VersusMatch } from './versusMatch';
+import { VersusMatch, SUDDEN_DEATH_AT_MS, RING_INTERVAL_MS } from './versusMatch';
 import { createRng } from '../engine/rng';
 
 const P = [
@@ -26,6 +26,75 @@ function runScripted(seed: number, frames: number): string {
   return m.stateHash();
 }
 
+/** 塌縮測試專用陣容：刻意指定角色，讓「倖存者」的技能不會產生爆風自殺
+ *  （c=aya/blink 只瞬移、d=rosa/bulwark 只給無敵），讓「注定陣亡者」帶會炸的技能
+ *  （a=lena/detonate、b=mira/inferno）以在塌縮期間實際跑放彈／爆風／破箱路徑。 */
+const PC = [
+  { id: 'a', character: 'lena' as const }, { id: 'b', character: 'mira' as const },
+  { id: 'c', character: 'aya' as const },  { id: 'd', character: 'rosa' as const },
+];
+
+/** 將一場比賽決定性地推進「完整 sudden-death 塌縮」，回傳跑完後的指紋與佐證旗標。
+ *
+ *  設計（為何塌縮路徑一定會被走到，且比賽必經塌縮收尾）：
+ *  - 不靠隨機戰鬥淘汰——若放任輸入流，比賽多半在 120s 前就分出勝負、step() 早退，
+ *    elapsedMs 永遠到不了塌縮門檻。改用 debugMovePlayer 把四人「釘」在固定環距格上，
+ *    再 debugSetElapsed 到塌縮前夕，逐幀 step 跨過全部 RING_INTERVAL_MS。
+ *  - 環距 d = min(x, 12-x, y, 10-y)。a/b/c 釘在 d=1/2/3 且彼此遠離的格（左上／右下／右上
+ *    三方），互不被爆風波及；d 釘在 d=5 的中心安全格、全程不會被塌縮觸及。
+ *  - 關鍵：只對 a、b（注定陣亡且互相隔離者）餵 bomb，藉此在塌縮期間實跑放彈／爆風／
+ *    破箱／grid 變異，且 a 在「第 1 圈塌縮」當幀即死，其腳下炸彈會被塌縮 bombs.filter
+ *    清掉——順帶覆蓋該分支。c、d 絕不放彈（避免踩自己的彈自爆而讓比賽在第 3 圈前就結束），
+ *    僅餵 ability：c=blink 只瞬移（每幀重新釘位修正）、d=bulwark 只給無敵，皆不致命。
+ *  - 即便 b 在第 2 圈前因自己的彈自爆，alive 仍有 c、d 兩人，比賽續行；只要 c 撐到第 3 圈，
+ *    塌縮就會推進到 collapsedRings=3 並殺 c，最後只剩 d → 比賽「經由塌縮」結束。
+ *  - 每幀重新釘位仍存活的目標玩家：抵銷 blink/任何位移，確保各人如期被對應圈殺死。
+ *  - 全程零 Math.random / Date.now：位置為定值、輸入走 createRng 決定性腳本。 */
+function runCollapse(seed: number): { hash: string; maxRings: number; finishedDuringCollapse: boolean } {
+  const m = new VersusMatch({ seed, arenaId: 3, players: PC });
+  const script = createRng(seed ^ 0x5eed1234);
+
+  // 釘位：環距 1 / 2 / 3 / 中心安全格（5）；a/b/c 三方遠離互不被爆風波及。
+  const PARK: Record<string, { x: number; y: number }> = {
+    a: { x: 1, y: 1 },  // d = 1，左上 → 第 1 圈塌縮致死
+    b: { x: 10, y: 8 }, // d = 2，右下 → 第 2 圈塌縮致死（或先自爆，皆不影響推進）
+    c: { x: 9, y: 3 },  // d = 3，右上 → 第 3 圈塌縮致死
+    d: { x: 6, y: 5 },  // d = 5，中心 → 全程安全 → 最終獲勝者
+  };
+  // 只有 a、b 會放彈（兩人遠離、且都注定陣亡，自爆/誤傷都不破壞推進）。
+  const BOMBERS = new Set(['a', 'b']);
+  for (const p of PC) m.debugMovePlayer(p.id, PARK[p.id].x, PARK[p.id].y);
+
+  // 推到塌縮前夕（門檻前一個 tick），確保第一個 step 之後才開始縮圈。
+  m.debugSetElapsed(SUDDEN_DEATH_AT_MS - 1000 / 60);
+
+  let maxRings = 0;
+  let finishedDuringCollapse = false;
+  // 跨越全部 MAX_COLLAPSE_RING 圈（門檻 + 3×RING_INTERVAL_MS）所需幀數，外加緩衝。
+  // 比賽會在第 3 圈殺掉 c、只剩 d 時提早 finished，後續 step() 早退、決定性不受影響。
+  const frames = Math.ceil((3 * RING_INTERVAL_MS + 2000) / (1000 / 60));
+  for (let f = 0; f < frames; f++) {
+    // 重新釘位仍存活的目標玩家，防止位移技能把人帶離該環。
+    const state = m.getState();
+    for (const p of state.players) {
+      if (p.alive) m.debugMovePlayer(p.id, PARK[p.id].x, PARK[p.id].y);
+    }
+    // 決定性 bomb/ability 腳本（不餵方向鍵以維持釘位）。
+    for (const p of PC) {
+      const r = script();
+      if (r < 0.15 && BOMBERS.has(p.id)) m.input(p.id, 'bomb');
+      else if (r < 0.3) m.input(p.id, 'ability');
+    }
+    m.step(1000 / 60);
+
+    const after = m.getState();
+    if (after.collapsedRings > maxRings) maxRings = after.collapsedRings;
+    if (after.status === 'finished' && after.collapsedRings > 0) finishedDuringCollapse = true;
+  }
+
+  return { hash: m.stateHash(), maxRings, finishedDuringCollapse };
+}
+
 describe('determinism', () => {
   it('同 seed＋同輸入流 → 每端 stateHash 一致（模擬 4 端各自重放）', () => {
     const h1 = runScripted(777, 3600); // 60s
@@ -33,6 +102,23 @@ describe('determinism', () => {
     const h3 = runScripted(777, 3600);
     expect(h2).toBe(h1);
     expect(h3).toBe(h1);
+  });
+
+  it('重放涵蓋 sudden-death 塌縮路徑：獨立多次跑出相同 stateHash', () => {
+    const r1 = runCollapse(424242);
+    const r2 = runCollapse(424242);
+    const r3 = runCollapse(424242);
+
+    // 先證明塌縮路徑確實被執行（否則此測試會「靜默通過」而沒測到該路徑）：
+    // 走完全部 MAX_COLLAPSE_RING 圈，且比賽是在塌縮進行中（collapsedRings>0）結束。
+    expect(r1.maxRings).toBe(3);
+    expect(r1.finishedDuringCollapse).toBe(true);
+    // 三次獨立重放（含塌縮致死、塌縮名次、grid→wall 變異）→ 指紋必須完全一致。
+    expect(r2.hash).toBe(r1.hash);
+    expect(r3.hash).toBe(r1.hash);
+    // 其餘旗標也應跨次一致。
+    expect(r2.maxRings).toBe(r1.maxRings);
+    expect(r3.maxRings).toBe(r1.maxRings);
   });
 
   it('不同 seed → hash 不同', () => {

--- a/src/scripts/games/bomber/versus/suddenDeath.test.ts
+++ b/src/scripts/games/bomber/versus/suddenDeath.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { VersusMatch, SUDDEN_DEATH_AT_MS, RING_INTERVAL_MS, MAX_COLLAPSE_RING } from './versusMatch';
+import { GRID_COLS, GRID_ROWS } from '../engine/constants';
+
+const P2 = [{ id: 'a', character: 'lena' as const }, { id: 'b', character: 'mira' as const }];
+
+describe('sudden death', () => {
+  it('120s 前不塌；120s 塌第 1 圈（d=1 全變牆）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.debugMovePlayer('a', 6, 5); m.debugMovePlayer('b', 6, 4); // 先撤到中央避免被塌死
+    m.debugSetElapsed(SUDDEN_DEATH_AT_MS - 10);
+    m.step(5);
+    expect(m.getState().collapsedRings).toBe(0);
+    m.step(20); // 跨過 120s
+    const s = m.getState();
+    expect(s.collapsedRings).toBe(1);
+    for (let x = 1; x < GRID_COLS - 1; x++) {
+      expect(s.grid[1][x]).toBe('wall');
+      expect(s.grid[GRID_ROWS - 2][x]).toBe('wall');
+    }
+  });
+
+  it('站在塌縮格上即死（無視盾）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    // a 留在出生點（d=1 圈上）、b 搬到中央
+    m.debugMovePlayer('b', 6, 5);
+    m.debugGivePowerUp('a', 'shield');
+    m.debugSetElapsed(SUDDEN_DEATH_AT_MS - 1);
+    m.step(10);
+    const s = m.getState();
+    expect(s.players[0].alive).toBe(false); // 盾擋不了塌縮
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('b');
+  });
+
+  it('每 3 秒一圈、最多塌 MAX_COLLAPSE_RING 圈', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.debugMovePlayer('a', 6, 5); m.debugMovePlayer('b', 6, 4);
+    m.debugSetElapsed(SUDDEN_DEATH_AT_MS - 1);
+    m.step(RING_INTERVAL_MS * 10); // 足夠塌完
+    expect(m.getState().collapsedRings).toBe(MAX_COLLAPSE_RING);
+  });
+});

--- a/src/scripts/games/bomber/versus/types.ts
+++ b/src/scripts/games/bomber/versus/types.ts
@@ -1,0 +1,45 @@
+// src/scripts/games/bomber/versus/types.ts
+import type { Dir, CharacterId, Grid, Bomb, BlastCell, PowerUp, PowerUpKind, AbilityId, Vec } from '../engine/types';
+
+export interface VersusPlayerInit { id: string; character: CharacterId; }
+
+export interface VPlayer {
+  id: string;
+  character: CharacterId;
+  x: number; y: number; prevX: number; prevY: number; dir: Dir;
+  alive: boolean;
+  /** 場終名次：1=冠軍。存活中為 0。 */
+  placement: number;
+  fireRange: number; maxBombs: number; speedLevel: number;
+  shield: boolean; invulnMs: number; moveCooldownMs: number;
+  abilityId: AbilityId; abilityCooldownMs: number; abilityMaxMs: number;
+}
+
+export type VersusStatus = 'playing' | 'finished';
+
+export interface VersusState {
+  status: VersusStatus;
+  arenaId: number;
+  elapsedMs: number;
+  grid: Grid;
+  players: VPlayer[];
+  bombs: Bomb[];
+  blasts: BlastCell[];
+  powerUps: PowerUp[];
+  /** sudden death：已塌完的圈數（0=未開始）。 */
+  collapsedRings: number;
+  /** 勝者 id；平局為 null（status=finished 時有意義）。 */
+  winnerId: string | null;
+}
+
+export type VersusEvent =
+  | { kind: 'bombPlaced'; x: number; y: number; ownerId: string }
+  | { kind: 'explode'; cells: Vec[] }
+  | { kind: 'crateBreak'; x: number; y: number }
+  | { kind: 'pickup'; playerId: string; powerUp: PowerUpKind }
+  | { kind: 'playerDead'; playerId: string }
+  | { kind: 'ringCollapse'; ring: number }
+  | { kind: 'finish'; winnerId: string | null }
+  | { kind: 'ability'; playerId: string; id: AbilityId };
+
+export type VersusInput = 'bomb' | 'ability';

--- a/src/scripts/games/bomber/versus/versusMatch.test.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.test.ts
@@ -60,3 +60,38 @@ describe('VersusMatch: 移動與放彈', () => {
     expect(a.shield).toBe(true);
   });
 });
+
+describe('VersusMatch: forfeit（斷線/離場強制淘汰）', () => {
+  it('forfeit 把存活玩家標記淘汰、給名次、發 playerDead 事件', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: [
+      { id: 'a', character: 'lena' as const },
+      { id: 'b', character: 'mira' as const },
+      { id: 'c', character: 'aya' as const },
+    ] });
+    m.forfeit('a');
+    const s = m.getState();
+    const a = s.players.find((p) => p.id === 'a')!;
+    expect(a.alive).toBe(false);
+    // 淘汰當下仍有 2 人存活 → placement = 2+1 = 3
+    expect(a.placement).toBe(3);
+    const ev = m.drainEvents();
+    expect(ev.some((e) => e.kind === 'playerDead' && e.playerId === 'a')).toBe(true);
+  });
+
+  it('forfeit 使存活剩 1 人 → 立即結束、倖存者勝出', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.forfeit('alice');
+    const s = m.getState();
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('bob');
+  });
+
+  it('forfeit 已淘汰或未知 id 安全無作用（冪等）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.forfeit('alice');
+    const before = m.stateHash();
+    m.forfeit('alice');   // 已淘汰：不重複
+    m.forfeit('nobody');  // 未知 id：忽略
+    expect(m.stateHash()).toBe(before);
+  });
+});

--- a/src/scripts/games/bomber/versus/versusMatch.test.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.test.ts
@@ -1,0 +1,62 @@
+// src/scripts/games/bomber/versus/versusMatch.test.ts
+import { describe, it, expect } from 'vitest';
+import { VersusMatch } from './versusMatch';
+
+const P2 = [{ id: 'alice', character: 'lena' as const }, { id: 'bob', character: 'mira' as const }];
+
+describe('VersusMatch: 建構', () => {
+  it('玩家出生在競技場出生點、versus 平衡屬性（命1/火2/彈1/速1）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const s = m.getState();
+    expect(s.players).toHaveLength(2);
+    expect(s.players[0].x).not.toBe(s.players[1].x);
+    for (const p of s.players) {
+      expect(p.alive).toBe(true);
+      expect(p.fireRange).toBe(2);
+      expect(p.maxBombs).toBe(1);
+      expect(p.speedLevel).toBe(1);
+      expect(p.shield).toBe(false);
+    }
+  });
+
+  it('保留角色技能、冷卻 = 單機 ×1.5', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const [a, b] = m.getState().players;
+    expect(a.abilityId).toBe('detonate');
+    expect(a.abilityMaxMs).toBe(9000 * 1.5);
+    expect(b.abilityId).toBe('inferno');
+    expect(b.abilityMaxMs).toBe(14000 * 1.5);
+  });
+});
+
+describe('VersusMatch: 移動與放彈', () => {
+  it('setHeld 後 step 會移動（grid-locked），且不能穿牆', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const before = m.getState().players[0];
+    m.setHeld('alice', 'right', true);
+    m.step(400);
+    m.setHeld('alice', 'right', false);
+    const after = m.getState().players[0];
+    expect(after.x).toBeGreaterThanOrEqual(before.x); // 卡箱則原地
+  });
+
+  it('放彈：owner=玩家 id、各自額度獨立', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.input('alice', 'bomb');
+    m.input('bob', 'bomb');
+    const s = m.getState();
+    expect(s.bombs).toHaveLength(2);
+    expect(new Set(s.bombs.map((b) => b.owner))).toEqual(new Set(['alice', 'bob']));
+    m.input('alice', 'bomb');
+    expect(m.getState().bombs).toHaveLength(2);
+  });
+
+  it('道具拾取提升屬性（fire/bomb/speed/shield；無 heart）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.debugGivePowerUp('alice', 'fire');
+    m.debugGivePowerUp('alice', 'shield');
+    const a = m.getState().players[0];
+    expect(a.fireRange).toBe(3);
+    expect(a.shield).toBe(true);
+  });
+});

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -1,0 +1,352 @@
+// src/scripts/games/bomber/versus/versusMatch.ts
+import type { Dir, Vec, PowerUpKind, Grid, Bomb, BlastCell, PowerUp } from '../engine/types';
+import { isWalkable, breakCrate } from '../engine/board';
+import { resolveChain } from '../engine/bomb';
+import { dirDelta, speedMs } from '../engine/player';
+import { getCharacter } from '../engine/characters';
+import { BOMB_FUSE_MS, BLAST_TTL_MS, GRID_COLS, GRID_ROWS } from '../engine/constants';
+import { createRng } from '../engine/rng';
+import { ARENAS, parseArena } from './arenas';
+import type { VersusState, VersusEvent, VersusPlayerInit, VPlayer, VersusInput } from './types';
+
+/** versus 模式技能冷卻倍數（比單機長，給更多對抗空間）。 */
+export const ABILITY_CD_MULT = 1.5;
+
+/** versus 出生屬性（全員一致，公平競技）。 */
+const VS_START = { fireRange: 2, maxBombs: 1, speedLevel: 1 } as const;
+
+/** 箱底道具生成機率。 */
+const POWERUP_RATE = 0.4;
+
+/** versus 可生成的道具種類（不含 heart，無生命系統）。 */
+const POWERUPS: PowerUpKind[] = ['fire', 'bomb', 'speed', 'shield'];
+
+/** Sudden death 開始時間（ms）。 */
+export const SUDDEN_DEATH_AT_MS = 120_000;
+
+/** Sudden death 每次縮圈間隔（ms）。 */
+export const RING_INTERVAL_MS = 3_000;
+
+/** 最大可縮圈數。 */
+export const MAX_COLLAPSE_RING = 3;
+
+export interface VersusOptions {
+  seed: number;
+  arenaId: number;
+  players: VersusPlayerInit[];
+}
+
+/** VersusMatch：雙人/多人競技場核心引擎。
+ *  - 禁用 Math.random / Date.now；全部走 deterministic rng。
+ *  - step(dtMs) 為主循環；外部每幀呼叫。
+ */
+export class VersusMatch {
+  // ---- 遊戲核心狀態 ----
+  private grid: Grid;
+  private players: VPlayer[];
+  private bombs: Bomb[] = [];
+  private blasts: BlastCell[] = [];
+  private powerUps: PowerUp[] = [];
+  /** 箱底隱藏道具：key = "x,y"。 */
+  private hiddenPowerUps: Record<string, PowerUpKind> = {};
+
+  private status: VersusState['status'] = 'playing';
+  private arenaId: number;
+  private elapsedMs = 0;
+  private collapsedRings = 0;
+  private winnerId: string | null = null;
+
+  /** 每位玩家目前按住的方向鍵集合。 */
+  private held: Map<string, Set<Dir>> = new Map();
+
+  private events: VersusEvent[] = [];
+
+  constructor(opts: VersusOptions) {
+    this.arenaId = opts.arenaId;
+    const playerCount = opts.players.length as 2 | 3 | 4;
+    const { grid, spawns } = parseArena(ARENAS[opts.arenaId], playerCount, opts.seed);
+    this.grid = grid;
+
+    // ---- 初始化箱底道具（左上象限擲骰，三象限鏡像複製） ----
+    const rng = createRng((opts.seed ^ 0xf00dbabe) >>> 0);
+    const midX = Math.floor((GRID_COLS - 1) / 2); // 6
+    const midY = Math.floor((GRID_ROWS - 1) / 2); // 5
+
+    const puMap: Record<string, PowerUpKind> = {};
+
+    // 第一步：只對左上象限的 crate 格擲骰
+    for (let y = 0; y <= midY; y++) {
+      for (let x = 0; x <= midX; x++) {
+        if (grid[y][x] === 'crate' && rng() < POWERUP_RATE) {
+          puMap[`${x},${y}`] = POWERUPS[Math.floor(rng() * 4)];
+        }
+      }
+    }
+
+    // 第二步：右上象限鏡像左上（x > midX, y <= midY）
+    for (let y = 0; y <= midY; y++) {
+      for (let x = midX + 1; x < GRID_COLS; x++) {
+        const mx = GRID_COLS - 1 - x;
+        const mirrorKey = `${mx},${y}`;
+        if (grid[y][x] === 'crate' && puMap[mirrorKey] !== undefined) {
+          puMap[`${x},${y}`] = puMap[mirrorKey];
+        }
+      }
+    }
+
+    // 第三步：下半鏡像上半（y > midY）
+    for (let y = midY + 1; y < GRID_ROWS; y++) {
+      const my = GRID_ROWS - 1 - y;
+      for (let x = 0; x < GRID_COLS; x++) {
+        const mirrorKey = `${x},${my}`;
+        if (grid[y][x] === 'crate' && puMap[mirrorKey] !== undefined) {
+          puMap[`${x},${y}`] = puMap[mirrorKey];
+        }
+      }
+    }
+
+    this.hiddenPowerUps = puMap;
+
+    // ---- 初始化玩家 ----
+    this.players = opts.players.map((pi, i) => {
+      const profile = getCharacter(pi.character);
+      const spawn = spawns[i];
+      const heldSet = new Set<Dir>();
+      this.held.set(pi.id, heldSet);
+
+      return {
+        id: pi.id,
+        character: pi.character,
+        x: spawn.x, y: spawn.y,
+        prevX: spawn.x, prevY: spawn.y,
+        dir: 'down' as Dir,
+        alive: true,
+        placement: 0,
+        // versus 平衡起始屬性
+        fireRange: VS_START.fireRange,
+        maxBombs: VS_START.maxBombs,
+        speedLevel: VS_START.speedLevel,
+        shield: false,
+        invulnMs: 0,
+        moveCooldownMs: 0,
+        // 技能：冷卻為單機 × ABILITY_CD_MULT
+        abilityId: profile.ability.id,
+        abilityMaxMs: profile.ability.cooldownMs * ABILITY_CD_MULT,
+        abilityCooldownMs: 0,
+      } satisfies VPlayer;
+    });
+  }
+
+  // ---- 輸入介面 ----
+
+  /** 設定某玩家的方向鍵按住狀態。 */
+  setHeld(playerId: string, dir: Dir, held: boolean): void {
+    const set = this.held.get(playerId);
+    if (!set) return;
+    if (held) set.add(dir);
+    else set.delete(dir);
+  }
+
+  /** 單次動作輸入（放彈 / 技能）。 */
+  input(playerId: string, action: VersusInput): void {
+    if (this.status !== 'playing') return;
+    const player = this.players.find((p) => p.id === playerId);
+    if (!player || !player.alive) return;
+
+    if (action === 'bomb') {
+      this.placeBomb(player);
+    } else if (action === 'ability') {
+      this.activateAbility(player);
+    }
+  }
+
+  // ---- 主循環 ----
+
+  /** 推進遊戲時間 dtMs 毫秒。 */
+  step(dtMs: number): void {
+    if (this.status !== 'playing') return;
+
+    this.elapsedMs += dtMs;
+
+    // 1. 玩家移動 + 屬性遞減
+    this.stepPlayers(dtMs);
+
+    // 2. 炸彈引信 + 爆炸結算
+    this.stepBombs(dtMs);
+
+    // 3. 爆風存活期遞減
+    this.stepBlasts(dtMs);
+
+    // TODO Task 4: 爆風/碰撞傷害判定
+    // TODO Task 5: sudden death 縮圈
+  }
+
+  // ---- 私有步驟 ----
+
+  /** 所有玩家：冷卻遞減、移動、道具拾取。 */
+  private stepPlayers(dtMs: number): void {
+    for (const p of this.players) {
+      if (!p.alive) continue;
+
+      // 遞減各項冷卻
+      if (p.invulnMs > 0) p.invulnMs = Math.max(0, p.invulnMs - dtMs);
+      if (p.abilityCooldownMs > 0) p.abilityCooldownMs = Math.max(0, p.abilityCooldownMs - dtMs);
+      if (p.moveCooldownMs > 0) {
+        p.moveCooldownMs = Math.max(0, p.moveCooldownMs - dtMs);
+      }
+
+      // 移動（冷卻歸零才處理）
+      if (p.moveCooldownMs <= 0) {
+        const heldSet = this.held.get(p.id);
+        const dir = heldSet && heldSet.size > 0 ? heldSet.values().next().value as Dir : null;
+        if (dir) {
+          p.dir = dir;
+          const v = dirDelta(dir);
+          const nx = p.x + v.x;
+          const ny = p.y + v.y;
+          // 可行走且無炸彈阻擋
+          if (isWalkable(this.grid, nx, ny) && !this.bombs.some((b) => b.x === nx && b.y === ny)) {
+            p.prevX = p.x; p.prevY = p.y;
+            p.x = nx; p.y = ny;
+            p.moveCooldownMs = speedMs(p.speedLevel);
+            // 移動後立即檢查道具拾取
+            this.checkPickup(p);
+          }
+        }
+      }
+    }
+  }
+
+  /** 炸彈引信遞減；到期者觸發連鎖爆炸。 */
+  private stepBombs(dtMs: number): void {
+    const detonating: Bomb[] = [];
+    for (const b of this.bombs) {
+      b.fuseMs -= dtMs;
+      if (b.fuseMs <= 0) detonating.push(b);
+    }
+    if (detonating.length === 0) return;
+
+    const { cells, brokenCrates, consumed } = resolveChain(this.grid, this.bombs, detonating);
+
+    // 移除已爆炸彈
+    this.bombs = this.bombs.filter((b) => !consumed.includes(b));
+
+    // 破壞木箱 + 揭露道具
+    for (const c of brokenCrates) {
+      this.grid = breakCrate(this.grid, c.x, c.y);
+      this.events.push({ kind: 'crateBreak', x: c.x, y: c.y });
+      const key = `${c.x},${c.y}`;
+      const drop = this.hiddenPowerUps[key];
+      if (drop) {
+        this.powerUps.push({ x: c.x, y: c.y, kind: drop });
+        delete this.hiddenPowerUps[key];
+      }
+    }
+
+    // 產生爆風格
+    for (const c of cells) this.blasts.push({ x: c.x, y: c.y, ttlMs: BLAST_TTL_MS });
+    this.events.push({ kind: 'explode', cells });
+  }
+
+  /** 爆風存活期遞減、清除過期格。 */
+  private stepBlasts(dtMs: number): void {
+    for (const bl of this.blasts) bl.ttlMs -= dtMs;
+    this.blasts = this.blasts.filter((bl) => bl.ttlMs > 0);
+  }
+
+  // ---- 放彈 ----
+
+  private placeBomb(player: VPlayer): void {
+    // 該玩家現役彈數未超額
+    if (this.bombs.filter((b) => b.owner === player.id).length >= player.maxBombs) return;
+    // 腳下無彈
+    if (this.bombs.some((b) => b.x === player.x && b.y === player.y)) return;
+
+    this.bombs.push({
+      x: player.x, y: player.y,
+      fuseMs: BOMB_FUSE_MS,
+      range: player.fireRange,
+      owner: player.id,
+    });
+    this.events.push({ kind: 'bombPlaced', x: player.x, y: player.y, ownerId: player.id });
+  }
+
+  // ---- 技能（空殼，Task 4 實作） ----
+
+  /** 技能啟動空殼：冷卻欄位已建置，效果由 Task 4 補充。 */
+  private activateAbility(player: VPlayer): void {
+    if (player.abilityCooldownMs > 0) return;
+    player.abilityCooldownMs = player.abilityMaxMs;
+    this.events.push({ kind: 'ability', playerId: player.id, id: player.abilityId });
+    // TODO Task 4: switch (player.abilityId) { case 'detonate': ... }
+  }
+
+  // ---- 道具拾取 ----
+
+  /** 玩家移動到 powerUp 格後呼叫。 */
+  private checkPickup(player: VPlayer): void {
+    const hit = this.powerUps.find((u) => u.x === player.x && u.y === player.y);
+    if (!hit) return;
+    this.powerUps = this.powerUps.filter((u) => u !== hit);
+    this.applyPowerUp(player, hit.kind);
+    this.events.push({ kind: 'pickup', playerId: player.id, powerUp: hit.kind });
+  }
+
+  /** 套用道具效果（no heart in versus）。 */
+  private applyPowerUp(player: VPlayer, kind: PowerUpKind): void {
+    const profile = getCharacter(player.character);
+    const caps = profile.caps;
+    if (kind === 'fire') player.fireRange = Math.min(player.fireRange + 1, caps.fireRange);
+    else if (kind === 'bomb') player.maxBombs = Math.min(player.maxBombs + 1, caps.maxBombs);
+    else if (kind === 'speed') player.speedLevel = Math.min(player.speedLevel + 1, caps.speedLevel);
+    else if (kind === 'shield') player.shield = true;
+    // heart 不適用於 versus（不含生命值系統）
+  }
+
+  // ---- 狀態查詢 ----
+
+  /** 深拷貝當前狀態。 */
+  getState(): VersusState {
+    return {
+      status: this.status,
+      arenaId: this.arenaId,
+      elapsedMs: this.elapsedMs,
+      grid: this.grid.map((row) => row.slice()),
+      players: this.players.map((p) => ({ ...p })),
+      bombs: this.bombs.map((b) => ({ ...b })),
+      blasts: this.blasts.map((bl) => ({ ...bl })),
+      powerUps: this.powerUps.map((u) => ({ ...u })),
+      collapsedRings: this.collapsedRings,
+      winnerId: this.winnerId,
+    };
+  }
+
+  /** 取出並清空事件佇列。 */
+  drainEvents(): VersusEvent[] {
+    const e = this.events;
+    this.events = [];
+    return e;
+  }
+
+  // ---- debug seams（測試用） ----
+
+  /** 直接對玩家套用道具效果。 */
+  debugGivePowerUp(playerId: string, kind: PowerUpKind): void {
+    const player = this.players.find((p) => p.id === playerId);
+    if (!player) return;
+    this.applyPowerUp(player, kind);
+  }
+
+  /** 強制移動玩家到指定格。 */
+  debugMovePlayer(playerId: string, x: number, y: number): void {
+    const player = this.players.find((p) => p.id === playerId);
+    if (!player) return;
+    player.x = x; player.y = y;
+    player.prevX = x; player.prevY = y;
+  }
+
+  /** 強制設定已經過時間（供 sudden death 測試用）。 */
+  debugSetElapsed(ms: number): void {
+    this.elapsedMs = ms;
+  }
+}

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -188,16 +188,18 @@ export class VersusMatch {
     // 4. 爆風傷害判定（以 tick 開始的無敵快照判定）
     this.resolveDamage(invulnAtStart);
 
-    // 5. 無敵值在傷害判定後才遞減（且僅遞減 tick 開始即有效者）
+    // 5. Sudden death 縮圈（塌縮格即死，無視盾/無敵）。
+    //    放在傷害判定後、勝負判定前，讓塌縮致死與本 tick 結束的勝負判定一致。
+    this.stepSuddenDeath();
+
+    // 6. 無敵值在傷害判定後才遞減（且僅遞減 tick 開始即有效者）
     for (const p of this.players) {
       if (!p.alive) continue;
       if ((invulnAtStart.get(p.id) ?? 0) > 0) p.invulnMs = Math.max(0, p.invulnMs - dtMs);
     }
 
-    // 6. 勝負判定
+    // 7. 勝負判定
     this.checkFinish();
-
-    // TODO Task 5: sudden death 縮圈
   }
 
   // ---- 私有步驟 ----
@@ -304,10 +306,54 @@ export class VersusMatch {
     // 本 tick 死後仍存活人數（dying 之外的 alive 玩家）。
     const aliveAfter = this.players.filter((p) => p.alive && !dying.includes(p)).length;
     const placement = aliveAfter + 1;
-    for (const p of dying) {
-      p.alive = false;
-      p.placement = placement;
-      this.events.push({ kind: 'playerDead', playerId: p.id });
+    for (const p of dying) this.killPlayer(p, placement);
+  }
+
+  /** 淘汰玩家：標記死亡、回填名次、發 playerDead 事件。
+   *  placement 由呼叫端依「同批死亡共享名次」語意算好後傳入
+   *  （= 該批死後仍存活人數 + 1）。傷害淘汰與塌縮淘汰共用此路徑；
+   *  盾/無敵的判定在呼叫端完成（塌縮路徑刻意不檢查盾/無敵）。 */
+  private killPlayer(player: VPlayer, placement: number): void {
+    if (!player.alive) return;
+    player.alive = false;
+    player.placement = placement;
+    this.events.push({ kind: 'playerDead', playerId: player.id });
+  }
+
+  // ---- Sudden death 塌縮圈 ----
+
+  /** Sudden death：120s 後每 3s 由外向內塌一圈（最多 MAX_COLLAPSE_RING 圈）。
+   *  該圈格子全變牆；格上的彈/道具/爆風一併清除；格上的玩家即死（無視盾/無敵）。
+   *  以 elapsedMs 推算「應塌到第幾圈」，缺幾圈就一次補齊（步進大 dtMs 也正確）。 */
+  private stepSuddenDeath(): void {
+    if (this.elapsedMs < SUDDEN_DEATH_AT_MS) return;
+    const due = 1 + Math.floor((this.elapsedMs - SUDDEN_DEATH_AT_MS) / RING_INTERVAL_MS);
+    const target = Math.min(MAX_COLLAPSE_RING, due);
+    while (this.collapsedRings < target) {
+      const r = this.collapsedRings + 1;
+      // 同一圈塌縮致死視為同批：共享名次 =（塌縮後仍存活人數）+ 1。
+      const onRing = (px: number, py: number): boolean => {
+        const d = Math.min(px, GRID_COLS - 1 - px, py, GRID_ROWS - 1 - py);
+        return d === r;
+      };
+      const dying = this.players.filter((p) => p.alive && onRing(p.x, p.y));
+      const aliveAfter = this.players.filter((p) => p.alive && !dying.includes(p)).length;
+      const placement = aliveAfter + 1;
+      for (let y = 0; y < GRID_ROWS; y++) {
+        for (let x = 0; x < GRID_COLS; x++) {
+          const d = Math.min(x, GRID_COLS - 1 - x, y, GRID_ROWS - 1 - y);
+          if (d !== r) continue;
+          this.grid[y][x] = 'wall';
+          // 該格上的彈/道具/爆風一併清除
+          this.bombs = this.bombs.filter((b) => !(b.x === x && b.y === y));
+          this.powerUps = this.powerUps.filter((p) => !(p.x === x && p.y === y));
+          this.blasts = this.blasts.filter((b) => !(b.x === x && b.y === y));
+        }
+      }
+      // 塌縮致死：無視盾/無敵，直接淘汰。
+      for (const p of dying) this.killPlayer(p, placement);
+      this.collapsedRings = r;
+      this.events.push({ kind: 'ringCollapse', ring: r });
     }
   }
 

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -515,7 +515,10 @@ export class VersusMatch {
    *  不應 hash 相同（lockstep desync 偵測賴此精準）。
    *  所有集合均以「穩定順序」串接：陣列照插入序（filter 保序、絕無重排），
    *  hiddenPowerUps 這個 Record 以 key 排序後串接（不依賴物件鍵插入序）。
-   *  純整數運算，無 Math.random / Date.now / Map/Set 迭代依賴。 */
+   *  純整數運算，無 Math.random / Date.now / Map/Set 迭代依賴。
+   *  刻意「不」納入 player.character 與 arenaId：兩者皆為每場比賽不可變、
+   *  且由共享 init 在各端完全一致，納入不增辨識度。注意：日後若有任何
+   *  改動會「變異」player.character（或讓 arenaId 於場中改變），必須回頭把它加入此 hash。 */
   stateHash(): string {
     let h = 0x811c9dc5;
     const mix = (s: string): void => {

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -2,9 +2,10 @@
 import type { Dir, Vec, PowerUpKind, Grid, Bomb, BlastCell, PowerUp } from '../engine/types';
 import { isWalkable, breakCrate } from '../engine/board';
 import { resolveChain } from '../engine/bomb';
+import { computeBlast } from '../engine/blast';
 import { dirDelta, speedMs } from '../engine/player';
 import { getCharacter } from '../engine/characters';
-import { BOMB_FUSE_MS, BLAST_TTL_MS, GRID_COLS, GRID_ROWS } from '../engine/constants';
+import { BOMB_FUSE_MS, BLAST_TTL_MS, GRID_COLS, GRID_ROWS, INVULN_MS } from '../engine/constants';
 import { createRng } from '../engine/rng';
 import { ARENAS, parseArena } from './arenas';
 import type { VersusState, VersusEvent, VersusPlayerInit, VPlayer, VersusInput } from './types';
@@ -168,16 +169,34 @@ export class VersusMatch {
 
     this.elapsedMs += dtMs;
 
-    // 1. 玩家移動 + 屬性遞減
-    this.stepPlayers(dtMs);
+    // 沿用單機 invulnAtStart 紀律：在移動/扣冷卻前快照每位玩家的無敵值，
+    // 傷害判定以「tick 開始」的無敵狀態為準，並在判定後才扣減（本 tick 取得的
+    // 無敵不會被同 tick 立即消耗）。
+    const invulnAtStart = new Map<string, number>();
+    for (const p of this.players) invulnAtStart.set(p.id, p.invulnMs);
 
-    // 2. 炸彈引信 + 爆炸結算
-    this.stepBombs(dtMs);
-
-    // 3. 爆風存活期遞減
+    // 1. 先遞減/清除上一 tick 的舊爆風（順序比照單機：blast 先於 bomb，
+    //    本 tick 新生的爆風才不會在生成同 tick 就被扣掉，得以參與傷害判定）。
     this.stepBlasts(dtMs);
 
-    // TODO Task 4: 爆風/碰撞傷害判定
+    // 2. 玩家移動 + 屬性遞減
+    this.stepPlayers(dtMs);
+
+    // 3. 炸彈引信 + 爆炸結算（產生本 tick 新爆風）
+    this.stepBombs(dtMs);
+
+    // 4. 爆風傷害判定（以 tick 開始的無敵快照判定）
+    this.resolveDamage(invulnAtStart);
+
+    // 5. 無敵值在傷害判定後才遞減（且僅遞減 tick 開始即有效者）
+    for (const p of this.players) {
+      if (!p.alive) continue;
+      if ((invulnAtStart.get(p.id) ?? 0) > 0) p.invulnMs = Math.max(0, p.invulnMs - dtMs);
+    }
+
+    // 6. 勝負判定
+    this.checkFinish();
+
     // TODO Task 5: sudden death 縮圈
   }
 
@@ -188,8 +207,8 @@ export class VersusMatch {
     for (const p of this.players) {
       if (!p.alive) continue;
 
-      // 遞減各項冷卻
-      if (p.invulnMs > 0) p.invulnMs = Math.max(0, p.invulnMs - dtMs);
+      // 遞減各項冷卻（invulnMs 不在此遞減——沿用單機紀律，於傷害判定後才扣，
+      // 見 step()）
       if (p.abilityCooldownMs > 0) p.abilityCooldownMs = Math.max(0, p.abilityCooldownMs - dtMs);
       if (p.moveCooldownMs > 0) {
         p.moveCooldownMs = Math.max(0, p.moveCooldownMs - dtMs);
@@ -254,6 +273,64 @@ export class VersusMatch {
     this.blasts = this.blasts.filter((bl) => bl.ttlMs > 0);
   }
 
+  // ---- 傷害 / 淘汰 ----
+
+  /** 爆風傷害判定（沿用單機 invulnAtStart 紀律）。
+   *  versus 雙方都是「格鎖定」移動的玩家、無「視覺格」需求——對稱公平，
+   *  直接以 x,y 判定是否落在爆風格。
+   *  命中：有盾 → 破盾 + 短暫無敵；無盾且 tick 開始即非無敵 → 淘汰。
+   *  同 tick 死亡者共享名次：placement = （本 tick 死後仍存活人數）+ 1，
+   *  全滅時即 placement = 1（平局名次自然落在第 1）。 */
+  private resolveDamage(invulnAtStart: Map<string, number>): void {
+    const onBlast = (x: number, y: number): boolean => this.blasts.some((b) => b.x === x && b.y === y);
+
+    // 先蒐集本 tick 命中爆風、且 tick 開始即非無敵、且無盾的待淘汰者。
+    const dying: VPlayer[] = [];
+    for (const p of this.players) {
+      if (!p.alive) continue;
+      if (!onBlast(p.x, p.y)) continue;
+      if (p.shield) {
+        // 盾擋一次：破盾 + 短暫無敵，不淘汰。
+        p.shield = false;
+        p.invulnMs = INVULN_MS;
+        continue;
+      }
+      if ((invulnAtStart.get(p.id) ?? 0) <= 0) {
+        dying.push(p);
+      }
+    }
+    if (dying.length === 0) return;
+
+    // 本 tick 死後仍存活人數（dying 之外的 alive 玩家）。
+    const aliveAfter = this.players.filter((p) => p.alive && !dying.includes(p)).length;
+    const placement = aliveAfter + 1;
+    for (const p of dying) {
+      p.alive = false;
+      p.placement = placement;
+      this.events.push({ kind: 'playerDead', playerId: p.id });
+    }
+  }
+
+  /** 勝負判定：存活 ≤ 1 即結束。
+   *  - 1 人存活：倖存者 placement=1、winnerId=其 id。
+   *  - 0 人存活（全滅同幀）：平局、winnerId=null（死亡者名次已於 resolveDamage 填為 1）。 */
+  private checkFinish(): void {
+    if (this.status !== 'playing') return;
+    const alive = this.players.filter((p) => p.alive);
+    if (alive.length > 1) return;
+
+    this.status = 'finished';
+    if (alive.length === 1) {
+      const winner = alive[0];
+      winner.placement = 1;
+      this.winnerId = winner.id;
+    } else {
+      // 全滅 = 平局。
+      this.winnerId = null;
+    }
+    this.events.push({ kind: 'finish', winnerId: this.winnerId });
+  }
+
   // ---- 放彈 ----
 
   private placeBomb(player: VPlayer): void {
@@ -271,14 +348,72 @@ export class VersusMatch {
     this.events.push({ kind: 'bombPlaced', x: player.x, y: player.y, ownerId: player.id });
   }
 
-  // ---- 技能（空殼，Task 4 實作） ----
+  // ---- 技能 ----
 
-  /** 技能啟動空殼：冷卻欄位已建置，效果由 Task 4 補充。 */
+  /** 技能啟動：扣冷卻、發事件、依角色執行 per-player 效果。 */
   private activateAbility(player: VPlayer): void {
     if (player.abilityCooldownMs > 0) return;
+
+    // detonate 需要場上有自己的彈才能發動（否則不消耗冷卻）——比照單機紀律。
+    if (player.abilityId === 'detonate' && !this.bombs.some((b) => b.owner === player.id)) return;
+
     player.abilityCooldownMs = player.abilityMaxMs;
     this.events.push({ kind: 'ability', playerId: player.id, id: player.abilityId });
-    // TODO Task 4: switch (player.abilityId) { case 'detonate': ... }
+
+    switch (player.abilityId) {
+      case 'detonate': this.effectDetonate(player); break;
+      case 'inferno': this.effectInferno(player); break;
+      case 'blink': this.effectBlink(player); break;
+      case 'bulwark': this.effectBulwark(player); break;
+    }
+  }
+
+  /** 遙控起爆（per-player）：立即引爆「自己」放置的所有炸彈（下個 tick 連鎖結算），
+   *  附短暫防護窗——絕不引爆他人的彈（owner 必須等於該玩家 id）。 */
+  private effectDetonate(player: VPlayer): void {
+    for (const b of this.bombs) {
+      if (b.owner === player.id) b.fuseMs = 0;
+    }
+    player.invulnMs = Math.max(player.invulnMs, 600);
+  }
+
+  /** 爆炎術（per-player）：以該玩家為中心瞬發大範圍爆炎，附短暫無敵以求自保。 */
+  private effectInferno(player: VPlayer): void {
+    player.invulnMs = Math.max(player.invulnMs, 700);
+    const { cells, brokenCrates } = computeBlast(this.grid, player.x, player.y, 4);
+    for (const c of brokenCrates) {
+      this.grid = breakCrate(this.grid, c.x, c.y);
+      this.events.push({ kind: 'crateBreak', x: c.x, y: c.y });
+      const key = `${c.x},${c.y}`;
+      const drop = this.hiddenPowerUps[key];
+      if (drop) { this.powerUps.push({ x: c.x, y: c.y, kind: drop }); delete this.hiddenPowerUps[key]; }
+    }
+    for (const c of cells) this.blasts.push({ x: c.x, y: c.y, ttlMs: BLAST_TTL_MS });
+    this.events.push({ kind: 'explode', cells });
+  }
+
+  /** 瞬步（per-player）：朝面向瞬移到最遠空格（最多 3 格，遇牆/彈停）。 */
+  private effectBlink(player: VPlayer): void {
+    const v = dirDelta(player.dir);
+    let steps = 0;
+    let nx = player.x, ny = player.y;
+    for (let i = 1; i <= 3; i++) {
+      const cx = player.x + v.x * i, cy = player.y + v.y * i;
+      if (!isWalkable(this.grid, cx, cy)) break;
+      if (this.bombs.some((b) => b.x === cx && b.y === cy)) break;
+      nx = cx; ny = cy;
+      steps++;
+    }
+    if (steps > 0) {
+      player.x = nx; player.y = ny;
+      player.prevX = nx; player.prevY = ny;
+      player.moveCooldownMs = 0;
+    }
+  }
+
+  /** 鐵壁（per-player）：數秒無敵。 */
+  private effectBulwark(player: VPlayer): void {
+    player.invulnMs = Math.max(player.invulnMs, 3000);
   }
 
   // ---- 道具拾取 ----

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -377,6 +377,24 @@ export class VersusMatch {
     this.events.push({ kind: 'finish', winnerId: this.winnerId });
   }
 
+  // ---- 斷線 / 離場強制淘汰 ----
+
+  /** 強制淘汰一名玩家（網路斷線/離場）。
+   *  名次語意與 resolveDamage 一致：placement =（淘汰後仍存活人數）+ 1。
+   *  淘汰後立即判定勝負（可能使對局結束）。已淘汰/未知 id / 對局已結束 → 安全無作用。
+   *
+   *  決定性鐵則：此方法不引入任何 RNG/時間相依——它只在 BomberLockstep.advance() 的
+   *  「指定幀」由各端同步呼叫（host 廣播 leave 幀，全端在同一 simFrame 套用），
+   *  故各端套用後 stateHash 仍一致。 */
+  forfeit(playerId: string): void {
+    if (this.status !== 'playing') return;
+    const player = this.players.find((p) => p.id === playerId);
+    if (!player || !player.alive) return;
+    const aliveAfter = this.players.filter((p) => p.alive && p !== player).length;
+    this.killPlayer(player, aliveAfter + 1);
+    this.checkFinish();
+  }
+
   // ---- 放彈 ----
 
   private placeBomb(player: VPlayer): void {

--- a/src/scripts/games/bomber/versus/versusMatch.ts
+++ b/src/scripts/games/bomber/versus/versusMatch.ts
@@ -509,6 +509,50 @@ export class VersusMatch {
     return e;
   }
 
+  /** 決定性狀態指紋（FNV-1a/32）。
+   *  涵蓋所有「會影響未來模擬」的狀態：時間、塌縮圈數、地形、玩家全屬性、
+   *  場上炸彈/爆風/道具、以及尚未揭露的箱底道具——兩個一旦分歧的狀態
+   *  不應 hash 相同（lockstep desync 偵測賴此精準）。
+   *  所有集合均以「穩定順序」串接：陣列照插入序（filter 保序、絕無重排），
+   *  hiddenPowerUps 這個 Record 以 key 排序後串接（不依賴物件鍵插入序）。
+   *  純整數運算，無 Math.random / Date.now / Map/Set 迭代依賴。 */
+  stateHash(): string {
+    let h = 0x811c9dc5;
+    const mix = (s: string): void => {
+      for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+      }
+    };
+    // 全域：狀態、時間、塌縮圈、勝者。
+    mix(this.status);
+    mix(String(this.elapsedMs | 0));
+    mix(String(this.collapsedRings));
+    mix(this.winnerId ?? '');
+    // 地形（壁/箱/地的破壞會改變未來走位與爆炸）。
+    mix(this.grid.map((row) => row.join('')).join('|'));
+    // 玩家：全屬性皆入 hash（位置/存活/名次/火力/彈數/速度/盾/無敵/移動冷卻/技能冷卻/朝向）。
+    for (const p of this.players) {
+      mix(
+        `${p.id},${p.x},${p.y},${p.prevX},${p.prevY},${p.dir},` +
+        `${p.alive ? 1 : 0},${p.placement},${p.fireRange},${p.maxBombs},${p.speedLevel},` +
+        `${p.shield ? 1 : 0},${p.invulnMs | 0},${p.moveCooldownMs | 0},` +
+        `${p.abilityId},${p.abilityCooldownMs | 0},${p.abilityMaxMs | 0}`
+      );
+    }
+    // 炸彈（插入序）。
+    for (const b of this.bombs) mix(`${b.x},${b.y},${b.fuseMs | 0},${b.range},${b.owner ?? ''}`);
+    // 爆風（插入序）。
+    for (const bl of this.blasts) mix(`${bl.x},${bl.y},${bl.ttlMs | 0}`);
+    // 場上可拾取道具（插入序）。
+    for (const u of this.powerUps) mix(`${u.x},${u.y},${u.kind}`);
+    // 箱底隱藏道具：key 排序後串接（影響未來掉落，必須入 hash 且順序穩定）。
+    for (const key of Object.keys(this.hiddenPowerUps).sort()) {
+      mix(`${key}=${this.hiddenPowerUps[key]}`);
+    }
+    return (h >>> 0).toString(16);
+  }
+
   // ---- debug seams（測試用） ----
 
   /** 直接對玩家套用道具效果。 */

--- a/src/scripts/games/bomber/versus/versusRules.test.ts
+++ b/src/scripts/games/bomber/versus/versusRules.test.ts
@@ -1,0 +1,90 @@
+// src/scripts/games/bomber/versus/versusRules.test.ts
+import { describe, it, expect } from 'vitest';
+import { VersusMatch } from './versusMatch';
+import { BOMB_FUSE_MS } from '../engine/constants';
+
+const P2 = [{ id: 'alice', character: 'lena' as const }, { id: 'bob', character: 'mira' as const }];
+const P3 = [...P2, { id: 'carol', character: 'aya' as const }];
+
+describe('VersusMatch: 傷害與淘汰', () => {
+  it('被爆風炸到：無盾即死（playerDead 事件、placement 由淘汰順序回填）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const bob = m.getState().players[1];
+    // 把 bob 搬到 alice 旁邊，alice 放彈走開引爆
+    const alice = m.getState().players[0];
+    m.debugMovePlayer('bob', alice.x + 1, alice.y);
+    m.input('alice', 'bomb');
+    // 走開到中央安全格：range-2 爆風下臂可達出生點 +2 格，須完全離開十字爆風範圍才算逃脫
+    m.debugMovePlayer('alice', 5, 5);
+    m.step(BOMB_FUSE_MS + 50);
+    const s = m.getState();
+    expect(s.players[1].alive).toBe(false);
+    expect(s.players[1].placement).toBe(2);   // 2 人場第一個死 = 第 2 名
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('alice');
+    expect(s.players[0].placement).toBe(1);
+  });
+
+  it('盾擋一次死：shield 消失、短暫無敵、不淘汰', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const alice = m.getState().players[0];
+    m.debugGivePowerUp('bob', 'shield');
+    m.debugMovePlayer('bob', alice.x + 1, alice.y);
+    m.input('alice', 'bomb');
+    m.debugMovePlayer('alice', alice.x, alice.y + 2);
+    m.step(BOMB_FUSE_MS + 50);
+    const bob = m.getState().players[1];
+    expect(bob.alive).toBe(true);
+    expect(bob.shield).toBe(false);
+    expect(bob.invulnMs).toBeGreaterThan(0);
+  });
+
+  it('3 人場：同幀雙殺 → 兩人同名次、倖存者勝', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P3 });
+    const a = m.getState().players[0];
+    m.debugMovePlayer('bob', a.x + 1, a.y);
+    m.debugMovePlayer('carol', a.x - 1 >= 1 ? a.x - 1 : a.x + 2, a.y);
+    m.input('alice', 'bomb');
+    m.debugMovePlayer('alice', 5, 5); // 同上：離開十字爆風到中央安全格
+    m.step(BOMB_FUSE_MS + 50);
+    const s = m.getState();
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBe('alice');
+    const placements = s.players.map((p) => p.placement).sort();
+    expect(placements).toEqual([1, 2, 2]); // 同幀死共享第 2 名
+  });
+
+  it('全滅同幀 = 平局（winnerId null、全員 placement 1）', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    const a = m.getState().players[0];
+    m.debugMovePlayer('bob', a.x + 1, a.y);
+    m.input('alice', 'bomb');
+    // alice 不走開 → 同歸於盡
+    m.step(BOMB_FUSE_MS + 50);
+    const s = m.getState();
+    expect(s.status).toBe('finished');
+    expect(s.winnerId).toBeNull();
+    expect(s.players.map((p) => p.placement)).toEqual([1, 1]);
+  });
+});
+
+describe('VersusMatch: 技能', () => {
+  it('lena 遙控起爆：引爆自己的彈、不動他人的彈', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.input('alice', 'bomb');
+    m.input('bob', 'bomb');
+    m.input('alice', 'ability');
+    m.step(50);
+    const s = m.getState();
+    expect(s.bombs.filter((b) => b.owner === 'alice')).toHaveLength(0); // 已爆
+    expect(s.bombs.filter((b) => b.owner === 'bob')).toHaveLength(1);   // 不受影響
+  });
+
+  it('技能冷卻獨立計時', () => {
+    const m = new VersusMatch({ seed: 1, arenaId: 0, players: P2 });
+    m.input('alice', 'bomb');
+    m.input('alice', 'ability');
+    expect(m.getState().players[0].abilityCooldownMs).toBeGreaterThan(0);
+    expect(m.getState().players[1].abilityCooldownMs).toBe(0);
+  });
+});

--- a/src/scripts/games/tetris/net/rankStore.ts
+++ b/src/scripts/games/tetris/net/rankStore.ts
@@ -61,6 +61,10 @@ export class MemoryRankStore implements RankStore {
   private brReports = new Map<string, Map<string, { standings: string[]; exp: number }>>();
   private settledBR = new Map<string, number>();
 
+  // MemoryRankStore 的隔離靠「不同實例 = 不同 Map」達成（每個 ladder 各持一個實例），
+  // 故無須在記憶體 key 內帶 namespace；ns 參數僅為與 Upstash 介面對齊（不使用）。
+  constructor(_ns = '') { /* namespace 對記憶體實作無作用：實例即隔離 */ }
+
   async getPlayer(id: string): Promise<PlayerRecord | null> {
     const p = this.players.get(id);
     return p ? normalizePlayer(p as unknown as Record<string, unknown>) : null;
@@ -122,7 +126,16 @@ export class MemoryRankStore implements RankStore {
 
 /** Upstash Redis REST 實作。 */
 export class UpstashRankStore implements RankStore {
-  constructor(private url: string, private token: string) {}
+  /**
+   * ns：key 命名空間前綴。預設 ''（tetris：所有 key 與原本 byte-identical）。
+   * bomber ladder 傳入 'bomber:' → 所有 key（含排行榜 zset）與 tetris 完全隔離。
+   */
+  constructor(private url: string, private token: string, private ns = '') {}
+
+  /** 套用 namespace 前綴；ns='' 時回原 key（tetris 不變）。 */
+  private k(key: string): string {
+    return this.ns + key;
+  }
 
   private async cmd(...parts: string[]): Promise<unknown> {
     const path = parts.map((p) => encodeURIComponent(p)).join('/');
@@ -132,17 +145,17 @@ export class UpstashRankStore implements RankStore {
   }
 
   async getPlayer(id: string): Promise<PlayerRecord | null> {
-    const r = await this.cmd('get', `player:${id}`);
+    const r = await this.cmd('get', this.k(`player:${id}`));
     return r ? normalizePlayer(JSON.parse(String(r)) as Record<string, unknown>) : null;
   }
   async setPlayer(id: string, rec: PlayerRecord): Promise<void> {
-    await this.cmd('set', `player:${id}`, JSON.stringify(rec));
-    await this.cmd('zadd', LB_KEY, String(rec.rating), id);
+    await this.cmd('set', this.k(`player:${id}`), JSON.stringify(rec));
+    await this.cmd('zadd', this.k(LB_KEY), String(rec.rating), id);
     // 截斷排行榜（保留前 LB_MAX）
-    await this.cmd('zremrangebyrank', LB_KEY, '0', String(-(LB_MAX + 1)));
+    await this.cmd('zremrangebyrank', this.k(LB_KEY), '0', String(-(LB_MAX + 1)));
   }
   async topPlayers(n: number): Promise<Array<{ id: string; rating: number }>> {
-    const r = (await this.cmd('zrange', LB_KEY, '0', String(n - 1), 'REV', 'WITHSCORES')) as string[] | null;
+    const r = (await this.cmd('zrange', this.k(LB_KEY), '0', String(n - 1), 'REV', 'WITHSCORES')) as string[] | null;
     const out: Array<{ id: string; rating: number }> = [];
     if (Array.isArray(r)) {
       for (let i = 0; i < r.length; i += 2) out.push({ id: r[i], rating: Number(r[i + 1]) });
@@ -150,27 +163,27 @@ export class UpstashRankStore implements RankStore {
     return out;
   }
   async getReport(matchId: string, reporter: string): Promise<string | null> {
-    const r = await this.cmd('get', `rep:${matchId}:${reporter}`);
+    const r = await this.cmd('get', this.k(`rep:${matchId}:${reporter}`));
     return r === null || r === undefined ? null : String(r);
   }
   async setReport(matchId: string, reporter: string, winner: string, ttlSec: number): Promise<void> {
-    await this.cmd('set', `rep:${matchId}:${reporter}`, winner, 'EX', String(ttlSec));
+    await this.cmd('set', this.k(`rep:${matchId}:${reporter}`), winner, 'EX', String(ttlSec));
   }
   async isSettled(matchId: string): Promise<boolean> {
-    return (await this.cmd('get', `done:${matchId}`)) !== null;
+    return (await this.cmd('get', this.k(`done:${matchId}`))) !== null;
   }
   async markSettled(matchId: string, ttlSec: number): Promise<boolean> {
-    const r = await this.cmd('set', `done:${matchId}`, '1', 'NX', 'EX', String(ttlSec));
+    const r = await this.cmd('set', this.k(`done:${matchId}`), '1', 'NX', 'EX', String(ttlSec));
     return r === 'OK'; // NX 成功回 "OK"，已存在回 null
   }
   async setBRReport(matchId: string, reporterId: string, standings: string[], ttlSec: number): Promise<void> {
-    const key = `brreport:${matchId}`;
+    const key = this.k(`brreport:${matchId}`);
     await this.cmd('hset', key, reporterId, JSON.stringify(standings));
     await this.cmd('expire', key, String(ttlSec));
   }
   async getBRReportsForMatch(matchId: string): Promise<Record<string, string[]>> {
     // HGETALL 回扁平陣列 [field1, value1, field2, value2, ...]
-    const r = (await this.cmd('hgetall', `brreport:${matchId}`)) as string[] | null;
+    const r = (await this.cmd('hgetall', this.k(`brreport:${matchId}`))) as string[] | null;
     const out: Record<string, string[]> = {};
     if (Array.isArray(r)) {
       for (let i = 0; i < r.length; i += 2) {
@@ -186,21 +199,40 @@ export class UpstashRankStore implements RankStore {
     return out;
   }
   async markSettledBR(matchId: string, ttlSec: number): Promise<boolean> {
-    const r = await this.cmd('set', `settledbr:${matchId}`, '1', 'NX', 'EX', String(ttlSec));
+    const r = await this.cmd('set', this.k(`settledbr:${matchId}`), '1', 'NX', 'EX', String(ttlSec));
     return r === 'OK'; // NX 成功回 "OK"，已存在回 null
   }
+}
+
+/** 解析 env → { url, token }（缺一半即報錯，避免生產環境靜默退回記憶體）。 */
+function resolveUpstash(env: Record<string, string | undefined>): { url?: string; token?: string } {
+  // Upstash 原生命名，或 Vercel Marketplace（Upstash for Redis）注入的 KV_REST_API_* 命名
+  const url = env.UPSTASH_REDIS_REST_URL || env.KV_REST_API_URL;
+  const token = env.UPSTASH_REDIS_REST_TOKEN || env.KV_REST_API_TOKEN;
+  if ((url && !token) || (token && !url)) {
+    throw new Error('Upstash 設定不完整：REST URL 與 TOKEN 必須同時提供（KV_REST_API_URL/TOKEN 或 UPSTASH_REDIS_REST_URL/TOKEN）');
+  }
+  return { url, token };
 }
 
 let singleton: RankStore | null = null;
 export function getRankStore(env: Record<string, string | undefined> = process.env): RankStore {
   if (singleton) return singleton;
-  // Upstash 原生命名，或 Vercel Marketplace（Upstash for Redis）注入的 KV_REST_API_* 命名
-  const url = env.UPSTASH_REDIS_REST_URL || env.KV_REST_API_URL;
-  const token = env.UPSTASH_REDIS_REST_TOKEN || env.KV_REST_API_TOKEN;
-  // 只設了一半 → 主動報錯，避免生產環境靜默退回記憶體（重啟即失資料）
-  if ((url && !token) || (token && !url)) {
-    throw new Error('Upstash 設定不完整：REST URL 與 TOKEN 必須同時提供（KV_REST_API_URL/TOKEN 或 UPSTASH_REDIS_REST_URL/TOKEN）');
-  }
+  const { url, token } = resolveUpstash(env);
+  // tetris ladder：namespace 預設 ''（所有 key 與原本 byte-identical）
   singleton = url && token ? new UpstashRankStore(url, token) : new MemoryRankStore();
   return singleton;
+}
+
+/**
+ * Bomber ladder 專用 rankStore（與 tetris 完全隔離的獨立單例）。
+ * Upstash 實作所有 key 帶 'bomber:' 前綴；Memory 實作則是獨立實例（各自的 Map）。
+ * 與 getRankStore() 互不共用單例，故 bomber 的積分/XP/排行榜不會碰到 tetris 紀錄。
+ */
+let bomberSingleton: RankStore | null = null;
+export function getBomberRankStore(env: Record<string, string | undefined> = process.env): RankStore {
+  if (bomberSingleton) return bomberSingleton;
+  const { url, token } = resolveUpstash(env);
+  bomberSingleton = url && token ? new UpstashRankStore(url, token, 'bomber:') : new MemoryRankStore('bomber:');
+  return bomberSingleton;
 }

--- a/src/scripts/games/tetris/net/signalClient.ts
+++ b/src/scripts/games/tetris/net/signalClient.ts
@@ -58,14 +58,34 @@ export async function createRoom(): Promise<string> {
   return r.room;
 }
 
-export async function putSlot(room: string, slot: Slot, data: string): Promise<void> {
-  if (!isValidSlot(slot)) throw new Error(`invalid slot: ${slot}`);
-  await postJson({ room, slot, data });
+/**
+ * 命名空間前綴：把房號加上遊戲別前綴，避免不同遊戲（tetris / bomber）的房號在
+ * 同一個 signal store（key = `sig:${room}:${slot}`）相撞。
+ *  - 預設 `ns = ''` → 房號原樣傳出，tetris 既有行為「位元級不變」（零回歸）。
+ *  - bomber 路徑傳入 `'bomber:'` → 實際房 key 變成 `bomber:AB12C`，與 tetris 的 `AB12C` 隔離。
+ * 顯示給使用者的房號仍是 createRoom() 回傳的乾淨 5 碼，前綴只作用在 store key 層。
+ */
+function nsRoom(ns: string, room: string): string {
+  return ns ? `${ns}${room}` : room;
 }
 
-export async function getSlot(room: string, slot: Slot): Promise<string | null> {
+export async function putSlot(
+  room: string,
+  slot: Slot,
+  data: string,
+  ns = '',
+): Promise<void> {
   if (!isValidSlot(slot)) throw new Error(`invalid slot: ${slot}`);
-  const res = await fetch(`${API}?room=${encodeURIComponent(room)}&slot=${slot}`);
+  await postJson({ room: nsRoom(ns, room), slot, data });
+}
+
+export async function getSlot(
+  room: string,
+  slot: Slot,
+  ns = '',
+): Promise<string | null> {
+  if (!isValidSlot(slot)) throw new Error(`invalid slot: ${slot}`);
+  const res = await fetch(`${API}?room=${encodeURIComponent(nsRoom(ns, room))}&slot=${slot}`);
   if (!res.ok) throw new Error(`signal GET ${res.status}`);
   const json = (await res.json()) as { data?: string | null };
   return json.data ?? null;
@@ -76,12 +96,13 @@ export async function pollSlot(
   room: string,
   slot: Slot,
   opts: { timeoutMs?: number; intervalMs?: number } = {},
+  ns = '',
 ): Promise<string> {
   const timeoutMs = opts.timeoutMs ?? 90_000;
   const intervalMs = opts.intervalMs ?? 1200;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    const data = await getSlot(room, slot);
+    const data = await getSlot(room, slot, ns);
     if (data) return data;
     await new Promise((r) => setTimeout(r, intervalMs));
   }

--- a/tests/e2e/bomber-online.spec.ts
+++ b/tests/e2e/bomber-online.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Dungeon Bomber 線上對戰雙頁籤端到端：開兩個 context，host 建房、guest 以房號加入，
+ * 透過 dev server 單程序的記憶體 signaling（/api/signal）+ 同機 WebRTC loopback 連線，
+ * 兩端 ready/start 後進入鎖步 versus，驗證雙方都到 status==='playing' 且 2 名玩家。
+ * BONUS：跑幾幀後驗證鎖步雙向同步（共同幀上兩端 stateHash 一致）。
+ * WebRTC 需 chromium。
+ */
+test.describe('Dungeon Bomber — online battle', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'WebRTC requires chromium');
+  test.setTimeout(120_000);
+
+  test('two browsers connect by room code and enter a synced versus match', async ({ browser }) => {
+    const ctxHost = await browser.newContext();
+    const ctxGuest = await browser.newContext();
+    const host = await ctxHost.newPage();
+    const guest = await ctxGuest.newPage();
+
+    try {
+      // 深連結直達 ONLINE 大廳入口（繞過選角；?online=1 → openOnline）。
+      await host.goto('/games/bomber?online=1');
+      await guest.goto('/games/bomber?online=1');
+
+      // online entry 區塊（CREATE / JOIN）就緒
+      await expect(host.locator('#online-create')).toBeVisible({ timeout: 20000 });
+      await expect(guest.locator('#online-join-btn')).toBeVisible({ timeout: 20000 });
+
+      // Host 建房 → 大廳出現大字房號
+      await host.locator('#online-create').click();
+      const room = await readRoom(host);
+      expect(room).toMatch(/^[A-Z0-9]{5}$/);
+
+      // Guest 以房號加入
+      await guest.locator('#online-room-input').fill(room);
+      await guest.locator('#online-join-btn').click();
+
+      // Host 端等到 guest 連上（START 需 connectedGuests >= 1；以 START 鈕變 enabled 為信號）。
+      // 先 host READY（START enable 條件：localReady && connectedGuests>=1）。
+      await host.locator('#lobby-ready').click();
+      await waitStartEnabled(host);
+
+      // Host 開局：resolveStart → 兩端握手組 roster、廣播 init → bootOnline → startVersusOnline。
+      await host.locator('#lobby-start').click();
+
+      // 兩端都進入 versus（startVersusOnline 後才掛 __bomberVersusDebug.match）。
+      await waitVersus(host);
+      await waitVersus(guest);
+
+      // ── 核心斷言：兩端都到 versus、2 名玩家、status==='playing' ──
+      const h0 = await readMatch(host);
+      const g0 = await readMatch(guest);
+      expect(h0.players).toBe(2);
+      expect(g0.players).toBe(2);
+      expect(h0.status).toBe('playing');
+      expect(g0.status).toBe('playing');
+
+      // ── BONUS：驅動雙向輸入後，鎖步維持決定性同步 ──
+      // 注意：故意「不」在尾端要求 status==='playing'——2 人小場放炸彈本來就可能分出勝負而
+      // finished。鎖步的同步證明在於「共同確認幀上兩端 stateHash 一致」（含 status/winnerId），
+      // 無論最終 playing 或 finished 皆成立。先讓鎖步空跑一下確認兩端推進。
+      await host.waitForTimeout(800);
+
+      // focus 各自 canvas（確保 keydown 抵達 window handler，並滿足 audio gesture）
+      await host.locator('#bomber-canvas').click({ position: { x: 5, y: 5 } }).catch(() => {});
+      await guest.locator('#bomber-canvas').click({ position: { x: 5, y: 5 } }).catch(() => {});
+
+      // 雙向輸入：各放一顆炸彈再走開（host=KeyD、guest=KeyA），用 in-page dispatch 確保可靠
+      // 觸達 window keydown handler。輕量輸入避免立刻自爆，讓鎖步多跑幾十幀可採樣到共同幀。
+      await dispatchKey(host, 'Space');
+      await dispatchKey(guest, 'Space');
+      await dispatchKey(host, 'KeyD');
+      await dispatchKey(guest, 'KeyA');
+      await host.waitForTimeout(300);
+      await dispatchKeyUp(host, 'KeyD');
+      await dispatchKeyUp(guest, 'KeyA');
+
+      // 讓鎖步把輸入消化掉、兩端追平
+      await host.waitForTimeout(800);
+
+      const h1 = await readMatch(host);
+      const g1 = await readMatch(guest);
+
+      // 鎖步持續推進、兩端確認幀接近（同機 loopback → 偏移很小）
+      expect(h1.frame).toBeGreaterThan(30);
+      expect(g1.frame).toBeGreaterThan(30);
+      expect(Math.abs(h1.frame - g1.frame)).toBeLessThanOrEqual(8);
+
+      // 決定性鎖步：找共同確認幀，兩端 stateHash 必須一致（無論 playing/finished）。
+      const synced = await assertHashSyncAtCommonFrame(host, guest);
+      expect(synced.matchedFrame).toBeGreaterThan(30);
+      expect(synced.hostHash).toBe(synced.guestHash);
+    } finally {
+      await ctxHost.close();
+      await ctxGuest.close();
+    }
+  });
+});
+
+/** 建房後房號顯示在大廳的大字房號 #lobby-code。 */
+async function readRoom(page: Page): Promise<string> {
+  const code = page.locator('#lobby-code');
+  await expect(code).toContainText(/[A-Z0-9]{5}/, { timeout: 30000 });
+  const text = (await code.textContent()) ?? '';
+  return text.match(/[A-Z0-9]{5}/)?.[0] ?? '';
+}
+
+/** Host START 鈕在 (localReady && connectedGuests>=1) 時 enabled——以此為「guest 已連上」信號。 */
+async function waitStartEnabled(page: Page): Promise<void> {
+  const start = page.locator('#lobby-start');
+  await expect(start).toBeVisible({ timeout: 30000 });
+  await expect(start).toBeEnabled({ timeout: 45000 });
+}
+
+/** startVersusOnline 後才掛 __bomberVersusDebug.match。 */
+async function waitVersus(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { __bomberVersusDebug?: { match?: unknown } }).__bomberVersusDebug?.match),
+    undefined,
+    { timeout: 45000 },
+  );
+}
+
+function readMatch(page: Page) {
+  return page.evaluate(() => {
+    const dbg = (window as unknown as {
+      __bomberVersusDebug: {
+        match: { getState(): { status: string; players: unknown[] }; stateHash(): string };
+        lockstep?: { confirmedFrame: number };
+      };
+    }).__bomberVersusDebug;
+    const s = dbg.match.getState();
+    return {
+      status: s.status,
+      players: s.players.length,
+      frame: dbg.lockstep?.confirmedFrame ?? 0,
+      hash: dbg.match.stateHash(),
+    };
+  });
+}
+
+/** in-page dispatch keydown（確保可靠觸達 window keydown handler，與 bomber solo spec 一致）。 */
+async function dispatchKey(page: Page, code: string): Promise<void> {
+  await page.evaluate(
+    (c) => window.dispatchEvent(new KeyboardEvent('keydown', { code: c, bubbles: true })),
+    code,
+  );
+}
+async function dispatchKeyUp(page: Page, code: string): Promise<void> {
+  await page.evaluate(
+    (c) => window.dispatchEvent(new KeyboardEvent('keyup', { code: c, bubbles: true })),
+    code,
+  );
+}
+
+/**
+ * 鎖步同步證明：在一段輪詢視窗內，各端記錄 {frame: hash}，找出兩端都採樣到的最高共同
+ * confirmedFrame，回傳該幀兩端的 stateHash。決定性鎖步下兩者必相等。
+ * （hash 只在「相同已確認幀」可比；同機 loopback 兩端 confirmedFrame 可能差幾幀，故取交集。）
+ */
+async function assertHashSyncAtCommonFrame(
+  host: Page,
+  guest: Page,
+): Promise<{ matchedFrame: number; hostHash: string; guestHash: string }> {
+  const sampleOnce = (page: Page) =>
+    page.evaluate(() => {
+      const dbg = (window as unknown as {
+        __bomberVersusDebug: {
+          match: { stateHash(): string };
+          lockstep?: { confirmedFrame: number };
+        };
+      }).__bomberVersusDebug;
+      return { frame: dbg.lockstep?.confirmedFrame ?? 0, hash: dbg.match.stateHash() };
+    });
+
+  const hostByFrame = new Map<number, string>();
+  const guestByFrame = new Map<number, string>();
+
+  // 採樣 ~3s（兩端鎖步持續推進；每輪兩端各取一次，記錄該幀的 hash）。
+  for (let i = 0; i < 30; i++) {
+    const [h, g] = await Promise.all([sampleOnce(host), sampleOnce(guest)]);
+    hostByFrame.set(h.frame, h.hash);
+    guestByFrame.set(g.frame, g.hash);
+    await host.waitForTimeout(100);
+  }
+
+  // 取兩端都採樣到的最高共同幀。
+  let matchedFrame = -1;
+  for (const f of hostByFrame.keys()) {
+    if (guestByFrame.has(f) && f > matchedFrame) matchedFrame = f;
+  }
+  if (matchedFrame < 0) {
+    throw new Error(
+      `no common confirmed frame sampled — host frames [${[...hostByFrame.keys()].join(',')}], ` +
+        `guest frames [${[...guestByFrame.keys()].join(',')}]`,
+    );
+  }
+  return {
+    matchedFrame,
+    hostHash: hostByFrame.get(matchedFrame)!,
+    guestHash: guestByFrame.get(matchedFrame)!,
+  };
+}

--- a/tests/e2e/games-hall.spec.ts
+++ b/tests/e2e/games-hall.spec.ts
@@ -42,7 +42,28 @@ test.describe('Dungeon Arcade — hall & mode select', () => {
     // 排行榜入口已移到 Tetris 主選單分頁；獨立頁仍可直接到達（深連結）。
     await page.goto('/games/leaderboard');
     await expect(page.getByText('LEADERBOARD')).toBeVisible();
+    // 預設 TETRIS 分頁啟用（保留原本載入行為）
+    await expect(page.locator('#lb-tab-tetris')).toHaveAttribute('aria-selected', 'true');
     // fetch 完成後不應停在「載入中」（證明 /api/leaderboard 有回應）
+    await expect(page.locator('#lb-board')).not.toContainText('載入中', { timeout: 10000 });
+  });
+
+  test('leaderboard BOMBER tab fetches game=bomber and renders', async ({ page }) => {
+    await page.goto('/games/leaderboard');
+    await expect(page.locator('#lb-tab-bomber')).toBeVisible();
+
+    // 點 BOMBER → 應打 /api/leaderboard?...game=bomber
+    const [bomberReq] = await Promise.all([
+      page.waitForRequest((req) => req.url().includes('/api/leaderboard') && req.url().includes('game=bomber'), {
+        timeout: 10000,
+      }),
+      page.locator('#lb-tab-bomber').click(),
+    ]);
+    expect(bomberReq.url()).toContain('game=bomber');
+
+    // 分頁狀態切換 + 載入結束（不停在「載入中」）
+    await expect(page.locator('#lb-tab-bomber')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('#lb-tab-tetris')).toHaveAttribute('aria-selected', 'false');
     await expect(page.locator('#lb-board')).not.toContainText('載入中', { timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Summary

為 `/games/bomber` 加入 **2-4 人連線生存對戰** 與 **bomber 獨立天梯排行榜**，連線棧複用已驗證的俄羅斯方塊 FFA 架構（lockstep / WebRTC / signaling / 共識結算），bomber 用 `bomber:` 命名空間與 tetris 完全隔離。依 `docs/superpowers/specs/2026-06-11-bomber-versus-online-design.md` 設計與 17 步計畫實作，全程 TDD + 三段審查（implementer → spec → code review）。

**核心內容**
- **純 TS 決定性引擎** `VersusMatch`（複用單機 engine 原語、零 Pixi、零 `Math.random`/`Date.now`）：8 張對稱競技場、傷害/淘汰/同幀共享名次/平局、四角技能（versus 平衡 ×1.5 冷卻）、sudden-death 塌縮圈、`stateHash` 決定性守衛（含塌縮重放）。
- **連線層**：`bomberLockstep`（固定 60fps、輸入延遲 3 幀、N 端決定性）、`bomberTransport`（Hub/Spoke WebRTC，仿 ffaTransport）、`signalClient` 加可選 `ns` 參數（tetris 位元等價）、`bomberNetMain` 房間碼握手 + `lobby` 房態機。
- **斷線處理**：host 廣播 `bomber-leave{p,f}`，leave frame 取「離開者最後輸入幀 +1」（跨端一致，避免 desync）。
- **結算與牌位**：`/api/bomber-match` 共識結算（**伺服器信任 replay 重模擬、忽略 client claim**＝防作弊）、SETTLED 防重複、Elo（2p `updateRatings` / 3-4p `updateRatingsNWay`）、XP、`bomber:` 前綴隔離天梯；結算 overlay（名次/Elo±/XP bar/REMATCH/LOBBY）；leaderboard 加 TETRIS/BOMBER 分頁。
- **本機 hotseat 除錯模式**：`?mode=hotseat`（雙鍵盤），已瀏覽器實測。

## Test Plan

- [x] 單元測試 `src/scripts/games` + `src/pages/api`：1008 passed / 0 failed（含 versus 引擎、lockstep N 端 hash 一致、replay==live、結算共識/防作弊、排行榜路由 tetris byte-identical）
- [x] `npm run build`：Complete
- [x] **雙頁籤線上 e2e** `tests/e2e/bomber-online.spec.ts`：建房→加入→進對戰→**兩瀏覽器 stateHash 共同幀一致**（`--repeat-each=3` 穩定）
- [x] `tests/e2e/games-hall.spec.ts`（排行榜 + bomber 分頁）綠
- [x] hotseat 本機實測：spawn/render/即時 loop/移動放彈/sudden-death
- [x] tetris 連線/天梯零迴歸（共用 signalClient/rankStore 改動皆 tetris 位元等價）
- [ ] **Vercel preview**：用真 KV 驗證跨裝置連線對戰 + 持久天梯排行榜寫入/顯示
- [ ] preview 上 ranked 計分（需錢包）端到端一場

## 注意事項

- **後續**：Task 7（3 套新地圖磚組 毒沼/寶庫/庭園）尚未做，arena 5-7 目前以既有主題磚組 fallback 渲染（可正常遊玩），美術另開 PR 補。
- 連線/排行榜本機可用記憶體 signaling/rankStore 測（單 dev session 內），跨裝置與持久化需 Vercel KV env（與 tetris online 共用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)