### PR TITLE
feat(bomber-versus): versus HUD — ability cooldown, powerups, sudden-death timer

### DIFF
--- a/src/scripts/games/bomber/render/EntityView.ts
+++ b/src/scripts/games/bomber/render/EntityView.ts
@@ -4,6 +4,7 @@ import { speedMs } from '../engine/player';
 import { BLAST_TTL_MS } from '../engine/constants';
 import { enemyMoveMs } from '../engine/enemy';
 import { lerp, type Layout } from './layout';
+import { footShadowGeom, SHADOW_FILL, SHADOW_ALPHA } from './footShadow';
 import type { BomberTextures } from './assets';
 
 /**
@@ -90,6 +91,10 @@ export class EntityView {
    */
   private walkFrameCache = new Map<string, Texture>();
 
+  // --- foot shadows ---
+  /** Single Graphics drawn UNDER all character/enemy sprites (soft ground shadow). */
+  private shadowG: Graphics;
+
   // --- sprite pools ---
   private playerSp:  Sprite;
   private enemyPool: Sprite[] = [];
@@ -109,6 +114,12 @@ export class EntityView {
 
   constructor(private layer: Container, private fxLayer: Container, textures: BomberTextures) {
     this.textures = textures;
+
+    // 腳底軟陰影：作為 entityLayer 的「第一個子節點」，永遠墊在角色/敵人 sprite 底下
+    // （entityLayer 本身在 gridLayer 之上，所以陰影在地板之上、sprite 之下）。
+    // 暗色低 alpha 遠低於 bloom threshold，不會發光。
+    this.shadowG = new Graphics();
+    this.layer.addChildAt(this.shadowG, 0);
 
     // 玩家（1 個）— 初始貼圖用 lena；render 時每幀依 character 切換
     this.playerSp = this._newSprite(textures.playerLena);
@@ -227,6 +238,9 @@ export class EntityView {
 
     const { cell, ox, oy } = layout;
 
+    // 0. 腳底陰影：每幀重畫；存活角色/敵人各一片扁橢圓（畫在 sprite 底下）
+    this.shadowG.clear();
+
     // 1. 出口
     this._renderExit(state, cell, ox, oy);
 
@@ -333,6 +347,11 @@ export class EntityView {
       const sp  = this._poolGet(this.enemyPool, ei++, tex);
       const breathe = dormantMimic ? 1 + Math.sin(this.enemyAnimMs * 0.004 + enemy.id) * 0.02 : 1;
       const sizeMul = dormantMimic ? 1.0 : (ENEMY_SIZE[enemy.kind as 'splitter' | 'mini'] ?? 0.85);
+      // 腳底陰影（依顯示尺寸縮放）；休眠 mimic 偽裝成箱子、不畫陰影以免破綻
+      if (!dormantMimic) {
+        const sh = footShadowGeom(rx, ry, cell, ox, oy, sizeMul);
+        this.shadowG.ellipse(sh.cx, sh.cy, sh.rx, sh.ry).fill({ color: SHADOW_FILL, alpha: SHADOW_ALPHA });
+      }
       const size = cell * sizeMul * breathe;
       sp.width  = size;
       sp.height = size;
@@ -364,6 +383,12 @@ export class EntityView {
     const pry = lerp(p.prevY, p.y, playerProgress);
     const ppx = ox + prx * cell + cell / 2;
     const ppy = oy + pry * cell + cell / 2;
+
+    // 玩家腳底陰影（sizeMul = 1）
+    {
+      const sh = footShadowGeom(prx, pry, cell, ox, oy, 1);
+      this.shadowG.ellipse(sh.cx, sh.cy, sh.rx, sh.ry).fill({ color: SHADOW_FILL, alpha: SHADOW_ALPHA });
+    }
 
     const isInvuln     = p.invulnMs > 0;
     const blinkVisible = !isInvuln || Math.sin(this.blinkPhase) > 0;

--- a/src/scripts/games/bomber/render/VersusEntityView.ts
+++ b/src/scripts/games/bomber/render/VersusEntityView.ts
@@ -2,6 +2,7 @@ import { Container, Sprite, Texture, Rectangle, Graphics } from 'pixi.js';
 import { speedMs } from '../engine/player';
 import { BLAST_TTL_MS, GRID_COLS, GRID_ROWS } from '../engine/constants';
 import { lerp, type Layout } from './layout';
+import { footShadowGeom, SHADOW_FILL, SHADOW_ALPHA } from './footShadow';
 import type { BomberTextures } from './assets';
 import type { VersusState, VPlayer } from '../versus/types';
 import { warningRing } from '../versus/suddenDeathWarning';
@@ -69,6 +70,10 @@ export class VersusEntityView {
   private textures: BomberTextures;
   private walkFrameCache = new Map<string, Texture>();
 
+  // --- foot shadows ---
+  /** Single Graphics drawn UNDER all player sprites (soft ground shadow). */
+  private shadowG: Graphics;
+
   // --- sprite pools ---
   private playerPool: Sprite[] = [];
   private bombPool:   Sprite[] = [];
@@ -83,6 +88,9 @@ export class VersusEntityView {
 
   constructor(private layer: Container, private fxLayer: Container, textures: BomberTextures) {
     this.textures = textures;
+    // 腳底軟陰影：entityLayer 的第一個子節點 → 永遠墊在玩家 sprite 底下、地板之上。
+    this.shadowG = new Graphics();
+    this.layer.addChildAt(this.shadowG, 0);
     this.warnG = new Graphics();
     this.fxLayer.addChild(this.warnG);
     this.fxG = new Graphics();
@@ -153,6 +161,9 @@ export class VersusEntityView {
 
     const { cell, ox, oy } = layout;
 
+    // 0. 腳底陰影：每幀重畫；存活玩家各一片扁橢圓（畫在 sprite 底下、淘汰者不畫）
+    this.shadowG.clear();
+
     // 1. 爆風 — 方向性件型 × 3 階段漸弱（比照 EntityView）
     const bKey = (x: number, y: number): number => y * 64 + x;
     const blastSet = new Set(state.blasts.map((b) => bKey(b.x, b.y)));
@@ -220,6 +231,10 @@ export class VersusEntityView {
       const progress = Math.min(1, Math.max(0, 1 - p.moveCooldownMs / speedMs(p.speedLevel)));
       const rx = lerp(p.prevX, p.x, progress);
       const ry = lerp(p.prevY, p.y, progress);
+
+      // 腳底陰影（sizeMul = 1，與玩家 sprite cell*0.95 相稱）
+      const sh = footShadowGeom(rx, ry, cell, ox, oy, 1);
+      this.shadowG.ellipse(sh.cx, sh.cy, sh.rx, sh.ry).fill({ color: SHADOW_FILL, alpha: SHADOW_ALPHA });
 
       // walk-cycle：移動中持續累加相位；靜止顯示站立幀
       const moving = p.moveCooldownMs > 0;

--- a/src/scripts/games/bomber/render/VersusHudView.ts
+++ b/src/scripts/games/bomber/render/VersusHudView.ts
@@ -2,7 +2,14 @@ import { Container, Text, TextStyle, Graphics, Sprite } from 'pixi.js';
 import type { BomberTextures } from './assets';
 import type { VersusState, VPlayer } from '../versus/types';
 import type { AbilityId } from '../engine/types';
-import { abilityRatio, suddenDeathHud, HUD_PLAYER_TINTS } from './versusHud';
+import {
+  abilityRatio,
+  suddenDeathHud,
+  formatCountdown,
+  panelLayout,
+  HUD_PLAYER_TINTS,
+  HUD_PANEL_W,
+} from './versusHud';
 
 const FONT_FAMILY = '"Press Start 2P", Consolas, monospace';
 
@@ -27,11 +34,12 @@ interface PlayerPanel {
   /** Powerup tiers (fire / bomb / speed) + shield, drawn as one compact text line + shield icon. */
   tierText: Text;
   shieldIcon: Sprite;
+  /** Current laid-out panel width (may shrink below HUD_PANEL_W for narrow 4-player). */
+  width: number;
 }
 
-const PANEL_W = 150;
+const PANEL_W = HUD_PANEL_W;
 const PANEL_H = 50;
-const PANEL_GAP = 8;
 const ARC_R = 15;
 const ARC_CX = 18;
 const ARC_CY = 24;
@@ -175,30 +183,31 @@ export class VersusHudView {
 
     root.addChild(bg, swatch, name, abilityArc, abilityIcon, abilityLabel, tierText, shieldIcon);
     this.container.addChild(root);
-    return { root, bg, swatch, name, abilityArc, abilityIcon, abilityLabel, tierText, shieldIcon };
+    return { root, bg, swatch, name, abilityArc, abilityIcon, abilityLabel, tierText, shieldIcon, width: PANEL_W };
   }
 
   private renderPanel(panel: PlayerPanel, p: VPlayer, seat: number, isLocal: boolean): void {
     const tint = HUD_PLAYER_TINTS[seat] ?? 0xffffff;
     const out = !p.alive;
+    const w = panel.width;
 
     // -- background frame (highlight local; dim eliminated) --
     panel.bg.clear();
     const bgAlpha = out ? 0.5 : 0.92;
-    panel.bg.rect(0, 0, PANEL_W, PANEL_H).fill({ color: 0x0a0817, alpha: bgAlpha });
-    panel.bg.rect(0, 0, PANEL_W, PANEL_H).stroke({
+    panel.bg.rect(0, 0, w, PANEL_H).fill({ color: 0x0a0817, alpha: bgAlpha });
+    panel.bg.rect(0, 0, w, PANEL_H).stroke({
       color: isLocal ? 0xffce6b : 0x2a2138,
       width: isLocal ? 2 : 1,
       alpha: isLocal ? 0.95 : 0.8,
     });
     if (isLocal && !out) {
       // subtle top accent line for the local player's panel
-      panel.bg.rect(0, 0, PANEL_W, 2).fill({ color: 0xffce6b, alpha: 0.9 });
+      panel.bg.rect(0, 0, w, 2).fill({ color: 0xffce6b, alpha: 0.9 });
     }
 
     // -- colour swatch (top-right of name row) --
     panel.swatch.clear();
-    panel.swatch.rect(PANEL_W - 14, 6, 8, 8).fill({ color: tint, alpha: out ? 0.4 : 1 });
+    panel.swatch.rect(w - 14, 6, 8, 8).fill({ color: tint, alpha: out ? 0.4 : 1 });
 
     // -- name / OUT label --
     const label = (p.character ?? '?').toUpperCase();
@@ -255,29 +264,25 @@ export class VersusHudView {
     panel.shieldIcon.y = 33;
   }
 
-  /** Lay panels across the top edge: P1/P3 on the left, P2/P4 on the right, mirrored from center. */
+  /**
+   * Lay panels across the top edge via the pure, width-aware panelLayout helper:
+   * P1/P3 on the left, P2/P4 on the right, mirrored from center. Panels shrink
+   * for narrow 4-player stages so their inner edge never overlaps the top-center
+   * sudden-death timer (2-player corners keep full width). See versusHud.ts.
+   */
   private relayoutPanels(): void {
     const n = this.panels.length;
     if (n === 0) return;
     const top = 4;
 
-    // Split into left group (even seats: 0,2) and right group (odd seats: 1,3),
-    // so 2 players sit at the two top corners and 3-4 fan inward — never overlapping the
-    // top-center sudden-death timer.
-    const left: number[] = [];
-    const right: number[] = [];
-    for (let i = 0; i < n; i++) (i % 2 === 0 ? left : right).push(i);
-
-    left.forEach((seat, k) => {
+    const slots = panelLayout(this.stageW, n);
+    for (let seat = 0; seat < n; seat++) {
       const panel = this.panels[seat];
-      panel.root.x = 6 + k * (PANEL_W + PANEL_GAP);
+      const slot = slots[seat];
+      panel.root.x = slot.x;
       panel.root.y = top;
-    });
-    right.forEach((seat, k) => {
-      const panel = this.panels[seat];
-      panel.root.x = this.stageW - 6 - PANEL_W - k * (PANEL_W + PANEL_GAP);
-      panel.root.y = top;
-    });
+      panel.width = slot.panelW;
+    }
   }
 
   // ─── sudden-death timer ────────────────────────────────────────────────────────
@@ -290,7 +295,7 @@ export class VersusHudView {
     let color: number;
     if (sd.phase === 'pre') {
       const s = sd.secondsToNext;
-      text = `SUDDEN DEATH 0:${String(Math.min(99, s)).padStart(2, '0')}`;
+      text = `SUDDEN DEATH ${formatCountdown(s)}`;
       // turn amber→red as it approaches
       color = s <= 5 ? 0xff5a3c : 0xffd23f;
     } else if (sd.phase === 'collapsing') {

--- a/src/scripts/games/bomber/render/VersusHudView.ts
+++ b/src/scripts/games/bomber/render/VersusHudView.ts
@@ -1,0 +1,343 @@
+import { Container, Text, TextStyle, Graphics, Sprite } from 'pixi.js';
+import type { BomberTextures } from './assets';
+import type { VersusState, VPlayer } from '../versus/types';
+import type { AbilityId } from '../engine/types';
+import { abilityRatio, suddenDeathHud, HUD_PLAYER_TINTS } from './versusHud';
+
+const FONT_FAMILY = '"Press Start 2P", Consolas, monospace';
+
+/** Per-ability accent colours (match select-screen auras / VersusEntityView). */
+const ABILITY_COLOR: Record<AbilityId, number> = {
+  detonate: 0xffb347,
+  inferno: 0xff5a3c,
+  blink: 0x36e0c0,
+  bulwark: 0x6b9fd0,
+};
+
+/** One per-player panel: name + swatch, ability cooldown arc, powerup tiers, shield, OUT state. */
+interface PlayerPanel {
+  root: Container;
+  bg: Graphics;
+  swatch: Graphics;
+  name: Text;
+  /** Ability radial: background ring + fill arc + READY/CD label. */
+  abilityArc: Graphics;
+  abilityIcon: Sprite;
+  abilityLabel: Text;
+  /** Powerup tiers (fire / bomb / speed) + shield, drawn as one compact text line + shield icon. */
+  tierText: Text;
+  shieldIcon: Sprite;
+}
+
+const PANEL_W = 150;
+const PANEL_H = 50;
+const PANEL_GAP = 8;
+const ARC_R = 15;
+const ARC_CX = 18;
+const ARC_CY = 24;
+
+/**
+ * Versus HUD (Pixi, mounted into stage.hudLayer — no bloom).
+ *
+ * Per-player panels are laid across the top edge (2–4 players, compact, non-overlapping).
+ * Each panel shows: character label + colour swatch, an ability cooldown radial arc that
+ * fills 0→1 as the ability recharges (READY glow when ready), powerup tiers (fire/bomb/speed),
+ * a shield indicator, and a dimmed "OUT" state when eliminated. The local player's panel
+ * (id === localId, online) is highlighted; hotseat may pass undefined → no highlight.
+ *
+ * A sudden-death timer sits top-center, driven purely off state.elapsedMs (deterministic).
+ *
+ * All pure logic lives in versusHud.ts (abilityRatio / suddenDeathHud), unit-tested separately.
+ */
+export class VersusHudView {
+  private container = new Container();
+  private panels: PlayerPanel[] = [];
+  /** playerId → panel index, rebuilt when the roster changes. */
+  private panelByPlayer = new Map<string, number>();
+
+  // ---- sudden-death timer (top center) ----
+  private sdContainer = new Container();
+  private sdBg = new Graphics();
+  private sdText: Text;
+
+  private stageW = 800;
+  private pulse = 0;
+  private readonly reducedMotion: boolean;
+
+  constructor(private layer: Container, private textures: BomberTextures) {
+    this.reducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    this.sdText = new Text({
+      text: '',
+      style: new TextStyle({ fontFamily: FONT_FAMILY, fontSize: 10, fill: 0xffd23f, letterSpacing: 1 }),
+    });
+    this.sdText.anchor.set(0.5, 0.5);
+    this.sdContainer.addChild(this.sdBg, this.sdText);
+    this.sdContainer.visible = false;
+
+    this.layer.addChild(this.container, this.sdContainer);
+  }
+
+  /** Set stage size (call on construct + every resize). Rebuilds panel layout. */
+  setLayout(w: number, _h = 600): void {
+    this.stageW = w;
+    this.relayoutSd();
+    this.relayoutPanels();
+  }
+
+  /** Alias used by versusMain's relayout path. */
+  onResize(w: number, h?: number): void {
+    this.setLayout(w, h);
+  }
+
+  /**
+   * Render the HUD for the current frame.
+   * @param state    current VersusState (players + elapsedMs)
+   * @param _layout  grid layout (unused for now; HUD is screen-anchored, reserved for future)
+   * @param localId  local player's id (online); undefined in hotseat → no highlight
+   */
+  render(state: VersusState, _layout: unknown, localId?: string): void {
+    if (!this.reducedMotion) {
+      this.pulse = (this.pulse + 0.05) % (Math.PI * 2);
+    }
+
+    this.ensurePanels(state.players);
+
+    for (let i = 0; i < state.players.length; i++) {
+      const p = state.players[i];
+      const idx = this.panelByPlayer.get(p.id);
+      if (idx === undefined) continue;
+      this.renderPanel(this.panels[idx], p, i, p.id === localId);
+    }
+
+    this.renderSuddenDeath(state.elapsedMs);
+  }
+
+  // ─── per-player panels ───────────────────────────────────────────────────────
+
+  /** Build/rebuild the panel pool to match the current roster (id order is stable). */
+  private ensurePanels(players: VPlayer[]): void {
+    const ids = players.map((p) => p.id).join('|');
+    if (ids === this._lastRosterKey) return;
+    this._lastRosterKey = ids;
+
+    // (Re)create exactly players.length panels.
+    while (this.panels.length < players.length) this.panels.push(this.createPanel());
+    while (this.panels.length > players.length) {
+      const extra = this.panels.pop();
+      if (extra) { extra.root.destroy({ children: true }); }
+    }
+
+    this.panelByPlayer.clear();
+    players.forEach((p, i) => this.panelByPlayer.set(p.id, i));
+
+    this.relayoutPanels();
+  }
+  private _lastRosterKey = '';
+
+  private createPanel(): PlayerPanel {
+    const root = new Container();
+    const bg = new Graphics();
+    const swatch = new Graphics();
+
+    const name = new Text({
+      text: '',
+      style: new TextStyle({ fontFamily: FONT_FAMILY, fontSize: 9, fill: 0xfff2e6, letterSpacing: 1 }),
+    });
+
+    const abilityArc = new Graphics();
+    const abilityIcon = new Sprite(this.textures.abDetonate);
+    abilityIcon.width = 18;
+    abilityIcon.height = 18;
+    abilityIcon.anchor.set(0.5);
+    abilityIcon.x = ARC_CX;
+    abilityIcon.y = ARC_CY;
+
+    const abilityLabel = new Text({
+      text: '',
+      style: new TextStyle({ fontFamily: FONT_FAMILY, fontSize: 8, fill: 0xfff2e6 }),
+    });
+    abilityLabel.anchor.set(0.5, 0);
+    abilityLabel.x = ARC_CX;
+    abilityLabel.y = ARC_CY + ARC_R + 3;
+
+    const tierText = new Text({
+      text: '',
+      style: new TextStyle({ fontFamily: FONT_FAMILY, fontSize: 9, fill: 0xffd23f, letterSpacing: 1 }),
+    });
+
+    const shieldIcon = new Sprite(this.textures.puShield);
+    shieldIcon.width = 14;
+    shieldIcon.height = 14;
+
+    root.addChild(bg, swatch, name, abilityArc, abilityIcon, abilityLabel, tierText, shieldIcon);
+    this.container.addChild(root);
+    return { root, bg, swatch, name, abilityArc, abilityIcon, abilityLabel, tierText, shieldIcon };
+  }
+
+  private renderPanel(panel: PlayerPanel, p: VPlayer, seat: number, isLocal: boolean): void {
+    const tint = HUD_PLAYER_TINTS[seat] ?? 0xffffff;
+    const out = !p.alive;
+
+    // -- background frame (highlight local; dim eliminated) --
+    panel.bg.clear();
+    const bgAlpha = out ? 0.5 : 0.92;
+    panel.bg.rect(0, 0, PANEL_W, PANEL_H).fill({ color: 0x0a0817, alpha: bgAlpha });
+    panel.bg.rect(0, 0, PANEL_W, PANEL_H).stroke({
+      color: isLocal ? 0xffce6b : 0x2a2138,
+      width: isLocal ? 2 : 1,
+      alpha: isLocal ? 0.95 : 0.8,
+    });
+    if (isLocal && !out) {
+      // subtle top accent line for the local player's panel
+      panel.bg.rect(0, 0, PANEL_W, 2).fill({ color: 0xffce6b, alpha: 0.9 });
+    }
+
+    // -- colour swatch (top-right of name row) --
+    panel.swatch.clear();
+    panel.swatch.rect(PANEL_W - 14, 6, 8, 8).fill({ color: tint, alpha: out ? 0.4 : 1 });
+
+    // -- name / OUT label --
+    const label = (p.character ?? '?').toUpperCase();
+    panel.name.text = out ? `${label} · OUT` : label;
+    panel.name.style.fill = out ? 0x8a7f74 : 0xfff2e6;
+    panel.name.x = 6;
+    panel.name.y = 5;
+
+    // -- ability cooldown radial arc --
+    const ratio = abilityRatio(p.abilityCooldownMs, p.abilityMaxMs);
+    const ready = p.abilityCooldownMs <= 0 || p.abilityMaxMs <= 0;
+    const aColor = ABILITY_COLOR[p.abilityId] ?? 0xffb347;
+
+    panel.abilityIcon.texture = this.abilityTexture(p.abilityId);
+    panel.abilityIcon.alpha = out ? 0.3 : ready ? 1 : 0.7;
+
+    const arc = panel.abilityArc;
+    arc.clear();
+    // base ring
+    arc.circle(ARC_CX, ARC_CY, ARC_R).stroke({ color: 0x2a2138, width: 3, alpha: out ? 0.4 : 0.9 });
+    if (!out) {
+      const start = -Math.PI / 2;
+      const end = start + ratio * Math.PI * 2;
+      if (ratio > 0) {
+        arc.arc(ARC_CX, ARC_CY, ARC_R, start, end).stroke({ color: aColor, width: 3, alpha: 0.95 });
+      }
+      if (ready) {
+        // READY glow ring (subtle pulse; static under reduced-motion)
+        const glow = this.reducedMotion ? 0.5 : 0.35 + Math.abs(Math.sin(this.pulse * 1.6)) * 0.35;
+        arc.circle(ARC_CX, ARC_CY, ARC_R + 2).stroke({ color: aColor, width: 2, alpha: glow });
+      }
+    }
+
+    if (out) {
+      panel.abilityLabel.text = '';
+    } else if (ready) {
+      panel.abilityLabel.text = 'READY';
+      panel.abilityLabel.style.fill = aColor;
+    } else {
+      panel.abilityLabel.text = `${Math.ceil(p.abilityCooldownMs / 1000)}`;
+      panel.abilityLabel.style.fill = 0xc0b8b0;
+    }
+
+    // -- powerup tiers: F / B / S (compact) --
+    const tierParts = [`F${p.fireRange}`, `B${p.maxBombs}`, `S${p.speedLevel}`];
+    panel.tierText.text = tierParts.join(' ');
+    panel.tierText.style.fill = out ? 0x6a6058 : 0xffd23f;
+    panel.tierText.x = 42;
+    panel.tierText.y = 22;
+
+    // -- shield indicator --
+    panel.shieldIcon.visible = !!p.shield && !out;
+    panel.shieldIcon.x = 42;
+    panel.shieldIcon.y = 33;
+  }
+
+  /** Lay panels across the top edge: P1/P3 on the left, P2/P4 on the right, mirrored from center. */
+  private relayoutPanels(): void {
+    const n = this.panels.length;
+    if (n === 0) return;
+    const top = 4;
+
+    // Split into left group (even seats: 0,2) and right group (odd seats: 1,3),
+    // so 2 players sit at the two top corners and 3-4 fan inward — never overlapping the
+    // top-center sudden-death timer.
+    const left: number[] = [];
+    const right: number[] = [];
+    for (let i = 0; i < n; i++) (i % 2 === 0 ? left : right).push(i);
+
+    left.forEach((seat, k) => {
+      const panel = this.panels[seat];
+      panel.root.x = 6 + k * (PANEL_W + PANEL_GAP);
+      panel.root.y = top;
+    });
+    right.forEach((seat, k) => {
+      const panel = this.panels[seat];
+      panel.root.x = this.stageW - 6 - PANEL_W - k * (PANEL_W + PANEL_GAP);
+      panel.root.y = top;
+    });
+  }
+
+  // ─── sudden-death timer ────────────────────────────────────────────────────────
+
+  private renderSuddenDeath(elapsedMs: number): void {
+    const sd = suddenDeathHud(elapsedMs);
+    this.sdContainer.visible = true;
+
+    let text: string;
+    let color: number;
+    if (sd.phase === 'pre') {
+      const s = sd.secondsToNext;
+      text = `SUDDEN DEATH 0:${String(Math.min(99, s)).padStart(2, '0')}`;
+      // turn amber→red as it approaches
+      color = s <= 5 ? 0xff5a3c : 0xffd23f;
+    } else if (sd.phase === 'collapsing') {
+      text = `COLLAPSING · RING ${sd.ring} · ${sd.secondsToNext}`;
+      color = 0xff5a3c;
+    } else {
+      text = 'COLLAPSING';
+      color = 0xff2a2a;
+    }
+
+    this.sdText.text = text;
+    this.sdText.style.fill = color;
+    // subtle pulse during the danger phases (static under reduced-motion)
+    const danger = sd.phase !== 'pre' || sd.secondsToNext <= 5;
+    this.sdText.alpha = danger && !this.reducedMotion
+      ? 0.7 + Math.abs(Math.sin(this.pulse * 2.2)) * 0.3
+      : 1;
+
+    this.relayoutSd();
+  }
+
+  private relayoutSd(): void {
+    const cx = Math.round(this.stageW / 2);
+    this.sdText.x = cx;
+    this.sdText.y = 16;
+
+    const tw = Math.max(120, this.sdText.width + 24);
+    this.sdBg.clear();
+    this.sdBg.roundRect(cx - tw / 2, 4, tw, 24, 4).fill({ color: 0x0a0817, alpha: 0.85 });
+    this.sdBg.roundRect(cx - tw / 2, 4, tw, 24, 4).stroke({ color: 0x5a3208, width: 1, alpha: 0.9 });
+  }
+
+  // ─── helpers ──────────────────────────────────────────────────────────────────
+
+  private abilityTexture(id: AbilityId): typeof this.textures.abDetonate {
+    return id === 'detonate' ? this.textures.abDetonate
+      : id === 'inferno' ? this.textures.abInferno
+      : id === 'blink' ? this.textures.abBlink
+      : this.textures.abBulwark;
+  }
+
+  /** Explicit teardown (destroys panels + sd container). Called from the versus handle's destroy(). */
+  destroy(): void {
+    for (const panel of this.panels) panel.root.destroy({ children: true });
+    this.panels = [];
+    this.panelByPlayer.clear();
+    this.sdContainer.destroy({ children: true });
+    this.container.destroy({ children: true });
+  }
+}

--- a/src/scripts/games/bomber/render/footShadow.test.ts
+++ b/src/scripts/games/bomber/render/footShadow.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  footShadowGeom,
+  SHADOW_FOOT_FRAC,
+  SHADOW_RX_FRAC,
+  SHADOW_RY_FRAC,
+} from './footShadow';
+
+describe('footShadowGeom (foot-shadow ellipse geometry)', () => {
+  const cell = 40;
+  const ox = 10;
+  const oy = 6;
+
+  it('centre x matches the sprite x (cell centre at interpolated col)', () => {
+    const g = footShadowGeom(3, 5, cell, ox, oy, 1);
+    // sprite x = ox + rx*cell + cell/2
+    expect(g.cx).toBe(ox + 3 * cell + cell / 2);
+  });
+
+  it('centre y sits near the feet (below the cell centre)', () => {
+    const g = footShadowGeom(3, 5, cell, ox, oy, 1);
+    const cellCentreY = oy + 5 * cell + cell / 2;
+    expect(g.cy).toBe(oy + 5 * cell + cell * SHADOW_FOOT_FRAC);
+    // SHADOW_FOOT_FRAC (0.8) > 0.5 → shadow is below the sprite centre, at the feet
+    expect(g.cy).toBeGreaterThan(cellCentreY);
+  });
+
+  it('radii are flattened (rx > ry) for a ground shadow', () => {
+    const g = footShadowGeom(0, 0, cell, ox, oy, 1);
+    expect(g.rx).toBe(cell * SHADOW_RX_FRAC);
+    expect(g.ry).toBe(cell * SHADOW_RY_FRAC);
+    expect(g.rx).toBeGreaterThan(g.ry);
+  });
+
+  it('scales radii by the size multiplier (bigger entities → bigger shadows)', () => {
+    const small = footShadowGeom(0, 0, cell, ox, oy, 0.55);
+    const big = footShadowGeom(0, 0, cell, ox, oy, 0.98);
+    expect(big.rx).toBeGreaterThan(small.rx);
+    expect(big.ry).toBeGreaterThan(small.ry);
+    expect(small.rx).toBeCloseTo(cell * SHADOW_RX_FRAC * 0.55, 6);
+    expect(big.ry).toBeCloseTo(cell * SHADOW_RY_FRAC * 0.98, 6);
+  });
+
+  it('is pure: same inputs → identical geometry across calls', () => {
+    const a = footShadowGeom(2.5, 4.25, cell, ox, oy, 0.85);
+    const b = footShadowGeom(2.5, 4.25, cell, ox, oy, 0.85);
+    expect(a).toEqual(b);
+  });
+
+  it('tracks interpolated (fractional) coords for smooth movement', () => {
+    const mid = footShadowGeom(2.5, 0, cell, ox, oy, 1);
+    const at2 = footShadowGeom(2, 0, cell, ox, oy, 1);
+    const at3 = footShadowGeom(3, 0, cell, ox, oy, 1);
+    expect(mid.cx).toBeCloseTo((at2.cx + at3.cx) / 2, 6);
+  });
+});

--- a/src/scripts/games/bomber/render/footShadow.ts
+++ b/src/scripts/games/bomber/render/footShadow.ts
@@ -1,0 +1,53 @@
+/**
+ * Foot-shadow geometry — render-only helper shared by EntityView (single-player
+ * player + enemies) and VersusEntityView (versus players).
+ *
+ * A flattened dark translucent ellipse drawn UNDER each living character/monster
+ * at its feet (bottom-centre of its cell) so sprites lift off the floor and are
+ * easier to identify. Pure / deterministic: position is derived from the same
+ * interpolated grid coords the sprite uses; no Math.random / Date.now.
+ */
+
+/** Shadow tuning constants (cell-relative). */
+export const SHADOW_FILL = 0x000000;
+export const SHADOW_ALPHA = 0.28;
+/** Vertical offset (cell units) from cell top to the shadow centre — at the feet. */
+export const SHADOW_FOOT_FRAC = 0.8;
+/** Horizontal radius as a fraction of cell (× per-entity size multiplier). */
+export const SHADOW_RX_FRAC = 0.3;
+/** Vertical radius as a fraction of cell (× per-entity size multiplier) — flattened. */
+export const SHADOW_RY_FRAC = 0.12;
+
+export interface ShadowGeom {
+  /** Ellipse centre x (screen px). */
+  cx: number;
+  /** Ellipse centre y (screen px) — near the sprite's feet. */
+  cy: number;
+  /** Horizontal radius (px). */
+  rx: number;
+  /** Vertical radius (px) — flattened. */
+  ry: number;
+}
+
+/**
+ * Compute the foot-shadow ellipse for an entity at interpolated grid coords
+ * (rx, ry) within a layout of cell size `cell` and grid origin (ox, oy).
+ *
+ * @param sizeMul per-entity display-size multiplier (1 for player; per-kind for
+ *   enemies so larger enemies cast larger shadows).
+ */
+export function footShadowGeom(
+  rx: number,
+  ry: number,
+  cell: number,
+  ox: number,
+  oy: number,
+  sizeMul: number,
+): ShadowGeom {
+  return {
+    cx: ox + rx * cell + cell / 2,
+    cy: oy + ry * cell + cell * SHADOW_FOOT_FRAC,
+    rx: cell * SHADOW_RX_FRAC * sizeMul,
+    ry: cell * SHADOW_RY_FRAC * sizeMul,
+  };
+}

--- a/src/scripts/games/bomber/render/versusHud.test.ts
+++ b/src/scripts/games/bomber/render/versusHud.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { abilityRatio, suddenDeathHud } from './versusHud';
+import {
+  abilityRatio,
+  suddenDeathHud,
+  formatCountdown,
+  panelLayout,
+  HUD_PANEL_W,
+  HUD_PANEL_EDGE,
+  HUD_PANEL_MIN_W,
+  HUD_SD_RESERVE_HALF,
+  HUD_SD_MARGIN,
+} from './versusHud';
 import {
   SUDDEN_DEATH_AT_MS,
   RING_INTERVAL_MS,
@@ -89,5 +99,143 @@ describe('suddenDeathHud (deterministic, elapsedMs only)', () => {
   it('is pure: same elapsed → same result', () => {
     const t = SUDDEN_DEATH_AT_MS + 1500;
     expect(suddenDeathHud(t)).toEqual(suddenDeathHud(t));
+  });
+});
+
+describe('formatCountdown (M:SS, clamps negatives)', () => {
+  it('120 → 2:00', () => {
+    expect(formatCountdown(120)).toBe('2:00');
+  });
+
+  it('99 → 1:39', () => {
+    expect(formatCountdown(99)).toBe('1:39');
+  });
+
+  it('60 → 1:00', () => {
+    expect(formatCountdown(60)).toBe('1:00');
+  });
+
+  it('45 → 0:45', () => {
+    expect(formatCountdown(45)).toBe('0:45');
+  });
+
+  it('5 → 0:05 (zero-pads seconds)', () => {
+    expect(formatCountdown(5)).toBe('0:05');
+  });
+
+  it('0 → 0:00', () => {
+    expect(formatCountdown(0)).toBe('0:00');
+  });
+
+  it('negative clamps to 0:00', () => {
+    expect(formatCountdown(-1)).toBe('0:00');
+    expect(formatCountdown(-37)).toBe('0:00');
+  });
+
+  it('floors fractional seconds', () => {
+    expect(formatCountdown(90.9)).toBe('1:30');
+    expect(formatCountdown(5.4)).toBe('0:05');
+  });
+});
+
+describe('panelLayout (width-aware, 4-player never overlaps center SD timer)', () => {
+  const SD_LEFT_EDGE = (stageW: number) =>
+    stageW / 2 - HUD_SD_RESERVE_HALF - HUD_SD_MARGIN;
+
+  it('2 players: full-width corner panels, no shrink', () => {
+    const lay = panelLayout(800, 2);
+    expect(lay.length).toBe(2);
+    // seat 0 left corner, seat 1 right corner, both PANEL_W
+    expect(lay[0].panelW).toBe(HUD_PANEL_W);
+    expect(lay[1].panelW).toBe(HUD_PANEL_W);
+    expect(lay[0].x).toBe(HUD_PANEL_EDGE);
+    expect(lay[1].x).toBe(800 - HUD_PANEL_EDGE - HUD_PANEL_W);
+  });
+
+  it('2 players stays full-width even at narrow widths (corners kept as-is)', () => {
+    const lay = panelLayout(640, 2);
+    expect(lay[0].panelW).toBe(HUD_PANEL_W);
+    expect(lay[1].panelW).toBe(HUD_PANEL_W);
+  });
+
+  it('4 players at a wide stage: full-width panels, left inner edge clears SD box', () => {
+    const stageW = 1280;
+    const lay = panelLayout(stageW, 4);
+    expect(lay.length).toBe(4);
+    // left group = seats 0,2 ; right group = seats 1,3
+    const leftInnerEdge = Math.max(
+      lay[0].x + lay[0].panelW,
+      lay[2].x + lay[2].panelW,
+    );
+    expect(leftInnerEdge).toBeLessThanOrEqual(SD_LEFT_EDGE(stageW));
+  });
+
+  it('4 players at narrow ~700px: panels shrink so left inner edge still clears SD box', () => {
+    const stageW = 700;
+    const lay = panelLayout(stageW, 4);
+    const leftInnerEdge = Math.max(
+      lay[0].x + lay[0].panelW,
+      lay[2].x + lay[2].panelW,
+    );
+    expect(leftInnerEdge).toBeLessThanOrEqual(SD_LEFT_EDGE(stageW));
+    // and panels must have shrunk below full width to achieve it
+    expect(lay[0].panelW).toBeLessThan(HUD_PANEL_W);
+  });
+
+  // Below ~540px the SD box + two min-width panels per side physically can't
+  // coexist (the MIN_W floor wins); the guarantee is documented to hold from
+  // there up. That floor is well below the flagged concern band (≲882px) and
+  // below the 628px mutual-overlap threshold, so it fully covers the issue.
+  const FOUR_PLAYER_MIN_W = 540;
+
+  it('4 players never overlaps the center SD box across a wide range of widths', () => {
+    for (let stageW = FOUR_PLAYER_MIN_W; stageW <= 1600; stageW += 17) {
+      const lay = panelLayout(stageW, 4);
+      const sdLeft = SD_LEFT_EDGE(stageW);
+      const sdRight = stageW - sdLeft;
+      const leftInnerEdge = Math.max(
+        lay[0].x + lay[0].panelW,
+        lay[2].x + lay[2].panelW,
+      );
+      const rightInnerEdge = Math.min(lay[1].x, lay[3].x);
+      expect(leftInnerEdge).toBeLessThanOrEqual(sdLeft + 1e-6);
+      expect(rightInnerEdge).toBeGreaterThanOrEqual(sdRight - 1e-6);
+    }
+  });
+
+  it('4 players clears SD box at the documented minimum width (540px)', () => {
+    const lay = panelLayout(FOUR_PLAYER_MIN_W, 4);
+    const leftInnerEdge = Math.max(
+      lay[0].x + lay[0].panelW,
+      lay[2].x + lay[2].panelW,
+    );
+    expect(leftInnerEdge).toBeLessThanOrEqual(SD_LEFT_EDGE(FOUR_PLAYER_MIN_W) + 1e-6);
+    expect(lay[0].panelW).toBe(HUD_PANEL_MIN_W); // pinned at the floor here
+  });
+
+  it('symmetric: right group mirrors the left group', () => {
+    const stageW = 760;
+    const lay = panelLayout(stageW, 4);
+    // seat 0 (left) mirrors seat 1 (right); seat 2 mirrors seat 3
+    expect(lay[1].x).toBeCloseTo(stageW - lay[0].x - lay[0].panelW, 6);
+    expect(lay[3].x).toBeCloseTo(stageW - lay[2].x - lay[2].panelW, 6);
+    expect(lay[1].panelW).toBeCloseTo(lay[0].panelW, 6);
+    expect(lay[3].panelW).toBeCloseTo(lay[2].panelW, 6);
+  });
+
+  it('3 players: 2 left (seats 0,2), 1 right (seat 1), still clears SD box when narrow', () => {
+    const stageW = 700;
+    const lay = panelLayout(stageW, 3);
+    expect(lay.length).toBe(3);
+    const leftInnerEdge = Math.max(
+      lay[0].x + lay[0].panelW,
+      lay[2].x + lay[2].panelW,
+    );
+    expect(leftInnerEdge).toBeLessThanOrEqual(SD_LEFT_EDGE(stageW) + 1e-6);
+  });
+
+  it('panel width never goes below a sane minimum', () => {
+    const lay = panelLayout(420, 4);
+    expect(lay[0].panelW).toBeGreaterThanOrEqual(60);
   });
 });

--- a/src/scripts/games/bomber/render/versusHud.test.ts
+++ b/src/scripts/games/bomber/render/versusHud.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { abilityRatio, suddenDeathHud } from './versusHud';
+import {
+  SUDDEN_DEATH_AT_MS,
+  RING_INTERVAL_MS,
+  MAX_COLLAPSE_RING,
+} from '../versus/versusMatch';
+
+describe('abilityRatio (recharge fill 0→1)', () => {
+  it('full cooldown → 0 (just used)', () => {
+    expect(abilityRatio(9000, 9000)).toBe(0);
+  });
+
+  it('zero cooldown → 1 (ready)', () => {
+    expect(abilityRatio(0, 9000)).toBe(1);
+  });
+
+  it('half cooldown → 0.5', () => {
+    expect(abilityRatio(4500, 9000)).toBeCloseTo(0.5, 6);
+  });
+
+  it('clamps over-full cooldown to 0', () => {
+    expect(abilityRatio(12000, 9000)).toBe(0);
+  });
+
+  it('clamps negative cooldown to 1', () => {
+    expect(abilityRatio(-500, 9000)).toBe(1);
+  });
+
+  it('maxMs <= 0 → 1 (treated as ready / no cooldown)', () => {
+    expect(abilityRatio(5000, 0)).toBe(1);
+    expect(abilityRatio(5000, -1)).toBe(1);
+  });
+});
+
+describe('suddenDeathHud (deterministic, elapsedMs only)', () => {
+  it('before sudden death: phase=pre, counts seconds down to 120s', () => {
+    const r0 = suddenDeathHud(0);
+    expect(r0.phase).toBe('pre');
+    expect(r0.ring).toBe(0);
+    expect(r0.secondsToNext).toBe(SUDDEN_DEATH_AT_MS / 1000); // 120
+
+    // 119.0s remaining → ceil(1000ms) = 1
+    const r119 = suddenDeathHud(SUDDEN_DEATH_AT_MS - 1000);
+    expect(r119.phase).toBe('pre');
+    expect(r119.secondsToNext).toBe(1);
+
+    // 119.5s elapsed → 0.5s remaining → ceil = 1
+    const rHalf = suddenDeathHud(SUDDEN_DEATH_AT_MS - 500);
+    expect(rHalf.phase).toBe('pre');
+    expect(rHalf.secondsToNext).toBe(1);
+  });
+
+  it('at 120s exactly: phase=collapsing, ring 1, counts to ring 2', () => {
+    const r = suddenDeathHud(SUDDEN_DEATH_AT_MS);
+    expect(r.phase).toBe('collapsing');
+    expect(r.ring).toBe(1);
+    // next collapse at 123s → 3s away → ceil = 3
+    expect(r.secondsToNext).toBe(RING_INTERVAL_MS / 1000);
+  });
+
+  it('at 123s: ring 2 has just collapsed, counts to ring 3', () => {
+    const r = suddenDeathHud(SUDDEN_DEATH_AT_MS + RING_INTERVAL_MS);
+    expect(r.phase).toBe('collapsing');
+    expect(r.ring).toBe(2);
+    expect(r.secondsToNext).toBe(RING_INTERVAL_MS / 1000);
+  });
+
+  it('at 126s: last ring (3) collapsed → phase=final', () => {
+    const r = suddenDeathHud(SUDDEN_DEATH_AT_MS + (MAX_COLLAPSE_RING - 1) * RING_INTERVAL_MS);
+    expect(r.phase).toBe('final');
+    expect(r.ring).toBe(MAX_COLLAPSE_RING);
+  });
+
+  it('past the last ring: stays final, ring stays at max', () => {
+    const r = suddenDeathHud(SUDDEN_DEATH_AT_MS + 10 * RING_INTERVAL_MS);
+    expect(r.phase).toBe('final');
+    expect(r.ring).toBe(MAX_COLLAPSE_RING);
+  });
+
+  it('mid-collapse interval: ring stays, secondsToNext counts down to next ring', () => {
+    // 1.0s into the first collapse interval → 2.0s until ring 2 → ceil = 2
+    const r = suddenDeathHud(SUDDEN_DEATH_AT_MS + 1000);
+    expect(r.phase).toBe('collapsing');
+    expect(r.ring).toBe(1);
+    expect(r.secondsToNext).toBe(2);
+  });
+
+  it('is pure: same elapsed → same result', () => {
+    const t = SUDDEN_DEATH_AT_MS + 1500;
+    expect(suddenDeathHud(t)).toEqual(suddenDeathHud(t));
+  });
+});

--- a/src/scripts/games/bomber/render/versusHud.ts
+++ b/src/scripts/games/bomber/render/versusHud.ts
@@ -75,5 +75,102 @@ export function suddenDeathHud(elapsedMs: number): SuddenDeathHud {
   };
 }
 
+/**
+ * Format a whole-second countdown as `M:SS` (e.g. 120→"2:00", 99→"1:39",
+ * 45→"0:45", 5→"0:05", 0→"0:00"). Negative inputs clamp to "0:00"; fractional
+ * seconds are floored. Pure — used for the sudden-death pre-phase timer.
+ */
+export function formatCountdown(seconds: number): string {
+  const total = seconds <= 0 ? 0 : Math.floor(seconds);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
 /** Per-player accent tints (P1 warm / P2 cool / P3 / P4). Mirrors VersusEntityView. */
 export const HUD_PLAYER_TINTS = [0xffffff, 0x9fd8ff, 0xffd6a0, 0xc0ffc0] as const;
+
+// ─── panel layout (pure, width-aware) ─────────────────────────────────────────
+// These constants are the single source of truth for the HUD panel geometry; the
+// Pixi view (VersusHudView) consumes panelLayout() rather than hard-coding x/width.
+
+/** Default (full) per-player panel width. */
+export const HUD_PANEL_W = 150;
+/** Gap between two panels in the same (left/right) group. */
+export const HUD_PANEL_GAP = 8;
+/** Distance from the stage edge to the outer panel. */
+export const HUD_PANEL_EDGE = 6;
+/**
+ * Half-width reserved for the centered sudden-death box. The SD box is
+ * `max(120, text+24)` wide and the widest text ("SUDDEN DEATH 2:00") renders
+ * around ~250px, so ~125 half-width; 130 leaves a little headroom. Panels are
+ * laid so their inner edge never crosses `stageW/2 ∓ HUD_SD_RESERVE_HALF`.
+ */
+export const HUD_SD_RESERVE_HALF = 130;
+/** Extra clearance between a panel's inner edge and the SD reserve. */
+export const HUD_SD_MARGIN = 6;
+/** Panels never shrink below this width (keeps text legible). */
+export const HUD_PANEL_MIN_W = 60;
+
+export interface PanelSlot {
+  /** Left x of the panel root. */
+  x: number;
+  /** Panel width for this layout (== HUD_PANEL_W unless shrunk for narrow 4-player). */
+  panelW: number;
+}
+
+/**
+ * Deterministic top-edge panel layout for `playerCount` players (2–4).
+ *
+ * Seats alternate left/right groups (even seats 0,2 → left; odd seats 1,3 →
+ * right), so 2 players sit at the two top corners and 3–4 fan inward — never
+ * overlapping the top-center sudden-death timer.
+ *
+ * Width-aware: when a group holds 2 panels (3–4 players) on a narrow stage, the
+ * panel width is shrunk uniformly so the group's inner edge stays clear of the
+ * centered SD box. 1-panel groups (2-player corners) keep the full width as-is.
+ *
+ * Returns one slot per seat, indexed by seat (0..playerCount-1). The layout is
+ * symmetric: the right group mirrors the left group about the stage center.
+ */
+export function panelLayout(stageWidth: number, playerCount: number): PanelSlot[] {
+  const n = Math.max(0, playerCount);
+  // Group sizes: left = even seats, right = odd seats.
+  const leftCount = Math.ceil(n / 2);
+  const rightCount = Math.floor(n / 2);
+  const maxGroup = Math.max(leftCount, rightCount);
+
+  // Available run from the stage edge to the SD reserve, for one half.
+  const available =
+    stageWidth / 2 - HUD_SD_RESERVE_HALF - HUD_SD_MARGIN - HUD_PANEL_EDGE;
+
+  // Only shrink when a group holds ≥2 panels; single-panel groups (2-player
+  // corners) keep full width regardless of stage width.
+  let panelW = HUD_PANEL_W;
+  if (maxGroup >= 2) {
+    const fit = (available - (maxGroup - 1) * HUD_PANEL_GAP) / maxGroup;
+    panelW = Math.max(HUD_PANEL_MIN_W, Math.min(HUD_PANEL_W, fit));
+  }
+
+  const slots: PanelSlot[] = [];
+  let leftK = 0;
+  let rightK = 0;
+  for (let seat = 0; seat < n; seat++) {
+    if (seat % 2 === 0) {
+      // left group, fans rightward from the edge
+      slots[seat] = {
+        x: HUD_PANEL_EDGE + leftK * (panelW + HUD_PANEL_GAP),
+        panelW,
+      };
+      leftK++;
+    } else {
+      // right group, mirrors the left from the right edge
+      slots[seat] = {
+        x: stageWidth - HUD_PANEL_EDGE - panelW - rightK * (panelW + HUD_PANEL_GAP),
+        panelW,
+      };
+      rightK++;
+    }
+  }
+  return slots;
+}

--- a/src/scripts/games/bomber/render/versusHud.ts
+++ b/src/scripts/games/bomber/render/versusHud.ts
@@ -1,0 +1,79 @@
+// src/scripts/games/bomber/render/versusHud.ts
+//
+// Pure, deterministic helpers for the Versus HUD (no Date.now / Math.random).
+// Tested in versusHud.test.ts. The Pixi view (VersusHudView) consumes these.
+
+import {
+  SUDDEN_DEATH_AT_MS,
+  RING_INTERVAL_MS,
+  MAX_COLLAPSE_RING,
+} from '../versus/versusMatch';
+
+/**
+ * Ability recharge fill ratio in [0,1]: 0 = just used (full cooldown),
+ * 1 = ready. `ratio = 1 - cooldownMs/maxMs`, clamped.
+ *
+ * `maxMs <= 0` is treated as "ready" (1) — defensive against an unset / zero
+ * cooldown so the indicator never shows a permanently-charging arc.
+ */
+export function abilityRatio(cooldownMs: number, maxMs: number): number {
+  if (maxMs <= 0) return 1;
+  const r = 1 - cooldownMs / maxMs;
+  if (r <= 0) return 0;
+  if (r >= 1) return 1;
+  return r;
+}
+
+export type SuddenDeathPhase = 'pre' | 'collapsing' | 'final';
+
+export interface SuddenDeathHud {
+  /** 'pre' before 120s; 'collapsing' while rings still falling; 'final' after the last ring. */
+  phase: SuddenDeathPhase;
+  /** Whole seconds (ceil) until the next event (sudden death start, or next ring collapse). 0 when final. */
+  secondsToNext: number;
+  /** Current/most-recent collapsed ring (0 before sudden death; clamps at MAX_COLLAPSE_RING). */
+  ring: number;
+}
+
+/**
+ * Deterministic sudden-death HUD state, driven purely by `state.elapsedMs`.
+ *
+ * Matches the engine collapse schedule exactly (versusMatch.stepSuddenDeath):
+ *   collapseTime(r) = SUDDEN_DEATH_AT_MS + (r - 1) * RING_INTERVAL_MS, for r in 1..MAX_COLLAPSE_RING.
+ *
+ * Phases (with SUDDEN_DEATH_AT_MS=120000, RING_INTERVAL_MS=3000, MAX_COLLAPSE_RING=3):
+ * - elapsed < 120000          → 'pre',        ring 0, secondsToNext = ceil((120000-elapsed)/1000)
+ * - 120000 ≤ elapsed < 126000 → 'collapsing', ring = current collapsed ring (1..2),
+ *                                secondsToNext = ceil(time to next ring)
+ * - elapsed ≥ 126000          → 'final',       ring = MAX_COLLAPSE_RING, secondsToNext 0
+ *   (the last ring (3) collapsed at 126000; the engine collapses no further ring)
+ */
+export function suddenDeathHud(elapsedMs: number): SuddenDeathHud {
+  if (elapsedMs < SUDDEN_DEATH_AT_MS) {
+    return {
+      phase: 'pre',
+      ring: 0,
+      secondsToNext: Math.ceil((SUDDEN_DEATH_AT_MS - elapsedMs) / 1000),
+    };
+  }
+
+  // due = which ring number "should" have collapsed by now (engine formula).
+  const due = 1 + Math.floor((elapsedMs - SUDDEN_DEATH_AT_MS) / RING_INTERVAL_MS);
+  const ring = Math.min(MAX_COLLAPSE_RING, due);
+
+  // After the last scheduled ring has collapsed there is nothing more to count to.
+  if (due >= MAX_COLLAPSE_RING) {
+    return { phase: 'final', ring: MAX_COLLAPSE_RING, secondsToNext: 0 };
+  }
+
+  // Time until the NEXT ring collapses: collapseTime(ring+1) - elapsed.
+  const nextCollapseAt = SUDDEN_DEATH_AT_MS + ring * RING_INTERVAL_MS;
+  return {
+    phase: 'collapsing',
+    ring,
+    secondsToNext: Math.ceil((nextCollapseAt - elapsedMs) / 1000),
+  };
+}
+
+/** Per-player accent tints (P1 warm / P2 cool / P3 / P4). Mirrors VersusEntityView. */
+export const HUD_PLAYER_TINTS = [0xffffff, 0x9fd8ff, 0xffd6a0, 0xc0ffc0] as const;

--- a/src/scripts/games/bomber/render/versusMain.ts
+++ b/src/scripts/games/bomber/render/versusMain.ts
@@ -4,6 +4,7 @@ import { SoundManager } from '../audio/SoundManager';
 import { PixiStage } from './PixiStage';
 import { GridView } from './GridView';
 import { VersusEntityView } from './VersusEntityView';
+import { VersusHudView } from './VersusHudView';
 import { computeLayout } from './layout';
 import { loadBomberTextures } from './assets';
 import type { Dir, CharacterId } from '../engine/types';
@@ -100,6 +101,8 @@ async function mountVersusLoop(
   lockstep?: BomberLockstep,
   /** 線上模式覆寫：finish 時呼叫此 hook 顯示結算畫面（傳入後不顯示基本 overlay）。 */
   onFinish?: (winnerId: string | null) => void,
+  /** 本端玩家 id（online 高亮其面板；hotseat 為 undefined → 不高亮）。 */
+  localId?: string,
 ): Promise<VersusHandle> {
   const stage = await PixiStage.create(canvas);
   const theme = ARENAS[arenaId]?.theme ?? 0;
@@ -107,13 +110,16 @@ async function mountVersusLoop(
   const textures = await loadBomberTextures();
   const grid = new GridView(stage.gridLayer, textures);
   const entity = new VersusEntityView(stage.entityLayer, stage.fxLayer, textures);
+  const hud = new VersusHudView(stage.hudLayer, textures);
   const sound = new SoundManager();
 
   let lay = computeLayout(stage.width, stage.height);
+  hud.setLayout(stage.width, stage.height);
 
   function relayout(): void {
     lay = computeLayout(stage.width, stage.height);
     grid.invalidate();
+    hud.onResize(stage.width, stage.height);
   }
   stage.app.renderer.on('resize', relayout);
 
@@ -182,6 +188,7 @@ async function mountVersusLoop(
     const s = match.getState();
     grid.render(s, lay, theme);
     entity.render(s, lay, dt);
+    hud.render(s, lay, localId);
     stage.update(dt);
   };
   stage.app.ticker.add(tick);
@@ -197,6 +204,7 @@ async function mountVersusLoop(
       retryBtn?.removeEventListener('click', onRetry);
       onDestroyExtra();
       stage.app.ticker.remove(tick);
+      hud.destroy();
       stage.app.destroy();
     },
   };
@@ -291,6 +299,10 @@ export async function startVersus(
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
     },
+    undefined, // lockstep
+    undefined, // onFinish
+    // hotseat：兩位玩家共用同一鍵盤，無單一「本端」玩家 → 不高亮任何面板。
+    undefined, // localId
   );
 }
 
@@ -358,7 +370,7 @@ export async function startVersusOnline(
     window.addEventListener('keyup', onKeyUp);
   };
 
-  void localId; // 本端玩家身分已由 lockstep（localId）持有；輸入即視為該玩家的動作
+  // 本端玩家身分（localId）：輸入即視為該玩家動作，並用於 HUD 高亮本端面板。
 
   // ── 線上結算畫面：finish → 顯示名次 → 簽章回報 → 收到 results 後補 Elo±/XP ──
   const onFinish = (winnerId: string | null): void => {
@@ -414,6 +426,7 @@ export async function startVersusOnline(
     },
     lockstep,
     onFinish,
+    localId, // 線上：高亮本端玩家面板
   );
 }
 


### PR DESCRIPTION
## Summary
為連線/熱座 versus 加 HUD（補上 QA 驗收標記的 M6 UX 缺口：競技模式玩家需知道技能何時就緒）。新 `render/VersusHudView.ts` 掛進 `hudLayer`、每幀 `render(state, layout, localId)`；單機沿用既有 HudView（不動）。

- **每位玩家面板**（2-4，頂端角落 fan-in 不擋中央計時器）：角色色標、**技能冷卻環**（填充 + READY 發光 / 剩餘秒數）、道具層級 `F{fire} B{bomb} S{speed}`、護盾圖示、淘汰 `· OUT` 變暗、線上模式本地玩家金框高亮。
- **頂部中央 sudden-death 計時器**：120s 前 `SUDDEN DEATH 0:NN`、塌縮中 `COLLAPSING · RING n · {秒}`，純由 elapsedMs 驅動（與引擎/警示同 schedule）。
- 純函式 `versusHud.ts`（`abilityRatio` / `suddenDeathHud`）+ 13 單元測試。reduced-motion 凍結脈動、resize 處理、teardown。

## Test Plan
- [x] `npx vitest run src/scripts/games/bomber`：319 passed（含 13 HUD 測試）、零引擎迴歸
- [x] `npm run build`：Complete；`tsc` 我的檔零錯
- [x] **實機驗證**（hotseat）：技能 READY↔冷卻秒數正確（mira 用技能→顯示 21s）、per-player 獨立、道具 F2 B1 S1、SD 計時器 `SUDDEN DEATH 0:99`→`COLLAPSING · RING 1`、淘汰 OUT、結構乾淨（面板群組 + SD 計時器）
- [ ] 4 人面板在 <~700px 窄桌面寬度的不重疊（觸控/手機已被 keyboard-notice 擋、不會到 HUD）— minor，待視覺確認

## 備註
單機 + hotseat + 2 人線上 不受影響（HudView 未動、versus 另掛新 HUD）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)