### PR TITLE
docs(claude): 重建專案制度層（CLAUDE.md 瘦身 + docs/claude 路由）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ localhost-*.json
 
 # superpowers brainstorm visual companion
 .superpowers/
+
+# 驗證/研究產物（截圖、素材驗證、research 暫存）—— 不入庫
+/*.png
+.research/
+**/_verify/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,267 +1,47 @@
-# CLAUDE.md
+# CLAUDE.md — super_galen_site
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+給在此 repo 工作的 Claude Code。**全域制度**（派工、判斷、維護）在 `~/.claude/rules/`，本檔只放本專案的路由與最高頻的「別踩雷」事實。
+事實日期 2026-07-05；與程式碼矛盾時**程式碼是真相**，順手改本檔（授權見 `~/.claude/rules/maintenance.md`）。
 
-## 專案概述
+## 一句話定位
 
-這是一個結合 **Astro 靜態網站** + **RPG 遊戲化介面** + **Web3/區塊鏈整合** 的全端開發者作品集部落格。
+Astro 7 靜態站 + RPG 遊戲化介面 + Web3 代幣，但 2026 的**實際開發重心是 `/games`（4 個遊戲、連線對戰）與 `/guild`（159 個成員頁）**。舊版 CLAUDE.md 把它當「作品集部落格」是過時的重心。
 
-**核心特色**：
-- 🎮 **RPG 風格互動介面**：完整的角色狀態系統、技能樹、物品欄、成就系統
-- ⛓️ **區塊鏈整合**：可升級的 ERC-20 代幣智能合約（SuperGalenToken）與 DApp 介面
-- 🌐 **完整 i18n 支援**：支援繁中、簡中、英、日、韓五種語言
-- 📝 **技術部落格**：26+ 篇技術文章，涵蓋 Web3、前端、後端主題
-- 🚀 **現代化架構**：Astro + TypeScript + Vite HMR
+## 按需讀取（不要憑記憶行動）
 
-## 技術棧
+| 何時讀 | 檔案 |
+|--------|------|
+| 要跑指令、測試、啟動、生圖 | `docs/claude/commands.md` |
+| 要理解架構、找檔、i18n 雙檔制 | `docs/claude/architecture.md` |
+| 要宣告完成、排查「改了沒生效」、審查高危區 | `docs/claude/verify.md` |
+| 開工 / 久未接觸本 repo | `docs/claude/letter-to-future-sessions.md` |
+| 想懂本 repo 的制度為何長這樣 | `docs/claude/harness-diagnostic-supergalen-2026-07.md` |
 
-### 前端
-- **框架**：Astro 5.x（靜態網站生成）
-- **語言**：TypeScript、Vanilla JavaScript (ES6+)
-- **樣式**：SCSS 模組化架構（30+ partials）
-- **特效**：Canvas 技能樹、CSS 動畫、像素風格設計
-- **多語系**：TypeScript i18n 系統 + JSON 動態載入
+## 每 session 必記的五條雷（不讀上表也要知道）
 
-### 區塊鏈
-- **智能合約**：Solidity（SuperGalenTokenV1 可升級 UUPS 模式）
-- **開發框架**：Hardhat 2.26.x
-- **Web3 函式庫**：ethers.js v6.15
-- **升級模式**：OpenZeppelin UUPS Proxy
-- **測試**：Hardhat + Chai（2 個測試檔案，76 個測試案例）
-- **支援網路**：Localhost (31337)、Polygon (137)
+1. **i18n 是雙檔制**：`src/i18n/translations/*.ts`（伺服器端）+ `public/assets/i18n/*.json`（客戶端），各五語（en/ja/ko/zh-CN/zh-TW）。同一 key 改一邊不報錯、只顯示舊文案——**兩邊都要改**，改完 grep 驗證。
+2. **本專案沒有 prettier / eslint**，只有 `solhint` 管 Solidity。完成判準裡沒有「跑 lint」這項（合約除外），別幻想去跑不存在的指令。
+3. **智能合約是真金白銀**：`npm run deploy:polygon` 打 Polygon 主網、UUPS 升級不可逆——**只有使用者明示才能碰**。私鑰在 `.env`，絕不入庫。
+4. **「改了沒生效」先查環境再查程式碼**：4321 埠可能被別的 worktree 佔（服務別分支）、Vite 可能服務舊 `<script>`。排查順序見 `docs/claude/verify.md`，別急著重改程式碼。
+5. **驗收 UI 後必附 4321 可點連結**給使用者（memory 鐵則）；產圖後也要放到可開的網址（他看不到 Read 工具的圖）。
 
-### 測試
-- **E2E 測試**：Playwright（跨瀏覽器測試）
-- **單元測試**：Vitest
-- **智能合約測試**：Hardhat + Chai
+## 完成判準（摘要，全文見 docs/claude/verify.md）
 
-### 開發工具
-- **版本控制**：Git + GitHub
-- **套件管理**：npm
-- **部署平台**：Vercel
-- **程式碼品質**：Solhint（Solidity Linter）、TypeScript
+- 先寫失敗測試（全域 TDD 鐵則；純文案/樣式微調豁免）→ 實作 → `npx vitest run` 全套綠（不是只跑新增的）。
+- **`npm run test` 是 watch 模式會掛住**，一律用 `npx vitest run`。
+- UI 改動跑相關 e2e：`npx playwright test <spec> --project=chromium`（e2e 自動在 4002 起 server，與 4321 無關）。
+- guild 頁走 `guild-page-verify` skill；合約跑 `npm run test:contracts` + solhint。
+- push 後查 Vercel build（`gh pr checks <PR#>`）；本專案**無 GitHub Actions**。
 
-## 開發指令
+## 樣式規則
 
-### 快速啟動（推薦）
+SCSS 模組化（`src/styles/`，36 partials）。**禁 `!important`、禁行內樣式。**
 
-```bash
-# 一鍵啟動完整開發環境（Hardhat + 合約部署 + Astro）
-./dev
-```
+## 素材生成 skill 路由
 
-這個腳本會自動：
-1. 啟動 Hardhat 本地節點（端口 8545）
-2. 部署智能合約到本地網路
-3. 啟動 Astro 開發伺服器（端口 4321）
-4. 顯示測試帳戶與合約地址
+任何圖 → `nanobanana-image-gen`（預設）；使用者說「用 codex」→ `codex-image-generation`；BGM → `gemini-music-gen`；音效 → Web Audio 合成不生檔。
 
-按 `Ctrl+C` 可停止所有服務。
+## Git
 
-### Astro 開發
-
-```bash
-# 啟動開發伺服器（HMR 自動重載）
-npm run dev
-
-# 編譯為生產環境
-npm run build
-
-# 預覽生產版本
-npm run preview
-```
-
-**訪問地址**：http://localhost:4321
-
-### 區塊鏈開發
-
-```bash
-# 編譯智能合約
-npm run compile
-
-# 執行所有合約測試（76 個測試案例）
-npm run test:contracts
-
-# 啟動本地區塊鏈節點（Hardhat Network）
-npm run node
-
-# 部署到本地網路（需在另一個終端機先啟動節點）
-npm run deploy:local
-
-# 部署到 Polygon 主網（需要 .env 設定）
-npm run deploy:polygon
-
-# 執行 Solidity Linter
-npx solhint 'blockchain/contracts/**/*.sol'
-```
-
-### 測試
-
-```bash
-# 執行單元測試
-npm run test
-
-# 執行單元測試（UI 模式）
-npm run test:unit:ui
-
-# 執行 E2E 測試
-npm run test:e2e
-
-# 執行 E2E 測試（UI 模式）
-npm run test:e2e:ui
-
-# 執行所有測試
-npm run test:all
-```
-
-### i18n 系統
-
-**架構**：
-- **伺服器端**：`src/i18n/translations/*.ts`（TypeScript 翻譯檔案）
-- **客戶端**：`public/assets/i18n/*.json`（前端 JavaScript 載入）
-
-**使用方式**：
-- **Astro 組件**：`import { t } from '../i18n'; t('key.path')`
-- **HTML 文字**：`<span data-i18n="key.path">預設文字</span>`
-- **JavaScript**：`window.i18n.t('key.path')`
-
-## 檔案結構
-
-```
-my-portfolio-blog-astro/
-├── dev                          # 一鍵啟動完整開發環境腳本
-├── astro.config.mjs             # Astro 配置
-├── vercel.json                  # Vercel 部署配置
-├── src/
-│   ├── components/              # Astro 組件
-│   │   ├── layout/              # 版面組件
-│   │   ├── rpg/                 # RPG 介面組件
-│   │   ├── i18n/                # 語言切換組件
-│   │   └── web3/                # Web3 組件
-│   ├── content/
-│   │   └── blog/                # 部落格文章（Markdown）
-│   ├── i18n/
-│   │   ├── translations/        # TypeScript 翻譯檔案
-│   │   └── index.ts             # i18n 工具函數
-│   ├── pages/
-│   │   ├── [lang]/              # 多語言路由
-│   │   ├── guild/               # 公會頁面
-│   │   └── journal/             # 日誌頁面
-│   ├── scripts/                 # TypeScript 腳本
-│   └── styles/                  # SCSS 樣式檔案
-├── public/
-│   ├── assets/                  # 靜態資源
-│   │   ├── i18n/                # 前端 JSON 翻譯檔案
-│   │   ├── images/              # 圖片
-│   │   └── video/               # 影片
-│   ├── scripts/                 # 前端 JavaScript
-│   └── guild/                   # Guild 成員靜態頁面
-├── blockchain/
-│   ├── contracts/               # Solidity 智能合約
-│   ├── scripts/                 # 部署腳本
-│   ├── test/                    # 合約測試
-│   └── deployments/             # 部署記錄
-├── tests/
-│   └── e2e/                     # Playwright E2E 測試
-├── hardhat.config.js            # Hardhat 配置
-├── playwright.config.ts         # Playwright 配置
-├── vitest.config.ts             # Vitest 配置
-└── package.json                 # npm 依賴
-```
-
-## 架構概覽
-
-### 前端架構
-
-**Astro 組件結構**：
-- `BaseLayout.astro`：基礎版面（包含 SEO、腳本載入）
-- `StatusBar.astro`：RPG 狀態列
-- `GameTabs.astro`：8 個互動頁籤
-- `SkillTreePanel.astro`：Canvas 技能樹
-- 其他 RPG 面板組件
-
-**核心管理器（單例模式）**：
-- `GameStateManager`：透過 Cookie 持久化玩家狀態（HP/MP/SP/Gold）
-- `I18nManager`：多語言支援，動態載入翻譯
-- `UnifiedWalletManager`：Web3 錢包連接（純 ethers.js）
-- `SGTPurchaseManager`：代幣購買流程
-- `NetworkMonitor`：Chain ID 偵測與網路切換
-
-### 區塊鏈架構
-
-**智能合約**：
-- `SuperGalenTokenV1.sol`：可升級 ERC20 代幣（UUPS 模式）
-  - 購買機制、時間鎖、角色訪問控制、黑名單、最大供應量限制
-- `MockUSDT.sol`：本地開發用 USDT 模擬合約
-
-**部署配置**：
-- **Localhost (31337)**：MockUSDT + 測試帳戶
-- **Polygon (137)**：真實 USDT
-
-### RPG 遊戲系統
-
-**8 個主要互動頁籤**：
-1. **狀態**：屬性點數與增減益效果
-2. **技能**：Canvas 技能樹（5 大分支）
-3. **故事**：個人簡介與職涯時間軸
-4. **物品**：Diablo 2 風格裝備欄
-5. **成就**：14 個成就系統
-6. **夥伴**：團隊成員展示
-7. **購買**：SGT 代幣購買介面
-8. **日誌**：部落格文章列表
-
-## 關鍵注意事項
-
-### 效能優化
-- **Vite HMR**：開發時即時更新
-- **靜態生成**：所有頁面預先生成
-- **資源優化**：Astro 自動處理 CSS/JS 打包
-
-### 安全性
-- **絕不提交 `.env`**：包含私鑰，已在 `.gitignore`
-- **智能合約安全**：時間鎖、角色控制、暫停機制
-
-### CSS 架構
-- **SCSS 模組化**：30+ partials
-- **絕不使用 `!important`**
-- **禁止行內樣式**
-
-### 開發工作流程
-
-1. **修改翻譯**：
-   - 伺服器端：編輯 `src/i18n/translations/*.ts`
-   - 客戶端：編輯 `public/assets/i18n/*.json`
-
-2. **修改智能合約**：
-   - 編輯 `blockchain/contracts/*.sol`
-   - 執行 `npm run compile`
-   - 執行 `npm run test:contracts`
-   - 重新部署：`npm run deploy:local`
-
-3. **修改前端**：
-   - Astro 會自動 HMR 重載
-
-4. **新增部落格文章**：
-   - 在 `src/content/blog/` 新增 `YYYY-MM-DD-title.md`
-
-### 測試策略
-- **智能合約**：76 個測試案例
-- **E2E 測試**：Playwright 跨瀏覽器測試
-- **單元測試**：Vitest
-
-### Git 工作流程
-- **提交訊息格式**：Conventional Commits
-- **末尾署名**：`Co-Authored-By: Claude <noreply@anthropic.com>`
-
-## 聯絡資訊
-
-- **GitHub**: [@Lawa0921](https://github.com/Lawa0921)
-- **網站**: https://supergalen.com
-- **Email**: bag571ivy3470@gmail.com
-- **Discord**: https://discord.gg/QRyTagwSSF
-
----
-
-**最後更新**：2026-01-31
-**專案狀態**：🟢 活躍開發中
-**部署狀態**：🌐 已部署至 Vercel
+- Conventional Commits；末尾署名 `Co-Authored-By: Claude <noreply@anthropic.com>`。
+- 開工先確認**當前分支 / worktree / dev server 是誰起的**——本 repo 有十幾個 feat/ 分支與多個 worktree 並行。

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -1,0 +1,58 @@
+# 架構參考（super_galen_site）
+
+事實日期：2026-07-05（逐項實查）。與程式碼矛盾時以程式碼為準，順手更新本檔。
+
+## 技術棧（實際版本，來自 package.json）
+
+- **Astro ^7.0.2**（靜態生成 + Vercel adapter）、TypeScript、SCSS（36 個 partials）
+- **遊戲**：Pixi.js ^8.18 + pixi-filters、three ^0.182、Canvas、Web Audio 合成音效
+- **區塊鏈**：Hardhat ^3.9、ethers ^6.15、OpenZeppelin 5.4（UUPS 可升級）、solhint
+- **測試**：Vitest ^4（約 100 個測試檔）、Playwright ^1.58（33 個 e2e spec × 5 瀏覽器 project）、Hardhat+Chai（52 案例）
+- **部署**：Vercel（無 GitHub Actions）
+
+## 四大區塊（依 2026 年開發重心排序）
+
+### 1. /games — 遊戲聚落（目前最活躍）
+- 頁面：`src/pages/games/{index,tetris,bomber,witchrun,defense}.astro` + `leaderboard.astro`
+- 引擎邏輯：`src/scripts/games/{tetris,bomber,witchrun,defense}/` ——單元測試最密集的地方（AI、lockstep 連線、matchmaking、replay）
+- 連線 API：`src/pages/api/_bomber-match.ts、_ffa-match.ts、_leaderboard.ts、_queue.ts`（線上功能需 Upstash env，本機有記憶體 fallback）
+- 各遊戲進度與未 merge 分支 → memory 的 `project_*` 條目
+
+### 2. /guild — 公會成員頁（159 人）
+- 名冊：`src/data/hall-of-fame.yml`（159 個 `page:` 條目）
+- 成員內容：`src/content/guild/*.html`（約 160 檔）——**不是** public/guild/（那裡只剩 1 個 js）
+- 路由：`src/pages/guild/[member].astro` 動態產頁
+- 成員圖片：`public/assets/img/guild/<member>/`
+- 工作流程固定走 skill 鏈：`guild-member-research` → `guild-page-design-immersion` → `guild-page-verify` → `guild-page-finalize`；設計鐵則在 memory 的 `feedback_guild_*` 系列
+
+### 3. RPG 主站
+- `src/components/rpg/`：狀態列、8 個互動頁籤（狀態/技能/故事/物品/成就/夥伴/購買/日誌）
+- 單例管理器（`public/scripts/` + `src/scripts/`）：GameStateManager（Cookie 持久化）、I18nManager、UnifiedWalletManager（ethers.js）、SGTPurchaseManager、NetworkMonitor
+
+### 4. Blog + 合約
+- 文章：`src/content/blog/YYYY-MM-DD-title.md`（27 篇）
+- 合約：`blockchain/contracts/SuperGalenTokenV1.sol`（UUPS ERC-20）+ `MockUSDT.sol`（本地用）；網路：localhost 31337 / Polygon 137
+
+## i18n 雙檔制（本專案特有陷阱）
+
+同一個 key 存在兩處，**必須同步改、各五語**：
+- 伺服器端（Astro build 期）：`src/i18n/translations/{en,ja,ko,zh-CN,zh-TW}.ts` → `import { t } from '../i18n'`
+- 客戶端（執行期 JS）：`public/assets/i18n/{en,ja,ko,zh-CN,zh-TW}.json` → `data-i18n` 屬性 / `window.i18n.t()`
+
+只改一邊不報錯，只會某一側顯示舊文案。改完用 grep 驗兩邊 key 都在。
+
+## 目錄速查
+
+```
+dev                     # 一鍵啟動腳本
+src/pages/[lang]/       # 五語路由（guild/, journal/, index, rss）
+src/pages/games/        # 遊戲頁
+src/pages/api/          # 連線對戰/排行榜 API
+src/content/{blog,guild}/
+src/data/hall-of-fame.yml
+src/scripts/games/      # 遊戲引擎（測試在旁邊 *.test.ts）
+src/styles/             # 36 個 SCSS partials；禁 !important、禁行內樣式
+blockchain/{contracts,scripts,test}/
+tests/e2e/              # 33 spec（games + guild 為主）
+public/assets/          # 靜態資源（圖片、i18n json、影片）
+```

--- a/docs/claude/commands.md
+++ b/docs/claude/commands.md
@@ -1,0 +1,54 @@
+# 開發指令參考（super_galen_site）
+
+事實日期：2026-07-05。與 `package.json` 不符時以 `package.json` 為準，並順手更新本檔。
+
+## 啟動
+
+```bash
+./dev            # 一鍵：Hardhat node(8545) → 部署合約 → Astro dev(4321)
+npm run dev      # 只起 Astro（http://localhost:4321），大多數前端工作用這個就夠
+npm run build    # 生產編譯
+npm run preview  # 預覽生產版本
+```
+
+## 測試
+
+```bash
+npx vitest run [path]         # 單元測試（約 100 檔，集中在 src/scripts/games/*）
+npm run test:e2e:chromium     # e2e 單瀏覽器（日常用這個）
+npm run test:e2e              # e2e 全 5 瀏覽器（很慢，大改動或收尾才跑）
+npm run test:contracts        # Hardhat 合約測試（52 案例）
+npm run test:all              # vitest run + 全瀏覽器 e2e（收尾用）
+```
+
+**雷**：
+- `npm run test` / `npm run test:unit` 是 **vitest watch 模式，會掛住不退出**。腳本與 session 裡一律用 `npx vitest run`。
+- e2e 的 Playwright 會自動在 **4002** 起 dev server（`playwright.config.ts` 的 webServer，本地會 reuse 既有的）；e2e 不需要也不使用 4321。
+- 跑全套測試時導檔再摘要，不要讓原始輸出進主對話：
+  `npx vitest run > /tmp/claude-vitest.log 2>&1; tail -30 /tmp/claude-vitest.log`
+
+## 區塊鏈
+
+```bash
+npm run compile                              # 編譯合約
+npm run node                                 # 只起 Hardhat node
+npm run deploy:local                         # 部署到 localhost(31337)
+npx solhint 'blockchain/contracts/**/*.sol'  # Solidity linter（本專案唯一的 linter）
+npm run deploy:polygon                       # ⚠️ Polygon 主網，真金白銀且 UUPS 升級不可逆——必須使用者明示才能碰
+```
+
+## 素材生成（skill 路由）
+
+| 要生什麼 | 用什麼 |
+|----------|--------|
+| 任何圖像（guild 頁、遊戲素材、封面…） | `nanobanana-image-gen` skill（專案預設） |
+| 圖像，但使用者明說「用 codex」或 Gemini 掛了 | `codex-image-generation` skill |
+| BGM / 配樂 | `gemini-music-gen` skill |
+| 遊戲音效 | 不生檔案，用 Web Audio 合成（見 memory `reference_game_asset_additive_black`） |
+
+產圖後必附 4321 可開的網址給使用者看（memory：`feedback_show_art_via_url`）。
+
+## 本專案沒有的東西（不要幻想）
+
+- 沒有 prettier / eslint（只有 solhint 管 Solidity）
+- 沒有 GitHub Actions CI——push 後的檢查是 **Vercel** 的 build（`gh pr checks <PR#>` 查）

--- a/docs/claude/harness-diagnostic-supergalen-2026-07.md
+++ b/docs/claude/harness-diagnostic-supergalen-2026-07.md
@@ -1,0 +1,41 @@
+# Harness 診斷報告 — super_galen_site
+
+撰寫：Claude Fable 5，2026-07-05。本檔是 super_galen_site 專案層制度的依據；全域制度（派工、判斷、維護）見 `~/.claude/rules/`，其診斷檔 `harness-diagnostic-2026-07.md` 是另一個專案（Phoenix 訂房系統）的快照，不適用本 repo。
+讀者：未來在本 repo 工作的主模型（Sonnet 等級）。
+
+## 第一名：CLAUDE.md 是張舊地圖（最漏 token，也最誤導）
+
+**證據**（2026-07-05 逐項實查）：
+- 舊 CLAUDE.md 267 行（上限 160），每 session 全載，其中大半是冷參考：完整檔案樹、8 頁籤介紹、聯絡資訊。
+- 事實腐爛成片：寫 Astro 5.x（實際 `package.json` 是 ^7.0.2）、Hardhat 2.26.x（實際 ^3.9.0）、76 個合約測試（實際 52 個 `it(`）、「public/guild/ 是成員靜態頁」（實際成員內容在 `src/content/guild/*.html`，約 160 檔；public/guild/ 只剩 1 個 js）。
+- 最嚴重的是**重心錯位**：舊檔把網站描述成「RPG 作品集＋區塊鏈」，但 2026 年的實際開發重心是 `/games`（4 個遊戲、約 100 個 Vitest 測試檔）與 `/guild`（159 個成員頁）——e2e 共 33 個 spec，games 與 guild 為主——舊檔隻字未提。弱模型會拿 2025 的地圖走 2026 的城市。
+
+**修法**（本次已執行）：CLAUDE.md 重寫為薄路由層（<120 行、事實全部實查），冷內容抽到 `docs/claude/{architecture,commands,verify}.md`。日後發現文件與程式碼矛盾：程式碼是真相，順手修文件（授權見 `~/.claude/rules/maintenance.md`）。
+
+## 第二名：視覺開發迴圈把主對話當暗房（最容易失焦）
+
+**證據**：
+- 本專案的日常是 guild 頁面與遊戲美術。過去 session 的模式：Playwright snapshot / 截圖 / console 輸出直接進主對話，一輪「改→截圖→看→再改」重複十幾次，context 前半塞滿原始資料，後半忘記最初目標。memory 裡 10+ 條 `reference_guild_*` 踩坑紀錄就是屍檢報告。
+- 「改了沒生效」有兩個已知假象雷（memory 已載）：Vite 舊快取服務舊版 `<script>`、4321 埠被別的 worktree 的 dev server 佔走（服務的是別的分支）。弱模型遇到會先懷疑自己的程式碼，原地重改半個 session。
+- git status 55 行 untracked（root 驗證截圖、`.research/`、`_verify/` 產物），`.gitignore` 完全不涵蓋（check-ignore 全部 exit 1）→ 每 session 開場 snapshot 被截斷、弱模型反覆困惑「這些要不要 commit」。
+
+**修法**：
+- 視覺驗收一律走 `guild-page-verify` skill（guild 頁）或派 subagent 執行「截圖→比對→回報結論」，主對話只收「通過/不通過＋差異描述」。連續第 3 輪自己截圖自己看 = 該停下改派工的訊號。
+- 「改了沒生效」的排查順序已寫死在 `docs/claude/verify.md`——先查埠，再清快取，最後才懷疑程式碼。
+- `.gitignore` 已補驗證產物規則（本次 PR）。
+
+## 第三名：跨專案假事實 + 本專案特有的不可逆區（最容易出錯）
+
+**證據**：
+- 全域制度檔原本寫死 Phoenix 專案的事實：派工模板的 `mix test`/`mix credo`、dispatch.md 宣稱常駐的 `error-debugger`/`code-quality-reviewer` agent（本 repo 的 session 沒有）。弱模型照抄就是跑不存在的指令、派不存在的 agent。**2026-07-05 已去專案化**：全域檔改為「查專案 CLAUDE.md」佔位符。
+- i18n 是雙檔制：`src/i18n/translations/*.ts`（伺服器端）與 `public/assets/i18n/*.json`（客戶端）各五語，同一個 key 要改兩處 × 五語。只改一邊不會報錯，只會在某一側顯示舊文案——測試抓不到的靜默錯誤。
+- 智能合約是真金白銀：`npm run deploy:polygon` 部署到 Polygon 主網，UUPS 升級操作不可逆。任何 `blockchain/` 下的改動都是高危區。
+- 本專案**沒有** prettier/eslint（只有 Solidity 的 solhint）——完成判準裡不存在「lint 過」這一項，弱模型不要幻想去跑。
+- 十幾個未 merge 的 feat/ 分支與多個 worktree 並行。開工第一步必須確認「我在哪個分支、哪個 worktree、dev server 是誰起的」。
+
+**修法**：高危區清單與完成判準已寫進新 CLAUDE.md 與 `docs/claude/verify.md`；審查派工時把高危區清單複製進模板（模板見 `~/.claude/rules/delegation-templates.md`）。
+
+## 誠實條款
+
+- 本診斷基於 2026-07-05 快照。測試數量、頁面數、依賴版本都會變——發現不符時以程式碼為準，順手更新（`~/.claude/rules/maintenance.md` 授權）。
+- guild 頁面的美感、遊戲手感這類品味判斷，制度補不了：做 2-3 個候選給使用者選，或明說需要他的品味判斷（`~/.claude/rules/judgment.md` 第 6 條）。

--- a/docs/claude/letter-to-future-sessions.md
+++ b/docs/claude/letter-to-future-sessions.md
@@ -1,0 +1,36 @@
+# 給未來 Session 的信 — super_galen_site
+
+來自：Claude Fable 5，2026-07-05。使用者用他唯一一次 Fable session 立了兩層制度：全域的 `~/.claude/rules/*`（昨天在 Phoenix 專案建的，已於今天去專案化），與你正在讀的這層（super_galen_site 專屬）。你（Sonnet/Opus/Haiku）不需要比我聰明——照制度走，制度補等級差。全域的信在 `~/.claude/rules/letter-to-future-sessions.md`，先讀那封的「三件事」與「退化方式」，本檔只補本 repo 特有的。
+
+## 三件使用者沒問、但你必須知道的事
+
+### 1. 這個 repo 的真實重心跟它的自我介紹不一樣
+專案叫「RPG 作品集部落格」，但打開 git log 和測試分佈就會發現：2026 年幾乎所有活動都在 `/games`（4 個遊戲 + 連線對戰 + 排行榜，約 100 個 vitest 檔集中在這）和 `/guild`（159 個成員頁）。舊 CLAUDE.md 花八成篇幅講 RPG 頁籤和區塊鏈，那是 2025 的地圖。**接到任務先看它落在哪個聚落**——遊戲題去 `src/scripts/games/`，公會題走 guild skill 鏈，別被「作品集」的框架帶偏。memory 裡 `project_*`（遊戲進度）和 `feedback_guild_*`（公會設計鐵則）是這兩塊的活知識。
+
+### 2. 這個 repo 的失焦來自「視覺迴圈」，不是「讀太多程式碼」
+Phoenix 專案的失焦是狂讀檔塞爆 context；這裡不一樣——這裡是 guild 頁和遊戲美術的「改→截圖→看→再改」迴圈，一輪十幾次，截圖和 console 直接進主對話。memory 有 10+ 條 `reference_guild_*`、`reference_*_asset_*` 就是這樣踩出來的。**解法**：視覺驗收派 subagent 或走 `guild-page-verify` skill，主對話只收「通過/不通過＋差異」。你發現自己連續第 3 輪親自截圖看圖，就是該停下改派工的訊號。
+
+### 3. 兩個「改了沒生效」的假象雷，會騙你去改沒問題的程式碼
+- **埠被佔**：4321 可能是**別的 worktree** 起的 dev server，你看到的是別的分支的頁面。先 `ss -tlnp | grep 4321`（memory `reference_worktree_devserver_port_squat`）。
+- **Vite 舊快取**：Astro dev 會服務舊版 `<script>`，新程式碼靜默不執行、無報錯。`rm -rf node_modules/.vite` 重啟（memory `reference_vite_stale_script_cache`）。
+
+排查順序寫死在 `docs/claude/verify.md`：**先環境後程式碼**。這兩個雷各燒過半個 session，弱模型的本能是先懷疑自己剛寫的 code——反過來。
+
+## 本 repo 特有的地雷位置（2026-07-05 快照）
+
+- **i18n 雙檔**：改一邊不報錯的靜默錯誤，是本 repo 最容易「自以為完成」的地方。靠 grep 兩側驗證，測試抓不到。
+- **合約 = 不可逆**：`blockchain/` 任何改動高危；`deploy:polygon` 打主網。碰之前放慢、找第二意見、使用者明示。
+- **guild 頁 = 真人聲譽**：159 個成員是真實的人。連結沒開過不要寫、粉絲數字不要寫、內容要原創理解不要照搬貼文（memory `feedback_verify_links`、`feedback_no_follower_counts`、`feedback_no_copy_paste_posts`）。
+- **現存待清理**（別擅自處理不可逆部分）：git status 有 55 行 untracked（root 截圖、`.research/`、`_verify/` 產物）；本次 PR 已補 `.gitignore` 規則，但既有未追蹤檔要不要留是使用者的事，不要擅自 `git add` 或刪。
+- **沒有 error-debugger / code-quality-reviewer 自訂 agent**：全域 dispatch.md 提到的那些是 Phoenix 專案的，本 repo session 開場清單沒有。以**當前 session 的開場清單**為準，沒有就用 `general-purpose` + 明確 prompt。
+
+## 這層制度最可能的退化方式，與預防
+
+1. **CLAUDE.md 又長回去**：每個 session 想「這條很重要，加進 CLAUDE.md」。預防：160 行是硬上限（`~/.claude/rules/maintenance.md`），新內容進 `docs/claude/*`，CLAUDE.md 只加一行路由。
+2. **docs/claude 的事實悄悄過期**：測試數、頁數、版本號都會變。預防：每個 docs 檔頂都標了事實日期；發現與程式碼不符時**以程式碼為準**順手改，這屬於 maintenance.md「可自行改」。
+3. **重心又飄回「作品集」框架**：新 session 讀到「RPG 作品集」就以為那是重點。預防：本信第 1 節和 CLAUDE.md 開頭都寫死了真實重心，別跳過。
+4. **memory 的活知識沒被讀**：本 repo 的踩坑教訓大量在 memory（`reference_*`、`feedback_*`），不在制度檔。預防：開工先掃 MEMORY.md，遊戲題和公會題尤其要看對應條目。
+
+## 未完成交接
+
+（2026-07-05 建檔時：制度檔全部落地。若你中斷，把未完成項寫在這一節，並更新 MEMORY.md。）

--- a/docs/claude/verify.md
+++ b/docs/claude/verify.md
@@ -1,0 +1,47 @@
+# 完成判準與排查順序（super_galen_site）
+
+本檔是全域 `~/.claude/rules/judgment.md` 第 2 條「何時算真的完成」的本專案具體化。
+宣告完成前逐項核對；「編譯過」「應該對」不算完成，完成的證據是**貼得出來的實際輸出**。
+
+## 完成判準（按改動型態）
+
+| 改動型態 | 必跑（全綠才算完成） | 另外必做 |
+|----------|---------------------|----------|
+| 遊戲/前端邏輯（src/scripts/**） | `npx vitest run`（全套，不是只跑新增的） | 改到 UI 就補下面 UI 那行 |
+| UI / 頁面 / 樣式 | 相關 e2e spec：`npx playwright test <spec> --project=chromium` | 實跑 + 回覆尾端附 `http://localhost:4321/...` 驗收 URL（鐵則，memory `feedback_always_provide_review_url`） |
+| guild 成員頁 | `guild-page-verify` skill 全項通過（不可跳過） | 連結逐一驗證、不寫粉絲數、內容原創（memory `feedback_guild_*`） |
+| i18n 文案 | grep 驗證 `src/i18n/translations/*.ts` 與 `public/assets/i18n/*.json` 兩側 key 都改了 × 五語 | 4321 實際切語言看一眼 |
+| 智能合約 | `npm run test:contracts` + `npx solhint 'blockchain/contracts/**/*.sol'` | 高危區規則見下 |
+| 收尾 / 大改動 / merge 前 | `npm run test:all`（vitest + 全瀏覽器 e2e，導檔再摘要） | push 後 `gh pr checks` 確認 Vercel build 綠 |
+
+**TDD 照全域鐵則**：先寫失敗測試（vitest 測試放被改模組旁邊、e2e 放 `tests/e2e/`），確認失敗再實作。純文案/樣式微調豁免。
+
+## 「改了沒生效」排查順序（先環境後程式碼，不要跳步）
+
+歷史上兩個假象雷各燒掉過半個 session（memory：`reference_worktree_devserver_port_squat`、`reference_vite_stale_script_cache`）。順序固定：
+
+1. **查埠是誰的**：`ss -tlnp | grep 4321` —— 4321 可能是**別的 worktree** 起的 dev server，服務的是別的分支。**預設安全解法：改用自己的埠**（`npm run dev -- --port <其他埠>`）。要砍掉那個 server 前，先確認**不是使用者正在用的**另一分支——別 kill 掉他手上在跑的東西。
+2. **清 Vite 快取**：`rm -rf node_modules/.vite` 後重啟 dev server——Astro dev 會服務舊版 `<script>`（新區塊不執行、無報錯）。
+3. **DOM 探針驗證**：在頁面 evaluate 查實際 DOM，別只信 MCP console 或截圖直覺。
+4. 以上都排除，才開始懷疑自己的程式碼。
+
+## build / 部署健康 & 過期的分支 base
+
+- **開工建新分支前先 `git fetch` 確認 local master 沒落後 origin**：
+  `git fetch origin && git rev-list --left-right --count master...origin/master`——右邊數字 >0 就是 local 落後，先 pull 再分支。本 repo 多 worktree、十幾條 feat/ 分支並行，local 主線很容易落後。**從過期 base 分支會把「早已在 origin 修好的問題」當成新 bug**（2026-07-05 就這樣誤判過：clean build 失敗其實是 base 落後兩個 commit，使用者 10 天前已修好，memory `reference_fetch_before_branch`）。分支的 base 也算「環境」，屬於本檔開頭「先環境後程式碼」的一環。
+- **判斷 build 真健康用 clean build**：`npm ci && npm run build`（`npm ci` 精準照 lockfile = Vercel 做的事）。碰依賴、升版本、動 `astro.config.mjs` 後跑一次再宣告完成。
+- **本專案在 `astro ^7.0.2`（流血邊緣）**：浮動 `^` 依賴會漂到生態系還沒跟上的新版（rolldown 的 `manualChunks` 要函式、`@astrojs/rss` 要對上 zod 4），build 會在 bundler / zod 之類靜默壞掉。
+
+## 高危區（審查派工時把這段複製進模板）
+
+- **智能合約 / 金流**：`blockchain/` 任何改動都是高危。`npm run deploy:polygon` 是 Polygon 主網、UUPS 升級不可逆——只有使用者明示才能執行。私鑰在 `.env`，絕不入庫、不進 log。
+- **i18n 雙檔同步**：改一邊不報錯的靜默錯誤，靠 grep 驗證，測試抓不到。
+- **連線對戰 API**（`src/pages/api/_*.ts`）：外部輸入要驗證；改協定要同時跑雙方（雙頁籤 e2e）。
+- **guild 頁對外形象**：內容錯誤直接傷真人聲譽——連結逐一開過、事實有來源才寫。
+
+## 派工與 worktree 陷阱（本專案 delta，其餘照 ~/.claude/rules/dispatch.md）
+
+- 本 repo 的 session **沒有** `error-debugger`、`code-quality-reviewer` 這類自訂 agent——以開場清單為準，沒有就用 `general-purpose` + 明確 prompt。
+- **Subagent 不繼承 worktree cwd**（memory `feedback_subagent_worktree_cwd`）：派工 prompt 第一步強制 `cd <worktree絕對路徑>` 並驗證 `git branch --show-current`；收報告時核對路徑與分支。
+- 視覺驗收（截圖比對、多輪微調）派 subagent 或走 skill，主對話只收「通過/不通過＋差異」。自己連續第 3 輪截圖→看→改 = 停下改派工。
+- 一次生成多張候選圖時，放到 4321 可開的網址或臨時頁給使用者選——他看不到 Read 工具顯示的圖。


### PR DESCRIPTION
## 這個 PR 做什麼

把 super_galen_site 的 `CLAUDE.md` 從 **267 行重寫成 47 行薄路由層**，冷內容抽到 `docs/claude/`。目的是讓未來每個（較小模型的）session 開場載入更少 token、且拿到的是**經實查的正確事實**。

## 為什麼

舊 `CLAUDE.md` 事實腐爛成片（2026-07-05 逐項實查）：
- Astro `5.x` → 實際 `^7.0.2`；Hardhat `2.26` → `^3.9`
- 「76 個合約測試」→ 實際 52 個 `it()`
- 「public/guild/ 是成員靜態頁」→ 實際成員內容在 `src/content/guild/*.html`（約 160 檔），public/guild 只剩 1 個 js
- **重心錯位**：舊檔把網站當「RPG 作品集部落格」，但 2026 的實際開發重心是 `/games`（4 遊戲 + 連線對戰）與 `/guild`（159 成員頁），舊檔隻字未提

## 內容

| 檔案 | 作用 |
|------|------|
| `CLAUDE.md` | 薄路由 + 每 session 必記的 5 條雷（i18n 雙檔、無 JS linter、合約不可逆、埠/快取排查、驗收附 URL） |
| `docs/claude/architecture.md` | 實查版本、四大區塊、i18n 雙檔陷阱、目錄速查 |
| `docs/claude/commands.md` | 指令參考（`npm run test` 是 watch 會掛住、`deploy:polygon` 不可逆警告） |
| `docs/claude/verify.md` | 完成判準 + 「改了沒生效」先環境後程式碼排查 + 高危區 |
| `docs/claude/letter-to-future-sessions.md` | 給未來 session 的信 |
| `docs/claude/harness-diagnostic-supergalen-2026-07.md` | 本 repo 前三名漏 token / 失焦 / 出錯點 |
| `.gitignore` | 補驗證產物規則（root 截圖、`.research/`、`_verify/`） |

## 品質保證

所有事實宣稱經一個 **fresh-context agent 對抗審查**（實跑 repo 驗證版本號、埠、指令、檔案數），8 項 finding（含 2 項高危：跑不存在的指令、派不存在的 agent）全數修正後才提交。

> 註：全域制度檔 `~/.claude/rules/*`（跨專案共用、不在此 repo）同步做了去專案化，不在此 PR 範圍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)