### PR TITLE
feat(caravan): M3 遠征事件鏈＋迷宮——探索玩法核心

### DIFF
--- a/docs/superpowers/plans/2026-07-18-caravan-m3-expedition.md
+++ b/docs/superpowers/plans/2026-07-18-caravan-m3-expedition.md
@@ -1,0 +1,170 @@
+# 《商隊與劍》M3：遠征事件鏈＋迷宮 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓玩家能真正出遠征：委託板選目標（貿易路線／迷宮）→ 事件卡鏈（敘事＋擲骰）→ 戰鬥遭遇（接 M2 引擎＋戰利品＋傷亡寫回）→ 迷宮逐層房卡 → 歸返結算。含探索深度機制：隱藏地點發現、事件旗標鏈、迷宮分歧。
+
+**Architecture:** `expedition.ts` 為遠征狀態機（純函式＋注入 Rng），事件卡/迷宮/物品全資料檔；存檔升 v3（背包＋遠征快照＋傷癒趟數）；UI 沿 M2 模式讀狀態渲染。
+
+**Tech Stack:** TypeScript、vitest、Playwright、DOM。
+
+## Global Constraints
+
+- 隨機只經注入 `Rng`；禁 `Math.random()`。繁中敘事。
+- 檢定用 `resolveCheck`（nat1/nat20 規則）；戰鬥用 M2 `combat.ts` 全套。
+- 存檔遷移不清檔（v2→v3）；毀損回 null；`parseAndMigrate` 路徑不變。
+- **M2 終審移交必修（Task 1 完成，否則敵方 support 招上線即 bug）**：`enemyAct` 依 `move.kind/target` 選目標（attack→hp 最低存活隊員；support/heal→hp 損最重的存活敵方同伴）；`attemptRetreat` 殿後攻擊改選敵人的**第一個 attack 招**（無攻擊招則不攻擊，僅記 log）。
+- 事件卡 schema 照規格 §3.2（context/weight/conditions/options/check/success/failure Effect 清單）。
+- Effect DSL 種類（M3 鎖定）：`{type:'gold',amount}`／`{type:'item',itemId,count}`（負數=失去）／`{type:'hp',target:'protagonist'|'party',amount}`／`{type:'flag',flag,value}`／`{type:'fight',encounterId}`／`{type:'discover',locationId}`（探索：解鎖隱藏地點）／`{type:'log',text}`。
+- 測試 `npx vitest run <path>`；e2e `npx playwright test tests/e2e/caravan.spec.ts --project=chromium --workers=1`。
+- Conventional Commits＋`Co-Authored-By: Claude <noreply@anthropic.com>`。
+
+## File Structure（M3 鎖定）
+
+```
+src/scripts/games/caravan/
+├── combat.ts / combat.test.ts       # modify：M2 移交必修＋EnemyUnit.loot
+├── expedition.ts / expedition.test.ts  # create：遠征狀態機＋事件結算＋迷宮
+├── save.ts / save.test.ts           # modify：v3（inventory/expedition 快照/injuredForTrips 結算）
+├── data/items.ts                    # create：物品表（M3 約 12 種）
+├── data/events.ts                   # create：事件卡（M3 首批 15 張，含旗標鏈與 discover）
+├── data/locations.ts                # create：路線 2 條＋迷宮 1 座（房卡表、深度係數、boss）＋隱藏地點 1 處
+├── data/enemies.ts                  # modify：擴充（狼群/盜匪/迷宮敵＋boss，含 loot 與 support 招示範）
+src/pages/games/caravan.astro        # modify：委託板/遠征畫面/擲骰結果/歸返結算
+tests/e2e/caravan.spec.ts            # modify：遠征全流程案例
+```
+
+## 介面契約（跨任務鎖定，簽名照抄）
+
+```ts
+// expedition.ts
+export type EffectSpec =
+  | { type: 'gold'; amount: number }
+  | { type: 'item'; itemId: string; count: number }
+  | { type: 'hp'; target: 'protagonist' | 'party'; amount: number }
+  | { type: 'flag'; flag: string; value: boolean }
+  | { type: 'fight'; encounterId: string }
+  | { type: 'discover'; locationId: string }
+  | { type: 'log'; text: string };
+
+export interface EventOption {
+  label: string;
+  requirement?: { job?: JobId; itemId?: string };
+  check?: { stat: Stat; dc: number };
+  success: EffectSpec[];
+  failure?: EffectSpec[];
+}
+export interface EventCard {
+  id: string;
+  context: { locationIds?: string[]; kind?: 'route' | 'dungeon' };
+  weight: number;
+  requiresFlags?: Record<string, boolean>;
+  title: string; body: string;
+  options: EventOption[];
+}
+export type RoomKind = 'fight' | 'treasure' | 'event' | 'rest' | 'unknown';
+export interface LocationDef {
+  id: string; name: string; kind: 'route' | 'dungeon';
+  hidden?: boolean;                       // 需 discover 才會出現在委託板
+  legs?: number;                          // route：事件數
+  floors?: number; roomsPerFloor?: [number, number]; bossEncounterId?: string; // dungeon
+  encounterTable: Array<{ weight: number; encounterId: string }>;
+  depthHpBonus?: number;                  // dungeon：每層敵人 maxHp 加值
+}
+export interface ExpeditionState {
+  locationId: string; kind: 'route' | 'dungeon';
+  step: number;                           // route: 第幾段；dungeon: 第幾層
+  totalSteps: number;
+  phase: 'event' | 'room-choice' | 'combat' | 'aftermath' | 'done';
+  currentEventId: string | null;
+  roomChoices: RoomKind[] | null;         // dungeon 每層抽出的房卡
+  pendingEncounterId: string | null;
+  loot: { gold: number; items: Record<string, number> };
+  eventLog: string[];                     // 遠征日誌（歸返結算顯示）
+  retreated: boolean;
+}
+export function startExpedition(rng: Rng, save: SaveData, locationId: string): ExpeditionState;
+export function drawEvent(rng: Rng, state: ExpeditionState, save: SaveData): EventCard;         // 過濾 context/requiresFlags 後加權抽；設 currentEventId
+export function availableOptions(option 過濾): EventOption[] 不需要——UI 端以 requirement 判斷 disabled；
+export function optionAvailable(save: SaveData, opt: EventOption): boolean;                     // job 在隊上？item 在包內？
+export function resolveOption(rng: Rng, state: ExpeditionState, save: SaveData, card: EventCard, optIndex: number):
+  { check: CheckResult | null; effects: EffectSpec[] };   // 擲骰（用主角對應屬性）、套 effects（fight 設 pendingEncounterId+phase='combat'；其餘立即入 loot/save）、推進 phase/step
+export function drawRooms(rng: Rng, state: ExpeditionState): RoomKind[];                        // dungeon 每層 2-3 張；boss 層固定 ['fight']
+export function chooseRoom(rng: Rng, state: ExpeditionState, save: SaveData, room: RoomKind):
+  { event?: EventCard; encounterId?: string; restHealed?: number; treasureGold?: number };      // 依房型分派
+export function buildEncounter(rng: Rng, state: ExpeditionState, encounterId: string): EnemyUnit[]; // 查表生成敵人並套深度加成
+export function finishCombat(state: ExpeditionState, save: SaveData, combat: CombatState,
+  fates: Array<{ id: string; fate: 'injured' | 'dead' }>): void;   // victory→敵 loot 入 state.loot、continue；retreated→retreated=true 掉一半金幣戰利品、跳到 aftermath；defeat→retreated 同等處理＋全隊傷亡已由 fates 呈現；套 fates 到 save（injuredForTrips=2/移除死亡傭兵——主角除外）
+export function advanceExpedition(rng: Rng, state: ExpeditionState): void;  // step+1；超過 totalSteps→phase='done'；dungeon 未到頂層→'room-choice'；route→'event'
+export function settleExpedition(state: ExpeditionState, save: SaveData): { goldGained: number; itemsGained: Record<string, number>; xpGained: number };
+  // loot 入 save.gold/inventory；每存活出征者 xp += 20 + step*5；injuredForTrips>0 的隊員 -1；自動 saveGame 由 UI 呼叫
+```
+
+`data/items.ts`：`export interface ItemDef { id: string; name: string; desc: string; value: number }`＋`export const ITEMS: Record<string, ItemDef>`。
+`data/locations.ts`：`export const LOCATIONS: Record<string, LocationDef>`＋`export function visibleLocations(save: SaveData): LocationDef[]`（hidden 未 discover 的不回傳；discover 旗標格式 `discovered:<locationId>` 存 save.flags）。
+`data/enemies.ts` 追加：`export const ENCOUNTERS: Record<string, () => EnemyUnit[]>`（M2 的 TRAINING_ENCOUNTER 保留）；`EnemyUnit` 增 `loot?: { gold: [number, number]; itemId?: string; itemChance?: number }`（combat.ts 型別上加、finishCombat 消費：gold 區間內 rng 均勻取整）。
+存檔 v3：`SaveDataV3 = v2 + { inventory: Record<string, number>; expedition: ExpeditionState | null }`；`MIGRATIONS[2]` 補 `inventory:{}` 與 `expedition:null`；`newGame` 產 v3；shape 驗證加這兩欄。
+
+## 內容要求（Task 4 資料檔，繁中原創、風格：簡潔有畫面感）
+
+- 事件 15 張：路線通用 8（含 2 張旗標鏈：`ev_merchant_map` 成功設 `clue:goblin-cave` → `ev_cave_entrance` requiresFlags 該旗標、成功 `discover` 隱藏迷宮）、森林路線限定 3、迷宮限定 4（含 rest/unknown 房抽到的）
+- 地點：路線「臨水道」（legs 4，狼/盜匪表）、「黑森林徑」（legs 5，狼/哥布林表）；迷宮「廢棄礦坑」（floors 4、每層 2-3 房、boss `enc_mine_overseer`、depthHpBonus 2）；隱藏迷宮「哥布林巢穴」（hidden，floors 3，由旗標鏈 discover）
+- 敵人：狼、盜匪×2 種（一含治療師——**驗證 enemyAct support 修繕**）、礦坑蜘蛛、監工 boss、巢穴頭目；全部帶 loot
+- 物品 12 種：藥草（事件可用 requirement）、繃帶、火把、哥布林耳環（賣錢）、礦石、蛛絲、boss 遺寶×2、雜項
+
+## Task 1: M2 移交必修＋戰利品欄位（combat.ts）
+
+**Files:** Modify combat.ts / combat.test.ts
+**要點（TDD，先寫失敗測試）：**
+- `EnemyUnit` 加 `loot?: { gold: [number, number]; itemId?: string; itemChance?: number }`（純型別，無行為測試）
+- `enemyAct`：意圖招式 `kind==='support'&&heal` → 目標＝敵方存活同伴中 `maxHp-hp` 最大者（含自己）；attack → 現行 hp 最低存活隊員。測試：敵治療師預告 heal → 治到受傷同伴而非玩家。
+- `attemptRetreat`：殿後攻擊改用 `aliveEnemy.moves.find(m => m.kind === 'attack')`；全無攻擊招→不攻擊只記 log。測試：敵只有 heal 招時撤退不受傷。
+- Commit：`fix(caravan): enemyAct 依招式類型選目標＋撤退攻擊選攻擊招（M2 終審移交）`
+
+## Task 2: expedition.ts 核心——事件抽選/選項結算/Effect DSL
+
+**Files:** Create expedition.ts / expedition.test.ts；Modify save.ts / save.test.ts（v3）
+**要點（TDD）：**
+- 先做存檔 v3（遷移＋newGame＋shape；測試：v2 檔遷移補 inventory/expedition、v1 直通 v3）
+- `startExpedition`/`drawEvent`（context/requiresFlags 過濾＋加權；測試用 2-3 張假卡驗過濾與 weight=0 排除）
+- `optionAvailable`（job 在隊上（主角+未重傷傭兵）/item 持有）
+- `resolveOption`：無 check 直接 success；有 check 用主角屬性 resolveCheck；套 EffectSpec 每一種（gold 疊 loot、item 進 loot.items 負數扣 save.inventory、hp 傷主角或全隊（不低於 1——遠征事件不打死人，戰鬥才會）、flag 寫 save.flags、fight 設 pending+phase、discover 寫 `discovered:<id>` 旗標＋eventLog、log 進 eventLog）；結算後非 fight→advanceExpedition
+- `advanceExpedition`/`settleExpedition`（xp 公式、傷癒趟數 -1、loot 入包、expedition 清 null）
+- 測試全種子化；至少 20 案例
+- Commit：`feat(caravan): 遠征狀態機——事件抽選/選項結算/Effect DSL/存檔 v3（M3）`
+
+## Task 3: 迷宮與戰鬥整合
+
+**Files:** Modify expedition.ts / expedition.test.ts / combat.ts（若需）
+**要點（TDD）：**
+- `drawRooms`（每層 rng 取 2-3 張、種類加權 fight40/treasure20/event20/rest10/unknown10；頂層 `['fight']` boss；unknown 進場時 rng 二選一實際化為 fight 或 treasure——探索的驚喜感）
+- `chooseRoom`：fight→encounterId（樓層表）、treasure→gold 骰＋機率物品、rest→全隊回 1d6+2（不超過 max）、event→抽 dungeon context 事件
+- `buildEncounter`：查 ENCOUNTERS＋depthHpBonus×(step-1) 套到 maxHp/hp
+- `finishCombat`：victory loot（每敵 gold 區間骰＋itemChance）、retreated/defeat 掉一半 loot 金幣（向下取整）、fates 套 save（傭兵 dead 從 companions 移除、injured 設 injuredForTrips=2；主角 injured 設 2——但主角不移除）
+- 測試：boss 層、深度加成數學、撤退折損、傭兵死亡移除
+- Commit：`feat(caravan): 迷宮房卡/深度加成/戰鬥結算整合（M3）`
+
+## Task 4: 內容資料檔
+
+**Files:** Create data/items.ts、data/events.ts、data/locations.ts；Modify data/enemies.ts
+**要點：** 照「內容要求」節；schema 正確性用 vitest 驗（新 data.test.ts：所有 encounterId/itemId/locationId 引用存在、事件 options 至少 1、weight>0、旗標鏈兩端對得上——**資料完整性測試**，防手滑）；敘事品質自審（每張卡讀起來像規格 §1 的示例語感）。
+- Commit：`feat(caravan): M3 首批內容——15 事件/2 路線/2 迷宮/12 物品/敵人擴充（M3）`
+
+## Task 5: UI 與 e2e 全流程
+
+**Files:** Modify src/pages/games/caravan.astro、tests/e2e/caravan.spec.ts
+**DOM 合約：** 城鎮加 `#btn-quest-board`；`#screen-quest`（`.quest-item[data-location-id]` 每地點一項＋`.quest-hidden-hint` 若有未發現地點顯示「？」）；`#screen-expedition`（`#exp-progress`「第 x/y 段」、`#event-card`>`#event-title`/`#event-body`、`#event-options .event-opt[data-opt-index]`（不可用加 `disabled`）、`#check-result`（骰面/總值/成敗，動畫 0.6s 內完成即可）、`#room-choices .room-btn[data-room]`、`#btn-exp-continue`）；戰鬥沿 M2 `#screen-combat`（多敵時 `#combat-targets .target-btn[data-target-id]` 啟用——M2 預留）；`#screen-settlement`（`#settle-gold`/`#settle-items`/`#settle-xp`/`#settle-log`、`#btn-settle-back`）。
+**流程：** 委託板列 `visibleLocations`；遠征各 phase 對應畫面；戰鬥結束呼 `finishCombat`＋`resolveCasualties`；`settleExpedition` 後 saveGame＋回城鎮（酒館補位 M4，本里程碑傭兵死了就是少人）；**每次事件結算後 saveGame（規格：每事件自動存）**；重整頁面若 save.expedition 非 null →「繼續遠征」回到當前 phase（combat 中途重整=回到該步 phase 前狀態，可接受）。
+**e2e（追加 describe，seed 選定原則：Task 5 實作者先用腳本掃出「臨水道第一事件為特定卡且首選項成功」的 seed，斷言確定性）：** (1) 委託板顯示 2 條路線＋隱藏提示；(2) 出遠征走完 4 段（含至少一次擲骰結果顯示）到結算畫面、金幣寫回城鎮顯示；(3) 遠征中重整→繼續遠征回到同段；(4) 迷宮：進礦坑選房卡（treasure 房拿金幣）、撤退回結算。
+- Commit：`feat(caravan): 遠征/迷宮/結算 UI 與全流程 e2e（M3）`
+
+## M3 完成判準
+
+- `npx vitest run` 全套綠（caravan ≥90）；e2e caravan spec 全綠（≥12 案例）
+- 實跑：完整走一遍 路線遠征→事件→戰鬥→歸返結算；礦坑 2 層＋撤退
+- 隱藏迷宮鏈可觸發（旗標→discover→委託板出現）
+- diff 只含 M3
+
+## M4 預告
+
+經濟（市集買賣/城鎮差價）、酒館招募/薪餉、委託型別擴充、升級加點 UI。M3 的 xp 已累積、items 已有 value 欄位供買賣。

--- a/src/pages/games/caravan.astro
+++ b/src/pages/games/caravan.astro
@@ -22,9 +22,32 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       <h2 class="town-name">啟程之鎮</h2>
       <p class="town-status">金幣 <span id="town-gold">0</span> G</p>
       <div class="town-actions">
+        <button id="btn-quest-board" class="caravan-btn">委託板</button>
         <button id="btn-training" class="caravan-btn">訓練場</button>
+        <button id="btn-resume-expedition" class="caravan-btn" hidden>繼續遠征</button>
       </div>
       <p class="town-hint">（更多城鎮功能將在後續里程碑開放）</p>
+    </section>
+
+    <!-- 委託板（M3：選擇貿易路線／迷宮出征） -->
+    <section id="screen-quest" class="screen" hidden>
+      <h2 class="quest-title">委託板</h2>
+      <div id="quest-list" class="quest-list"></div>
+      <p class="quest-hidden-hint" hidden>？ 迷霧深處似乎還藏著什麼，尚待線索指引……</p>
+      <button id="btn-quest-back" class="caravan-btn">返回城鎮</button>
+    </section>
+
+    <!-- 遠征畫面（M3：事件卡鏈／迷宮房卡） -->
+    <section id="screen-expedition" class="screen" hidden>
+      <p id="exp-progress" class="exp-progress"></p>
+      <div id="event-card" class="event-card" hidden>
+        <h3 id="event-title" class="event-title"></h3>
+        <p id="event-body" class="event-body"></p>
+        <div id="event-options" class="event-options"></div>
+      </div>
+      <div id="room-choices" class="room-choices"></div>
+      <p id="check-result" class="check-result" hidden></p>
+      <button id="btn-exp-continue" class="caravan-btn" hidden>繼續前進</button>
     </section>
 
     <!-- 戰鬥畫面（M2：訓練場入口；M3 併入遠征遭遇） -->
@@ -43,29 +66,93 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         <button id="btn-combat-back" class="caravan-btn">返回城鎮</button>
       </div>
     </section>
+
+    <!-- 結算畫面（M3：遠征歸返） -->
+    <section id="screen-settlement" class="screen" hidden>
+      <h2 class="settle-title">遠征結算</h2>
+      <div id="settle-log" class="settle-log"></div>
+      <dl class="settle-stats">
+        <div class="settle-stat">
+          <dt>戰利品金幣</dt>
+          <dd><span id="settle-gold">0</span> G</dd>
+        </div>
+        <div class="settle-stat">
+          <dt>經驗值</dt>
+          <dd><span id="settle-xp">0</span> XP</dd>
+        </div>
+      </dl>
+      <p class="settle-items-label">帶回的物品：</p>
+      <ul id="settle-items" class="settle-items"></ul>
+      <button id="btn-settle-back" class="caravan-btn">返回城鎮</button>
+    </section>
   </main>
 </BaseLayout>
 
 <script>
   import { newGame, saveGame, loadGame } from '@scripts/games/caravan/save';
+  import type { SaveData } from '@scripts/games/caravan/save';
   import { createRng } from '@scripts/games/caravan/rng';
   import {
-    startCombat, partyAct, enemyAct, attemptRetreat, currentActor,
+    startCombat, partyAct, enemyAct, attemptRetreat, currentActor, resolveCasualties,
   } from '@scripts/games/caravan/combat';
-  import type { CombatState, CombatantBase, Move } from '@scripts/games/caravan/combat';
+  import type { CombatState, CombatantBase, Move, PartyMember } from '@scripts/games/caravan/combat';
+  import {
+    startExpedition, drawEvent, optionAvailable, resolveOption, drawRooms, chooseRoom,
+    buildEncounter, applyPartyHp, finishCombat, settleExpedition,
+  } from '@scripts/games/caravan/expedition';
+  import type { ExpeditionState, EventCard, RoomKind } from '@scripts/games/caravan/expedition';
+  import type { CheckResult } from '@scripts/games/caravan/check';
   import { memberFromRecord } from '@scripts/games/caravan/data/jobs';
   import { TRAINING_ENCOUNTER } from '@scripts/games/caravan/data/enemies';
+  import { visibleLocations, LOCATIONS } from '@scripts/games/caravan/data/locations';
+  import { EVENTS } from '@scripts/games/caravan/data/events';
+  import { ITEMS } from '@scripts/games/caravan/data/items';
 
   const titleScreen = document.getElementById('screen-title')!;
   const townScreen = document.getElementById('screen-town')!;
+  const questScreen = document.getElementById('screen-quest')!;
+  const expeditionScreen = document.getElementById('screen-expedition')!;
   const combatScreen = document.getElementById('screen-combat')!;
+  const settlementScreen = document.getElementById('screen-settlement')!;
+
+  const screens = {
+    title: titleScreen,
+    town: townScreen,
+    quest: questScreen,
+    expedition: expeditionScreen,
+    combat: combatScreen,
+    settlement: settlementScreen,
+  } as const;
+
+  function showScreen(name: keyof typeof screens): void {
+    for (const key of Object.keys(screens) as (keyof typeof screens)[]) {
+      screens[key].hidden = key !== name;
+    }
+  }
+
   const btnNew = document.getElementById('btn-new-game')!;
   const btnContinue = document.getElementById('btn-continue')!;
   const btnTraining = document.getElementById('btn-training')!;
+  const btnQuestBoard = document.getElementById('btn-quest-board')!;
+  const btnResumeExpedition = document.getElementById('btn-resume-expedition')!;
   const goldEl = document.getElementById('town-gold')!;
+
+  const btnQuestBack = document.getElementById('btn-quest-back')!;
+  const questListEl = document.getElementById('quest-list')!;
+  const hiddenHintEl = document.querySelector('.quest-hidden-hint') as HTMLElement;
+
+  const expProgressEl = document.getElementById('exp-progress')!;
+  const eventCardEl = document.getElementById('event-card')!;
+  const eventTitleEl = document.getElementById('event-title')!;
+  const eventBodyEl = document.getElementById('event-body')!;
+  const eventOptionsEl = document.getElementById('event-options')!;
+  const roomChoicesEl = document.getElementById('room-choices')!;
+  const checkResultEl = document.getElementById('check-result')!;
+  const btnExpContinue = document.getElementById('btn-exp-continue')!;
 
   const combatEnemiesEl = document.getElementById('combat-enemies')!;
   const combatPartyEl = document.getElementById('combat-party')!;
+  const combatTargetsEl = document.getElementById('combat-targets')!;
   const combatLogEl = document.getElementById('combat-log')!;
   const combatActionsEl = document.getElementById('combat-actions')!;
   const combatResultEl = document.getElementById('combat-result')!;
@@ -73,33 +160,317 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   const btnRetreat = document.getElementById('btn-retreat')!;
   const btnCombatBack = document.getElementById('btn-combat-back')!;
 
-  function showTown(gold: number): void {
-    goldEl.textContent = String(gold);
-    titleScreen.hidden = true;
-    townScreen.hidden = false;
-    combatScreen.hidden = true;
+  const settleGoldEl = document.getElementById('settle-gold')!;
+  const settleXpEl = document.getElementById('settle-xp')!;
+  const settleItemsEl = document.getElementById('settle-items')!;
+  const settleLogEl = document.getElementById('settle-log')!;
+  const btnSettleBack = document.getElementById('btn-settle-back')!;
+
+  let save: SaveData | null = loadGame();
+  if (save) btnContinue.hidden = false;
+
+  function updateResumeButton(): void {
+    btnResumeExpedition.hidden = !(save && save.expedition);
   }
 
-  const existing = loadGame();
-  if (existing) btnContinue.hidden = false;
+  function showTown(gold: number): void {
+    goldEl.textContent = String(gold);
+    showScreen('town');
+    updateResumeButton();
+  }
 
   btnNew.addEventListener('click', () => {
-    const save = newGame();
+    save = newGame();
     saveGame(save);
     showTown(save.gold);
   });
 
   btnContinue.addEventListener('click', () => {
-    const save = loadGame();
-    if (save) showTown(save.gold);
+    if (!save) return;
+    showTown(save.gold);
   });
-
-  // ---- 戰鬥（M2：訓練場，純模擬、不動存檔） ----
 
   const seedParam = new URLSearchParams(location.search).get('seed');
   const rng = createRng(seedParam ? Number(seedParam) : Date.now());
 
+  // ---------------------------------------------------------------------
+  // 委託板（M3）
+  // ---------------------------------------------------------------------
+
+  function renderQuestBoard(): void {
+    if (!save) return;
+    const locs = visibleLocations(save);
+    questListEl.innerHTML = '';
+    for (const loc of locs) {
+      const div = document.createElement('div');
+      div.className = 'quest-item';
+      div.dataset.locationId = loc.id;
+      const name = document.createElement('p');
+      name.className = 'quest-name';
+      name.textContent = loc.name;
+      const kind = document.createElement('p');
+      kind.className = 'quest-kind';
+      kind.textContent =
+        loc.kind === 'dungeon' ? `迷宮．共 ${loc.floors} 層` : `商路．共 ${loc.legs} 段`;
+      div.append(name, kind);
+      div.addEventListener('click', () => beginExpedition(loc.id));
+      questListEl.appendChild(div);
+    }
+    const hasHidden = Object.values(LOCATIONS).some(
+      (loc) => loc.hidden && save!.flags[`discovered:${loc.id}`] !== true
+    );
+    hiddenHintEl.hidden = !hasHidden;
+  }
+
+  btnQuestBoard.addEventListener('click', () => {
+    renderQuestBoard();
+    showScreen('quest');
+  });
+
+  btnQuestBack.addEventListener('click', () => {
+    showScreen('town');
+  });
+
+  btnResumeExpedition.addEventListener('click', () => {
+    if (!save || !save.expedition) return;
+    expedition = save.expedition;
+    showScreen('expedition');
+    dispatchPhase();
+  });
+
+  // ---------------------------------------------------------------------
+  // 遠征狀態機（M3）
+  // ---------------------------------------------------------------------
+
+  let expedition: ExpeditionState | null = null;
+  let pendingContinue: (() => void) | null = null;
+
+  const ROOM_LABELS: Record<RoomKind, string> = {
+    fight: '⚔ 殺氣瀰漫',
+    treasure: '✧ 微光閃爍',
+    event: '？ 未明岔路',
+    rest: '☾ 靜謐歇腳處',
+    unknown: '❔ 深不可測',
+  };
+
+  function beginExpedition(locationId: string): void {
+    if (!save) return;
+    expedition = startExpedition(rng, save, locationId);
+    save.expedition = expedition;
+    saveGame(save);
+    showScreen('expedition');
+    dispatchPhase();
+  }
+
+  function dispatchPhase(): void {
+    if (!expedition) return;
+    if (expedition.phase === 'event') enterEventPhase();
+    else if (expedition.phase === 'room-choice') enterRoomChoicePhase();
+    else if (expedition.phase === 'combat') enterCombatPhase();
+    else if (expedition.phase === 'done') enterSettlementPhase();
+  }
+
+  function renderExpProgress(): void {
+    if (!expedition) return;
+    const unit = expedition.kind === 'dungeon' ? '層' : '段';
+    expProgressEl.textContent = `第 ${expedition.step}/${expedition.totalSteps} ${unit}`;
+  }
+
+  function renderCheckResult(check: CheckResult | null): void {
+    if (!check) {
+      checkResultEl.hidden = true;
+      checkResultEl.textContent = '';
+      return;
+    }
+    checkResultEl.hidden = false;
+    const outcome = check.success ? '成功' : '失敗';
+    checkResultEl.textContent = `擲骰 ${check.die}（總值 ${check.total} / 目標 DC ${check.dc}）── ${outcome}！`;
+  }
+
+  function enterEventPhase(): void {
+    if (!expedition || !save) return;
+    let card: EventCard | undefined;
+    if (expedition.currentEventId) {
+      card = EVENTS.find((c) => c.id === expedition!.currentEventId);
+    }
+    if (!card) {
+      card = drawEvent(rng, expedition, save);
+      saveGame(save);
+    }
+    renderEventCard(card);
+  }
+
+  function renderEventCard(card: EventCard): void {
+    if (!save) return;
+    pendingContinue = null;
+    btnExpContinue.hidden = true;
+    checkResultEl.hidden = true;
+    checkResultEl.textContent = '';
+    roomChoicesEl.innerHTML = '';
+    eventCardEl.hidden = false;
+    eventTitleEl.textContent = card.title;
+    eventBodyEl.textContent = card.body;
+    eventOptionsEl.innerHTML = '';
+    card.options.forEach((opt, idx) => {
+      const btn = document.createElement('button');
+      btn.className = 'caravan-btn event-opt';
+      btn.dataset.optIndex = String(idx);
+      btn.textContent = opt.label;
+      btn.disabled = !optionAvailable(save!, opt);
+      btn.addEventListener('click', () => handleOptionChoice(card, idx));
+      eventOptionsEl.appendChild(btn);
+    });
+    renderExpProgress();
+    showScreen('expedition');
+  }
+
+  function handleOptionChoice(card: EventCard, idx: number): void {
+    if (!expedition || !save) return;
+    const { check } = resolveOption(rng, expedition, save, card, idx);
+    saveGame(save);
+    eventOptionsEl.querySelectorAll('.event-opt').forEach((b) => {
+      (b as HTMLButtonElement).disabled = true;
+    });
+    renderCheckResult(check);
+    btnExpContinue.hidden = false;
+    pendingContinue = () => dispatchPhase();
+  }
+
+  function enterRoomChoicePhase(): void {
+    if (!expedition || !save) return;
+    if (!expedition.roomChoices) {
+      drawRooms(rng, expedition);
+      saveGame(save);
+    }
+    eventCardEl.hidden = true;
+    checkResultEl.hidden = true;
+    checkResultEl.textContent = '';
+    btnExpContinue.hidden = true;
+    pendingContinue = null;
+    renderRoomChoices();
+    renderExpProgress();
+    showScreen('expedition');
+  }
+
+  function renderRoomChoices(): void {
+    roomChoicesEl.innerHTML = '';
+    for (const room of expedition!.roomChoices ?? []) {
+      const btn = document.createElement('button');
+      btn.className = 'caravan-btn room-btn';
+      btn.dataset.room = room;
+      btn.textContent = ROOM_LABELS[room];
+      btn.addEventListener('click', () => handleRoomChoice(room));
+      roomChoicesEl.appendChild(btn);
+    }
+  }
+
+  function handleRoomChoice(room: RoomKind): void {
+    if (!expedition || !save) return;
+    roomChoicesEl.innerHTML = '';
+    const result = chooseRoom(rng, expedition, save, room);
+    saveGame(save);
+    if (result.event) {
+      renderEventCard(result.event);
+      return;
+    }
+    let message = '';
+    if (result.treasureGold !== undefined) {
+      message = `你在房間角落翻找，發現了 ${result.treasureGold} 枚金幣！`;
+    } else if (result.restHealed !== undefined) {
+      message = `商隊在此稍作歇息，全員恢復了 ${result.restHealed} 點生命。`;
+    } else if (result.encounterId) {
+      message = '房間深處傳出低吼——戰鬥一觸即發！';
+    }
+    checkResultEl.hidden = false;
+    checkResultEl.textContent = message;
+    btnExpContinue.hidden = false;
+    pendingContinue = () => dispatchPhase();
+  }
+
+  btnExpContinue.addEventListener('click', () => {
+    const fn = pendingContinue;
+    pendingContinue = null;
+    fn?.();
+  });
+
+  function buildExpeditionParty(): PartyMember[] {
+    if (!save || !expedition) return [];
+    const members = [memberFromRecord(save.protagonist)];
+    for (const companion of save.companions) {
+      if (companion.injuredForTrips === 0) members.push(memberFromRecord(companion));
+    }
+    applyPartyHp(expedition, members);
+    return members;
+  }
+
+  function enterCombatPhase(): void {
+    if (!expedition || !save) return;
+    combatContext = 'expedition';
+    const party = buildExpeditionParty();
+    const enemies = buildEncounter(rng, expedition, expedition.pendingEncounterId!);
+    state = startCombat(rng, party, enemies);
+    selectedTargetId = null;
+    showScreen('combat');
+    combatResultEl.hidden = true;
+    render();
+  }
+
+  function enterSettlementPhase(): void {
+    if (!expedition || !save) return;
+    const finished = expedition;
+    const result = settleExpedition(finished, save);
+    saveGame(save);
+    renderSettlement(result, finished);
+    showScreen('settlement');
+    expedition = null;
+    updateResumeButton();
+  }
+
+  function renderSettlement(
+    result: { goldGained: number; itemsGained: Record<string, number>; xpGained: number },
+    exp: ExpeditionState
+  ): void {
+    settleGoldEl.textContent = String(result.goldGained);
+    settleXpEl.textContent = String(result.xpGained);
+
+    settleItemsEl.innerHTML = '';
+    const entries = Object.entries(result.itemsGained);
+    if (entries.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = '（無）';
+      settleItemsEl.appendChild(li);
+    } else {
+      for (const [itemId, count] of entries) {
+        const li = document.createElement('li');
+        li.textContent = `${ITEMS[itemId]?.name ?? itemId} x${count}`;
+        settleItemsEl.appendChild(li);
+      }
+    }
+
+    settleLogEl.innerHTML = '';
+    const headline = document.createElement('p');
+    headline.className = 'settle-headline';
+    headline.textContent = exp.retreated
+      ? '商隊未能走完全程，帶著剩餘的戰利品鎩羽而歸療傷。'
+      : '商隊順利完成了這趟遠征，滿載而歸。';
+    settleLogEl.appendChild(headline);
+    for (const line of exp.eventLog) {
+      const p = document.createElement('p');
+      p.textContent = line;
+      settleLogEl.appendChild(p);
+    }
+  }
+
+  btnSettleBack.addEventListener('click', () => {
+    if (!save) return;
+    showTown(save.gold);
+  });
+
+  // ---- 戰鬥（M2：訓練場；M3：併入遠征遭遇） ----
+
   let state: CombatState | null = null;
+  let combatContext: 'training' | 'expedition' = 'training';
+  let selectedTargetId: string | null = null;
 
   function unitIntentText(unit: CombatantBase): string {
     if (!state || unit.hp <= 0) return '';
@@ -147,9 +518,34 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   function resolveTargetId(actorId: string, move: Move): string | null {
     if (!state) return null;
     if (move.target === 'enemy') {
+      if (selectedTargetId && state.enemies.some((e) => e.id === selectedTargetId && e.hp > 0)) {
+        return selectedTargetId;
+      }
       return state.enemies.find((e) => e.hp > 0)?.id ?? null;
     }
-    return actorId; // 支援/防禦招式 M2 固定自標
+    return actorId; // 支援/防禦招式固定自標
+  }
+
+  function renderCombatTargets(): void {
+    if (!state) return;
+    const aliveEnemies = state.enemies.filter((e) => e.hp > 0);
+    combatTargetsEl.innerHTML = '';
+    if (aliveEnemies.length < 2) {
+      selectedTargetId = null;
+      return;
+    }
+    for (const enemy of aliveEnemies) {
+      const btn = document.createElement('button');
+      btn.className = 'caravan-btn target-btn';
+      btn.dataset.targetId = enemy.id;
+      btn.textContent = enemy.name;
+      if (enemy.id === selectedTargetId) btn.classList.add('target-selected');
+      btn.addEventListener('click', () => {
+        selectedTargetId = enemy.id;
+        renderCombatTargets();
+      });
+      combatTargetsEl.appendChild(btn);
+    }
   }
 
   function renderActions(actorId: string): void {
@@ -167,6 +563,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         const targetId = resolveTargetId(actor.id, move);
         if (!targetId) return;
         partyAct(rng, state, actor.id, move.id, targetId);
+        selectedTargetId = null;
         render();
       });
       combatActionsEl.appendChild(btn);
@@ -174,9 +571,12 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   }
 
   function showResult(outcome: CombatState['outcome']): void {
-    const text = outcome === 'victory' ? '勝利！敵人被擊潰了，商隊可以返回城鎮休整。'
-      : outcome === 'defeat' ? '敗北……商隊被迫撤回城鎮療傷。'
-      : '商隊已撤退，保住了性命。';
+    const text =
+      outcome === 'victory'
+        ? '勝利！敵人被擊潰了，商隊可以繼續前進。'
+        : outcome === 'defeat'
+          ? '敗北……商隊被迫撤回城鎮療傷。'
+          : '商隊已撤退，保住了性命。';
     combatResultTextEl.textContent = text;
     combatResultEl.hidden = false;
   }
@@ -189,6 +589,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
     if (state.outcome !== 'ongoing') {
       combatActionsEl.innerHTML = '';
+      combatTargetsEl.innerHTML = '';
       btnRetreat.hidden = true;
       showResult(state.outcome);
       return;
@@ -200,6 +601,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     if (!actor) return;
     if (actor.side === 'enemy') {
       combatActionsEl.innerHTML = '';
+      combatTargetsEl.innerHTML = '';
       const enemyId = actor.id;
       const scheduledState = state;
       setTimeout(() => {
@@ -209,15 +611,16 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       }, 600);
     } else {
       renderActions(actor.id);
+      renderCombatTargets();
     }
   }
 
   btnTraining.addEventListener('click', () => {
-    const save = loadGame();
     if (!save) return;
+    combatContext = 'training';
+    selectedTargetId = null;
     state = startCombat(rng, [memberFromRecord(save.protagonist)], TRAINING_ENCOUNTER());
-    townScreen.hidden = true;
-    combatScreen.hidden = false;
+    showScreen('combat');
     combatResultEl.hidden = true;
     render();
   });
@@ -230,8 +633,15 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
   btnCombatBack.addEventListener('click', () => {
     if (!state) return;
-    combatScreen.hidden = true;
-    townScreen.hidden = false;
+    if (combatContext === 'expedition' && expedition && save) {
+      const fates = resolveCasualties(rng, state);
+      finishCombat(rng, expedition, save, state, fates);
+      saveGame(save);
+      state = null;
+      dispatchPhase();
+      return;
+    }
+    showScreen('town');
     state = null;
   });
 </script>
@@ -246,7 +656,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     color: #2b2620;
     font-family: 'Noto Serif TC', serif;
   }
-  .screen { text-align: center; padding: 2rem; }
+  .screen { text-align: center; padding: 2rem; max-width: 34rem; }
   .game-title { font-size: 3rem; letter-spacing: 0.3em; margin-bottom: 0.25rem; }
   .game-subtitle { letter-spacing: 0.5em; color: #8a7f6d; margin-bottom: 2.5rem; }
   .title-actions { display: flex; flex-direction: column; gap: 0.75rem; align-items: center; }
@@ -259,11 +669,61 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     letter-spacing: 0.2em;
   }
   .caravan-btn:hover { background: #2b2620; color: #f5f0e6; }
+  .caravan-btn:disabled {
+    color: #b7ac98;
+    border-color: #cfc6b0;
+    cursor: not-allowed;
+  }
+  .caravan-btn:disabled:hover { background: transparent; color: #b7ac98; }
   .town-name { font-size: 1.8rem; margin-bottom: 0.5rem; }
   .town-status { font-size: 1.1rem; }
-  .town-actions { margin-top: 1.5rem; }
+  .town-actions { margin-top: 1.5rem; display: flex; flex-wrap: wrap; gap: 0.75rem; justify-content: center; }
   .town-hint { margin-top: 1.5rem; color: #8a7f6d; font-size: 0.9rem; }
 
+  /* 委託板 */
+  .quest-title { font-size: 1.6rem; letter-spacing: 0.3em; margin-bottom: 1.25rem; }
+  .quest-list { display: flex; flex-direction: column; gap: 0.75rem; margin-bottom: 1.25rem; }
+  .quest-item {
+    border: 1px solid #cfc6b0;
+    background: #fffdf8;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    cursor: pointer;
+  }
+  .quest-item:hover { border-color: #2b2620; }
+  .quest-name { font-weight: 600; margin: 0 0 0.25rem; }
+  .quest-kind { font-size: 0.85rem; color: #8a7f6d; margin: 0; }
+  .quest-hidden-hint { color: #8a7f6d; font-style: italic; margin-bottom: 1rem; }
+
+  /* 遠征畫面 */
+  .exp-progress { letter-spacing: 0.2em; color: #8a7f6d; margin-bottom: 1rem; }
+  .event-card {
+    border: 1px solid #cfc6b0;
+    background: #fffdf8;
+    padding: 1.25rem 1.5rem;
+    text-align: left;
+    margin-bottom: 1rem;
+  }
+  .event-title { font-size: 1.3rem; margin: 0 0 0.75rem; letter-spacing: 0.1em; }
+  .event-body { line-height: 1.8; margin: 0 0 1rem; }
+  .event-options { display: flex; flex-direction: column; gap: 0.5rem; }
+  .event-opt { text-align: left; }
+  .room-choices {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+  .room-choices:empty { display: none; }
+  .check-result {
+    border: 1px solid #cfc6b0;
+    background: #fffdf8;
+    padding: 0.6rem 1rem;
+    margin-bottom: 1rem;
+  }
+
+  /* 戰鬥畫面 */
   .combat-title { font-size: 1.6rem; letter-spacing: 0.3em; margin-bottom: 1.5rem; }
   .combat-field {
     display: flex;
@@ -282,7 +742,16 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .unit-name { font-weight: 600; margin: 0 0 0.15rem; }
   .unit-hp { font-size: 0.85rem; color: #5c5344; margin: 0; }
   .unit-intent { font-size: 0.75rem; font-style: italic; color: #8a7f6d; margin: 0.15rem 0 0; min-height: 1em; }
+  .combat-targets {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
   .combat-targets:empty { display: none; }
+  .target-btn { padding: 0.35rem 0.9rem; font-size: 0.85rem; }
+  .target-selected { background: #2b2620; color: #f5f0e6; }
   .combat-log {
     max-width: 30rem;
     max-height: 8rem;
@@ -305,4 +774,37 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .combat-retreat { font-size: 0.85rem; padding: 0.4rem 1.5rem; }
   .combat-result { margin-top: 1.5rem; }
   .combat-result .result-text { font-size: 1.1rem; margin-bottom: 1rem; }
+
+  /* 結算畫面 */
+  .settle-title { font-size: 1.6rem; letter-spacing: 0.3em; margin-bottom: 1rem; }
+  .settle-log {
+    border: 1px solid #cfc6b0;
+    background: #fffdf8;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    max-height: 10rem;
+    overflow-y: auto;
+    margin-bottom: 1rem;
+  }
+  .settle-log p { margin: 0.3rem 0; font-size: 0.9rem; }
+  .settle-headline { font-weight: 600; }
+  .settle-stats {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    margin: 0 0 1rem;
+  }
+  .settle-stat dt { font-size: 0.8rem; color: #8a7f6d; }
+  .settle-stat dd { font-size: 1.3rem; margin: 0; }
+  .settle-items-label { text-align: left; margin-bottom: 0.4rem; color: #8a7f6d; }
+  .settle-items {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+    text-align: left;
+    border: 1px solid #cfc6b0;
+    background: #fffdf8;
+  }
+  .settle-items li { padding: 0.4rem 0.9rem; border-bottom: 1px solid #ece5d5; }
+  .settle-items li:last-child { border-bottom: none; }
 </style>

--- a/src/scripts/games/caravan/combat.test.ts
+++ b/src/scripts/games/caravan/combat.test.ts
@@ -176,6 +176,41 @@ describe('動作結算', () => {
     expect(state.log.some((e) => e.kind === 'retreat')).toBe(true);
   });
 
+  it('EnemyUnit.loot 為選填欄位（型別使用 fixture，M3 Task 3 消費）', () => {
+    const foe = makeEnemy('foe', 10, { loot: { gold: [5, 10], itemId: 'iron-ore', itemChance: 0.5 } });
+    expect(foe.loot?.gold).toEqual([5, 10]);
+    expect(foe.loot?.itemId).toBe('iron-ore');
+    expect(foe.loot?.itemChance).toBe(0.5);
+  });
+
+  it('enemyAct：治療意圖鎖定敵方（含自己）中扣血最多者，玩家隊不受影響', () => {
+    const healMove: Move = { id: 'heal', name: '傷患照護', kind: 'support', target: 'ally', hitStat: 'cha',
+      heal: { dice: 1, sides: 8, bonusStat: 'cha' }, narration: '{actor}治癒了{target}，恢復 {amount} 點！' };
+    const healer = makeEnemy('healer', 10, { moves: [strike, healMove], intents: [{ weight: 1, moveId: 'heal' }],
+      stats: { str: 8, dex: 10, int: 10, cha: 16, con: 10 } });
+    const warrior = makeEnemy('warrior', 8, { hp: 4 }); // maxHp 10, hp 4 → 缺 6，全場最大缺口
+    const hero = makeMember('hero', 14);
+    const state = startCombat(scriptedRng([5, 15, 10]), [hero], [healer, warrior]);
+    expect(state.enemyIntents['healer']).toBe('heal');
+    enemyAct(scriptedRng([6]), state, 'healer'); // 6 + cha(+3) = 9 → applied = min(9, 10-4=6) = 6
+    expect(warrior.hp).toBe(10);
+    expect(hero.hp).toBe(20);
+    expect(state.log.some((e) => e.kind === 'heal')).toBe(true);
+  });
+
+  it('attemptRetreat：敵人無 attack 招時不執行攻擊，殿後者 hp 不變、outcome 仍 retreated', () => {
+    const healMove: Move = { id: 'heal', name: '祝禱', kind: 'support', target: 'ally', hitStat: 'cha',
+      heal: { dice: 1, sides: 8, bonusStat: 'cha' }, narration: '{actor}治癒了{target}！' };
+    const foe = makeEnemy('foe', 10, { moves: [healMove], intents: [{ weight: 1, moveId: 'heal' }] });
+    const a = makeMember('a', 14); const b = makeMember('b', 8);
+    const state = startCombat(scriptedRng([15, 5, 10]), [a, b], [foe]);
+    attemptRetreat(scriptedRng([]), state);
+    expect(state.outcome).toBe('retreated');
+    expect(a.hp).toBe(20);
+    expect(b.hp).toBe(20);
+    expect(state.log.every((e) => e.kind === 'info' || e.kind === 'retreat')).toBe(true);
+  });
+
   it('resolveCasualties：主角必重傷；傭兵過 DC10 重傷、不過死亡', () => {
     const boss = makeMember('boss', 10, { isProtagonist: true });
     const merc1 = makeMember('m1', 10); const merc2 = makeMember('m2', 10);

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -19,7 +19,10 @@ export interface CombatantBase {
 
 export interface PartyMember extends CombatantBase { isProtagonist?: boolean; }
 
-export interface EnemyUnit extends CombatantBase { intents: Array<{ weight: number; moveId: string }>; }
+export interface EnemyUnit extends CombatantBase {
+  intents: Array<{ weight: number; moveId: string }>;
+  loot?: { gold: [number, number]; itemId?: string; itemChance?: number };
+}
 
 export interface CombatEvent { kind: 'action'|'damage'|'heal'|'down'|'info'|'retreat'|'victory'|'defeat'; text: string; }
 
@@ -160,9 +163,19 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
   if (!enemy || state.outcome !== 'ongoing') return;
   const moveId = state.enemyIntents[enemyId] ?? enemy.moves[0].id;
   const move = enemy.moves.find((m) => m.id === moveId) ?? enemy.moves[0];
-  const alive = state.party.filter((p) => p.hp > 0);
-  if (alive.length === 0) return;
-  const target = alive.reduce((low, p) => (p.hp < low.hp ? p : low), alive[0]);
+  let target: CombatantBase;
+  if (move.kind === 'support' && move.heal) {
+    // 治療招：目標＝敵方存活同伴（可含自己）中缺血（maxHp - hp）最大者
+    const aliveEnemies = state.enemies.filter((e) => e.hp > 0);
+    if (aliveEnemies.length === 0) return;
+    target = aliveEnemies.reduce(
+      (most, e) => (e.maxHp - e.hp > most.maxHp - most.hp ? e : most), aliveEnemies[0]
+    );
+  } else {
+    const aliveParty = state.party.filter((p) => p.hp > 0);
+    if (aliveParty.length === 0) return;
+    target = aliveParty.reduce((low, p) => (p.hp < low.hp ? p : low), aliveParty[0]);
+  }
   performMove(rng, state, enemy, move, target);
   state.enemyIntents[enemyId] = rng.weightedPick(
     enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
@@ -181,7 +194,10 @@ export function attemptRetreat(rng: Rng, state: CombatState): void {
       .map((id) => aliveParty.find((p) => p.id === id))
       .find((p) => p !== undefined)!;
     state.log.push({ kind: 'retreat', text: `${rear.name}殿後掩護撤退……` });
-    performMove(rng, state, aliveEnemy, aliveEnemy.moves[0], rear);
+    const attackMove = aliveEnemy.moves.find((m) => m.kind === 'attack');
+    if (attackMove) {
+      performMove(rng, state, aliveEnemy, attackMove, rear);
+    }
   }
   state.outcome = 'retreated';
   state.log.push({ kind: 'retreat', text: '商隊撤出了戰鬥。' });

--- a/src/scripts/games/caravan/data/data.test.ts
+++ b/src/scripts/games/caravan/data/data.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import { ITEMS } from './items';
+import { LOCATIONS, visibleLocations } from './locations';
+import { ENCOUNTERS } from './enemies';
+import { EVENTS } from './events';
+import type { EventCard, EffectSpec } from '../expedition';
+import { startExpedition, drawEvent } from '../expedition';
+import { createRng } from '../rng';
+import { newGame } from '../save';
+
+function allEffects(card: EventCard): EffectSpec[] {
+  const out: EffectSpec[] = [];
+  for (const opt of card.options) {
+    out.push(...opt.success);
+    if (opt.failure) out.push(...opt.failure);
+  }
+  return out;
+}
+
+describe('caravan content data integrity（M3 Task 4）', () => {
+  // ---------------------------------------------------------------------
+  // items.ts
+  // ---------------------------------------------------------------------
+  it('ITEMS 有 12 種，且 ore 存在（Task 3 寶箱房寫死給 ore）', () => {
+    expect(Object.keys(ITEMS).length).toBe(12);
+    expect(ITEMS.ore).toBeDefined();
+    for (const item of Object.values(ITEMS)) {
+      expect(item.id).toBeTruthy();
+      expect(item.name).toBeTruthy();
+      expect(item.desc.length).toBeGreaterThan(0);
+      expect(item.value).toBeGreaterThan(0);
+    }
+  });
+
+  // ---------------------------------------------------------------------
+  // locations.ts
+  // ---------------------------------------------------------------------
+  it('LOCATIONS 有計畫指定的 4 個地點，其中 1 個為 hidden', () => {
+    expect(Object.keys(LOCATIONS).length).toBe(4);
+    const hidden = Object.values(LOCATIONS).filter((l) => l.hidden);
+    expect(hidden.length).toBe(1);
+  });
+
+  it('route 地點必有 legs；dungeon 地點必有 floors/roomsPerFloor/bossEncounterId', () => {
+    for (const loc of Object.values(LOCATIONS)) {
+      if (loc.kind === 'dungeon') {
+        expect(loc.floors).toBeGreaterThan(0);
+        expect(loc.roomsPerFloor).toBeDefined();
+        expect(loc.roomsPerFloor![0]).toBeGreaterThan(0);
+        expect(loc.bossEncounterId).toBeTruthy();
+      } else {
+        expect(loc.legs).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('LOCATIONS 的 encounterTable/bossEncounterId 全部存在於 ENCOUNTERS', () => {
+    for (const loc of Object.values(LOCATIONS)) {
+      expect(loc.encounterTable.length).toBeGreaterThan(0);
+      for (const entry of loc.encounterTable) {
+        expect(ENCOUNTERS[entry.encounterId]).toBeDefined();
+      }
+      if (loc.bossEncounterId) {
+        expect(ENCOUNTERS[loc.bossEncounterId]).toBeDefined();
+      }
+    }
+  });
+
+  it('visibleLocations：hidden 地點未 discover 時不列出，discover 後出現', () => {
+    const save = newGame();
+    const before = visibleLocations(save);
+    expect(before.length).toBe(3);
+    expect(before.some((l) => l.hidden)).toBe(false);
+
+    const hiddenLoc = Object.values(LOCATIONS).find((l) => l.hidden)!;
+    save.flags[`discovered:${hiddenLoc.id}`] = true;
+    const after = visibleLocations(save);
+    expect(after.length).toBe(4);
+    expect(after.some((l) => l.id === hiddenLoc.id)).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // enemies.ts（ENCOUNTERS）
+  // ---------------------------------------------------------------------
+  it('ENCOUNTERS 內每個工廠產出的敵人 loot.gold min<=max，loot.itemId（若有）存在於 ITEMS', () => {
+    expect(Object.keys(ENCOUNTERS).length).toBeGreaterThan(0);
+    for (const [encounterId, factory] of Object.entries(ENCOUNTERS)) {
+      const enemies = factory();
+      expect(enemies.length, `${encounterId} 應至少產出 1 隻敵人`).toBeGreaterThan(0);
+      for (const enemy of enemies) {
+        if (!enemy.loot) continue;
+        const [min, max] = enemy.loot.gold;
+        expect(min).toBeLessThanOrEqual(max);
+        if (enemy.loot.itemId) {
+          expect(ITEMS[enemy.loot.itemId]).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('boss 遭遇（監工/巢穴頭目）HP 落在 25-35 區間', () => {
+    for (const encounterId of ['enc_mine_overseer', 'enc_goblin_den_chief']) {
+      const enemies = ENCOUNTERS[encounterId]();
+      expect(enemies.length).toBe(1);
+      expect(enemies[0].maxHp).toBeGreaterThanOrEqual(25);
+      expect(enemies[0].maxHp).toBeLessThanOrEqual(35);
+    }
+  });
+
+  it('每次呼叫工廠都回傳全新物件（不共用可變狀態，同 TRAINING_ENCOUNTER 慣例）', () => {
+    const first = ENCOUNTERS.enc_wolf_pair();
+    first[0].hp = 1;
+    const second = ENCOUNTERS.enc_wolf_pair();
+    expect(second[0].hp).toBe(second[0].maxHp);
+  });
+
+  // ---------------------------------------------------------------------
+  // events.ts
+  // ---------------------------------------------------------------------
+  it('EVENTS 共 15 張，路線通用 8／森林限定 3／迷宮限定 4', () => {
+    expect(EVENTS.length).toBe(15);
+    const routeGeneric = EVENTS.filter(
+      (c) => c.context.kind === 'route' && !c.context.locationIds
+    );
+    const forestOnly = EVENTS.filter((c) => c.context.locationIds?.includes('blackwood-trail'));
+    const dungeonOnly = EVENTS.filter((c) => c.context.kind === 'dungeon');
+    expect(routeGeneric.length).toBe(8);
+    expect(forestOnly.length).toBe(3);
+    expect(dungeonOnly.length).toBe(4);
+  });
+
+  it('所有事件 options 至少 1 個、card.weight > 0', () => {
+    for (const card of EVENTS) {
+      expect(card.options.length).toBeGreaterThanOrEqual(1);
+      expect(card.options.length).toBeLessThanOrEqual(3);
+      expect(card.weight).toBeGreaterThan(0);
+    }
+  });
+
+  it('五屬性（str/dex/int/cha/con）都至少有一個事件選項用到', () => {
+    const stats = new Set(
+      EVENTS.flatMap((c) => c.options.map((o) => o.check?.stat).filter((s): s is NonNullable<typeof s> => !!s))
+    );
+    expect(stats.size).toBe(5);
+  });
+
+  it('body 有畫面感的長度（60-120 字量級，寬鬆檢查 40-160）', () => {
+    for (const card of EVENTS) {
+      expect(card.body.length, `${card.id} body 太短`).toBeGreaterThanOrEqual(40);
+      expect(card.body.length, `${card.id} body 太長`).toBeLessThanOrEqual(160);
+      expect(card.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('每個成功/失敗結果都至少有一個效果（讓玩家有敘事回饋）', () => {
+    for (const card of EVENTS) {
+      for (const opt of card.options) {
+        expect(opt.success.length, `${card.id}/${opt.label} success 空`).toBeGreaterThan(0);
+        if (opt.check) {
+          // 有檢定就該有 failure 分支給玩家回饋（純敘事無檢定的選項可省略 failure）
+          expect(opt.failure?.length ?? 0, `${card.id}/${opt.label} 有 check 卻無 failure 效果`).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('所有 item 效果的 itemId 存在於 ITEMS', () => {
+    for (const card of EVENTS) {
+      for (const effect of allEffects(card)) {
+        if (effect.type === 'item') {
+          expect(ITEMS[effect.itemId], `${card.id} 引用不存在的物品 ${effect.itemId}`).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('所有 discover 效果的 locationId 存在於 LOCATIONS', () => {
+    for (const card of EVENTS) {
+      for (const effect of allEffects(card)) {
+        if (effect.type === 'discover') {
+          expect(LOCATIONS[effect.locationId], `${card.id} 引用不存在的地點 ${effect.locationId}`).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('所有 fight 效果的 encounterId 存在於 ENCOUNTERS，且 fight 必為所在效果陣列最後一項', () => {
+    for (const card of EVENTS) {
+      for (const opt of card.options) {
+        for (const list of [opt.success, opt.failure ?? []]) {
+          const fightIndex = list.findIndex((e) => e.type === 'fight');
+          if (fightIndex === -1) continue;
+          expect(fightIndex, `${card.id}/${opt.label} fight 不是陣列最後一項`).toBe(list.length - 1);
+          const effect = list[fightIndex] as Extract<EffectSpec, { type: 'fight' }>;
+          expect(ENCOUNTERS[effect.encounterId], `${card.id} 引用不存在的遭遇 ${effect.encounterId}`).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('requiresFlags 的每個旗標，至少有一張卡的效果會設定它（旗標鏈兩端對得上）', () => {
+    const settableFlags = new Set<string>();
+    for (const card of EVENTS) {
+      for (const effect of allEffects(card)) {
+        if (effect.type === 'flag' && effect.value === true) settableFlags.add(effect.flag);
+        if (effect.type === 'discover') settableFlags.add(`discovered:${effect.locationId}`);
+      }
+    }
+    let sawRequiresFlags = false;
+    for (const card of EVENTS) {
+      if (!card.requiresFlags) continue;
+      for (const [flag, expected] of Object.entries(card.requiresFlags)) {
+        if (!expected) continue;
+        sawRequiresFlags = true;
+        expect(settableFlags.has(flag), `requiresFlags 旗標「${flag}」沒有任何卡片會設定它`).toBe(true);
+      }
+    }
+    expect(sawRequiresFlags, '應該至少有一張旗標鏈卡片（ev_cave_entrance）').toBe(true);
+  });
+
+  it('旗標鏈範例：ev_merchant_map 設 clue:goblin-cave，ev_cave_entrance 需要它並 discover goblin-den', () => {
+    const mapCard = EVENTS.find((c) => c.id === 'ev_merchant_map');
+    const caveCard = EVENTS.find((c) => c.id === 'ev_cave_entrance');
+    expect(mapCard).toBeDefined();
+    expect(caveCard).toBeDefined();
+    expect(caveCard!.requiresFlags).toEqual({ 'clue:goblin-cave': true });
+    const mapSetsFlag = allEffects(mapCard!).some(
+      (e) => e.type === 'flag' && e.flag === 'clue:goblin-cave' && e.value === true
+    );
+    expect(mapSetsFlag).toBe(true);
+    const caveDiscovers = allEffects(caveCard!).some(
+      (e) => e.type === 'discover' && e.locationId === 'goblin-den'
+    );
+    expect(caveDiscovers).toBe(true);
+    expect(LOCATIONS['goblin-den']?.hidden).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------
+  // 整合：資料檔在模組載入時完成 register，接得上 expedition.ts 引擎
+  // ---------------------------------------------------------------------
+  it('資料檔載入時自我註冊，startExpedition/drawEvent 可對真實地點/事件運作', () => {
+    const rng = createRng(42);
+    const save = newGame();
+    const state = startExpedition(rng, save, 'riverside-road');
+    expect(state.totalSteps).toBe(4);
+    const card = drawEvent(rng, state, save);
+    expect(EVENTS.some((c) => c.id === card.id)).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/data.test.ts
+++ b/src/scripts/games/caravan/data/data.test.ts
@@ -18,6 +18,16 @@ function allEffects(card: EventCard): EffectSpec[] {
 }
 
 describe('caravan content data integrity（M3 Task 4）', () => {
+  it('所有選項 requirement.itemId 都存在於 ITEMS（M3 終審覆蓋缺口）', () => {
+    for (const card of Object.values(EVENTS)) {
+      for (const opt of card.options) {
+        if (opt.requirement?.itemId) {
+          expect(ITEMS[opt.requirement.itemId], `${card.id} 的 requirement.itemId「${opt.requirement.itemId}」不存在`).toBeDefined();
+        }
+      }
+    }
+  });
+
   // ---------------------------------------------------------------------
   // items.ts
   // ---------------------------------------------------------------------

--- a/src/scripts/games/caravan/data/enemies.ts
+++ b/src/scripts/games/caravan/data/enemies.ts
@@ -1,4 +1,9 @@
 import type { Move, EnemyUnit } from '../combat';
+import { registerEncounters } from '../expedition';
+
+// ---------------------------------------------------------------------------
+// 訓練場（M2，維持不變）
+// ---------------------------------------------------------------------------
 
 const dagger: Move = {
   id: 'dagger', name: '短刀', kind: 'attack', target: 'enemy', hitStat: 'str',
@@ -21,3 +26,172 @@ export const TRAINING_ENCOUNTER = (): EnemyUnit[] => [
   makeGoblinScout('goblin-scout-1'),
   makeGoblinScout('goblin-scout-2'),
 ];
+
+// ---------------------------------------------------------------------------
+// M3 遠征遭遇：狼／盜匪（含治療師）／礦坑蜘蛛／哥布林掠奪者／兩隻 boss
+// 數值量級比照訓練場哥布林（HP8/def11），boss 落在 HP25-35。
+// ---------------------------------------------------------------------------
+
+const wolfBite: Move = {
+  id: 'wolf-bite', name: '狼咬', kind: 'attack', target: 'enemy', hitStat: 'dex',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' },
+  narration: '{actor}低吼著撲上，獠牙咬向{target}，造成 {amount} 點傷害！',
+};
+
+function makeWolf(id: string): EnemyUnit {
+  return {
+    id, name: '荒野孤狼',
+    stats: { str: 12, dex: 15, int: 4, cha: 4, con: 11 },
+    maxHp: 10, hp: 10, defense: 12,
+    moves: [wolfBite],
+    intents: [{ weight: 1, moveId: 'wolf-bite' }],
+    loot: { gold: [3, 8] },
+  };
+}
+
+const banditSlash: Move = {
+  id: 'bandit-slash', name: '劈砍', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 8, bonusStat: 'str' },
+  narration: '{actor}揮刀劈向{target}，造成 {amount} 點傷害！',
+};
+
+function makeBanditThug(id: string): EnemyUnit {
+  return {
+    id, name: '盜匪打手',
+    stats: { str: 13, dex: 12, int: 8, cha: 8, con: 12 },
+    maxHp: 12, hp: 12, defense: 13,
+    moves: [banditSlash],
+    intents: [{ weight: 1, moveId: 'bandit-slash' }],
+    loot: { gold: [5, 12], itemId: 'tattered-map', itemChance: 0.15 },
+  };
+}
+
+const banditMend: Move = {
+  id: 'bandit-mend', name: '禁咒止血', kind: 'support', target: 'ally', hitStat: 'cha',
+  heal: { dice: 1, sides: 6, bonusStat: 'cha' },
+  narration: '{actor}低聲吟誦禁咒，為{target}止住血流，恢復 {amount} 點生命。',
+};
+
+const banditDagger: Move = {
+  id: 'bandit-dagger', name: '短刃', kind: 'attack', target: 'enemy', hitStat: 'dex',
+  damage: { dice: 1, sides: 4, bonusStat: 'dex' },
+  narration: '{actor}抽出短刃劃向{target}，造成 {amount} 點傷害！',
+};
+
+/** 盜匪的隨隊治療師：意圖在治療同伴與攻擊之間交替（驗證 enemyAct 的 support 目標修繕） */
+function makeBanditMedic(id: string): EnemyUnit {
+  return {
+    id, name: '盜匪祭司',
+    stats: { str: 9, dex: 12, int: 10, cha: 14, con: 10 },
+    maxHp: 9, hp: 9, defense: 11,
+    moves: [banditMend, banditDagger],
+    intents: [
+      { weight: 1, moveId: 'bandit-mend' },
+      { weight: 1, moveId: 'bandit-dagger' },
+    ],
+    loot: { gold: [4, 9] },
+  };
+}
+
+const spiderBite: Move = {
+  id: 'spider-bite', name: '毒牙', kind: 'attack', target: 'enemy', hitStat: 'dex',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' },
+  narration: '{actor}以毒牙刺向{target}，造成 {amount} 點傷害！',
+};
+
+function makeMineSpider(id: string): EnemyUnit {
+  return {
+    id, name: '礦坑蜘蛛',
+    stats: { str: 10, dex: 16, int: 2, cha: 2, con: 10 },
+    maxHp: 11, hp: 11, defense: 13,
+    moves: [spiderBite],
+    intents: [{ weight: 1, moveId: 'spider-bite' }],
+    loot: { gold: [2, 6], itemId: 'spider-silk', itemChance: 0.3 },
+  };
+}
+
+const raiderClub: Move = {
+  id: 'raider-club', name: '狼牙棒', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' },
+  narration: '{actor}掄起狼牙棒砸向{target}，造成 {amount} 點傷害！',
+};
+
+function makeGoblinRaider(id: string): EnemyUnit {
+  return {
+    id, name: '哥布林掠奪者',
+    stats: { str: 11, dex: 13, int: 8, cha: 8, con: 10 },
+    maxHp: 9, hp: 9, defense: 12,
+    moves: [raiderClub],
+    intents: [{ weight: 1, moveId: 'raider-club' }],
+    loot: { gold: [3, 7], itemId: 'goblin-earring', itemChance: 0.2 },
+  };
+}
+
+const overseerWhip: Move = {
+  id: 'overseer-whip', name: '監工鞭', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 8, bonusStat: 'str' },
+  narration: '{actor}揮舞監工鞭抽向{target}，造成 {amount} 點傷害！',
+};
+
+const overseerSlam: Move = {
+  id: 'overseer-slam', name: '鐵鎚重擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 2, sides: 6, bonusStat: 'str' },
+  narration: '{actor}掄起沉重鐵鎚砸向{target}，造成 {amount} 點傷害！',
+};
+
+/** 廢棄礦坑 boss：礦坑監工 */
+function makeMineOverseer(): EnemyUnit {
+  return {
+    id: 'mine-overseer', name: '礦坑監工',
+    stats: { str: 16, dex: 9, int: 8, cha: 6, con: 16 },
+    maxHp: 30, hp: 30, defense: 15,
+    moves: [overseerWhip, overseerSlam],
+    intents: [
+      { weight: 2, moveId: 'overseer-whip' },
+      { weight: 1, moveId: 'overseer-slam' },
+    ],
+    loot: { gold: [30, 50], itemId: 'overseer-ledger', itemChance: 0.8 },
+  };
+}
+
+const chiefAxe: Move = {
+  id: 'chief-axe', name: '巨斧劈砍', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 10, bonusStat: 'str' },
+  narration: '{actor}掄起巨斧劈向{target}，造成 {amount} 點傷害！',
+};
+
+const chiefHowl: Move = {
+  id: 'chief-howl', name: '狂野嗥叫', kind: 'support', target: 'ally', hitStat: 'con',
+  heal: { dice: 1, sides: 8, bonusStat: 'con' },
+  narration: '{actor}仰頭長嗥，體內野性甦醒，恢復 {amount} 點生命。',
+};
+
+/** 哥布林巢穴 boss：巢穴頭目（單體，狂嗥招式自我療傷） */
+function makeGoblinDenChief(): EnemyUnit {
+  return {
+    id: 'goblin-den-chief', name: '巢穴頭目',
+    stats: { str: 15, dex: 12, int: 9, cha: 10, con: 14 },
+    maxHp: 28, hp: 28, defense: 14,
+    moves: [chiefAxe, chiefHowl],
+    intents: [
+      { weight: 3, moveId: 'chief-axe' },
+      { weight: 1, moveId: 'chief-howl' },
+    ],
+    loot: { gold: [35, 55], itemId: 'den-idol', itemChance: 0.9 },
+  };
+}
+
+/** M3 遭遇表：encounterId -> 產生 EnemyUnit[] 的工廠函式。每次呼叫回傳全新物件。 */
+export const ENCOUNTERS: Record<string, () => EnemyUnit[]> = {
+  enc_wolf_pair: () => [makeWolf('wolf-1'), makeWolf('wolf-2')],
+  enc_bandit_raid: () => [makeBanditThug('bandit-thug-1'), makeBanditMedic('bandit-medic-1')],
+  enc_mine_spiders: () => [makeMineSpider('mine-spider-1'), makeMineSpider('mine-spider-2')],
+  enc_goblin_raiders: () => [
+    makeGoblinRaider('goblin-raider-1'),
+    makeGoblinRaider('goblin-raider-2'),
+  ],
+  enc_mine_overseer: () => [makeMineOverseer()],
+  enc_goblin_den_chief: () => [makeGoblinDenChief()],
+};
+
+registerEncounters(ENCOUNTERS);

--- a/src/scripts/games/caravan/data/events.ts
+++ b/src/scripts/games/caravan/data/events.ts
@@ -1,0 +1,457 @@
+import type { EventCard } from '../expedition';
+import { registerEvents } from '../expedition';
+
+// ---------------------------------------------------------------------------
+// M3 首批事件卡：15 張
+// 路線通用 8（含旗標鏈 2：ev_merchant_map → ev_cave_entrance）
+// 森林（黑森林徑）限定 3
+// 迷宮限定 4
+// ---------------------------------------------------------------------------
+
+export const EVENTS: EventCard[] = [
+  // ---- 路線通用 8 -----------------------------------------------------
+  {
+    id: 'ev_bandit_toll',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '隘口的路霸',
+    body: '商隊行至狹窄隘口，幾名手持棍棒的路霸從岩石後閃出，攔住了去路。為首的傢伙咧嘴一笑：「此路是我開，此樹是我栽，想過去，留下買路財。」車夫緊張地攥緊了韁繩。',
+    options: [
+      {
+        label: '掏錢消災',
+        success: [
+          { type: 'gold', amount: -15 },
+          { type: 'log', text: '你付清買路財，商隊平安通過隘口。' },
+        ],
+      },
+      {
+        label: '怒目逼退（力量）',
+        check: { stat: 'str', dc: 13 },
+        success: [
+          { type: 'log', text: '你亮出腰間劍鋒，寒光一閃，路霸悻悻然讓開了道。' },
+        ],
+        failure: [
+          { type: 'log', text: '路霸不吃這套，反倒吆喝同夥圍了上來！' },
+          { type: 'fight', encounterId: 'enc_bandit_raid' },
+        ],
+      },
+      {
+        label: '拔劍迎戰',
+        success: [{ type: 'fight', encounterId: 'enc_bandit_raid' }],
+      },
+    ],
+  },
+  {
+    id: 'ev_broken_wheel',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '車輪斷裂',
+    body: '一聲刺耳的斷裂聲響起，貨車的輪軸應聲斷裂，車身猛地一沉，貨物散落一地。夜幕即將降臨，若不盡快處理，商隊只能困在荒郊野外過夜。',
+    options: [
+      {
+        label: '連夜搶修（智力）',
+        check: { stat: 'int', dc: 12 },
+        success: [
+          { type: 'log', text: '你巧手修復輪軸，商隊沒有耽擱行程，天亮前重新上路。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'party', amount: -2 },
+          { type: 'log', text: '搶修失敗，眾人連夜合力推車，累得筋疲力盡。' },
+        ],
+      },
+      {
+        label: '用礦石打副應急鐵箍',
+        requirement: { itemId: 'ore' },
+        success: [
+          { type: 'item', itemId: 'ore', count: -1 },
+          { type: 'log', text: '你用隨行的礦石打了個應急鐵箍，勉強撐住了輪軸。' },
+        ],
+      },
+      {
+        label: '原地紮營等天亮',
+        success: [
+          { type: 'gold', amount: -5 },
+          { type: 'log', text: '你們原地紮營，隔日再想辦法，雖多花了一天糧食，倒也平安。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_wounded_traveler',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '路遇傷者',
+    body: '路邊倒著一名渾身是血的旅人，斷斷續續地呻吟著。他的行囊散落一旁，看起來是遭了劫。商隊眾人面面相覷——救，還是不救？',
+    options: [
+      {
+        label: '以藥草治療',
+        requirement: { itemId: 'herb' },
+        success: [
+          { type: 'item', itemId: 'herb', count: -1 },
+          { type: 'gold', amount: 20 },
+          { type: 'log', text: '你們用藥草治好了傷者的傷口，他感激地塞給你們一袋銀幣。' },
+        ],
+      },
+      {
+        label: '施展醫術（體質）',
+        check: { stat: 'con', dc: 12 },
+        success: [
+          { type: 'gold', amount: 15 },
+          { type: 'log', text: '你徒手為傷者止血包紮，他掙扎著留下幾枚銅板道謝。' },
+        ],
+        failure: [
+          { type: 'log', text: '你手忙腳亂，傷口越包越糟，傷者只能咬牙自己撐著離開。' },
+        ],
+      },
+      {
+        label: '無暇他顧，逕自離開',
+        success: [
+          { type: 'log', text: '你們選擇繼續趕路，把傷者留在原地，誰都沒有回頭看。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_merchant_map',
+    context: { kind: 'route' },
+    weight: 6,
+    title: '神秘的地圖販子',
+    body: '一名披著破斗篷的商人攔住商隊，神秘兮兮地攤開一張泛黃的地圖殘片：「這上頭標記著一處哥布林巢穴的入口，敢不敢買下這條發財的門路？」',
+    options: [
+      {
+        label: '殺價買下（魅力）',
+        check: { stat: 'cha', dc: 12 },
+        success: [
+          { type: 'gold', amount: -10 },
+          { type: 'flag', flag: 'clue:goblin-cave', value: true },
+          { type: 'log', text: '你殺價買下地圖殘片，上頭標記著一處隱密的山洞入口。' },
+        ],
+        failure: [
+          { type: 'gold', amount: -20 },
+          { type: 'flag', flag: 'clue:goblin-cave', value: true },
+          { type: 'log', text: '商人油鹽不進，你不甘不願地照原價買下了地圖。' },
+        ],
+      },
+      {
+        label: '不予理會，逕自離去',
+        success: [{ type: 'log', text: '你婉拒了商人的兜售，商隊繼續趕路。' }],
+      },
+    ],
+  },
+  {
+    id: 'ev_cave_entrance',
+    context: { kind: 'route' },
+    weight: 6,
+    requiresFlags: { 'clue:goblin-cave': true },
+    title: '山壁上的裂隙',
+    body: '按著地圖上模糊的墨跡，你注意到山壁間一處被藤蔓掩住的裂隙，隱約還能聞到野獸的騷味。地圖上打了個粗魯的叉——就是這裡。',
+    options: [
+      {
+        label: '循圖探查（智力）',
+        check: { stat: 'int', dc: 13 },
+        success: [
+          { type: 'discover', locationId: 'goblin-den' },
+          { type: 'log', text: '你撥開藤蔓，找到了藏在裂隙後的洞口——哥布林的巢穴就在眼前。' },
+        ],
+        failure: [
+          { type: 'log', text: '地圖標示模糊，你在山壁間繞了半天，一無所獲。' },
+        ],
+      },
+      {
+        label: '無視地圖，直接離開',
+        success: [
+          { type: 'log', text: '你把地圖收進行囊，決定不節外生枝，先前進再說。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_river_crossing',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '湍急的溪流',
+    body: '前方一道湍急的溪流擋住去路，水面下的石塊濕滑難行。遠處傳來潺潺水聲，混雜著若有似無的低吼，讓人不敢大意。',
+    options: [
+      {
+        label: '涉水而過（敏捷）',
+        check: { stat: 'dex', dc: 13 },
+        success: [
+          { type: 'log', text: '你腳步輕巧地踏過濕滑石塊，商隊安然渡過溪流。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'party', amount: -3 },
+          { type: 'item', itemId: 'torch', count: -1 },
+          { type: 'log', text: '一個踉蹌，你跌入水中，隨身的火把也泡濕報廢了。' },
+        ],
+      },
+      {
+        label: '繞遠路走乾燥小徑',
+        success: [
+          { type: 'gold', amount: -5 },
+          { type: 'log', text: '你選擇繞行乾燥的小徑，雖多花了些時間，商隊倒是毫髮無傷。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_campfire_stories',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '篝火夜話',
+    body: '夜幕低垂，商隊在路旁紮營。篝火劈啪作響，隊員們圍坐取暖，氣氛卻有些沉悶——這是連日趕路後難得的喘息時刻。',
+    options: [
+      {
+        label: '帶頭說笑（魅力）',
+        check: { stat: 'cha', dc: 11 },
+        success: [
+          { type: 'hp', target: 'party', amount: 4 },
+          { type: 'log', text: '你講的笑話逗樂了眾人，一夜好眠後大家精神百倍。' },
+        ],
+        failure: [
+          { type: 'log', text: '你的笑話冷場，眾人尷尬地笑了兩聲，各自裹著毯子睡去。' },
+        ],
+      },
+      {
+        label: '早早歇息',
+        success: [
+          { type: 'hp', target: 'party', amount: 2 },
+          { type: 'log', text: '商隊安靜地紮營歇息，恢復了些許體力。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_wolf_howl',
+    context: { kind: 'route' },
+    weight: 10,
+    title: '遠方的狼嚎',
+    body: '天色漸暗，遠方傳來此起彼落的狼嚎，聲音越來越近。隊員們握緊了武器，馬匹也開始不安地噴著鼻息，蹄子焦躁地刨著地面。',
+    options: [
+      {
+        label: '紮營戒備（敏捷）',
+        check: { stat: 'dex', dc: 13 },
+        success: [
+          { type: 'log', text: '你及時發現草叢中的狼群蹤跡，商隊嚴陣以待，狼群知難而退。' },
+        ],
+        failure: [
+          { type: 'log', text: '狼群趁隙從暗處撲了上來！' },
+          { type: 'fight', encounterId: 'enc_wolf_pair' },
+        ],
+      },
+      {
+        label: '點燃火把驅狼',
+        requirement: { itemId: 'torch' },
+        success: [
+          { type: 'item', itemId: 'torch', count: -1 },
+          { type: 'log', text: '熊熊火光嚇退了黑暗中窺伺的狼群，牠們悻悻然遁入林間。' },
+        ],
+      },
+      {
+        label: '強行趕路，賭牠們不會靠近',
+        success: [
+          { type: 'log', text: '你們加快腳步，狼嚎聲漸漸遠去，總算是有驚無險。' },
+        ],
+      },
+    ],
+  },
+
+  // ---- 森林（黑森林徑）限定 3 -------------------------------------------
+  {
+    id: 'ev_forest_shrine',
+    context: { kind: 'route', locationIds: ['blackwood-trail'] },
+    weight: 8,
+    title: '林間的荒祠',
+    body: '密林深處立著一座爬滿青苔的荒祠，石像的面容早已風化模糊，祠前散落著半朽的祭品。空氣中瀰漫著一股說不出的詭異寧靜。',
+    options: [
+      {
+        label: '上前查看（智力）',
+        check: { stat: 'int', dc: 13 },
+        success: [
+          { type: 'gold', amount: 25 },
+          { type: 'log', text: '你在荒祠底座摸出一格暗格，裡頭藏著往來商旅遺落的錢袋。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'party', amount: -3 },
+          { type: 'log', text: '觸動了暗藏的機關，一支毒箭擦過你的肩膀。' },
+        ],
+      },
+      {
+        label: '敬而遠之，繼續趕路',
+        success: [
+          { type: 'log', text: '你們對著荒祠行了個禮，快步離開這片詭異的林地。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_goblin_scout_trail',
+    context: { kind: 'route', locationIds: ['blackwood-trail'] },
+    weight: 8,
+    title: '哥布林的腳印',
+    body: '泥地上留著一串雜亂的腳印，混著獸皮鞋底與粗製武器拖行的痕跡——是哥布林斥候不久前經過的痕跡。順著腳印望去，林葉還在輕輕晃動。',
+    options: [
+      {
+        label: '循跡跟蹤，伺機偷襲（敏捷）',
+        check: { stat: 'dex', dc: 14 },
+        success: [
+          { type: 'gold', amount: 12 },
+          { type: 'item', itemId: 'goblin-earring', count: 1 },
+          { type: 'log', text: '你悄悄尾隨，撂倒了落單的哥布林斥候，順手摸走了牠的耳環。' },
+        ],
+        failure: [
+          { type: 'log', text: '枯枝一聲脆響，暴露了行蹤——哥布林轉身撲了上來！' },
+          { type: 'fight', encounterId: 'enc_goblin_raiders' },
+        ],
+      },
+      {
+        label: '避開腳印，繞道而行',
+        success: [
+          { type: 'log', text: '你們刻意避開腳印聚集之處，平安無事地穿過林地。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_forest_herbalist',
+    context: { kind: 'route', locationIds: ['blackwood-trail'] },
+    weight: 8,
+    title: '隱居的採藥人',
+    body: '林間小屋前，一名白髮蒼蒼的採藥人正低頭篩選藥草，對商隊的到來恍若未覺。屋簷下掛滿了曬乾的藥草束，散發著淡淡的清香。',
+    options: [
+      {
+        label: '請教藥草知識（智力）',
+        check: { stat: 'int', dc: 12 },
+        success: [
+          { type: 'item', itemId: 'herb', count: 2 },
+          { type: 'log', text: '採藥人見你談吐不俗，傳授了辨識藥草的訣竅，還送你兩把藥草。' },
+        ],
+        failure: [
+          { type: 'log', text: '採藥人對你愛答不理，只顧著低頭篩選他的藥草。' },
+        ],
+      },
+      {
+        label: '花錢買藥草',
+        success: [
+          { type: 'gold', amount: -15 },
+          { type: 'item', itemId: 'herb', count: 3 },
+          { type: 'log', text: '你付了些銀錢，換來三把曬乾的藥草。' },
+        ],
+      },
+    ],
+  },
+
+  // ---- 迷宮限定 4 ------------------------------------------------------
+  {
+    id: 'ev_mine_gas_pocket',
+    context: { kind: 'dungeon', locationIds: ['abandoned-mine'] },
+    weight: 8,
+    title: '瀰漫的毒氣',
+    body: '坑道深處瀰漫著一股嗆鼻的氣味，火把的光芒在此處微微發綠。前方的空氣彷彿凝滯，每吸一口都讓人頭暈目眩。',
+    options: [
+      {
+        label: '摒息通過（體質）',
+        check: { stat: 'con', dc: 13 },
+        success: [
+          { type: 'log', text: '你摒住呼吸快速通過，商隊安然無恙地穿越了毒氣坑道。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'party', amount: -4 },
+          { type: 'log', text: '嗆人的毒氣灌入肺裡，眾人咳得眼淚直流，踉蹌逃出坑道。' },
+        ],
+      },
+      {
+        label: '點燃火把試探',
+        requirement: { itemId: 'torch' },
+        success: [
+          { type: 'item', itemId: 'torch', count: -1 },
+          { type: 'gold', amount: 8 },
+          { type: 'log', text: '火把湊近瞬間氣體轟然引燃，所幸只是虛驚一場，坑道深處還散落著幾枚錢幣。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_collapsed_tunnel',
+    context: { kind: 'dungeon', locationIds: ['abandoned-mine'] },
+    weight: 8,
+    title: '坍塌的坑道',
+    body: '前方坑道半數坍塌，碎石與斷裂的支撐木堵住了去路。頭頂不時傳來令人心驚的碎石聲響，彷彿隨時會再次崩落。',
+    options: [
+      {
+        label: '合力清出通路（力量）',
+        check: { stat: 'str', dc: 14 },
+        success: [
+          { type: 'log', text: '眾人合力搬開落石，硬是清出一條僅容通過的縫隙。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'party', amount: -2 },
+          { type: 'log', text: '碎石鬆動崩落，砸得眾人灰頭土臉，勉強擠了過去。' },
+        ],
+      },
+      {
+        label: '另尋岔路繞行',
+        success: [
+          { type: 'log', text: '你們退回岔路，繞了一大圈才重新接上主坑道。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_ancient_totem',
+    context: { kind: 'dungeon', locationIds: ['goblin-den'] },
+    weight: 8,
+    title: '古老的圖騰柱',
+    body: '巢穴深處立著一根爬滿獸骨與羽毛的圖騰柱，上頭刻著粗獷的哥布林紋樣，柱底隱約堆著一些雜物，散發著某種令人不安的氣息。',
+    options: [
+      {
+        label: '破壞圖騰，激怒守衛（力量）',
+        check: { stat: 'str', dc: 13 },
+        success: [
+          { type: 'gold', amount: 20 },
+          { type: 'item', itemId: 'ore', count: 1 },
+          { type: 'log', text: '你一斧劈開圖騰柱，裡頭滾出幾枚錢幣與一塊礦石。' },
+        ],
+        failure: [
+          { type: 'log', text: '圖騰柱轟然倒下，驚醒了埋伏在暗處的哥布林！' },
+          { type: 'fight', encounterId: 'enc_goblin_raiders' },
+        ],
+      },
+      {
+        label: '獻上祭品安撫',
+        success: [
+          { type: 'gold', amount: -10 },
+          { type: 'log', text: '你在圖騰前擺上幾枚銅幣，古怪的低吟聲漸漸平息下來。' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ev_unknown_chest_trap',
+    context: { kind: 'dungeon' },
+    weight: 8,
+    title: '可疑的箱子',
+    body: '側室角落擺著一只鑲銅木箱，箱蓋上刻著繁複的紋路，邊緣有幾道細如髮絲的刻痕——不像是自然形成的，透著一股蓄意設計的惡意。',
+    options: [
+      {
+        label: '仔細檢查機關（敏捷）',
+        check: { stat: 'dex', dc: 13 },
+        success: [
+          { type: 'gold', amount: 22 },
+          { type: 'log', text: '你巧妙拆解了箱蓋上的毒針機關，裡頭是滿滿的銀幣。' },
+        ],
+        failure: [
+          { type: 'hp', target: 'protagonist', amount: -3 },
+          { type: 'log', text: '毒針彈出刺中你的手指，一陣刺痛竄上手臂。' },
+        ],
+      },
+      {
+        label: '不予理會，直接離開',
+        success: [
+          { type: 'log', text: '你決定不冒這個險，逕自離開了這處可疑的箱子。' },
+        ],
+      },
+    ],
+  },
+];
+
+registerEvents(EVENTS);

--- a/src/scripts/games/caravan/data/items.ts
+++ b/src/scripts/games/caravan/data/items.ts
@@ -1,0 +1,82 @@
+export interface ItemDef {
+  id: string;
+  name: string;
+  desc: string;
+  value: number;
+}
+
+/** M3 首批物品：12 種（藥草/繃帶/火把/哥布林耳環/礦石/蛛絲/boss 遺寶×2/雜項 4） */
+export const ITEMS: Record<string, ItemDef> = {
+  herb: {
+    id: 'herb',
+    name: '藥草',
+    desc: '山野常見的藥草，搗碎外敷可止血鎮痛，旅人隨身必備。',
+    value: 5,
+  },
+  bandage: {
+    id: 'bandage',
+    name: '繃帶',
+    desc: '浸過藥水的紗布，是戰場急救的最後一道防線。',
+    value: 8,
+  },
+  torch: {
+    id: 'torch',
+    name: '火把',
+    desc: '浸油麻布纏繞的木棒，能照亮迷宮最深的暗處，也能嚇退夜行的野獸。',
+    value: 6,
+  },
+  'goblin-earring': {
+    id: 'goblin-earring',
+    name: '哥布林耳環',
+    desc: '哥布林戰士佩戴的骨製耳環，樣式粗獷，商人願意為這種戰利品出好價錢。',
+    value: 15,
+  },
+  ore: {
+    id: 'ore',
+    name: '礦石',
+    desc: '從礦坑深處挖出的鐵礦原石，未經冶煉，鍛造師搶著要。',
+    value: 12,
+  },
+  'spider-silk': {
+    id: 'spider-silk',
+    name: '蛛絲',
+    desc: '礦坑蜘蛛吐出的絲線，堅韌如鋼，紡織坊高價收購。',
+    value: 18,
+  },
+  'overseer-ledger': {
+    id: 'overseer-ledger',
+    name: '監工的密帳',
+    desc: '記錄著非法奴役礦工帳目的皮革帳本，城裡的商會會為它付出重金。',
+    value: 60,
+  },
+  'den-idol': {
+    id: 'den-idol',
+    name: '巢穴圖騰',
+    desc: '哥布林部族供奉的骨雕圖騰，紋路詭異，收藏家趨之若鶩。',
+    value: 70,
+  },
+  'dried-rations': {
+    id: 'dried-rations',
+    name: '乾糧',
+    desc: '壓縮乾燥的行軍糧，難吃但耐放，長途跋涉的必備品。',
+    value: 4,
+  },
+  'silver-locket': {
+    id: 'silver-locket',
+    name: '銀懷錶',
+    desc: '刻著陌生家徽的銀製懷錶，錶蓋內側還留著一撮髮絲，不知是誰的遺物。',
+    value: 25,
+  },
+  'tattered-map': {
+    id: 'tattered-map',
+    name: '破損地圖',
+    desc: '邊緣燒焦的羊皮地圖，殘存的墨跡似乎標記著某處地標。',
+    value: 10,
+  },
+  'spice-pouch': {
+    id: 'spice-pouch',
+    name: '香料包',
+    desc: '異域香料混合的小布包，遠方城鎮的廚師願意高價收購。',
+    value: 14,
+  },
+};

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -1,0 +1,61 @@
+import type { LocationDef } from '../expedition';
+import { registerLocations } from '../expedition';
+import type { SaveData } from '../save';
+
+/** M3 首批地點：貿易路線 2 條、迷宮 1 座、隱藏迷宮 1 座（旗標鏈 discover） */
+export const LOCATIONS: Record<string, LocationDef> = {
+  'riverside-road': {
+    id: 'riverside-road',
+    name: '臨水道',
+    kind: 'route',
+    legs: 4,
+    encounterTable: [
+      { weight: 60, encounterId: 'enc_wolf_pair' },
+      { weight: 40, encounterId: 'enc_bandit_raid' },
+    ],
+  },
+  'blackwood-trail': {
+    id: 'blackwood-trail',
+    name: '黑森林徑',
+    kind: 'route',
+    legs: 5,
+    encounterTable: [
+      { weight: 50, encounterId: 'enc_wolf_pair' },
+      { weight: 50, encounterId: 'enc_goblin_raiders' },
+    ],
+  },
+  'abandoned-mine': {
+    id: 'abandoned-mine',
+    name: '廢棄礦坑',
+    kind: 'dungeon',
+    floors: 4,
+    roomsPerFloor: [2, 3],
+    depthHpBonus: 2,
+    bossEncounterId: 'enc_mine_overseer',
+    encounterTable: [
+      { weight: 70, encounterId: 'enc_mine_spiders' },
+      { weight: 30, encounterId: 'enc_bandit_raid' },
+    ],
+  },
+  'goblin-den': {
+    id: 'goblin-den',
+    name: '哥布林巢穴',
+    kind: 'dungeon',
+    hidden: true,
+    floors: 3,
+    roomsPerFloor: [2, 3],
+    depthHpBonus: 3,
+    bossEncounterId: 'enc_goblin_den_chief',
+    encounterTable: [{ weight: 100, encounterId: 'enc_goblin_raiders' }],
+  },
+};
+
+/** hidden 且未設 `discovered:<id>` 旗標的地點，不列入委託板 */
+export function visibleLocations(save: SaveData): LocationDef[] {
+  return Object.values(LOCATIONS).filter((loc) => {
+    if (!loc.hidden) return true;
+    return save.flags[`discovered:${loc.id}`] === true;
+  });
+}
+
+registerLocations(LOCATIONS);

--- a/src/scripts/games/caravan/expedition.test.ts
+++ b/src/scripts/games/caravan/expedition.test.ts
@@ -573,6 +573,16 @@ describe('settleExpedition', () => {
     expect(save.companions[0].injuredForTrips).toBe(0);
   });
 
+  it('主角的 injuredForTrips 也會遞減（不遞減會永久卡在重傷——M3 終審地雷）', () => {
+    const save = makeSave();
+    save.protagonist.injuredForTrips = 2;
+    const state = makeState({ step: 1 });
+    settleExpedition(state, save);
+    expect(save.protagonist.injuredForTrips).toBe(1);
+    settleExpedition(makeState({ step: 1 }), save);
+    expect(save.protagonist.injuredForTrips).toBe(0);
+  });
+
   it('結算後 save.expedition 清為 null', () => {
     const save = makeSave();
     save.expedition = makeState();

--- a/src/scripts/games/caravan/expedition.test.ts
+++ b/src/scripts/games/caravan/expedition.test.ts
@@ -2,26 +2,35 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   registerLocations,
   registerEvents,
+  registerEncounters,
   startExpedition,
   drawEvent,
   optionAvailable,
   resolveOption,
   advanceExpedition,
   settleExpedition,
+  drawRooms,
+  chooseRoom,
+  buildEncounter,
+  finishCombat,
+  applyPartyHp,
 } from './expedition';
 import type { EventCard, LocationDef, ExpeditionState } from './expedition';
 import { newGame } from './save';
 import type { SaveData, CompanionRecord } from './save';
 import type { Rng } from './rng';
+import type { EnemyUnit, PartyMember, CombatState } from './combat';
 
-/** 依序回傳指定骰值的假 RNG；weightedPick 依 pickIndex 佇列選出候選陣列中的第幾個 */
-function fakeRng(opts: { d20?: number[]; pickIndex?: number[] } = {}): Rng {
+/** 依序回傳指定骰值的假 RNG；weightedPick 依 pickIndex 佇列選出候選陣列中的第幾個；next 依序回傳（預設全 0） */
+function fakeRng(opts: { d20?: number[]; pickIndex?: number[]; next?: number[] } = {}): Rng {
   let d20i = 0;
   let picki = 0;
+  let nexti = 0;
   const d20s = opts.d20 ?? [10];
   const picks = opts.pickIndex ?? [0];
+  const nexts = opts.next ?? [0];
   return {
-    next: () => 0,
+    next: () => nexts[nexti++ % nexts.length],
     roll: () => d20s[d20i++ % d20s.length],
     d20: () => d20s[d20i++ % d20s.length],
     pick: (arr) => arr[0],
@@ -32,6 +41,32 @@ function fakeRng(opts: { d20?: number[]; pickIndex?: number[] } = {}): Rng {
       if (!hit) throw new Error(`weightedPick: index 超出範圍（${idx}）`);
       return hit.value;
     },
+  };
+}
+
+function makeEnemy(overrides: Partial<EnemyUnit> = {}): EnemyUnit {
+  return {
+    id: 'e1', name: '敵人',
+    stats: { str: 10, dex: 10, int: 10, cha: 10, con: 10 },
+    maxHp: 10, hp: 10, defense: 10, moves: [], intents: [],
+    ...overrides,
+  };
+}
+
+function makePartyMember(overrides: Partial<PartyMember> = {}): PartyMember {
+  return {
+    id: 'protagonist', name: '主角',
+    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 },
+    maxHp: 22, hp: 22, defense: 10, moves: [], isProtagonist: true,
+    ...overrides,
+  };
+}
+
+function makeCombat(overrides: Partial<CombatState> = {}): CombatState {
+  return {
+    round: 1, order: [], turnIndex: 0,
+    party: [], enemies: [], guarding: {}, enemyIntents: {}, log: [], outcome: 'victory',
+    ...overrides,
   };
 }
 
@@ -550,5 +585,344 @@ describe('settleExpedition', () => {
     const state = makeState({ loot: { gold: 12, items: { herb: 1 } }, step: 1 });
     const result = settleExpedition(state, save);
     expect(result).toEqual({ goldGained: 12, itemsGained: { herb: 1 }, xpGained: 25 });
+  });
+});
+
+describe('drawRooms', () => {
+  it('非頂層：張數由 loc.roomsPerFloor 決定（roll 選 span 內的低點）', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    // LOC_DUNGEON_A.roomsPerFloor=[2,3]，span=2；roll 回 1 → count=2+1-1=2
+    const chosen = drawRooms(fakeRng({ d20: [1], pickIndex: [0, 0] }), state);
+    expect(chosen.length).toBe(2);
+    expect(state.roomChoices).toEqual(chosen);
+  });
+
+  it('非頂層：roll 選 span 內的高點時抽 3 張', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    // roll 回 2 → count=2+2-1=3
+    const chosen = drawRooms(fakeRng({ d20: [2], pickIndex: [0, 0, 0] }), state);
+    expect(chosen.length).toBe(3);
+  });
+
+  it('同層不重複抽同型（不放回抽法）', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    const chosen = drawRooms(fakeRng({ d20: [2], pickIndex: [0, 0, 0] }), state);
+    // pool 依序 [fight,treasure,event,rest,unknown]；每抽一張就從剩餘池移除，
+    // pickIndex 全 0 代表每次都選「剩餘池的第一個」→ fight, treasure, event
+    expect(chosen).toEqual(['fight', 'treasure', 'event']);
+    expect(new Set(chosen).size).toBe(chosen.length);
+  });
+
+  it('頂層（step===totalSteps）固定 [\'fight\']（boss）', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 3, totalSteps: 3 });
+    const chosen = drawRooms(fakeRng(), state);
+    expect(chosen).toEqual(['fight']);
+    expect(state.roomChoices).toEqual(['fight']);
+  });
+
+  it('未指定 roomsPerFloor 時預設 [2,3]', () => {
+    registerLocations({
+      loc_dungeon_b: {
+        id: 'loc_dungeon_b', name: '哥布林巢穴', kind: 'dungeon', floors: 2,
+        encounterTable: [{ weight: 1, encounterId: 'enc_goblin_nest' }],
+      },
+    });
+    const state = makeState({ locationId: 'loc_dungeon_b', kind: 'dungeon', step: 1, totalSteps: 2 });
+    // 預設 span=[2,3]→span=2；roll 回 2 → count=2+2-1=3
+    const chosen = drawRooms(fakeRng({ d20: [2], pickIndex: [0, 0, 0] }), state);
+    expect(chosen.length).toBe(3);
+  });
+});
+
+describe('chooseRoom', () => {
+  describe('fight', () => {
+    it('非頂層：查 encounterTable 加權抽 encounterId，設 pendingEncounterId+phase=combat', () => {
+      const save = makeSave();
+      const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+      const result = chooseRoom(fakeRng({ pickIndex: [0] }), state, save, 'fight');
+      expect(result.encounterId).toBe('enc_spider');
+      expect(state.pendingEncounterId).toBe('enc_spider');
+      expect(state.phase).toBe('combat');
+    });
+
+    it('頂層（boss）：固定用 bossEncounterId，不查 encounterTable', () => {
+      const save = makeSave();
+      const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 3, totalSteps: 3 });
+      const result = chooseRoom(fakeRng(), state, save, 'fight');
+      expect(result.encounterId).toBe('enc_boss');
+      expect(state.pendingEncounterId).toBe('enc_boss');
+      expect(state.phase).toBe('combat');
+    });
+  });
+
+  describe('treasure', () => {
+    it('gold = roll(6)*10 + step*10，入 state.loot.gold', () => {
+      const save = makeSave();
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 2, totalSteps: 3,
+        loot: { gold: 0, items: {} },
+      });
+      // roll(6)=3、step=2 → 3*10+2*10=50；next=0.99 不中物品機率
+      const result = chooseRoom(fakeRng({ d20: [3], next: [0.99] }), state, save, 'treasure');
+      expect(result.treasureGold).toBe(50);
+      expect(state.loot.gold).toBe(50);
+      expect(state.loot.items.ore).toBeUndefined();
+    });
+
+    it('10% 機率（next()<0.1）額外給 1 個 ore（M3 簡化固定物品）', () => {
+      const save = makeSave();
+      const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+      const result = chooseRoom(fakeRng({ d20: [1], next: [0.05] }), state, save, 'treasure');
+      expect(result.treasureGold).toBeDefined();
+      expect(state.loot.items.ore).toBe(1);
+    });
+
+    it('未中機率（next()>=0.1）不給物品', () => {
+      const save = makeSave();
+      const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+      chooseRoom(fakeRng({ d20: [1], next: [0.5] }), state, save, 'treasure');
+      expect(state.loot.items.ore).toBeUndefined();
+    });
+
+    it('結算後呼叫 advanceExpedition（step 前進、phase 依 kind 推進）', () => {
+      const save = makeSave();
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3, phase: 'room-choice',
+      });
+      chooseRoom(fakeRng({ d20: [1], next: [0.99] }), state, save, 'treasure');
+      expect(state.step).toBe(2);
+      expect(state.phase).toBe('room-choice');
+    });
+  });
+
+  describe('rest', () => {
+    it('全隊回 1d6+2，不超過各自 maxHp（不同成員各自 cap）', () => {
+      const save = makeSave({
+        companions: [makeCompanion({ id: 'ally', maxHp: 20, injuredForTrips: 0 })],
+      });
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3,
+        partyHp: { [save.protagonist.id]: 10, ally: 18 },
+      });
+      // roll(6)=4 → healed=4+2=6：protagonist 10+6=16（未達 max 22）；ally 18+6=24→cap 於 20
+      const result = chooseRoom(fakeRng({ d20: [4] }), state, save, 'rest');
+      expect(result.restHealed).toBe(6);
+      expect(state.partyHp[save.protagonist.id]).toBe(16);
+      expect(state.partyHp.ally).toBe(20);
+    });
+
+    it('結算後呼叫 advanceExpedition', () => {
+      const save = makeSave();
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3, phase: 'room-choice',
+      });
+      chooseRoom(fakeRng({ d20: [4] }), state, save, 'rest');
+      expect(state.step).toBe(2);
+      expect(state.phase).toBe('room-choice');
+    });
+  });
+
+  describe('event', () => {
+    it('抽 dungeon context 事件並回傳 { event }，不呼叫 advanceExpedition', () => {
+      const save = makeSave();
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3, phase: 'room-choice',
+      });
+      // 候選（context.kind 過濾後）：[evUniversal, evDungeonOnly]；pickIndex=1 → evDungeonOnly
+      const result = chooseRoom(fakeRng({ pickIndex: [1] }), state, save, 'event');
+      expect(result.event?.id).toBe('ev_dungeon_only');
+      expect(state.phase).toBe('event');
+      expect(state.step).toBe(1); // 未呼叫 advanceExpedition
+    });
+  });
+
+  describe('unknown', () => {
+    it('next()<0.5 實際化為 fight，走 fight 邏輯', () => {
+      const save = makeSave();
+      const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+      const result = chooseRoom(fakeRng({ next: [0.1], pickIndex: [0] }), state, save, 'unknown');
+      expect(result.encounterId).toBe('enc_spider');
+      expect(state.phase).toBe('combat');
+    });
+
+    it('next()>=0.5 實際化為 treasure，走 treasure 邏輯（含 advanceExpedition）', () => {
+      const save = makeSave();
+      const state = makeState({
+        locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3, phase: 'room-choice',
+      });
+      // next 佇列：[0]=0.9→實際化 treasure；[1]=0.99→物品機率未中
+      const result = chooseRoom(fakeRng({ d20: [5], next: [0.9, 0.99] }), state, save, 'unknown');
+      expect(result.treasureGold).toBe(5 * 10 + 1 * 10);
+      expect(state.step).toBe(2);
+      expect(state.phase).toBe('room-choice');
+    });
+  });
+});
+
+describe('buildEncounter', () => {
+  beforeEach(() => {
+    registerEncounters({
+      enc_spider: () => [makeEnemy({ id: 'spider-1' })],
+    });
+  });
+
+  it('查 registerEncounters 登記表生成敵人', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    const enemies = buildEncounter(fakeRng(), state, 'enc_spider');
+    expect(enemies.map((e) => e.id)).toEqual(['spider-1']);
+  });
+
+  it('找不到 encounterId 丟 Error', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    expect(() => buildEncounter(fakeRng(), state, 'no-such-encounter')).toThrow();
+  });
+
+  it('dungeon：套用 depthHpBonus×(step-1)（step=3 → +2×2=+4）', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 3, totalSteps: 3 });
+    const [enemy] = buildEncounter(fakeRng(), state, 'enc_spider');
+    expect(enemy.maxHp).toBe(10 + 4);
+    expect(enemy.hp).toBe(10 + 4);
+  });
+
+  it('dungeon 第一層（step=1）：加成為 0', () => {
+    const state = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon', step: 1, totalSteps: 3 });
+    const [enemy] = buildEncounter(fakeRng(), state, 'enc_spider');
+    expect(enemy.maxHp).toBe(10);
+    expect(enemy.hp).toBe(10);
+  });
+
+  it('route：不套用深度加成', () => {
+    const state = makeState({ locationId: 'loc_route_a', kind: 'route', step: 2, totalSteps: 2 });
+    const [enemy] = buildEncounter(fakeRng(), state, 'enc_spider');
+    expect(enemy.maxHp).toBe(10);
+    expect(enemy.hp).toBe(10);
+  });
+});
+
+describe('applyPartyHp', () => {
+  it('把 state.partyHp 覆蓋到對應 member.hp', () => {
+    const state = makeState({ partyHp: { protagonist: 15, ally: 9 } });
+    const members = [makePartyMember({ id: 'protagonist', hp: 22 }), makePartyMember({ id: 'ally', hp: 20 })];
+    applyPartyHp(state, members);
+    expect(members[0].hp).toBe(15);
+    expect(members[1].hp).toBe(9);
+  });
+
+  it('partyHp 缺 key 時不動該 member 的 hp', () => {
+    const state = makeState({ partyHp: { protagonist: 15 } });
+    const members = [makePartyMember({ id: 'protagonist', hp: 22 }), makePartyMember({ id: 'stranger', hp: 7 })];
+    applyPartyHp(state, members);
+    expect(members[0].hp).toBe(15);
+    expect(members[1].hp).toBe(7); // 未出現在 partyHp，維持原值
+  });
+});
+
+describe('finishCombat', () => {
+  it('無論勝敗都把 combat.party 最終 hp 寫回 state.partyHp', () => {
+    const save = makeSave();
+    const state = makeState({ partyHp: { [save.protagonist.id]: 22 } });
+    const combat = makeCombat({
+      outcome: 'defeat',
+      party: [makePartyMember({ id: save.protagonist.id, hp: 0 })],
+    });
+    finishCombat(fakeRng(), state, save, combat, []);
+    expect(state.partyHp[save.protagonist.id]).toBe(0);
+  });
+
+  it('victory：loot gold 區間下界（roll=1 → 取最小值）', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 0, items: {} } });
+    const enemy = makeEnemy({ id: 'e1', loot: { gold: [8, 8] } });
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [enemy] });
+    finishCombat(fakeRng({ d20: [1] }), state, save, combat, []);
+    expect(state.loot.gold).toBe(8);
+  });
+
+  it('victory：loot gold 區間上界（roll=span → 取最大值）', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 0, items: {} } });
+    const enemy = makeEnemy({ id: 'e1', loot: { gold: [5, 10] } }); // span=6
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [enemy] });
+    finishCombat(fakeRng({ d20: [6] }), state, save, combat, []);
+    expect(state.loot.gold).toBe(10);
+  });
+
+  it('victory：itemChance 命中額外給指定物品', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 0, items: {} } });
+    const enemy = makeEnemy({ id: 'e1', loot: { gold: [1, 1], itemId: 'goblin-ear', itemChance: 0.3 } });
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [enemy] });
+    finishCombat(fakeRng({ d20: [1], next: [0.1] }), state, save, combat, []);
+    expect(state.loot.items['goblin-ear']).toBe(1);
+  });
+
+  it('victory：itemChance 未命中不給物品', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 0, items: {} } });
+    const enemy = makeEnemy({ id: 'e1', loot: { gold: [1, 1], itemId: 'goblin-ear', itemChance: 0.3 } });
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [enemy] });
+    finishCombat(fakeRng({ d20: [1], next: [0.5] }), state, save, combat, []);
+    expect(state.loot.items['goblin-ear']).toBeUndefined();
+  });
+
+  it('victory 後呼叫 advanceExpedition 推進 step/phase', () => {
+    const save = makeSave();
+    const state = makeState({ kind: 'dungeon', step: 1, totalSteps: 3, loot: { gold: 0, items: {} } });
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, []);
+    expect(state.step).toBe(2);
+    expect(state.phase).toBe('room-choice');
+  });
+
+  it('retreated：retreated=true、loot.gold 折半（向下取整）、phase=done', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 7, items: {} }, step: 2, totalSteps: 5, phase: 'combat' });
+    const combat = makeCombat({ outcome: 'retreated', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, []);
+    expect(state.retreated).toBe(true);
+    expect(state.loot.gold).toBe(3);
+    expect(state.phase).toBe('done');
+  });
+
+  it('defeat：同 retreated 的折損與提前結束（phase=done）', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 9, items: {} }, step: 2, totalSteps: 5, phase: 'combat' });
+    const combat = makeCombat({ outcome: 'defeat', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, []);
+    expect(state.retreated).toBe(true);
+    expect(state.loot.gold).toBe(4);
+    expect(state.phase).toBe('done');
+  });
+
+  it('fates dead：非主角傭兵從 companions 移除', () => {
+    const save = makeSave({
+      companions: [makeCompanion({ id: 'c1' }), makeCompanion({ id: 'c2' })],
+    });
+    const state = makeState();
+    const combat = makeCombat({ outcome: 'defeat', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, [{ id: 'c1', fate: 'dead' }]);
+    expect(save.companions.map((c) => c.id)).toEqual(['c2']);
+  });
+
+  it('fates dead：主角即使出現在 fates 中也不會被移除（防禦性）', () => {
+    const save = makeSave();
+    const protagonistId = save.protagonist.id;
+    const state = makeState();
+    const combat = makeCombat({ outcome: 'defeat', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, [{ id: protagonistId, fate: 'dead' }]);
+    expect(save.protagonist.id).toBe(protagonistId);
+    expect(save.protagonist.injuredForTrips).toBe(0); // dead 分支不會誤把主角轉成 injured
+  });
+
+  it('fates injured：傭兵與主角皆設 injuredForTrips=2', () => {
+    const save = makeSave({ companions: [makeCompanion({ id: 'c1', injuredForTrips: 0 })] });
+    const state = makeState();
+    const combat = makeCombat({ outcome: 'victory', party: [], enemies: [] });
+    finishCombat(fakeRng(), state, save, combat, [
+      { id: 'c1', fate: 'injured' },
+      { id: save.protagonist.id, fate: 'injured' },
+    ]);
+    expect(save.companions[0].injuredForTrips).toBe(2);
+    expect(save.protagonist.injuredForTrips).toBe(2);
   });
 });

--- a/src/scripts/games/caravan/expedition.test.ts
+++ b/src/scripts/games/caravan/expedition.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerLocations,
+  registerEvents,
+  startExpedition,
+  drawEvent,
+  optionAvailable,
+  resolveOption,
+  advanceExpedition,
+  settleExpedition,
+} from './expedition';
+import type { EventCard, LocationDef, ExpeditionState } from './expedition';
+import { newGame } from './save';
+import type { SaveData, CompanionRecord } from './save';
+import type { Rng } from './rng';
+
+/** 依序回傳指定骰值的假 RNG；weightedPick 依 pickIndex 佇列選出候選陣列中的第幾個 */
+function fakeRng(opts: { d20?: number[]; pickIndex?: number[] } = {}): Rng {
+  let d20i = 0;
+  let picki = 0;
+  const d20s = opts.d20 ?? [10];
+  const picks = opts.pickIndex ?? [0];
+  return {
+    next: () => 0,
+    roll: () => d20s[d20i++ % d20s.length],
+    d20: () => d20s[d20i++ % d20s.length],
+    pick: (arr) => arr[0],
+    weightedPick: (items) => {
+      if (items.length === 0) throw new Error('weightedPick: 空清單');
+      const idx = picks[picki++ % picks.length];
+      const hit = items[idx];
+      if (!hit) throw new Error(`weightedPick: index 超出範圍（${idx}）`);
+      return hit.value;
+    },
+  };
+}
+
+const LOC_ROUTE_A: LocationDef = {
+  id: 'loc_route_a', name: '臨水道', kind: 'route', legs: 2,
+  encounterTable: [{ weight: 1, encounterId: 'enc_wolf' }],
+};
+const LOC_ROUTE_B: LocationDef = {
+  id: 'loc_route_b', name: '黑森林徑', kind: 'route', legs: 1, hidden: true,
+  encounterTable: [{ weight: 1, encounterId: 'enc_goblin' }],
+};
+const LOC_DUNGEON_A: LocationDef = {
+  id: 'loc_dungeon_a', name: '廢棄礦坑', kind: 'dungeon', floors: 3,
+  roomsPerFloor: [2, 3], bossEncounterId: 'enc_boss',
+  encounterTable: [{ weight: 1, encounterId: 'enc_spider' }],
+  depthHpBonus: 2,
+};
+
+function makeSave(overrides: Partial<SaveData> = {}): SaveData {
+  const s = newGame(1000);
+  return { ...s, ...overrides };
+}
+
+function makeCompanion(overrides: Partial<CompanionRecord> = {}): CompanionRecord {
+  return {
+    id: 'comp-1', name: '傭兵', job: 'cleric', level: 1, xp: 0,
+    stats: { str: 10, dex: 10, int: 10, cha: 14, con: 12 },
+    maxHp: 20, injuredForTrips: 0,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<ExpeditionState> = {}): ExpeditionState {
+  return {
+    locationId: 'loc_route_a', kind: 'route', step: 1, totalSteps: 4,
+    phase: 'event', currentEventId: null, roomChoices: null, pendingEncounterId: null,
+    loot: { gold: 0, items: {} }, eventLog: [], retreated: false,
+    partyHp: { protagonist: 22 },
+    ...overrides,
+  };
+}
+
+const evUniversal: EventCard = {
+  id: 'ev_universal', context: {}, weight: 1,
+  title: '路遇行商', body: '一名行商向你招手。',
+  options: [{ label: '打聲招呼', success: [{ type: 'log', text: '你與行商寒暄了幾句。' }] }],
+};
+const evRouteAOnly: EventCard = {
+  id: 'ev_route_a_only', context: { locationIds: ['loc_route_a'] }, weight: 1,
+  title: '水道旁的告示', body: '木樁上釘著一張告示。', options: [{ label: '看看', success: [] }],
+};
+const evDungeonOnly: EventCard = {
+  id: 'ev_dungeon_only', context: { kind: 'dungeon' }, weight: 1,
+  title: '坑道回聲', body: '深處傳來奇異的回聲。', options: [{ label: '前進', success: [] }],
+};
+const evWeightZero: EventCard = {
+  id: 'ev_weight_zero', context: {}, weight: 0,
+  title: '不該出現的卡', body: '……', options: [{ label: '？', success: [] }],
+};
+const evFlagged: EventCard = {
+  id: 'ev_flagged', context: {}, weight: 1, requiresFlags: { met_guildmaster: true },
+  title: '公會的委託', body: '公會長交代的後續。', options: [{ label: '接下', success: [] }],
+};
+
+beforeEach(() => {
+  registerLocations({
+    loc_route_a: LOC_ROUTE_A,
+    loc_route_b: LOC_ROUTE_B,
+    loc_dungeon_a: LOC_DUNGEON_A,
+  });
+  registerEvents([evUniversal, evRouteAOnly, evDungeonOnly, evWeightZero, evFlagged]);
+});
+
+describe('startExpedition', () => {
+  it('route 地點：totalSteps=legs、phase=event、step=1、loot 歸零', () => {
+    const save = makeSave();
+    const state = startExpedition(fakeRng(), save, 'loc_route_a');
+    expect(state.kind).toBe('route');
+    expect(state.totalSteps).toBe(2);
+    expect(state.step).toBe(1);
+    expect(state.phase).toBe('event');
+    expect(state.loot).toEqual({ gold: 0, items: {} });
+    expect(state.retreated).toBe(false);
+  });
+
+  it('dungeon 地點：totalSteps=floors、phase=room-choice', () => {
+    const save = makeSave();
+    const state = startExpedition(fakeRng(), save, 'loc_dungeon_a');
+    expect(state.kind).toBe('dungeon');
+    expect(state.totalSteps).toBe(3);
+    expect(state.phase).toBe('room-choice');
+  });
+
+  it('不存在的地點 id 丟 Error', () => {
+    const save = makeSave();
+    expect(() => startExpedition(fakeRng(), save, 'no-such-place')).toThrow();
+  });
+
+  it('partyHp 只含主角與未重傷的傭兵', () => {
+    const save = makeSave({
+      companions: [
+        makeCompanion({ id: 'healthy', maxHp: 18, injuredForTrips: 0 }),
+        makeCompanion({ id: 'hurt', maxHp: 16, injuredForTrips: 2 }),
+      ],
+    });
+    const state = startExpedition(fakeRng(), save, 'loc_route_a');
+    expect(state.partyHp[save.protagonist.id]).toBe(save.protagonist.maxHp);
+    expect(state.partyHp.healthy).toBe(18);
+    expect(state.partyHp.hurt).toBeUndefined();
+  });
+});
+
+describe('drawEvent', () => {
+  it('context.locationIds 指定時只在該地點出現', () => {
+    const save = makeSave();
+    const stateB = makeState({ locationId: 'loc_route_b' });
+    // 候選過濾後只剩 evUniversal：evRouteAOnly 鎖定 loc_route_a 被排除、
+    // evDungeonOnly 因 kind 不符被排除、evWeightZero/evFlagged 各自被排除
+    const card = drawEvent(fakeRng({ pickIndex: [0] }), stateB, save);
+    expect(card.id).toBe('ev_universal');
+  });
+
+  it('未填 locationIds 的卡視為通用，任何地點皆可能出現', () => {
+    const save = makeSave();
+    const stateA = makeState({ locationId: 'loc_route_a' });
+    // 候選：[evUniversal, evRouteAOnly]，指定 pickIndex=1 抽出限定卡
+    const card = drawEvent(fakeRng({ pickIndex: [1] }), stateA, save);
+    expect(card.id).toBe('ev_route_a_only');
+  });
+
+  it('context.kind 過濾：dungeon 限定卡不會出現在 route', () => {
+    registerEvents([evUniversal, evDungeonOnly]);
+    const save = makeSave();
+    const stateA = makeState({ locationId: 'loc_route_a', kind: 'route' });
+    // evDungeonOnly 被過濾掉後候選只剩 evUniversal，無論 pickIndex 為何都只能抽到它
+    const card = drawEvent(fakeRng({ pickIndex: [0] }), stateA, save);
+    expect(card.id).toBe('ev_universal');
+  });
+
+  it('context.kind 過濾：dungeon 狀態下 dungeon 限定卡入選', () => {
+    const save = makeSave();
+    const stateDungeon = makeState({ locationId: 'loc_dungeon_a', kind: 'dungeon' });
+    // 候選（dungeon）：[evUniversal, evDungeonOnly]
+    const card = drawEvent(fakeRng({ pickIndex: [1] }), stateDungeon, save);
+    expect(card.id).toBe('ev_dungeon_only');
+  });
+
+  it('weight<=0 的卡永遠不會入選候選', () => {
+    registerEvents([evWeightZero]);
+    const save = makeSave();
+    expect(() => drawEvent(fakeRng(), makeState(), save)).toThrow();
+  });
+
+  it('requiresFlags 未滿足時排除該卡', () => {
+    const save = makeSave({ flags: {} });
+    const state = makeState();
+    // 候選：[evUniversal, evRouteAOnly]（evFlagged 因 met_guildmaster 不為 true 被排除）
+    const card = drawEvent(fakeRng({ pickIndex: [0] }), state, save);
+    expect(card.id).not.toBe('ev_flagged');
+  });
+
+  it('requiresFlags 完全相等時該卡入選候選', () => {
+    registerEvents([evFlagged]);
+    const save = makeSave({ flags: { met_guildmaster: true } });
+    const card = drawEvent(fakeRng({ pickIndex: [0] }), makeState(), save);
+    expect(card.id).toBe('ev_flagged');
+  });
+
+  it('設定 state.currentEventId 與 phase=event', () => {
+    const save = makeSave();
+    const state = makeState({ phase: 'room-choice', currentEventId: null });
+    const card = drawEvent(fakeRng({ pickIndex: [0] }), state, save);
+    expect(state.currentEventId).toBe(card.id);
+    expect(state.phase).toBe('event');
+  });
+
+  it('候選為空集合（資料錯誤）丟 Error', () => {
+    registerEvents([evDungeonOnly]); // route 狀態下必然過濾光
+    const save = makeSave();
+    expect(() => drawEvent(fakeRng(), makeState({ kind: 'route' }), save)).toThrow();
+  });
+});
+
+describe('optionAvailable', () => {
+  it('無 requirement 一律可用', () => {
+    const save = makeSave();
+    expect(optionAvailable(save, { label: 'x', success: [] })).toBe(true);
+  });
+
+  it('job requirement：主角職業本身符合', () => {
+    const save = makeSave(); // protagonist job = swordsman
+    expect(optionAvailable(save, { label: 'x', requirement: { job: 'swordsman' }, success: [] })).toBe(true);
+  });
+
+  it('job requirement：未重傷傭兵職業符合', () => {
+    const save = makeSave({ companions: [makeCompanion({ job: 'cleric', injuredForTrips: 0 })] });
+    expect(optionAvailable(save, { label: 'x', requirement: { job: 'cleric' }, success: [] })).toBe(true);
+  });
+
+  it('job requirement：只有重傷傭兵持有該職業時視為不符', () => {
+    const save = makeSave({ companions: [makeCompanion({ job: 'cleric', injuredForTrips: 2 })] });
+    expect(optionAvailable(save, { label: 'x', requirement: { job: 'cleric' }, success: [] })).toBe(false);
+  });
+
+  it('itemId requirement：持有數量 >0 才符合', () => {
+    const save = makeSave({ inventory: { herb: 1 } });
+    expect(optionAvailable(save, { label: 'x', requirement: { itemId: 'herb' }, success: [] })).toBe(true);
+  });
+
+  it('itemId requirement：未持有時不符', () => {
+    const save = makeSave({ inventory: {} });
+    expect(optionAvailable(save, { label: 'x', requirement: { itemId: 'herb' }, success: [] })).toBe(false);
+  });
+
+  it('同時要求 job 與 itemId：只滿足一項仍視為不符', () => {
+    const save = makeSave({ inventory: { herb: 1 } }); // protagonist 不是 cleric
+    expect(
+      optionAvailable(save, { label: 'x', requirement: { job: 'cleric', itemId: 'herb' }, success: [] })
+    ).toBe(false);
+  });
+});
+
+describe('resolveOption', () => {
+  it('requirement 不滿足時丟 Error（防禦性，UI 應已 disabled）', () => {
+    const save = makeSave({ inventory: {} });
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '用藥草', requirement: { itemId: 'herb' }, success: [] }],
+    };
+    expect(() => resolveOption(fakeRng(), state, save, card, 0)).toThrow();
+  });
+
+  it('optIndex 超出範圍丟 Error', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = { id: 'c', context: {}, weight: 1, title: 't', body: 'b', options: [] };
+    expect(() => resolveOption(fakeRng(), state, save, card, 0)).toThrow();
+  });
+
+  it('無 check：直接套用 success 效果，check 回傳 null', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '拾金', success: [{ type: 'gold', amount: 5 }] }],
+    };
+    const result = resolveOption(fakeRng(), state, save, card, 0);
+    expect(result.check).toBeNull();
+    expect(state.loot.gold).toBe(5);
+  });
+
+  it('有 check：成功時套用 success 效果', () => {
+    const save = makeSave(); // protagonist str=14 → statMod(14)=+2
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{
+        label: '試著搬開巨石', check: { stat: 'str', dc: 10 },
+        success: [{ type: 'gold', amount: 10 }],
+        failure: [{ type: 'gold', amount: 0 }],
+      }],
+    };
+    // d20=10 → total=10+2=12 >= dc10 → success
+    const result = resolveOption(fakeRng({ d20: [10] }), state, save, card, 0);
+    expect(result.check?.success).toBe(true);
+    expect(state.loot.gold).toBe(10);
+  });
+
+  it('有 check：失敗時套用 failure 效果', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{
+        label: '試著搬開巨石', check: { stat: 'str', dc: 20 },
+        success: [{ type: 'gold', amount: 10 }],
+        failure: [{ type: 'log', text: '你沒能搬動巨石。' }],
+      }],
+    };
+    // d20=2 → total=2+2=4 < dc20 → failure
+    const result = resolveOption(fakeRng({ d20: [2] }), state, save, card, 0);
+    expect(result.check?.success).toBe(false);
+    expect(state.loot.gold).toBe(0);
+    expect(state.eventLog).toContain('你沒能搬動巨石。');
+  });
+
+  it('check 失敗但沒有 failure 陣列：不套用任何效果也不拋錯', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '賭一把', check: { stat: 'str', dc: 20 }, success: [{ type: 'gold', amount: 99 }] }],
+    };
+    const result = resolveOption(fakeRng({ d20: [1] }), state, save, card, 0);
+    expect(result.effects).toEqual([]);
+    expect(state.loot.gold).toBe(0);
+  });
+
+  it('effect gold：疊加進 state.loot.gold（可負數）', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 5, items: {} } });
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '被打劫', success: [{ type: 'gold', amount: -3 }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.loot.gold).toBe(2);
+  });
+
+  it('effect item 正數：進 state.loot.items', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '拾獲藥草', success: [{ type: 'item', itemId: 'herb', count: 2 }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.loot.items.herb).toBe(2);
+  });
+
+  it('effect item 負數：直接扣 save.inventory（不進 loot），不低於 0', () => {
+    const save = makeSave({ inventory: { herb: 1 } });
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '用掉藥草', requirement: { itemId: 'herb' },
+        success: [{ type: 'item', itemId: 'herb', count: -5 }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(save.inventory.herb).toBe(0);
+    expect(state.loot.items.herb).toBeUndefined();
+  });
+
+  it('effect hp target=protagonist：扣血但不低於 1', () => {
+    const save = makeSave();
+    const state = makeState({ partyHp: { [save.protagonist.id]: 3 } });
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '踩到陷阱', success: [{ type: 'hp', target: 'protagonist', amount: -99 }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.partyHp[save.protagonist.id]).toBe(1);
+  });
+
+  it('effect hp target=party：套用到所有 partyHp 中的成員', () => {
+    const save = makeSave({ companions: [makeCompanion({ id: 'ally', maxHp: 20, injuredForTrips: 0 })] });
+    const state = makeState({
+      partyHp: { [save.protagonist.id]: save.protagonist.maxHp, ally: 20 },
+    });
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '毒霧', success: [{ type: 'hp', target: 'party', amount: -5 }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.partyHp[save.protagonist.id]).toBe(save.protagonist.maxHp - 5);
+    expect(state.partyHp.ally).toBe(15);
+  });
+
+  it('effect flag：寫入 save.flags', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '答應委託', success: [{ type: 'flag', flag: 'met_guildmaster', value: true }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(save.flags.met_guildmaster).toBe(true);
+  });
+
+  it('effect fight：設定 pendingEncounterId 與 phase=combat，且中止自動推進（step 不變）', () => {
+    const save = makeSave();
+    const state = makeState({ step: 1 });
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '遭到伏擊', success: [{ type: 'fight', encounterId: 'enc_wolf' }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.pendingEncounterId).toBe('enc_wolf');
+    expect(state.phase).toBe('combat');
+    expect(state.step).toBe(1); // 沒有呼叫 advanceExpedition
+  });
+
+  it('effect discover：寫入 discovered:<id> 旗標並記入 eventLog', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '追查線索', success: [{ type: 'discover', locationId: 'goblin-cave' }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(save.flags['discovered:goblin-cave']).toBe(true);
+    expect(state.eventLog.some((line) => line.includes('goblin-cave'))).toBe(true);
+  });
+
+  it('effect log：文字進 eventLog', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '沉思', success: [{ type: 'log', text: '你在原地沉思了片刻。' }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.eventLog).toEqual(['你在原地沉思了片刻。']);
+  });
+
+  it('多個效果依陣列順序逐一套用', () => {
+    const save = makeSave();
+    const state = makeState();
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{
+        label: '搜刮', success: [
+          { type: 'gold', amount: 3 },
+          { type: 'item', itemId: 'ore', count: 1 },
+          { type: 'log', text: '你搜刮了一番。' },
+        ],
+      }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.loot.gold).toBe(3);
+    expect(state.loot.items.ore).toBe(1);
+    expect(state.eventLog).toEqual(['你搜刮了一番。']);
+  });
+
+  it('非 fight 效果結尾會呼叫 advanceExpedition（step 前進）', () => {
+    const save = makeSave();
+    const state = makeState({ step: 1, totalSteps: 4 });
+    const card: EventCard = {
+      id: 'c', context: {}, weight: 1, title: 't', body: 'b',
+      options: [{ label: '前進', success: [{ type: 'log', text: '你繼續上路。' }] }],
+    };
+    resolveOption(fakeRng(), state, save, card, 0);
+    expect(state.step).toBe(2);
+    expect(state.phase).toBe('event');
+  });
+});
+
+describe('advanceExpedition', () => {
+  it('route：step+1 未超過 totalSteps 時 phase 維持 event', () => {
+    const state = makeState({ kind: 'route', step: 1, totalSteps: 4, phase: 'combat' });
+    advanceExpedition(fakeRng(), state);
+    expect(state.step).toBe(2);
+    expect(state.phase).toBe('event');
+  });
+
+  it('step 超過 totalSteps 時 phase=done', () => {
+    const state = makeState({ kind: 'route', step: 4, totalSteps: 4 });
+    advanceExpedition(fakeRng(), state);
+    expect(state.step).toBe(5);
+    expect(state.phase).toBe('done');
+  });
+
+  it('dungeon：未到頂層時 phase=room-choice', () => {
+    const state = makeState({ kind: 'dungeon', step: 1, totalSteps: 3, phase: 'combat' });
+    advanceExpedition(fakeRng(), state);
+    expect(state.step).toBe(2);
+    expect(state.phase).toBe('room-choice');
+  });
+
+  it('推進時清空 currentEventId', () => {
+    const state = makeState({ step: 1, totalSteps: 4, currentEventId: 'ev_universal' });
+    advanceExpedition(fakeRng(), state);
+    expect(state.currentEventId).toBeNull();
+  });
+});
+
+describe('settleExpedition', () => {
+  it('loot 的 gold 與 items 併入 save', () => {
+    const save = makeSave({ gold: 100, inventory: { ore: 1 } });
+    const state = makeState({ loot: { gold: 30, items: { ore: 2, herb: 1 } }, step: 2 });
+    settleExpedition(state, save);
+    expect(save.gold).toBe(130);
+    expect(save.inventory).toEqual({ ore: 3, herb: 1 });
+  });
+
+  it('xp = 20 + step*5，主角一定拿到', () => {
+    const save = makeSave();
+    const state = makeState({ step: 3 });
+    const result = settleExpedition(state, save);
+    expect(result.xpGained).toBe(35);
+    expect(save.protagonist.xp).toBe(35);
+  });
+
+  it('未重傷傭兵一起拿 xp', () => {
+    const save = makeSave({ companions: [makeCompanion({ id: 'c1', xp: 0, injuredForTrips: 0 })] });
+    const state = makeState({ step: 1 });
+    settleExpedition(state, save);
+    expect(save.companions[0].xp).toBe(25);
+  });
+
+  it('重傷傭兵不拿 xp，injuredForTrips -1', () => {
+    const save = makeSave({ companions: [makeCompanion({ id: 'c1', xp: 0, injuredForTrips: 2 })] });
+    const state = makeState({ step: 1 });
+    settleExpedition(state, save);
+    expect(save.companions[0].xp).toBe(0);
+    expect(save.companions[0].injuredForTrips).toBe(1);
+  });
+
+  it('injuredForTrips 不會降到 0 以下', () => {
+    const save = makeSave({ companions: [makeCompanion({ id: 'c1', injuredForTrips: 0 })] });
+    const state = makeState({ step: 1 });
+    settleExpedition(state, save);
+    expect(save.companions[0].injuredForTrips).toBe(0);
+  });
+
+  it('結算後 save.expedition 清為 null', () => {
+    const save = makeSave();
+    save.expedition = makeState();
+    settleExpedition(makeState({ step: 1 }), save);
+    expect(save.expedition).toBeNull();
+  });
+
+  it('回傳 goldGained/itemsGained/xpGained 摘要', () => {
+    const save = makeSave();
+    const state = makeState({ loot: { gold: 12, items: { herb: 1 } }, step: 1 });
+    const result = settleExpedition(state, save);
+    expect(result).toEqual({ goldGained: 12, itemsGained: { herb: 1 }, xpGained: 25 });
+  });
+});

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -315,6 +315,8 @@ export function settleExpedition(
   // 多出的那 5 xp 是完賽獎勵（刻意設計，非 bug——見 Task 2 report 的顧慮欄）。
   const xpGained = 20 + state.step * 5;
   save.protagonist.xp += xpGained;
+  // 主角的重傷趟數也要遞減——只寫不減會讓主角永久卡在重傷（M3 終審抓到的地雷）
+  save.protagonist.injuredForTrips = Math.max(0, save.protagonist.injuredForTrips - 1);
   for (const companion of save.companions) {
     if (companion.injuredForTrips === 0) {
       companion.xp += xpGained;

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -1,0 +1,370 @@
+import type { Rng } from './rng';
+import type { Stat } from './types';
+import type { SaveData } from './save';
+import type { CheckResult } from './check';
+import { resolveCheck, statMod } from './check';
+import type { CombatState, EnemyUnit } from './combat';
+import type { JobId } from './data/jobs';
+
+// ---------------------------------------------------------------------------
+// Effect DSL（M3 鎖定，見 docs/superpowers/plans/2026-07-18-caravan-m3-expedition.md）
+// ---------------------------------------------------------------------------
+
+export type EffectSpec =
+  | { type: 'gold'; amount: number }
+  | { type: 'item'; itemId: string; count: number }
+  | { type: 'hp'; target: 'protagonist' | 'party'; amount: number }
+  | { type: 'flag'; flag: string; value: boolean }
+  | { type: 'fight'; encounterId: string }
+  | { type: 'discover'; locationId: string }
+  | { type: 'log'; text: string };
+
+export interface EventOption {
+  label: string;
+  requirement?: { job?: JobId; itemId?: string };
+  check?: { stat: Stat; dc: number };
+  success: EffectSpec[];
+  failure?: EffectSpec[];
+}
+
+export interface EventCard {
+  id: string;
+  context: { locationIds?: string[]; kind?: 'route' | 'dungeon' };
+  weight: number;
+  requiresFlags?: Record<string, boolean>;
+  title: string;
+  body: string;
+  options: EventOption[];
+}
+
+export type RoomKind = 'fight' | 'treasure' | 'event' | 'rest' | 'unknown';
+
+export interface LocationDef {
+  id: string;
+  name: string;
+  kind: 'route' | 'dungeon';
+  hidden?: boolean; // 需 discover 才會出現在委託板
+  legs?: number; // route：事件數
+  floors?: number;
+  roomsPerFloor?: [number, number];
+  bossEncounterId?: string; // dungeon
+  encounterTable: Array<{ weight: number; encounterId: string }>;
+  depthHpBonus?: number; // dungeon：每層敵人 maxHp 加值
+}
+
+export interface ExpeditionState {
+  locationId: string;
+  kind: 'route' | 'dungeon';
+  step: number; // route: 第幾段；dungeon: 第幾層
+  totalSteps: number;
+  phase: 'event' | 'room-choice' | 'combat' | 'aftermath' | 'done';
+  currentEventId: string | null;
+  roomChoices: RoomKind[] | null; // dungeon 每層抽出的房卡
+  pendingEncounterId: string | null;
+  loot: { gold: number; items: Record<string, number> };
+  eventLog: string[]; // 遠征日誌（歸返結算顯示）
+  retreated: boolean;
+  /**
+   * 遠征期間的即時生命值（partyId -> hp）。不在計畫文件鎖定的介面契約列表中，
+   * 是實作 `hp` EffectSpec 所必需的延伸欄位（契約本身沒有別的地方能存這個數字）。
+   * 由 startExpedition 用主角＋未重傷傭兵的 maxHp 初始化；戰鬥（Task 3 buildEncounter
+   * / combat.ts memberFromRecord）目前仍各自以滿血起始，不讀這個值——Task 3 若要銜接
+   * 「遠征受的傷會帶進戰鬥」，需額外決定要不要接上這裡。
+   */
+  partyHp: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// 內容目錄（location / event catalog）
+//
+// data/locations.ts、data/events.ts 要到 Task 4 才會建立，但 startExpedition/
+// drawEvent 的簽名（跨任務鎖定）不帶目錄參數。這裡用一個模組層級的可變登記表
+// 解套：Task 4 的資料檔（或載入資料檔的頁面）在啟動時呼叫 registerLocations /
+// registerEvents 把 LOCATIONS / EVENTS 灌進來；本檔自己的測試則用假資料呼叫
+// 這兩個函式模擬。
+// ---------------------------------------------------------------------------
+
+let locationCatalog: Record<string, LocationDef> = {};
+let eventCatalog: EventCard[] = [];
+
+export function registerLocations(locations: Record<string, LocationDef>): void {
+  locationCatalog = locations;
+}
+
+export function registerEvents(events: EventCard[]): void {
+  eventCatalog = events;
+}
+
+function getLocation(locationId: string): LocationDef | undefined {
+  return locationCatalog[locationId];
+}
+
+// ---------------------------------------------------------------------------
+// 狀態機
+// ---------------------------------------------------------------------------
+
+export function startExpedition(rng: Rng, save: SaveData, locationId: string): ExpeditionState {
+  void rng; // 保留給 Task 3：地城開場可能要立刻 drawRooms
+  const loc = getLocation(locationId);
+  if (!loc) {
+    throw new Error(`startExpedition: 找不到地點「${locationId}」`);
+  }
+  const totalSteps = loc.kind === 'dungeon' ? (loc.floors ?? 1) : (loc.legs ?? 1);
+
+  const partyHp: Record<string, number> = { [save.protagonist.id]: save.protagonist.maxHp };
+  for (const companion of save.companions) {
+    if (companion.injuredForTrips === 0) {
+      partyHp[companion.id] = companion.maxHp;
+    }
+  }
+
+  return {
+    locationId,
+    kind: loc.kind,
+    step: 1,
+    totalSteps,
+    phase: loc.kind === 'dungeon' ? 'room-choice' : 'event',
+    currentEventId: null,
+    roomChoices: null,
+    pendingEncounterId: null,
+    loot: { gold: 0, items: {} },
+    eventLog: [],
+    retreated: false,
+    partyHp,
+  };
+}
+
+/** 過濾 context/requiresFlags 後加權抽；設 state.currentEventId/phase */
+export function drawEvent(rng: Rng, state: ExpeditionState, save: SaveData): EventCard {
+  const candidates = eventCatalog.filter((card) => {
+    if (card.weight <= 0) return false;
+    if (card.context.kind && card.context.kind !== state.kind) return false;
+    if (
+      card.context.locationIds &&
+      card.context.locationIds.length > 0 &&
+      !card.context.locationIds.includes(state.locationId)
+    ) {
+      return false;
+    }
+    if (card.requiresFlags) {
+      for (const [flag, expected] of Object.entries(card.requiresFlags)) {
+        if ((save.flags[flag] ?? false) !== expected) return false;
+      }
+    }
+    return true;
+  });
+  if (candidates.length === 0) {
+    throw new Error(
+      `drawEvent: 找不到符合條件的事件卡（location=${state.locationId}, kind=${state.kind}）——資料設定錯誤`
+    );
+  }
+  const card = rng.weightedPick(candidates.map((c) => ({ weight: c.weight, value: c })));
+  state.currentEventId = card.id;
+  state.phase = 'event';
+  return card;
+}
+
+/** job 在隊上（主角或未重傷傭兵）？item 在包內？兩者皆須滿足（若都指定） */
+export function optionAvailable(save: SaveData, opt: EventOption): boolean {
+  const requirement = opt.requirement;
+  if (!requirement) return true;
+  if (requirement.job) {
+    const hasJob =
+      save.protagonist.job === requirement.job ||
+      save.companions.some((c) => c.job === requirement.job && c.injuredForTrips === 0);
+    if (!hasJob) return false;
+  }
+  if (requirement.itemId) {
+    if ((save.inventory[requirement.itemId] ?? 0) <= 0) return false;
+  }
+  return true;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function applyHpEffect(
+  state: ExpeditionState,
+  save: SaveData,
+  targetId: string,
+  amount: number
+): void {
+  const isProtagonist = targetId === save.protagonist.id;
+  const maxHp = isProtagonist
+    ? save.protagonist.maxHp
+    : save.companions.find((c) => c.id === targetId)?.maxHp;
+  if (maxHp === undefined) return;
+  const current = state.partyHp[targetId] ?? maxHp;
+  // 遠征事件不打死人，只有戰鬥才會——所以下限是 1 不是 0
+  state.partyHp[targetId] = clamp(current + amount, 1, maxHp);
+}
+
+function applyEffect(effect: EffectSpec, state: ExpeditionState, save: SaveData): void {
+  switch (effect.type) {
+    case 'gold':
+      state.loot.gold += effect.amount;
+      break;
+    case 'item':
+      if (effect.count > 0) {
+        state.loot.items[effect.itemId] = (state.loot.items[effect.itemId] ?? 0) + effect.count;
+      } else if (effect.count < 0) {
+        save.inventory[effect.itemId] = Math.max(
+          0,
+          (save.inventory[effect.itemId] ?? 0) + effect.count
+        );
+      }
+      break;
+    case 'hp': {
+      const targets =
+        effect.target === 'protagonist' ? [save.protagonist.id] : Object.keys(state.partyHp);
+      for (const id of targets) applyHpEffect(state, save, id, effect.amount);
+      break;
+    }
+    case 'flag':
+      save.flags[effect.flag] = effect.value;
+      break;
+    case 'fight':
+      state.pendingEncounterId = effect.encounterId;
+      state.phase = 'combat';
+      break;
+    case 'discover':
+      save.flags[`discovered:${effect.locationId}`] = true;
+      state.eventLog.push(`你發現了新地點：${effect.locationId}`);
+      break;
+    case 'log':
+      state.eventLog.push(effect.text);
+      break;
+  }
+}
+
+/**
+ * 擲骰（用主角對應屬性）、套 effects（fight 設 pendingEncounterId+phase='combat'；
+ * 其餘立即入 loot/save）、推進 phase/step。
+ */
+export function resolveOption(
+  rng: Rng,
+  state: ExpeditionState,
+  save: SaveData,
+  card: EventCard,
+  optIndex: number
+): { check: CheckResult | null; effects: EffectSpec[] } {
+  const opt = card.options[optIndex];
+  if (!opt) {
+    throw new Error(`resolveOption: 選項索引超出範圍（${optIndex}）`);
+  }
+  if (!optionAvailable(save, opt)) {
+    throw new Error(`resolveOption: 選項「${opt.label}」不符資格`);
+  }
+
+  let check: CheckResult | null = null;
+  let effects: EffectSpec[];
+  if (opt.check) {
+    const modifier = statMod(save.protagonist.stats[opt.check.stat]);
+    check = resolveCheck(rng, { stat: opt.check.stat, dc: opt.check.dc, modifier });
+    effects = check.success ? opt.success : (opt.failure ?? []);
+  } else {
+    effects = opt.success;
+  }
+
+  let triggeredFight = false;
+  for (const effect of effects) {
+    applyEffect(effect, state, save);
+    if (effect.type === 'fight') {
+      triggeredFight = true;
+      break;
+    }
+  }
+
+  if (!triggeredFight) {
+    advanceExpedition(rng, state);
+  }
+
+  return { check, effects };
+}
+
+/** step+1；超過 totalSteps→phase='done'；dungeon 未到頂層→'room-choice'；route→'event' */
+export function advanceExpedition(rng: Rng, state: ExpeditionState): void {
+  void rng; // 保留給 Task 3：dungeon 進下一層可能要立刻 drawRooms
+  state.step += 1;
+  state.currentEventId = null;
+  if (state.step > state.totalSteps) {
+    state.phase = 'done';
+  } else if (state.kind === 'dungeon') {
+    state.phase = 'room-choice';
+    state.roomChoices = null;
+  } else {
+    state.phase = 'event';
+  }
+}
+
+/** loot 入 save.gold/inventory；每存活出征者 xp += 20 + step*5；injuredForTrips>0 的隊員 -1 */
+export function settleExpedition(
+  state: ExpeditionState,
+  save: SaveData
+): { goldGained: number; itemsGained: Record<string, number>; xpGained: number } {
+  const goldGained = state.loot.gold;
+  const itemsGained = { ...state.loot.items };
+
+  save.gold += goldGained;
+  for (const [itemId, count] of Object.entries(itemsGained)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+
+  const xpGained = 20 + state.step * 5;
+  save.protagonist.xp += xpGained;
+  for (const companion of save.companions) {
+    if (companion.injuredForTrips === 0) {
+      companion.xp += xpGained;
+    } else {
+      companion.injuredForTrips = Math.max(0, companion.injuredForTrips - 1);
+    }
+  }
+
+  save.expedition = null;
+
+  return { goldGained, itemsGained, xpGained };
+}
+
+// ---------------------------------------------------------------------------
+// 迷宮房卡與戰鬥整合（Task 3）——型別先鎖定，函式本體留給 Task 3 實作
+// ---------------------------------------------------------------------------
+
+export function drawRooms(rng: Rng, state: ExpeditionState): RoomKind[] {
+  void rng;
+  void state;
+  throw new Error('drawRooms: 尚未實作（Task 3）');
+}
+
+export function chooseRoom(
+  rng: Rng,
+  state: ExpeditionState,
+  save: SaveData,
+  room: RoomKind
+): { event?: EventCard; encounterId?: string; restHealed?: number; treasureGold?: number } {
+  void rng;
+  void state;
+  void save;
+  void room;
+  throw new Error('chooseRoom: 尚未實作（Task 3）');
+}
+
+export function buildEncounter(rng: Rng, state: ExpeditionState, encounterId: string): EnemyUnit[] {
+  void rng;
+  void state;
+  void encounterId;
+  throw new Error('buildEncounter: 尚未實作（Task 3）');
+}
+
+export function finishCombat(
+  state: ExpeditionState,
+  save: SaveData,
+  combat: CombatState,
+  fates: Array<{ id: string; fate: 'injured' | 'dead' }>
+): void {
+  void state;
+  void save;
+  void combat;
+  void fates;
+  throw new Error('finishCombat: 尚未實作（Task 3）');
+}

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -3,7 +3,7 @@ import type { Stat } from './types';
 import type { SaveData } from './save';
 import type { CheckResult } from './check';
 import { resolveCheck, statMod } from './check';
-import type { CombatState, EnemyUnit } from './combat';
+import type { CombatState, EnemyUnit, PartyMember } from './combat';
 import type { JobId } from './data/jobs';
 
 // ---------------------------------------------------------------------------
@@ -311,6 +311,8 @@ export function settleExpedition(
     save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
   }
 
+  // 完賽時 step=totalSteps+1（advanceExpedition 遞增後才會把 phase 轉成 'done'），
+  // 多出的那 5 xp 是完賽獎勵（刻意設計，非 bug——見 Task 2 report 的顧慮欄）。
   const xpGained = 20 + state.step * 5;
   save.protagonist.xp += xpGained;
   for (const companion of save.companions) {
@@ -327,44 +329,208 @@ export function settleExpedition(
 }
 
 // ---------------------------------------------------------------------------
-// 迷宮房卡與戰鬥整合（Task 3）——型別先鎖定，函式本體留給 Task 3 實作
+// 迷宮房卡與戰鬥整合（Task 3）
 // ---------------------------------------------------------------------------
 
-export function drawRooms(rng: Rng, state: ExpeditionState): RoomKind[] {
-  void rng;
-  void state;
-  throw new Error('drawRooms: 尚未實作（Task 3）');
+let encounterCatalog: Record<string, () => EnemyUnit[]> = {};
+
+/**
+ * 登記遭遇表：encounterId -> 產生 EnemyUnit[] 的工廠函式。與 registerLocations/
+ * registerEvents 同一模式——Task 4 的 data/enemies.ts（或載入資料檔的入口）啟動時呼叫；
+ * 本檔測試用假表模擬。
+ */
+export function registerEncounters(table: Record<string, () => EnemyUnit[]>): void {
+  encounterCatalog = table;
 }
 
+const ROOM_WEIGHTS: Array<{ weight: number; value: RoomKind }> = [
+  { weight: 40, value: 'fight' },
+  { weight: 20, value: 'treasure' },
+  { weight: 20, value: 'event' },
+  { weight: 10, value: 'rest' },
+  { weight: 10, value: 'unknown' },
+];
+
+/**
+ * dungeon 每層抽 2-3 張房卡（張數由 loc.roomsPerFloor 決定，未設定預設 [2,3]）；
+ * 種類加權 fight40/treasure20/event20/rest10/unknown10，同層用不放回抽法保證不重複；
+ * 頂層（step===totalSteps）固定 ['fight']（boss）。設定並回傳 state.roomChoices。
+ */
+export function drawRooms(rng: Rng, state: ExpeditionState): RoomKind[] {
+  if (state.step === state.totalSteps) {
+    state.roomChoices = ['fight'];
+    return state.roomChoices;
+  }
+
+  const loc = getLocation(state.locationId);
+  const [minRooms, maxRooms] = loc?.roomsPerFloor ?? [2, 3];
+  const span = Math.max(1, maxRooms - minRooms + 1);
+  const count = minRooms + rng.roll(span) - 1;
+
+  const chosen: RoomKind[] = [];
+  let pool = ROOM_WEIGHTS;
+  for (let i = 0; i < count && pool.length > 0; i++) {
+    const kind = rng.weightedPick(pool);
+    chosen.push(kind);
+    pool = pool.filter((entry) => entry.value !== kind);
+  }
+  state.roomChoices = chosen;
+  return chosen;
+}
+
+/**
+ * 依房型分派：
+ * - fight：查樓層 encounterTable 加權抽 encounterId（頂層用 bossEncounterId）、設
+ *   pendingEncounterId+phase='combat'（結算延到 finishCombat 呼 advanceExpedition）
+ * - treasure：gold=roll(6)*10+step*10 入 loot；10% 機率（M3 簡化）固定給 1 個 'ore'；結算後 advanceExpedition
+ * - rest：全隊 partyHp 回 1d6+2（不超過各自 maxHp，maxHp 從 save 的 roster 查）；結算後 advanceExpedition
+ * - event：drawEvent（dungeon context，等玩家選項，不推進 step）
+ * - unknown：rng 二選一實際化為 fight 或 treasure，遞迴走對應邏輯
+ */
 export function chooseRoom(
   rng: Rng,
   state: ExpeditionState,
   save: SaveData,
   room: RoomKind
 ): { event?: EventCard; encounterId?: string; restHealed?: number; treasureGold?: number } {
-  void rng;
-  void state;
-  void save;
-  void room;
-  throw new Error('chooseRoom: 尚未實作（Task 3）');
+  switch (room) {
+    case 'fight': {
+      const loc = getLocation(state.locationId);
+      if (!loc) {
+        throw new Error(`chooseRoom: 找不到地點「${state.locationId}」`);
+      }
+      const isBoss = state.step === state.totalSteps;
+      const encounterId =
+        isBoss && loc.bossEncounterId
+          ? loc.bossEncounterId
+          : rng.weightedPick(
+              loc.encounterTable.map((e) => ({ weight: e.weight, value: e.encounterId }))
+            );
+      state.pendingEncounterId = encounterId;
+      state.phase = 'combat';
+      return { encounterId };
+    }
+    case 'treasure': {
+      const treasureGold = rng.roll(6) * 10 + state.step * 10;
+      state.loot.gold += treasureGold;
+      if (rng.next() < 0.1) {
+        state.loot.items.ore = (state.loot.items.ore ?? 0) + 1;
+      }
+      advanceExpedition(rng, state);
+      return { treasureGold };
+    }
+    case 'rest': {
+      const restHealed = rng.roll(6) + 2;
+      for (const id of Object.keys(state.partyHp)) {
+        const maxHp =
+          id === save.protagonist.id
+            ? save.protagonist.maxHp
+            : save.companions.find((c) => c.id === id)?.maxHp;
+        if (maxHp === undefined) continue;
+        state.partyHp[id] = Math.min(maxHp, state.partyHp[id] + restHealed);
+      }
+      advanceExpedition(rng, state);
+      return { restHealed };
+    }
+    case 'event': {
+      const event = drawEvent(rng, state, save);
+      return { event };
+    }
+    case 'unknown': {
+      const realized: RoomKind = rng.next() < 0.5 ? 'fight' : 'treasure';
+      return chooseRoom(rng, state, save, realized);
+    }
+  }
 }
 
+/**
+ * 查 registerEncounters 登記表生成敵人；dungeon 時每敵 maxHp/hp 套用
+ * depthHpBonus×(step-1)（route 不加成）。
+ */
 export function buildEncounter(rng: Rng, state: ExpeditionState, encounterId: string): EnemyUnit[] {
-  void rng;
-  void state;
-  void encounterId;
-  throw new Error('buildEncounter: 尚未實作（Task 3）');
+  void rng; // 目前查表生成是決定性的，不需要隨機；保留參數位與其他遠征函式簽名一致
+  const factory = encounterCatalog[encounterId];
+  if (!factory) {
+    throw new Error(`buildEncounter: 找不到遭遇「${encounterId}」（先呼叫 registerEncounters 登記）`);
+  }
+  const enemies = factory();
+  if (state.kind === 'dungeon') {
+    const loc = getLocation(state.locationId);
+    const bonus = (loc?.depthHpBonus ?? 0) * (state.step - 1);
+    if (bonus > 0) {
+      for (const enemy of enemies) {
+        enemy.maxHp += bonus;
+        enemy.hp += bonus;
+      }
+    }
+  }
+  return enemies;
 }
 
+/**
+ * 把 state.partyHp 覆蓋到對應 member.hp；partyHp 沒有的 key 不動該 member。
+ * 供 Task 5 在組隊進入戰鬥前，把遠征期間累積的傷勢灌回 PartyMember。
+ */
+export function applyPartyHp(state: ExpeditionState, members: PartyMember[]): void {
+  for (const member of members) {
+    const hp = state.partyHp[member.id];
+    if (hp !== undefined) member.hp = hp;
+  }
+}
+
+/**
+ * 戰鬥結束後把結果併回遠征狀態：
+ * - partyHp 雙向同步：不論勝敗，combat.party 的最終 hp 都寫回 state.partyHp
+ * - victory：每敵 loot（gold 區間 rng 均勻取整、itemChance 命中額外給 1 個 itemId）入
+ *   state.loot，再呼 advanceExpedition 依 kind 推進 phase
+ * - retreated / defeat：state.retreated=true、loot.gold 折半（向下取整）、phase='done'
+ *   提前結束遠征
+ * - fates 套 save：dead 傭兵從 companions 移除（主角不移除）；injured →
+ *   injuredForTrips=2（主角同）
+ *
+ * 契約缺口（詳見本任務報告「偏離契約之處」）：介面契約鎖定的簽名沒有 rng 參數，
+ * 但 loot 的 gold 區間骰與 itemChance 判定必須要有隨機來源，這裡在第一個參數位
+ * 加了 rng（與其餘遠征函式的慣例位置一致）。
+ */
 export function finishCombat(
+  rng: Rng,
   state: ExpeditionState,
   save: SaveData,
   combat: CombatState,
   fates: Array<{ id: string; fate: 'injured' | 'dead' }>
 ): void {
-  void state;
-  void save;
-  void combat;
-  void fates;
-  throw new Error('finishCombat: 尚未實作（Task 3）');
+  for (const member of combat.party) {
+    state.partyHp[member.id] = member.hp;
+  }
+
+  if (combat.outcome === 'victory') {
+    for (const enemy of combat.enemies) {
+      if (!enemy.loot) continue;
+      const [min, max] = enemy.loot.gold;
+      const gold = min + rng.roll(max - min + 1) - 1;
+      state.loot.gold += gold;
+      if (enemy.loot.itemId && enemy.loot.itemChance && rng.next() < enemy.loot.itemChance) {
+        state.loot.items[enemy.loot.itemId] = (state.loot.items[enemy.loot.itemId] ?? 0) + 1;
+      }
+    }
+    advanceExpedition(rng, state);
+  } else {
+    state.retreated = true;
+    state.loot.gold = Math.floor(state.loot.gold / 2);
+    state.phase = 'done';
+  }
+  state.pendingEncounterId = null;
+
+  for (const fate of fates) {
+    if (fate.fate === 'dead') {
+      if (fate.id !== save.protagonist.id) {
+        save.companions = save.companions.filter((c) => c.id !== fate.id);
+      }
+    } else if (fate.id === save.protagonist.id) {
+      save.protagonist.injuredForTrips = 2;
+    } else {
+      const companion = save.companions.find((c) => c.id === fate.id);
+      if (companion) companion.injuredForTrips = 2;
+    }
+  }
 }

--- a/src/scripts/games/caravan/save.test.ts
+++ b/src/scripts/games/caravan/save.test.ts
@@ -5,22 +5,46 @@ import { SAVE_KEY, saveGame, loadGame, exportSave, importSave, newGame } from '.
 beforeEach(() => localStorage.clear());
 
 describe('save（版本化存檔）', () => {
-  it('newGame 產出 v2：含預設主角與空傭兵清單', () => {
+  it('newGame 產出 v3：含預設主角、空傭兵清單、空背包、無進行中遠征', () => {
     const s = newGame(1000);
-    expect(s.version).toBe(2);
+    expect(s.version).toBe(3);
     expect(s.protagonist.name).toBe('你');
     expect(s.protagonist.job).toBe('swordsman');
     expect(s.companions).toEqual([]);
     expect(s.gold).toBe(200);
+    expect(s.inventory).toEqual({});
+    expect(s.expedition).toBeNull();
   });
 
-  it('v1 舊檔 loadGame 自動遷移為 v2 且保留原金幣與旗標', () => {
+  it('v1 舊檔 loadGame 一路遷移到 v3 且保留原金幣與旗標', () => {
     localStorage.setItem(SAVE_KEY, JSON.stringify({ version: 1, createdAt: 5, gold: 777, flags: { met: true } }));
     const s = loadGame();
-    expect(s?.version).toBe(2);
+    expect(s?.version).toBe(3);
     expect(s?.gold).toBe(777);
     expect(s?.flags).toEqual({ met: true });
     expect(s?.protagonist.id).toBe('protagonist');
+    expect(s?.inventory).toEqual({});
+    expect(s?.expedition).toBeNull();
+  });
+
+  it('v2 舊檔 loadGame 遷移為 v3：補上 inventory/expedition，其餘欄位不變', () => {
+    localStorage.setItem(
+      SAVE_KEY,
+      JSON.stringify({
+        version: 2,
+        createdAt: 5,
+        gold: 300,
+        flags: { hello: true },
+        protagonist: { id: 'protagonist', name: '你', job: 'swordsman', level: 1, xp: 0,
+          stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22, injuredForTrips: 0 },
+        companions: [],
+      })
+    );
+    const s = loadGame();
+    expect(s?.version).toBe(3);
+    expect(s?.gold).toBe(300);
+    expect(s?.inventory).toEqual({});
+    expect(s?.expedition).toBeNull();
   });
 
   it('v2 檔缺 protagonist → 視為毀損回 null', () => {
@@ -28,17 +52,33 @@ describe('save（版本化存檔）', () => {
     expect(loadGame()).toBeNull();
   });
 
-  it('importSave 對 v1 字串也會遷移（與 loadGame 同路徑）', () => {
-    const v1 = btoa(encodeURIComponent(JSON.stringify({ version: 1, createdAt: 5, gold: 42, flags: {} })));
-    const s = importSave(v1);
-    expect(s?.version).toBe(2);
-    expect(s?.gold).toBe(42);
+  it('v3 檔缺 inventory → 視為毀損回 null', () => {
+    const s = newGame(1000) as unknown as Record<string, unknown>;
+    delete s.inventory;
+    localStorage.setItem(SAVE_KEY, JSON.stringify(s));
+    expect(loadGame()).toBeNull();
   });
 
-  it('saveGame 後 loadGame 取回相同資料', () => {
+  it('v3 檔 expedition 型別錯誤（非 null 也非物件）→ 視為毀損回 null', () => {
+    const s = newGame(1000) as unknown as Record<string, unknown>;
+    s.expedition = 'not-an-object-or-null';
+    localStorage.setItem(SAVE_KEY, JSON.stringify(s));
+    expect(loadGame()).toBeNull();
+  });
+
+  it('importSave 對 v1 字串也會遷移到 v3（與 loadGame 同路徑）', () => {
+    const v1 = btoa(encodeURIComponent(JSON.stringify({ version: 1, createdAt: 5, gold: 42, flags: {} })));
+    const s = importSave(v1);
+    expect(s?.version).toBe(3);
+    expect(s?.gold).toBe(42);
+    expect(s?.inventory).toEqual({});
+  });
+
+  it('saveGame 後 loadGame 取回相同資料（含 inventory/expedition）', () => {
     const s = newGame(1000);
     s.gold = 350;
     s.flags['met_guildmaster'] = true;
+    s.inventory['herb'] = 3;
     saveGame(s);
     expect(loadGame()).toEqual(s);
   });

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -1,4 +1,5 @@
 import type { StatBlock } from './types';
+import type { ExpeditionState } from './expedition';
 
 export const SAVE_KEY = 'caravan-save-v1';
 
@@ -23,10 +24,23 @@ export interface SaveDataV2 {
   companions: CompanionRecord[];
 }
 
-/** 對外別名，後續版本跟著改指向最新 schema */
-export type SaveData = SaveDataV2;
+export interface SaveDataV3 {
+  version: 3;
+  createdAt: number;
+  gold: number;
+  flags: Record<string, boolean>;
+  protagonist: CompanionRecord;
+  companions: CompanionRecord[];
+  /** 背包：itemId -> 持有數量 */
+  inventory: Record<string, number>;
+  /** 進行中的遠征快照；重整頁面靠這個接續，非遠征中為 null */
+  expedition: ExpeditionState | null;
+}
 
-const CURRENT_VERSION = 2;
+/** 對外別名，後續版本跟著改指向最新 schema */
+export type SaveData = SaveDataV3;
+
+const CURRENT_VERSION = 3;
 
 function defaultProtagonist(): CompanionRecord {
   return {
@@ -44,9 +58,10 @@ function defaultProtagonist(): CompanionRecord {
 /** 逐版遷移表：M2+ 擴充 schema 時在此補 (v) => v+1 的轉換，玩家不清檔 */
 const MIGRATIONS: Record<number, (old: Record<string, unknown>) => Record<string, unknown>> = {
   1: (old) => ({ ...old, version: 2, protagonist: defaultProtagonist(), companions: [] }),
+  2: (old) => ({ ...old, version: 3, inventory: {}, expedition: null }),
 };
 
-/** 驗證物件是否符合 SaveDataV2 的完整 shape（含 protagonist/companions）*/
+/** 驗證物件是否符合 SaveDataV3 的完整 shape（含 protagonist/companions/inventory/expedition）*/
 function isValidSaveShape(value: unknown): value is SaveData {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
@@ -58,7 +73,10 @@ function isValidSaveShape(value: unknown): value is SaveData {
     v.flags === null ||
     typeof v.protagonist !== 'object' ||
     v.protagonist === null ||
-    !Array.isArray(v.companions)
+    !Array.isArray(v.companions) ||
+    typeof v.inventory !== 'object' ||
+    v.inventory === null ||
+    (v.expedition !== null && typeof v.expedition !== 'object')
   ) {
     return false;
   }
@@ -83,12 +101,14 @@ function parseAndMigrate(raw: unknown): SaveData | null {
 
 export function newGame(now: number = Date.now()): SaveData {
   return {
-    version: 2,
+    version: 3,
     createdAt: now,
     gold: 200,
     flags: {},
     protagonist: defaultProtagonist(),
     companions: [],
+    inventory: {},
+    expedition: null,
   };
 }
 

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -119,3 +119,171 @@ test.describe('商隊與劍：訓練場戰鬥', () => {
     await expect(page.locator('#screen-combat')).toBeVisible();
   });
 });
+
+test.describe('商隊與劍：遠征系統', () => {
+  // 種子挑選原則（見 scratch-seed-scan.ts 的一次性模擬，已刪除）：
+  // 用「每一步都點第一個可用選項／房卡，戰鬥用第一招打到分出勝負」的固定策略
+  // 對種子做模擬，找出「首事件確定、首選項可用、結果確定」且能驗證完整流程的種子。
+  // seed=30（臨水道）：leg1=ev_wolf_howl 首選項可用且擲骰成功；leg2=ev_wounded_traveler
+  // 首選項因缺藥草被 disable；leg4 擲骰失敗觸發 enc_wolf_pair 戰鬥，玩家一路用預設目標
+  // （不手動選標）打到 6 回合後獲勝；結算 goldGained=9、xpGained=45、無戰利品物品。
+  // seed=2（廢棄礦坑）：第 1 層房卡固定為 fight/treasure/rest，選 treasure 得 70 金；
+  // 第 2 層房卡 fight/rest，選 fight 進入 enc_mine_spiders 後立即撤退；
+  // 結算 goldGained=35（70 折半無條件捨去）、xpGained=30。
+  async function newGameWithSeed(page: import('@playwright/test').Page, seed: number): Promise<void> {
+    await page.goto(`/games/caravan?seed=${seed}`);
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-new-game');
+    await expect(page.locator('#screen-town')).toBeVisible();
+  }
+
+  test('委託板：顯示 2 條路線＋1 迷宮，隱藏地點提示存在，巢穴不在列', async ({ page }) => {
+    await newGameWithSeed(page, 1);
+    await page.click('#btn-quest-board');
+    await expect(page.locator('#screen-quest')).toBeVisible();
+    await expect(page.locator('.quest-item[data-location-id]')).toHaveCount(3);
+    await expect(page.locator('.quest-item[data-location-id="riverside-road"]')).toBeVisible();
+    await expect(page.locator('.quest-item[data-location-id="blackwood-trail"]')).toBeVisible();
+    await expect(page.locator('.quest-item[data-location-id="abandoned-mine"]')).toBeVisible();
+    await expect(page.locator('.quest-item[data-location-id="goblin-den"]')).toHaveCount(0);
+    await expect(page.locator('.quest-hidden-hint')).toBeVisible();
+    await expect(page.locator('.quest-hidden-hint')).toContainText('？');
+  });
+
+  test('完整路線遠征（seed=30）：事件卡→擲骰→戰鬥→結算，金幣寫回城鎮', async ({ page }) => {
+    await newGameWithSeed(page, 30);
+    await page.click('#btn-quest-board');
+    await page.click('.quest-item[data-location-id="riverside-road"]');
+    await expect(page.locator('#screen-expedition')).toBeVisible();
+    await expect(page.locator('#exp-progress')).toHaveText('第 1/4 段');
+
+    // leg1：ev_wolf_howl，首選項可用，第 2 個選項因缺火把被 disable
+    await expect(page.locator('#event-title')).toHaveText('遠方的狼嚎');
+    await expect(page.locator('.event-opt[data-opt-index="0"]')).toBeEnabled();
+    await expect(page.locator('.event-opt[data-opt-index="1"]')).toBeDisabled();
+    await page.click('.event-opt[data-opt-index="0"]');
+    await expect(page.locator('#check-result')).toBeVisible();
+    await expect(page.locator('#check-result')).toContainText('成功');
+    await page.click('#btn-exp-continue');
+
+    // leg2：ev_wounded_traveler，首選項因缺藥草被 disable，改點第 2 個
+    await expect(page.locator('#exp-progress')).toHaveText('第 2/4 段');
+    await expect(page.locator('#event-title')).toHaveText('路遇傷者');
+    await expect(page.locator('.event-opt[data-opt-index="0"]')).toBeDisabled();
+    await page.click('.event-opt[data-opt-index="1"]');
+    await expect(page.locator('#check-result')).toContainText('失敗');
+    await page.click('#btn-exp-continue');
+
+    // leg3：ev_broken_wheel，首選項可用，檢定失敗但無戰鬥
+    await expect(page.locator('#exp-progress')).toHaveText('第 3/4 段');
+    await expect(page.locator('#event-title')).toHaveText('車輪斷裂');
+    await page.click('.event-opt[data-opt-index="0"]');
+    await expect(page.locator('#check-result')).toContainText('失敗');
+    await page.click('#btn-exp-continue');
+
+    // leg4：ev_wolf_howl 再次出現，檢定失敗觸發戰鬥
+    await expect(page.locator('#exp-progress')).toHaveText('第 4/4 段');
+    await expect(page.locator('#event-title')).toHaveText('遠方的狼嚎');
+    await page.click('.event-opt[data-opt-index="0"]');
+    await expect(page.locator('#check-result')).toContainText('失敗');
+    await page.click('#btn-exp-continue');
+
+    // 進入戰鬥：enc_wolf_pair，兩隻敵人存活時應顯示多目標選擇
+    await expect(page.locator('#screen-combat')).toBeVisible();
+    await expect(page.locator('#combat-enemies .combat-unit')).toHaveCount(2);
+    await expect(page.locator('#combat-targets .target-btn[data-target-id]')).toHaveCount(2);
+
+    // 用預設目標（不手動選標）打到分出勝負，維持種子預先模擬的決定性結果
+    for (let i = 0; i < 40; i++) {
+      const result = page.locator('#combat-result');
+      if (await result.isVisible()) break;
+      const move = page.locator('#combat-actions .move-btn').first();
+      if (await move.isVisible().catch(() => false)) {
+        await move.click();
+      }
+      await page.waitForTimeout(250);
+    }
+    await expect(page.locator('#combat-result')).toBeVisible();
+    await expect(page.locator('#combat-result')).toContainText('勝利');
+    await page.click('#btn-combat-back');
+
+    // 結算畫面：seed=30 模擬得出 goldGained=9、xpGained=45、無戰利品物品
+    await expect(page.locator('#screen-settlement')).toBeVisible();
+    await expect(page.locator('#settle-gold')).toHaveText('9');
+    await expect(page.locator('#settle-xp')).toHaveText('45');
+    await expect(page.locator('#settle-items li')).toHaveText('（無）');
+    await expect(page.locator('#settle-log')).toContainText('順利完成');
+
+    await page.click('#btn-settle-back');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await expect(page.locator('#town-gold')).toHaveText('209');
+  });
+
+  test('遠征中重整頁面 → 城鎮出現「繼續遠征」→ 回到同一張事件卡', async ({ page }) => {
+    await newGameWithSeed(page, 30);
+    await page.click('#btn-quest-board');
+    await page.click('.quest-item[data-location-id="riverside-road"]');
+    await expect(page.locator('#screen-expedition')).toBeVisible();
+    const titleBefore = await page.locator('#event-title').textContent();
+    const progressBefore = await page.locator('#exp-progress').textContent();
+
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#btn-continue')).toBeVisible();
+    await page.click('#btn-continue');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await expect(page.locator('#btn-resume-expedition')).toBeVisible();
+
+    await page.click('#btn-resume-expedition');
+    await expect(page.locator('#screen-expedition')).toBeVisible();
+    await expect(page.locator('#event-title')).toHaveText(titleBefore ?? '');
+    await expect(page.locator('#exp-progress')).toHaveText(progressBefore ?? '');
+  });
+
+  test('迷宮（seed=2）：房卡選擇、選 treasure 房入 loot、戰鬥中撤退、結算', async ({ page }) => {
+    await newGameWithSeed(page, 2);
+    await page.click('#btn-quest-board');
+    await page.click('.quest-item[data-location-id="abandoned-mine"]');
+    await expect(page.locator('#screen-expedition')).toBeVisible();
+    await expect(page.locator('#exp-progress')).toHaveText('第 1/4 層');
+
+    // 第 1 層房卡固定為 fight/treasure/rest（seed=2 模擬確認）
+    await expect(page.locator('#room-choices .room-btn[data-room]')).toHaveCount(3);
+    await expect(page.locator('.room-btn[data-room="treasure"]')).toBeVisible();
+
+    await page.click('.room-btn[data-room="treasure"]');
+    await expect(page.locator('#check-result')).toBeVisible();
+    await expect(page.locator('#check-result')).toContainText('70');
+    await page.click('#btn-exp-continue');
+
+    // 第 2 層房卡為 fight/rest，選 fight 進入戰鬥
+    await expect(page.locator('#exp-progress')).toHaveText('第 2/4 層');
+    await expect(page.locator('#room-choices .room-btn[data-room]')).toHaveCount(2);
+    await page.click('.room-btn[data-room="fight"]');
+    await expect(page.locator('#check-result')).toContainText('戰鬥');
+    await page.click('#btn-exp-continue');
+
+    // 戰鬥：enc_mine_spiders，兩隻敵人存活，驗證多目標選擇可操作
+    await expect(page.locator('#screen-combat')).toBeVisible();
+    await expect(page.locator('#combat-targets .target-btn[data-target-id]')).toHaveCount(2);
+    await page.locator('#combat-targets .target-btn').nth(1).click();
+    await expect(page.locator('#combat-targets .target-btn').nth(1)).toHaveClass(/target-selected/);
+
+    await page.click('#btn-retreat');
+    await expect(page.locator('#combat-result')).toBeVisible();
+    await expect(page.locator('#combat-result')).toContainText('撤');
+    await page.click('#btn-combat-back');
+
+    // 結算：撤退折半（70/2=35），xp 依 step=2 計算為 30
+    await expect(page.locator('#screen-settlement')).toBeVisible();
+    await expect(page.locator('#settle-gold')).toHaveText('35');
+    await expect(page.locator('#settle-xp')).toHaveText('30');
+    await expect(page.locator('#settle-log')).toContainText('鎩羽而歸');
+
+    await page.click('#btn-settle-back');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await expect(page.locator('#town-gold')).toHaveText('235');
+  });
+});


### PR DESCRIPTION
《商隊與劍》M3：遠征玩法閉環（城鎮→委託板→事件鏈→戰鬥→迷宮→歸返結算）。

- 遠征狀態機：事件卡加權抽選（地形/旗標過濾）、選項檢定與 Effect DSL（金錢/物品/血量/旗標/戰鬥/發現/敘事）
- 探索深度：**隱藏地點發現機制**（旗標鏈：商人的地圖→洞穴入口→解鎖哥布林巢穴）、迷宮逐層房卡選擇（戰鬥/寶箱/事件/休息/未知）、深度加成風險報酬、隨時撤退（戰利品折半）
- 戰鬥整合：遭遇→M2 引擎→戰利品/傷亡寫回；遠征血量與戰鬥雙向同步（事件扣血影響戰鬥）；傭兵永久死亡、主角必存活
- 存檔 v3：背包＋遠征快照（重整可續玩）＋自動遷移
- 首批內容：15 張繁中事件卡（五屬性檢定全覆蓋）、2 條路線、2 座迷宮（含隱藏）、12 物品、7 種敵組（含觸發 support AI 的治療師）＋19 條資料完整性測試
- M2 終審移交必修完成：enemyAct 依招式類型選目標、撤退攻擊選攻擊招

測試：caravan 引擎 **153 單元測試**（TDD、種子化）、e2e **12/12**（含引擎預算精確值斷言的完整遠征流程）、全套 vitest **1329/1329**。審查閘門抓到並修復：registry 接線、partyHp 同步缺口、主角重傷永久卡死地雷、資料測試覆蓋缺口。opus 終審 Ready to merge。

經濟基準（給 M4）：一趟路線 ≈60-110 金當量/45-50xp；礦坑 ≈120-220 金當量；起始 200 金。

🤖 Generated with [Claude Code](https://claude.com/claude-code)