### PR TITLE
fix(deploy): CDN 快取修正——未 hash 腳本不再 immutable、版本參數繞過 stale 快取

### DIFF
--- a/src/components/layout/GlobalScripts.astro
+++ b/src/components/layout/GlobalScripts.astro
@@ -29,7 +29,7 @@
 <script src="/scripts/debug-utils.js" defer></script>
 
 <!-- i18n 管理器 -->
-<script src="/scripts/i18n-manager.js" defer></script>
+<script src="/scripts/i18n-manager.js?v=20260718" defer></script>
 
 <!-- i18n 輔助函數 -->
 <script src="/scripts/i18n-helper.js" defer></script>
@@ -79,7 +79,7 @@
 <script src="/scripts/arcade-transition.js" defer></script>
 
 <!-- 主要 JavaScript -->
-<script src="/scripts/main.js" defer></script>
+<script src="/scripts/main.js?v=20260718" defer></script>
 <script src="/scripts/cheat.js" defer></script>
 
 <!-- Tab 特定模組將由 LazyLoader 動態載入 -->

--- a/src/components/layout/GlobalScriptsMinimal.astro
+++ b/src/components/layout/GlobalScriptsMinimal.astro
@@ -20,7 +20,7 @@
 <script src="/scripts/lazy-loader.js?v=2" defer></script>
 
 <!-- i18n 管理器與輔助函數 -->
-<script src="/scripts/i18n-manager.js" defer></script>
+<script src="/scripts/i18n-manager.js?v=20260718" defer></script>
 <script src="/scripts/i18n-helper.js" defer></script>
 
 <!-- 合約配置（內嵌預設值） -->
@@ -53,4 +53,4 @@
 <script src="/scripts/advanced-animations.js" defer></script>
 
 <!-- 主要 JavaScript（theme toggle、header 錢包事件、外部連結） -->
-<script src="/scripts/main.js" defer></script>
+<script src="/scripts/main.js?v=20260718" defer></script>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1204,7 +1204,7 @@ const attributes = [
 <script src="/scripts/gamestate.js" defer></script>
 
 <!-- i18n 管理器 -->
-<script src="/scripts/i18n-manager.js" defer></script>
+<script src="/scripts/i18n-manager.js?v=20260718" defer></script>
 <script src="/scripts/i18n-helper.js" defer></script>
 
 <!-- 技能樹系統 -->
@@ -1227,7 +1227,7 @@ const attributes = [
 <script src="/scripts/debug-utils.js" defer></script>
 <script src="/scripts/lazy-loader.js?v=2" defer></script>
 <script src="/scripts/mobile-menu.js" defer></script>
-<script src="/scripts/main.js" defer></script>
+<script src="/scripts/main.js?v=20260718" defer></script>
 
 <!-- Web3 系統：錢包、網路監控（購買面板腳本由 LazyLoader 按需載入） -->
 <script src="/scripts/contracts-config.js" defer></script>

--- a/vercel.json
+++ b/vercel.json
@@ -39,6 +39,24 @@
           "value": "public, max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/scripts/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/assets/i18n/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
生產環境實查（詳見 commit message）：Cloudflare 依 vercel.json 的 immutable header 把未 hash 的 /scripts/*.js 凍結，實測 supergalen.com 新部署九天後仍服務舊版 i18n-manager.js/main.js（age: 787528）。本 PR 修 header 策略 + 對受影響腳本做 URL 版本升級，讓 #176/#178 的修復真正抵達使用者。

驗證：本機 build 綠、perf-static e2e 8/8 綠、vercel.json JSON 格式驗證過。合併後將以 curl 實測生產環境 header 與腳本內容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)