### PR TITLE
fix(bomber-versus): round-2 QA — SD warning, touch notice, tie scoring (highest-standard)

### DIFF
--- a/src/pages/api/_bomber-match.test.ts
+++ b/src/pages/api/_bomber-match.test.ts
@@ -122,6 +122,56 @@ function buildDrawScenario(seed: number, n: number) {
   return { wallets, playerIds, standings, stateHash, replay, matchId, winnerId };
 }
 
+/**
+ * 跑一場 3 人「mid-match 同名次」局：P1、P2 frame 0 自爆原地不動（同 fuse → 同幀全滅 →
+ * 共享第 2 名），P0 全程不動倖存奪冠。引擎真名次 = { P0:1, P1:2, P2:2 }、winnerId=P0（非平局）。
+ * 兩位同名次玩家在 standings 陣列中佔 index 1、2 —— 舊邏輯依索引給 placement 2/3（不公平），
+ * 新邏輯須改用重模擬真名次給兩人並列第 2 → 相同 Elo/XP。回傳與 buildScenario 同形。
+ */
+function buildTieScenario(seed: number) {
+  const n = 3;
+  const wallets = Array.from({ length: n }, () => Wallet.createRandom());
+  const playerIds = wallets.map((w) => w.address);
+  const characters: Record<string, CharacterId> = {};
+  playerIds.forEach((id, i) => (characters[id] = CHARS[i % CHARS.length]));
+
+  const hub = new LoopbackBomberHub();
+  const nodes = playerIds.map(
+    (localId) =>
+      new BomberLockstep({
+        playerIds,
+        localId,
+        seed,
+        arenaId: 0,
+        characters,
+        transport: hub.transportFor(localId),
+      }),
+  );
+  // P1、P2 同幀自爆原地不動 → 同幀全滅共享第 2 名；P0 不動 → 唯一冠軍。
+  nodes[1].queueLocal({ t: 'bomb' });
+  nodes[2].queueLocal({ t: 'bomb' });
+  let dead = false;
+  for (let f = 0; f < 6000 && nodes[0].match.getState().status === 'playing'; f++) {
+    for (const node of nodes) {
+      if ((node.localId === playerIds[1] || node.localId === playerIds[2]) && dead) continue;
+      node.tick();
+    }
+    const st = nodes[0].match.getState();
+    const p1 = st.players.find((p) => p.id === playerIds[1]);
+    const p2 = st.players.find((p) => p.id === playerIds[2]);
+    if (p1 && p2 && !p1.alive && !p2.alive) dead = true;
+  }
+  settle(nodes, hub);
+
+  const node = nodes[0];
+  const replay = node.getReplay();
+  const standings = liveStandings(node.match, playerIds);
+  const stateHash = node.match.stateHash();
+  const winnerId = node.match.getState().winnerId;
+  const matchId = `bomber-${seed.toString(36)}-room1`;
+  return { wallets, playerIds, standings, stateHash, replay, matchId, winnerId };
+}
+
 /** 為某 wallet 對 (matchId, standings) 產生合法簽章（沿用 buildFfaResultMessage）。 */
 async function sign(wallet: Wallet | HDNodeWallet, matchId: string, standings: string[]) {
   const placements = standings.map((_, i) => i + 1);
@@ -506,5 +556,84 @@ describe('POST /api/bomber-match — 平局（FIX 3：server 重模擬 winnerId=
       expect(rec!.losses).toBe(0);
       expect(rec!.games).toBe(1);
     }
+  });
+});
+
+describe('POST /api/bomber-match — mid-match 同名次公平計分（伺服器真名次，非陣列索引）', () => {
+  it('3 人場 [1,2,2]：兩位同名次玩家 ratingAfter 與 xpGained 完全相同；冠軍記勝', async () => {
+    const POST = await loadPost();
+    const { wallets, standings, stateHash, replay, matchId, winnerId } = buildTieScenario(42);
+    // 前置：此局非平局（有唯一冠軍），但有兩位同幀死共享第 2 名。
+    expect(winnerId).not.toBeNull();
+    const { simulateVersusReplay } = await import('@scripts/games/bomber/net/versusReplay');
+    const placements = simulateVersusReplay(replay).placements;
+    // 真名次：冠軍唯一 1，另兩位並列 2（其中一人在 standings index1、一人 index2）。
+    const placeVals = standings.map((id) => placements[id]);
+    expect(placeVals[0]).toBe(1); // standings[0] = 冠軍
+    expect(placeVals[1]).toBe(2);
+    expect(placeVals[2]).toBe(2); // 同名次（舊邏輯會誤判為 3）
+
+    // 達門檻（3 人門檻 2）→ applied。
+    let body: {
+      outcome: string;
+      results: Array<{ id: string; placement: number; ratingBefore: number; ratingAfter: number; xpGained: number }>;
+    } | null = null;
+    for (const w of [wallets[0], wallets[1]]) {
+      const res = await POST(
+        ctx({
+          matchId,
+          reporterId: w.address,
+          standings,
+          stateHash,
+          signature: await sign(w, matchId, standings),
+          replay,
+        }),
+      );
+      body = await res.json();
+    }
+    expect(body!.outcome).toBe('applied');
+    expect(body!.results).toHaveLength(3);
+
+    const byId = (id: string) => body!.results.find((r) => r.id === id.toLowerCase())!;
+    const champ = byId(standings[0]);
+    const tieA = byId(standings[1]);
+    const tieB = byId(standings[2]);
+
+    // 回應的 placement 應為真名次（並列 2），而非陣列索引 2/3。
+    expect(champ.placement).toBe(1);
+    expect(tieA.placement).toBe(2);
+    expect(tieB.placement).toBe(2);
+
+    // 冠軍漲分、兩位敗方掉分。
+    expect(champ.ratingAfter).toBeGreaterThan(champ.ratingBefore);
+    expect(tieA.ratingAfter).toBeLessThan(tieA.ratingBefore);
+    expect(tieB.ratingAfter).toBeLessThan(tieB.ratingBefore);
+
+    // 核心修正：兩位同名次玩家所有起手分皆相同（皆新玩家 1000），
+    // 故 ratingAfter 與 xpGained 必須「完全相等」——不得因錢包位址序而拆出 ±Elo/XP 差。
+    expect(tieA.ratingBefore).toBe(1000);
+    expect(tieB.ratingBefore).toBe(1000);
+    expect(tieA.ratingAfter).toBe(tieB.ratingAfter);
+    expect(tieA.xpGained).toBe(tieB.xpGained);
+
+    // 儲存層驗證：冠軍記 1 勝、兩位敗方各記 1 敗；三人 games 各 +1；三人皆 top3（placement<=3）。
+    const { getBomberRankStore } = await import('@scripts/games/tetris/net/rankStore');
+    const store = getBomberRankStore();
+    const cRec = await store.getPlayer(standings[0].toLowerCase());
+    expect(cRec!.wins).toBe(1);
+    expect(cRec!.losses).toBe(0);
+    expect(cRec!.top3).toBe(1);
+    for (const id of [standings[1], standings[2]]) {
+      const rec = await store.getPlayer(id.toLowerCase());
+      expect(rec!.wins).toBe(0);
+      expect(rec!.losses).toBe(1);
+      expect(rec!.top3).toBe(1);
+      expect(rec!.games).toBe(1);
+    }
+    // 兩位同名次玩家儲存的 rating 也相同（與回應一致）。
+    const ra = await store.getPlayer(standings[1].toLowerCase());
+    const rb = await store.getPlayer(standings[2].toLowerCase());
+    expect(ra!.rating).toBe(rb!.rating);
+    expect(ra!.xp).toBe(rb!.xp);
   });
 });

--- a/src/pages/api/bomber-match.ts
+++ b/src/pages/api/bomber-match.ts
@@ -54,11 +54,19 @@ export interface BomberSettleResult {
  *    updateRatings 以符合 Task 規格「2 人場走 updateRatings」。）
  * - XP 由 progression.ts xpForMatch/levelForXp 累加回推等級。
  * ratings 為各玩家當前基底（後端讀取，client 傳入一律不可信，故此處只吃後端讀到的值）。
+ *
+ * placements：伺服器重模擬 replay 得到的「真名次」map（id→placement，1=冠軍；可含同名次，
+ *   如同幀雙殺 {a:1,b:2,c:2}）。計分一律用真名次，而非 standings 陣列索引——後者會把同名次者
+ *   依 playerIds/錢包序硬拆成相鄰名次，使本應平手的兩人得到不同 Elo（±8–11）/XP（5–10），
+ *   純由位址順序決定，不公平。placements 為伺服器自算（非 client 傳入），故可信。
+ *   ※ standings[0] 仍為唯一冠軍（winnerId 非 null → placement 1 唯一）；2 人非平局場真名次
+ *     必為 [1,2]，故 2 人 updateRatings('a') 路徑不受影響。
  */
 async function applyBomberResult(
   store: RankStore,
   standings: string[],
   ratings: Record<string, number>,
+  placements: Record<string, number>,
   draw = false,
 ): Promise<BomberSettleResult[]> {
   const players = standings.length;
@@ -84,29 +92,34 @@ async function applyBomberResult(
     return out;
   }
 
-  // 1) 算新 ELO（before 用 ratings；2 人顯式 updateRatings，其餘 N-way）
+  // 真名次取用（伺服器重模擬結果；非平局場 standings[0] 必為唯一 placement 1）。
+  // 防禦：若某 id 缺真名次（理論上不會，因 placements 由同一份 replay 算出），退回陣列索引。
+  const realPlacement = (id: string, i: number): number => placements[id] ?? i + 1;
+
+  // 1) 算新 ELO（before 用 ratings；2 人顯式 updateRatings，其餘 N-way 用真名次給同名次者並列）
   let newRatings: Record<string, number>;
   if (players === 2) {
-    const [a, b] = standings; // index0 = 冠軍 = 勝方
+    const [a, b] = standings; // index0 = 冠軍 = 勝方（非平局場真名次必為 [1,2]）
     const ra = Number(ratings[a] ?? DEFAULT_RATING);
     const rb = Number(ratings[b] ?? DEFAULT_RATING);
     const upd = updateRatings(ra, rb, 'a'); // a = 冠軍 = winner
     newRatings = { [a]: upd.a, [b]: upd.b };
   } else {
+    // 真名次餵入 → placementScore 對同名次回 0.5 → 同名次玩家獲對稱 Elo。
     const ratingInput = standings.map((id, i) => ({
       id,
       rating: Number(ratings[id] ?? DEFAULT_RATING),
-      placement: i + 1,
+      placement: realPlacement(id, i),
     }));
     newRatings = updateRatingsNWay(ratingInput);
   }
 
-  // 2) 逐位玩家更新紀錄並記錄 before/after 供回應
+  // 2) 逐位玩家更新紀錄並記錄 before/after 供回應（一律以真名次計 XP / 勝負 / top3）
   const out: BomberSettleResult[] = [];
   for (let i = 0; i < standings.length; i++) {
     const id = standings[i];
-    const placement = i + 1;
-    const isWinner = placement === 1;
+    const placement = realPlacement(id, i);
+    const isWinner = placement === 1; // 唯一冠軍（winnerId 非 null → placement 1 唯一）
     const rec = (await store.getPlayer(id)) ?? fresh();
     const ratingBefore = rec.rating;
     const xpGained = xpForMatch(players, placement, isWinner);
@@ -238,10 +251,15 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     ratings[id] = rec?.rating ?? DEFAULT_RATING;
   }
 
-  // 平局判定：server 重模擬 replay（verify 已過 → 與宣稱名次一致），winnerId=null 即平局。
-  // 一律以 server 自算結果為準，不信任任何 client 傳入的勝者/平局旗標。
-  const draw = simulateVersusReplay(replay).winnerId === null;
+  // server 重模擬 replay（verify 已過 → 與宣稱名次/盤面一致），取真名次與勝者。
+  // 一律以 server 自算結果為準，不信任任何 client 傳入的勝者/平局旗標/名次。
+  const sim = simulateVersusReplay(replay);
+  const draw = sim.winnerId === null;
+  // 真名次 map：lowercase key 以對齊 consensus（結算與儲存皆用 lowerStandings）。
+  // sim.placements 以 replay.playerIds（原始大小寫地址）為 key → 此處統一小寫。
+  const realPlacements: Record<string, number> = {};
+  for (const [id, p] of Object.entries(sim.placements)) realPlacements[id.toLowerCase()] = p;
 
-  const results = await applyBomberResult(store, consensus, ratings, draw);
+  const results = await applyBomberResult(store, consensus, ratings, realPlacements, draw);
   return json({ outcome: 'applied', results });
 };

--- a/src/pages/games/bomber.astro
+++ b/src/pages/games/bomber.astro
@@ -67,6 +67,16 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
       <canvas id="bomber-canvas"></canvas>
     </div>
 
+    <!-- Touch-device notice: Bomber is keyboard-only (coarse pointer → play entry suppressed) -->
+    <div class="touch-notice" id="touch-notice" hidden>
+      <h2 class="touch-notice-title">KEYBOARD REQUIRED</h2>
+      <p class="touch-notice-body">
+        Dungeon Bomber needs a <strong>keyboard</strong> to play.<br />
+        Please open this game on a <strong>computer</strong>.
+      </p>
+      <a class="ms-btn ms-back touch-notice-back" href="/games">← ARCADE</a>
+    </div>
+
     <!-- ── Mode Select — Layout B: Cinematic Hero Stage ── -->
     <div class="mode-select" id="mode-select">
       <!-- CRT scanline + vignette overlay -->
@@ -392,6 +402,43 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     opacity: 0.75;
     pointer-events: none;
     display: none; /* 僅遊戲中顯示；選角畫面隱藏（避免和 PRESS START 重疊），start() 時揭露 */
+  }
+  .bomber-hint.is-visible {
+    display: block; /* 開局後揭露操作提示（取代行內 style.display） */
+  }
+
+  /* ─── Touch-device notice (keyboard-only game) ───────── */
+  .touch-notice {
+    position: absolute;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 22px;
+    padding: 28px;
+    text-align: center;
+    font-family: 'Press Start 2P', Consolas, monospace;
+    background: #0a0c14;
+  }
+  .touch-notice[hidden] {
+    display: none;
+  }
+  .touch-notice-title {
+    margin: 0;
+    font-size: 18px;
+    color: #ffd23f;
+    text-shadow: 0 0 12px rgba(255, 210, 63, 0.4);
+  }
+  .touch-notice-body {
+    margin: 0;
+    font-size: 11px;
+    line-height: 2;
+    color: #cfe9ff;
+  }
+  .touch-notice-body strong {
+    color: #ffd23f;
   }
 
   /* ─── Mode-select full-screen (Layout B) ─────────────── */
@@ -1660,6 +1707,7 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   import { startBomber } from '@scripts/games/bomber/render/main';
   import type { CharacterId } from '@scripts/games/bomber/engine/types';
   import { ARENAS } from '@scripts/games/bomber/versus/arenas';
+  import { shouldShowTouchNotice } from '@scripts/games/bomber/touchNotice';
 
   const VALID_CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
 
@@ -1669,16 +1717,28 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
   let started = false;
   let onlineOpen = false; // ONLINE 大廳開啟中（攔截選角鍵盤導覽）
 
+  // ── Touch-device guard: Bomber is keyboard-only ──────────
+  // coarse pointer（手機／觸控，多半無實體鍵盤）→ 顯示「請用電腦」提示並收掉所有
+  // 遊玩入口（選角/START/ONLINE/各 autostart deep-link），避免進場後無法操作而被判離場。
+  // 桌機（fine pointer）行為完全不變。
+  const touchBlocked = shouldShowTouchNotice(matchMedia('(pointer: coarse)').matches);
+  if (touchBlocked) {
+    started = true; // 中和 start()/鍵盤導覽/所有 `!started` deep-link 入口
+    document.getElementById('touch-notice')?.removeAttribute('hidden');
+    modeSelect?.remove();
+    document.getElementById('online-screen')?.remove();
+  }
+
   // ── VERSUS hotseat debug entry: ?mode=hotseat ────────────
   // 本機雙人同鍵盤（P1 WASD+Space+E、P2 方向鍵+Enter+Shift）。
   // 可選 ?arena=0-7（越界回退 0）、?seed=<int>。網路對戰留待後續 Task。
-  if (params.get('mode') === 'hotseat' && canvas) {
+  if (!touchBlocked && params.get('mode') === 'hotseat' && canvas) {
     started = true;
     modeSelect?.remove();
     const hint = document.querySelector('.bomber-hint') as HTMLElement | null;
     if (hint) {
       hint.textContent = 'P1 WASD+SPACE+E  ·  P2 ←↑→↓+ENTER+SHIFT  ·  MUTE M';
-      hint.style.display = 'block';
+      hint.classList.add('is-visible');
     }
     const arenaParam = Number(params.get('arena'));
     const seedParam = Number(params.get('seed'));
@@ -1733,7 +1793,7 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     started = true;
     modeSelect?.remove();
     const hint = document.querySelector('.bomber-hint') as HTMLElement | null;
-    if (hint) hint.style.display = 'block';
+    if (hint) hint.classList.add('is-visible');
     startBomber(canvas, id).catch((err: unknown) => console.error('[bomber] start failed', err));
   }
 
@@ -1985,7 +2045,7 @@ const heroMeta: Record<string, { rom: string; epithet: string; aura: string; ele
     const hint = document.querySelector('.bomber-hint') as HTMLElement | null;
     if (hint) {
       hint.textContent = 'MOVE WASD/←↑→↓  ·  BOMB SPACE/ENTER  ·  SKILL E/SHIFT  ·  MUTE M';
-      hint.style.display = 'block';
+      hint.classList.add('is-visible');
     }
 
     // 結算回報接線：matchId = bomber-<seed36>-<room>；reporterId = 本端身分；

--- a/src/scripts/games/bomber/net/versusReplay.test.ts
+++ b/src/scripts/games/bomber/net/versusReplay.test.ts
@@ -8,8 +8,39 @@ import {
 } from './versusReplay';
 import type { CharacterId } from '../engine/types';
 import { VersusMatch } from '../versus/versusMatch';
+import { placementScore } from '@scripts/games/tetris/net/ffaElo';
 
 const CHARS: CharacterId[] = ['lena', 'mira', 'aya', 'rosa'];
+
+/**
+ * 跑一場 3 人局，P1+P2 同幀自爆（同 fuse、原地不動 → 同幀全滅），P0 全程不動倖存。
+ * 引擎名次：P0=1（冠軍），P1=P2=2（同幀死共享第 2 名）。winnerId=P0（非平局）。
+ * 回傳倖存端 nodes[0]，供取 replay 重模擬。
+ */
+function runTwoTiedSecondMatch(seed: number): {
+  node: BomberLockstep;
+  nodes: BomberLockstep[];
+  playerIds: string[];
+} {
+  const playerIds = ['P0', 'P1', 'P2'];
+  const { nodes } = buildNodes(playerIds, seed, 0);
+  // P1、P2 frame 0 自爆原地不動 → 同幀全滅 → 共享第 2 名；P0 不動 → 冠軍。
+  nodes[1].queueLocal({ t: 'bomb' });
+  nodes[2].queueLocal({ t: 'bomb' });
+  let dead = false;
+  for (let f = 0; f < 6000 && nodes[0].match.getState().status === 'playing'; f++) {
+    for (const node of nodes) {
+      if ((node.localId === 'P1' || node.localId === 'P2') && dead) continue;
+      node.tick();
+    }
+    const st = nodes[0].match.getState();
+    const p1 = st.players.find((p) => p.id === 'P1');
+    const p2 = st.players.find((p) => p.id === 'P2');
+    if (p1 && p2 && !p1.alive && !p2.alive) dead = true;
+  }
+  settle(nodes);
+  return { node: nodes[0], nodes, playerIds };
+}
 
 /** 建 N 個接同一 LoopbackBomberHub 的 BomberLockstep 節點。 */
 function buildNodes(
@@ -326,5 +357,41 @@ describe('verifyVersusReplay — 防禦縱深（FIX 2）', () => {
       inputs: [{ f: 0, p: 'P1', a: [{ t: 'held', d: 'up', v: 1 } as unknown as VersusAction] }],
     };
     expect(verifyVersusReplay(badV, claimed)).toBe(false);
+  });
+});
+
+describe('placementScore — 同名次 tie 行為（結算端依賴此）', () => {
+  it('placementScore(x, x) === 0.5（同名次＝平手期望分）', () => {
+    expect(placementScore(2, 2)).toBe(0.5);
+    expect(placementScore(1, 1)).toBe(0.5);
+    expect(placementScore(1, 2)).toBe(1);
+    expect(placementScore(2, 1)).toBe(0);
+  });
+});
+
+describe('simulateVersusReplay — 回傳真實 per-player placement map（伺服器真名次來源）', () => {
+  it('分出勝負（無同名次）：placements == standings 名次 [1,2]', () => {
+    const { node } = runSelfBombMatch(3);
+    const replay = node.getReplay();
+    const sim = simulateVersusReplay(replay);
+    // P1 冠軍 placement 1、P0 自爆 placement 2
+    expect(sim.placements).toEqual({ P1: 1, P0: 2 });
+  });
+
+  it('mid-match 同名次（P1+P2 同幀死）：placements 反映真實共享名次 {P0:1, P1:2, P2:2}', () => {
+    const { node } = runTwoTiedSecondMatch(42);
+    const replay = node.getReplay();
+    const sim = simulateVersusReplay(replay);
+    // 引擎真名次：冠軍唯一 1、兩位同幀死共享 2（非依 playerIds 序拆成 2/3）。
+    expect(sim.winnerId).toBe('P0');
+    expect(sim.placements).toEqual({ P0: 1, P1: 2, P2: 2 });
+    // standings 仍為 winner-first（平手以 playerIds 序穩定），不破壞既有契約。
+    expect(sim.standings).toEqual(['P0', 'P1', 'P2']);
+  });
+
+  it('placements 涵蓋全體 playerIds（每位皆有名次）', () => {
+    const { node } = runTwoTiedSecondMatch(7);
+    const sim = simulateVersusReplay(node.getReplay());
+    expect(Object.keys(sim.placements).sort()).toEqual(['P0', 'P1', 'P2']);
   });
 });

--- a/src/scripts/games/bomber/net/versusReplay.ts
+++ b/src/scripts/games/bomber/net/versusReplay.ts
@@ -48,6 +48,13 @@ export interface VersusReplayResult {
   stateHash: string;
   /** server 重模擬出的勝者 id；null = 平局（全滅同幀）。結算端用此判定平局，不信任 client。 */
   winnerId: string | null;
+  /**
+   * 各玩家「真實名次」map（id → placement，1=冠軍）。直接取自重模擬後 VersusMatch 的
+   * players[].placement —— 與引擎「同幀死共享名次」語意一致（如 3 人同幀雙殺 → {a:1,b:2,c:2}）。
+   * 結算端（bomber-match.ts）以此計分，避免將 standings 陣列索引（會以 playerIds 序拆開同名次者）
+   * 誤當名次而給同名次玩家不公平的 Elo/XP 差。為伺服器真名次來源，絕不信任 client 傳入。
+   */
+  placements: Record<string, number>;
 }
 
 /**
@@ -141,10 +148,16 @@ export function simulateVersusReplay(replay: VersusReplay): VersusReplayResult {
     match.step(SIM_DT);
   }
 
+  // 各玩家真實名次（id → placement）直接取自引擎，保留同幀死共享名次語意。
+  const finalState = match.getState();
+  const placements: Record<string, number> = {};
+  for (const p of finalState.players) placements[p.id] = p.placement;
+
   return {
     standings: liveStandings(match, replay.playerIds),
     stateHash: match.stateHash(),
-    winnerId: match.getState().winnerId,
+    winnerId: finalState.winnerId,
+    placements,
   };
 }
 

--- a/src/scripts/games/bomber/render/VersusEntityView.ts
+++ b/src/scripts/games/bomber/render/VersusEntityView.ts
@@ -4,6 +4,7 @@ import { BLAST_TTL_MS, GRID_COLS, GRID_ROWS } from '../engine/constants';
 import { lerp, type Layout } from './layout';
 import type { BomberTextures } from './assets';
 import type { VersusState, VPlayer } from '../versus/types';
+import { warningRing } from '../versus/suddenDeathWarning';
 import type { AbilityId, CharacterId } from '../engine/types';
 
 /**
@@ -15,8 +16,9 @@ import type { AbilityId, CharacterId } from '../engine/types';
  * - 所有存活玩家（walk sheet：列依朝向、幀依移動 walk-cycle；淘汰者隱藏）
  * - 護盾泡（持盾玩家）、無敵閃爍
  * - 技能環形震波（drainEvents → triggerAbility）
- * - Sudden death 警告：collapsedRings 變化後 3 秒內，下一圈（d === collapsedRings+1）
- *   格子以脈動紅色半透明覆層提示即將塌縮
+ * - Sudden death 警告：以 elapsedMs 推算「即將塌縮的那一圈」（warningRing），
+ *   在該圈真正塌縮前的提前視窗內，把該圈格子以脈動紅色半透明覆層警示。
+ *   如此 ring 1 會在 120s「之前」就先閃（領先塌縮），且絕不警示引擎不塌的 ring 4+。
  *
  * 策略：沿用 EntityView 的 recreate-per-frame pool（多的隱藏、不足時新增）。
  */
@@ -63,9 +65,6 @@ export class VersusEntityView {
   private blinkPhase    = 0;
   /** 各玩家 walk-cycle 時基（id → ms），移動時累加、靜止保持站立幀。 */
   private playerWalkMs   = new Map<string, number>();
-  /** Sudden death 警告剩餘顯示時間（ms）；collapsedRings 變化時重設為 3000。 */
-  private warnMs = 0;
-  private lastCollapsedRings = 0;
 
   private textures: BomberTextures;
   private walkFrameCache = new Map<string, Texture>();
@@ -257,27 +256,20 @@ export class VersusEntityView {
   private _renderFx(state: VersusState, layout: Layout, dtMs: number): void {
     const { cell, ox, oy } = layout;
 
-    // -- Sudden death 警告覆層（下一圈格子脈動紅色半透明） --
-    if (state.collapsedRings !== this.lastCollapsedRings) {
-      this.warnMs = 3000; // 每次塌縮後警示下一圈 3 秒
-      this.lastCollapsedRings = state.collapsedRings;
-    }
+    // -- Sudden death 警告覆層（即將塌縮的那一圈，脈動紅色半透明） --
+    // 由 elapsedMs 推算（warningRing）：在塌縮前的提前視窗內警示，讓 ring 1 在 120s 前先閃，
+    // 且絕不警示引擎不塌的 ring 4+（warningRing 已封住 r > MAX_COLLAPSE_RING）。
     const wg = this.warnG;
     wg.clear();
-    if (this.warnMs > 0) {
-      this.warnMs = Math.max(0, this.warnMs - dtMs);
-      const nextRing = state.collapsedRings + 1;
-      // 圈半徑超出盤面中心則無下一圈可警示
-      const maxRing = Math.floor(Math.min(GRID_COLS, GRID_ROWS) / 2);
-      if (nextRing <= maxRing) {
-        const pulse = 0.18 + Math.abs(Math.sin(this.pulsePhase * 2.4)) * 0.32; // 0.18→0.5
-        for (let y = 0; y < GRID_ROWS; y++) {
-          for (let x = 0; x < GRID_COLS; x++) {
-            const d = Math.min(x, GRID_COLS - 1 - x, y, GRID_ROWS - 1 - y);
-            if (d !== nextRing) continue;
-            wg.rect(ox + x * cell, oy + y * cell, cell, cell)
-              .fill({ color: 0xff2a2a, alpha: pulse });
-          }
+    const warnRing = warningRing(state.elapsedMs);
+    if (warnRing !== null) {
+      const pulse = 0.18 + Math.abs(Math.sin(this.pulsePhase * 2.4)) * 0.32; // 0.18→0.5
+      for (let y = 0; y < GRID_ROWS; y++) {
+        for (let x = 0; x < GRID_COLS; x++) {
+          const d = Math.min(x, GRID_COLS - 1 - x, y, GRID_ROWS - 1 - y);
+          if (d !== warnRing) continue;
+          wg.rect(ox + x * cell, oy + y * cell, cell, cell)
+            .fill({ color: 0xff2a2a, alpha: pulse });
         }
       }
     }

--- a/src/scripts/games/bomber/render/versusMain.ts
+++ b/src/scripts/games/bomber/render/versusMain.ts
@@ -186,10 +186,13 @@ async function mountVersusLoop(
   };
   stage.app.ticker.add(tick);
 
+  let destroyed = false; // 冪等保護：host-drop abort 路徑可能呼叫 destroy() 兩次（abort + 重檢）
   const handle: VersusHandle = {
     match,
     lockstep,
     destroy() {
+      if (destroyed) return; // 第二次起為 no-op，避免重複 teardown 拋錯
+      destroyed = true;
       stage.app.renderer.off('resize', relayout);
       retryBtn?.removeEventListener('click', onRetry);
       onDestroyExtra();

--- a/src/scripts/games/bomber/touchNotice.test.ts
+++ b/src/scripts/games/bomber/touchNotice.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowTouchNotice } from './touchNotice';
+
+describe('shouldShowTouchNotice', () => {
+  it('coarse pointer（觸控裝置）→ true（顯示提示、收掉入口）', () => {
+    expect(shouldShowTouchNotice(true)).toBe(true);
+  });
+
+  it('fine pointer（桌機滑鼠）→ false（行為與一般桌機相同）', () => {
+    expect(shouldShowTouchNotice(false)).toBe(false);
+  });
+
+  it('純函式：同輸入結果一致', () => {
+    expect(shouldShowTouchNotice(true)).toBe(shouldShowTouchNotice(true));
+    expect(shouldShowTouchNotice(false)).toBe(shouldShowTouchNotice(false));
+  });
+});

--- a/src/scripts/games/bomber/touchNotice.ts
+++ b/src/scripts/games/bomber/touchNotice.ts
@@ -1,0 +1,16 @@
+// src/scripts/games/bomber/touchNotice.ts
+
+/**
+ * 純函式：是否該顯示「需用鍵盤、請用電腦」提示並收掉遊玩入口。
+ *
+ * Dungeon Bomber 與 Tetris 一樣是純鍵盤操作（WASD/方向鍵 + Space + E/Shift），
+ * 觸控裝置（手機／平板，多半無實體鍵盤）進場會無法移動／放炸彈，
+ * 線上對戰更會直接被判離場（forfeit）。因此偵測到 coarse pointer 即顯示提示、
+ * 攔掉遊玩與線上入口。
+ *
+ * 決定性：只依輸入的 coarse 旗標，不碰 matchMedia/Date.now/Math.random
+ *（呼叫端負責把 matchMedia('(pointer: coarse)').matches 傳進來）。
+ */
+export function shouldShowTouchNotice(coarse: boolean): boolean {
+  return coarse === true;
+}

--- a/src/scripts/games/bomber/versus/suddenDeathWarning.test.ts
+++ b/src/scripts/games/bomber/versus/suddenDeathWarning.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { warningRing, ringCollapseTimeMs, WARNING_LEAD_MS } from './suddenDeathWarning';
+import { SUDDEN_DEATH_AT_MS, RING_INTERVAL_MS, MAX_COLLAPSE_RING } from './versusMatch';
+
+describe('warningRing (sudden-death lead-in)', () => {
+  it('在第一圈視窗開始前回傳 null', () => {
+    expect(warningRing(0)).toBeNull();
+    expect(warningRing(SUDDEN_DEATH_AT_MS - WARNING_LEAD_MS - 1)).toBeNull(); // 116999
+  });
+
+  it('在 ring1 塌縮前 LEAD 內回傳 1（領先塌縮、120s 前就閃）', () => {
+    expect(warningRing(SUDDEN_DEATH_AT_MS - WARNING_LEAD_MS)).toBe(1); // 117000 視窗起點（含）
+    expect(warningRing(SUDDEN_DEATH_AT_MS - 1)).toBe(1);               // 119999 視窗內
+    expect(warningRing(SUDDEN_DEATH_AT_MS - 1500)).toBe(1);           // ~1.5s 前仍為 1
+  });
+
+  it('ring1 塌縮當下即切換為警示下一圈（ring2），不再警示 ring1', () => {
+    // 120000：ring1 已（或正）塌縮，視窗變為 ring2 的 [120000,123000)
+    expect(warningRing(ringCollapseTimeMs(1))).toBe(2);
+    expect(warningRing(SUDDEN_DEATH_AT_MS + 1)).toBe(2);
+  });
+
+  it('兩次塌縮之間警示「即將塌的那一圈」', () => {
+    expect(warningRing(ringCollapseTimeMs(2) - 1)).toBe(2); // 122999 → ring2 即將塌
+    expect(warningRing(ringCollapseTimeMs(2))).toBe(3);     // 123000 → 改警示 ring3
+    expect(warningRing(ringCollapseTimeMs(3) - 1)).toBe(3); // 125999 → ring3 即將塌
+  });
+
+  it('ring3（最後一圈）塌縮後回傳 null（絕不警示 ring4+）', () => {
+    expect(warningRing(ringCollapseTimeMs(MAX_COLLAPSE_RING))).toBeNull(); // 126000
+    expect(warningRing(999_999)).toBeNull();
+  });
+
+  it('時間表與引擎公式對齊：collapseTime(r)=SUDDEN_DEATH_AT_MS+(r-1)*RING_INTERVAL_MS', () => {
+    expect(ringCollapseTimeMs(1)).toBe(SUDDEN_DEATH_AT_MS);
+    expect(ringCollapseTimeMs(2)).toBe(SUDDEN_DEATH_AT_MS + RING_INTERVAL_MS);
+    expect(ringCollapseTimeMs(3)).toBe(SUDDEN_DEATH_AT_MS + 2 * RING_INTERVAL_MS);
+  });
+
+  it('是純函式：同一 elapsedMs 多次呼叫結果一致', () => {
+    const t = SUDDEN_DEATH_AT_MS - 500;
+    expect(warningRing(t)).toBe(warningRing(t));
+    expect(warningRing(t)).toBe(1);
+  });
+});

--- a/src/scripts/games/bomber/versus/suddenDeathWarning.ts
+++ b/src/scripts/games/bomber/versus/suddenDeathWarning.ts
@@ -1,0 +1,44 @@
+// src/scripts/games/bomber/versus/suddenDeathWarning.ts
+import { SUDDEN_DEATH_AT_MS, RING_INTERVAL_MS, MAX_COLLAPSE_RING } from './versusMatch';
+
+/** 縮圈警示提前量（ms）：在某圈真正塌縮前 N 毫秒就開始閃紅提示。 */
+export const WARNING_LEAD_MS = 3_000;
+
+/**
+ * 縮圈時間表：第 r 圈（1..MAX_COLLAPSE_RING）在
+ *   collapseTime(r) = SUDDEN_DEATH_AT_MS + (r - 1) * RING_INTERVAL_MS
+ * 這一刻由引擎 stepSuddenDeath 塌縮（與 versusMatch 完全對齊）。
+ */
+export function ringCollapseTimeMs(ring: number): number {
+  return SUDDEN_DEATH_AT_MS + (ring - 1) * RING_INTERVAL_MS;
+}
+
+/**
+ * 純函式：依 elapsedMs 推算「此刻應閃紅警示哪一圈即將塌縮」。
+ *
+ * 規則：
+ * - 對每個將塌的圈 r（1..MAX_COLLAPSE_RING），其警示視窗為
+ *     [collapseTime(r) - WARNING_LEAD_MS, collapseTime(r))
+ *   亦即「在塌縮前 WARNING_LEAD_MS 內」閃紅，塌縮當下即停止（讓警示「領先」塌縮）。
+ * - 不會警示 r > MAX_COLLAPSE_RING（引擎根本不塌這些圈）。
+ * - 視窗外回傳 null（不顯示警示）。
+ *
+ * 完全決定性：只依賴傳入的 elapsedMs，不碰 Date.now / Math.random。
+ *
+ * 範例（SUDDEN_DEATH_AT_MS=120000, RING_INTERVAL_MS=3000, LEAD=3000）：
+ * - 116999 → null（尚未進入任何視窗）
+ * - 117000 → 1（ring1 在 120000 塌，視窗 [117000,120000)）
+ * - 119999 → 1
+ * - 120000 → 2（ring1 已塌，ring2 在 123000 塌，視窗 [120000,123000)）
+ * - 125999 → 3
+ * - 126000 → null（ring3 已塌，無 ring4 可警示）
+ */
+export function warningRing(elapsedMs: number): number | null {
+  for (let r = 1; r <= MAX_COLLAPSE_RING; r++) {
+    const collapseAt = ringCollapseTimeMs(r);
+    if (elapsedMs >= collapseAt - WARNING_LEAD_MS && elapsedMs < collapseAt) {
+      return r;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
第二輪最高標準對抗式驗收（render/視覺、arena 公平性、殘留作弊三個新角度）找到並修正：

- **[High] Sudden-death 第一圈無預警**：警示綁 `collapsedRings` 變化，但第一圈在同幀塌掉 → 出生角落玩家 120s 無預警暴斃。改為 `warningRing(elapsedMs)` 純函式**前置 3 秒**預警（ring1 在 117–120s 閃），並 cap 到 `MAX_COLLAPSE_RING`（不再誤警第 4 圈）。
- **[Important] 無觸控提示**：bomber 純鍵盤但手機無提示 → 玩家進對局不能動。`shouldShowTouchNotice` + coarse-pointer 顯示 KEYBOARD REQUIRED、抑制所有遊玩入口（仿 tetris）。
- **[Important] 場中並列名次誤判**：同幀並列（如 3 人共享第 2）依陣列序計分 → 並列者差 ±8–11 Elo / 5–10 XP。`simulateVersusReplay` 回傳**伺服器端真實 placements**，`applyBomberResult` 改用真實 placement（`placementScore(x,x)=0.5` → tie-aware N-way Elo + 相同 XP）。
- **[Minor]** inline style→class、`destroy()` 冪等。

## Test Plan
- [x] `npx vitest run src/pages/api src/scripts/games/bomber`：306 bomber + 48 api passed（含 warningRing 7 例、touchNotice、3 人並列計分測試）
- [x] `npx vitest run src/scripts/games/tetris/net`：286 passed（零迴歸、未動 ffaElo）
- [x] `npm run build`：Complete
- [x] warning 時序對照引擎公式驗證一致；tie 測試修前失敗修後過

## 已知未修（已評估、非本 PR 範圍）
- **3 人位置不對稱**：8 張皆 4 象限對稱，3 人時無主第 4 角資源偏袒 p2/p3（起始資源相等、屬二階優勢）。正解需專屬 3-spawn 120° 對稱地圖（大改）→ 建議接受或限定 ranked 為 2/4 人，另議。
- **versus 無 HUD**（技能冷卻/道具指示）：UX 增強、非 bug。
- **2 錢包共謀刷分**：與 tetris 天梯同立場（無 staking 的虛榮榜可接受）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)