### PR TITLE
feat(caravan): 升格獨立入口——/caravan landing＋遊戲廳旗艦卡分級

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,11 @@ export default defineConfig({
   output: 'static',
   adapter: vercel(),
 
+  // /games/caravan 已升格為獨立入口 /caravan（2026-07-19）
+  redirects: {
+    '/games/caravan': '/caravan',
+  },
+
   // i18n 路由配置
   i18n: {
     defaultLocale: 'zh-TW',

--- a/src/pages/caravan/index.astro
+++ b/src/pages/caravan/index.astro
@@ -1,0 +1,196 @@
+---
+/**
+ * /caravan — 《商隊與劍》獨立入口 landing。
+ * 內容量數字從 data 檔 build 時實算，不寫死。遊戲本體在 /caravan/play。
+ */
+import BaseLayout from '@components/layout/BaseLayout.astro';
+import { EVENTS } from '@scripts/games/caravan/data/events';
+import { LOCATIONS } from '@scripts/games/caravan/data/locations';
+import { TOWNS } from '@scripts/games/caravan/data/towns';
+import { JOBS } from '@scripts/games/caravan/data/jobs';
+import { ITEMS } from '@scripts/games/caravan/data/items';
+import { ENCOUNTERS, TRAINING_ENCOUNTER } from '@scripts/games/caravan/data/enemies';
+
+const allUnits = [...TRAINING_ENCOUNTER(), ...Object.values(ENCOUNTERS).flatMap((mk) => mk())];
+const stats = {
+  events: EVENTS.length,
+  locations: Object.keys(LOCATIONS).length,
+  towns: Object.keys(TOWNS).length,
+  enemies: new Set(allUnits.map((u) => u.name)).size,
+  equipment: Object.values(ITEMS).filter((i) => i.equip).length,
+  jobs: Object.keys(JOBS).length,
+};
+const jobList = Object.values(JOBS);
+---
+
+<BaseLayout
+  title="商隊與劍 CARAVAN & SWORD — 文字跑團長篇 RPG"
+  description="經營商隊、擲骰決定命運的長篇文字冒險：42 張事件卡、聲望解鎖的商路與迷宮、裝備養成與隱藏路線。"
+  lang="zh-TW"
+>
+  <main class="cv-landing">
+    <!-- Hero -->
+    <header class="cv-hero">
+      <img class="cv-hero-art" src="/assets/games/caravan/title-banner.webp" alt="" width="1280" height="720" loading="eager" />
+      <div class="cv-hero-text">
+        <p class="cv-kicker">長篇文字冒險 RPG</p>
+        <h1 class="cv-title">商隊與劍</h1>
+        <p class="cv-subtitle">CARAVAN &amp; SWORD</p>
+        <p class="cv-tagline">一輛馬車、一把劍、一條沒人走完的商路。<br />擲骰決定命運，帳本決定生死。</p>
+        <div class="cv-cta">
+          <a class="cv-btn cv-btn-primary" href="/caravan/play">開始旅程</a>
+          <a class="cv-btn cv-btn-continue" id="cv-continue" href="/caravan/play" hidden>繼續旅程</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- 內容量數字帶 -->
+    <section class="cv-stats" aria-label="遊戲內容規模">
+      <div class="cv-stat"><b>{stats.events}</b><span>張事件卡</span></div>
+      <div class="cv-stat"><b>{stats.locations}</b><span>條商路與迷宮</span></div>
+      <div class="cv-stat"><b>{stats.towns}</b><span>座城鎮</span></div>
+      <div class="cv-stat"><b>{stats.enemies}</b><span>種敵人</span></div>
+      <div class="cv-stat"><b>{stats.equipment}</b><span>件裝備</span></div>
+      <div class="cv-stat"><b>{stats.jobs}</b><span>種職業</span></div>
+    </section>
+
+    <!-- 世界觀引言 -->
+    <section class="cv-lore">
+      <p>
+        王國邊陲的商路早已不安穩：哥布林在礦坑深處築巢，霧嶺古道傳出亡靈的箭鳴，
+        鹽泉城的商人開得起任何價錢——只要你的貨能活著運到。
+        你繼承了一輛舊馬車與一小袋金幣，在啟程之鎮的廣場上召集旅伴。
+        每一次遠征都是一場跑團：抽事件、擲骰、選擇，然後承擔後果。
+      </p>
+    </section>
+
+    <!-- 特色 -->
+    <section class="cv-features">
+      <article class="cv-feature">
+        <img src="/assets/games/caravan/event-rare-treasure-map.webp" alt="" width="960" height="720" loading="lazy" />
+        <h2>擲骰決定命運</h2>
+        <p>d20 檢定驅動每個抉擇——說服、潛行、強攻或繞路。nat20 的奇蹟與 nat1 的災難都會寫進你的旅途，回合制戰鬥有意圖預示與架盾反擊。</p>
+      </article>
+      <article class="cv-feature">
+        <img src="/assets/games/caravan/town-riverbend-town.webp" alt="" width="1280" height="720" loading="lazy" />
+        <h2>商隊經營</h2>
+        <p>四鎮物價各異：礦石在河灣鎮翻倍、香料在林邊聚落搶手。升級馬車、招募旅伴、押貨跨鎮套利——薪餉與傷勢都是帳本上的真實成本。</p>
+      </article>
+      <article class="cv-feature">
+        <img src="/assets/games/caravan/event-mercenary-ruins.webp" alt="" width="960" height="720" loading="lazy" />
+        <h2>養成與祕密</h2>
+        <p>裝備三欄改寫戰鬥招式，聲望解鎖高階商路與鹽晶洞窟。褪色的軍旗、奇怪的商人三連環——旗標鏈事件把你引向地圖上不存在的地方。</p>
+      </article>
+    </section>
+
+    <!-- 職業列 -->
+    <section class="cv-jobs" aria-label="可用職業">
+      {jobList.map((job) => (
+        <figure class="cv-job">
+          <img src={job.art} alt={job.name} width="600" height="800" loading="lazy" />
+          <figcaption>{job.name}</figcaption>
+        </figure>
+      ))}
+    </section>
+
+    <!-- 底部 CTA -->
+    <footer class="cv-footer">
+      <a class="cv-btn cv-btn-primary" href="/caravan/play">啟程</a>
+      <nav class="cv-footer-links">
+        <a href="/games">← 遊戲廳</a>
+        <a href="/">主站</a>
+      </nav>
+    </footer>
+  </main>
+</BaseLayout>
+
+<script>
+  import { SAVE_KEY } from '@scripts/games/caravan/save';
+  // 有存檔才顯示「繼續旅程」
+  try {
+    if (localStorage.getItem(SAVE_KEY)) document.getElementById('cv-continue')?.removeAttribute('hidden');
+  } catch { /* localStorage 不可用時僅顯示開始 */ }
+</script>
+
+<style>
+  .cv-landing {
+    min-height: 100vh;
+    background: #f5f0e6;
+    color: #2b2620;
+    font-family: 'Noto Serif TC', serif;
+  }
+
+  /* Hero */
+  .cv-hero { position: relative; }
+  .cv-hero-art { display: block; width: 100%; height: min(62vh, 560px); object-fit: cover; }
+  .cv-hero-text {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: flex-end;
+    padding: 2rem 1rem 2.5rem; text-align: center;
+    background: linear-gradient(180deg, transparent 35%, rgba(43, 32, 20, 0.72) 100%);
+    color: #f8f3e8;
+  }
+  .cv-kicker { letter-spacing: 0.5em; font-size: 0.85rem; margin: 0 0 0.5rem; color: #ffd98a; text-shadow: 0 1px 8px rgba(43, 32, 20, 0.85); }
+  .cv-title { font-size: clamp(2.4rem, 7vw, 4rem); letter-spacing: 0.28em; margin: 0; text-shadow: 0 2px 18px rgba(0,0,0,0.55); }
+  .cv-subtitle { letter-spacing: 0.45em; margin: 0.35rem 0 0.9rem; color: #e8dcc2; font-size: 0.95rem; }
+  .cv-tagline { margin: 0 0 1.4rem; line-height: 1.9; font-size: 1.02rem; color: #f3ead6; }
+  .cv-cta { display: flex; gap: 0.9rem; }
+  .cv-btn {
+    display: inline-block; padding: 0.8rem 2.4rem; border: 1px solid #8a7a5c;
+    color: #2b2620; background: #f5f0e6; text-decoration: none; letter-spacing: 0.3em;
+    font-family: inherit; font-size: 1rem; transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+  .cv-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 18px rgba(43, 32, 20, 0.35); }
+  .cv-btn-primary { background: #b3552e; border-color: #8a3c1e; color: #fff6ea; }
+  .cv-btn-continue[hidden] { display: none; }
+
+  /* 數字帶 */
+  .cv-stats {
+    display: flex; flex-wrap: wrap; justify-content: center; gap: 0;
+    max-width: 60rem; margin: 0 auto; padding: 2.2rem 1rem 0.6rem;
+  }
+  .cv-stat {
+    flex: 1 1 8rem; text-align: center; padding: 0.6rem 1rem;
+    border-right: 1px solid #d9cfb8;
+  }
+  .cv-stat:last-child { border-right: none; }
+  .cv-stat b { display: block; font-size: 2.1rem; color: #8a3c1e; }
+  .cv-stat span { font-size: 0.85rem; letter-spacing: 0.18em; color: #6b5f4c; }
+
+  /* 世界觀 */
+  .cv-lore { max-width: 42rem; margin: 0 auto; padding: 1.8rem 1.5rem; }
+  .cv-lore p { line-height: 2.1; text-align: justify; margin: 0; font-size: 1.02rem; }
+
+  /* 特色 */
+  .cv-features {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1.6rem; max-width: 64rem; margin: 0 auto; padding: 1.2rem 1.5rem 2rem;
+  }
+  .cv-feature img {
+    display: block; width: 100%; height: 11rem; object-fit: cover;
+    border: 1px solid #cfc6b0;
+  }
+  .cv-feature h2 { font-size: 1.15rem; letter-spacing: 0.2em; margin: 0.9rem 0 0.4rem; }
+  .cv-feature p { line-height: 1.9; font-size: 0.92rem; color: #4a4234; margin: 0; }
+
+  /* 職業列 */
+  .cv-jobs {
+    display: flex; flex-wrap: wrap; justify-content: center; gap: 1.2rem;
+    max-width: 60rem; margin: 0 auto; padding: 0.5rem 1.5rem 2.4rem;
+  }
+  .cv-job { margin: 0; text-align: center; }
+  .cv-job img {
+    display: block; width: 9.5rem; height: 12.5rem; object-fit: cover;
+    border: 1px solid #cfc6b0;
+  }
+  .cv-job figcaption { margin-top: 0.5rem; letter-spacing: 0.3em; font-size: 0.95rem; }
+
+  /* Footer */
+  .cv-footer {
+    display: flex; flex-direction: column; align-items: center; gap: 1.2rem;
+    padding: 1rem 1rem 3.5rem;
+  }
+  .cv-footer-links { display: flex; gap: 1.6rem; }
+  .cv-footer-links a { color: #6b5f4c; text-decoration: none; letter-spacing: 0.15em; font-size: 0.9rem; }
+  .cv-footer-links a:hover { color: #8a3c1e; }
+</style>

--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -1,5 +1,5 @@
 ---
-// src/pages/games/caravan.astro
+// src/pages/caravan/play.astro — 遊戲本體（landing 在 /caravan）
 import BaseLayout from '@components/layout/BaseLayout.astro';
 import ArcadeBgm from '@components/ArcadeBgm.astro';
 

--- a/src/pages/games/index.astro
+++ b/src/pages/games/index.astro
@@ -6,15 +6,20 @@
 import BaseLayout from '@components/layout/BaseLayout.astro';
 import ArcadeBgm from '@components/ArcadeBgm.astro';
 import { defaultLang, type Language } from '@i18n/index';
+import { EVENTS } from '@scripts/games/caravan/data/events';
+import { TOWNS } from '@scripts/games/caravan/data/towns';
+import { ENCOUNTERS, TRAINING_ENCOUNTER } from '@scripts/games/caravan/data/enemies';
 
 const lang: Language = defaultLang;
+// 旗艦卡（長篇 RPG，獨立入口）的內容量數字——build 時從 data 實算
+const cvUnits = [...TRAINING_ENCOUNTER(), ...Object.values(ENCOUNTERS).flatMap((mk) => mk())];
+const cvStats = { events: EVENTS.length, towns: Object.keys(TOWNS).length, enemies: new Set(cvUnits.map((u) => u.name)).size };
 
 const games = [
   { id: 'tetris', title: 'BATTLE TETRIS', href: '/games/tetris', active: true, art: '/assets/games/tetris/card-tetris.webp' },
   { id: 'bomber', title: 'DUNGEON BOMBER', href: '/games/bomber', active: true, art: '/assets/games/bomber/card-bomber.webp' },
   { id: 'witchrun', title: 'WITCH RUN', href: '/games/witchrun', active: true, art: '/assets/games/witchrun/card-witchrun.webp' },
   { id: 'defense', title: 'DUNGEON DEFENSE', href: '/games/defense', active: true, art: '/assets/games/defense/card-defense.webp' },
-  { id: 'caravan', title: 'CARAVAN & SWORD', href: '/games/caravan', active: true, art: '/assets/games/caravan/card-caravan.webp' },
 ];
 ---
 
@@ -45,6 +50,16 @@ const games = [
         )
       )}
     </div>
+
+    <a class="card-flagship" href="/caravan">
+      <img class="flagship-art" src="/assets/games/caravan/title-banner.webp" alt="" loading="eager" />
+      <div class="flagship-body">
+        <span class="flagship-tag">長篇文字冒險 RPG</span>
+        <span class="flagship-title">CARAVAN &amp; SWORD</span>
+        <span class="flagship-stats">{cvStats.events} 事件卡 · {cvStats.towns} 城鎮 · {cvStats.enemies} 種敵人 · 裝備養成 · 聲望解鎖</span>
+        <span class="flagship-play">ENTER ▶</span>
+      </div>
+    </a>
 
     <a class="lb-link" href="/games/leaderboard"><i class="fas fa-trophy"></i> 排行榜 LEADERBOARD</a>
   </main>
@@ -168,6 +183,49 @@ const games = [
     opacity: 0.85;
     position: relative;
     background: center / contain no-repeat url('/assets/games/tetris/icons/lock.webp');
+  }
+
+  /* ---- 旗艦卡（長篇 RPG，與 arcade 小卡刻意區隔：橫幅 + 暖金） ---- */
+  .card-flagship {
+    position: relative;
+    display: block;
+    width: min(980px, 100%);
+    height: 190px;
+    border-radius: 14px;
+    overflow: hidden;
+    text-decoration: none;
+    border: 2px solid rgba(255, 190, 92, 0.85);
+    box-shadow: 0 0 18px rgba(255, 170, 60, 0.4), inset 0 0 20px rgba(255, 170, 60, 0.1);
+    transition: transform 0.18s ease, box-shadow 0.18s ease;
+    animation: arcadeCardIn 0.5s 1.06s both ease;
+  }
+  .card-flagship:hover {
+    transform: translateY(-6px) scale(1.015);
+    box-shadow: 0 0 30px rgba(255, 170, 60, 0.75), inset 0 0 26px rgba(255, 170, 60, 0.18);
+  }
+  .flagship-art {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    object-fit: cover; object-position: center 62%;
+    transition: transform 0.18s ease;
+  }
+  .card-flagship:hover .flagship-art { transform: scale(1.04); }
+  .card-flagship::after {
+    content: '';
+    position: absolute; inset: 0;
+    background: linear-gradient(90deg, rgba(4, 6, 13, 0.88) 0%, rgba(4, 6, 13, 0.55) 42%, transparent 75%);
+  }
+  .flagship-body {
+    position: absolute; inset: 0; z-index: 1;
+    display: flex; flex-direction: column; justify-content: center; gap: 9px;
+    padding: 0 28px; max-width: 62%;
+  }
+  .flagship-tag { font-size: 9px; letter-spacing: 3px; color: #ffbe5c; }
+  .flagship-title { font-size: 19px; letter-spacing: 3px; color: #fff3dd; text-shadow: 0 0 14px rgba(255, 190, 92, 0.6); }
+  .flagship-stats { font-size: 8px; letter-spacing: 1.5px; line-height: 1.9; color: #d8c9a8; }
+  .flagship-play { font-size: 10px; letter-spacing: 2px; color: #ffbe5c; margin-top: 2px; }
+  @media (max-width: 560px) {
+    .card-flagship { height: 230px; }
+    .flagship-body { max-width: 88%; padding: 0 18px; }
   }
 
   .lb-link {

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('商隊與劍：外殼流程', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/games/caravan');
+    await page.goto('/caravan/play');
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -31,18 +31,45 @@ test.describe('商隊與劍：外殼流程', () => {
     await expect(page.locator('#town-gold')).toHaveText('200');
   });
 
-  test('遊戲廳有 CARAVAN & SWORD 卡片並連到遊戲', async ({ page }) => {
+  test('遊戲廳旗艦卡連到獨立入口 landing，開始旅程進入遊戲', async ({ page }) => {
     await page.goto('/games');
-    const card = page.locator('a[href="/games/caravan"]');
-    await expect(card).toBeVisible();
-    await card.click();
+    const flagship = page.locator('a.card-flagship[href="/caravan"]');
+    await expect(flagship).toBeVisible();
+    await flagship.click();
+    await expect(page).toHaveURL(/\/caravan\/?$/);
+    await page.locator('a.cv-btn-primary[href="/caravan/play"]').first().click();
     await expect(page.locator('#screen-title')).toBeVisible();
+  });
+});
+
+test.describe('商隊與劍：獨立入口 landing', () => {
+  test('內容量數字帶與 CTA 齊備；有存檔時顯示繼續旅程', async ({ page }) => {
+    await page.goto('/caravan');
+    // 數字帶六項且數字 > 0（build 時從 data 實算）
+    const stats = page.locator('.cv-stat b');
+    await expect(stats).toHaveCount(6);
+    for (const text of await stats.allTextContents()) {
+      expect(Number(text)).toBeGreaterThan(0);
+    }
+    // 無存檔：僅開始旅程
+    await expect(page.locator('#cv-continue')).toBeHidden();
+    // 造一份存檔 → 繼續旅程出現
+    await page.evaluate(() => localStorage.setItem('caravan-save-v1', '{"v":5}'));
+    await page.reload();
+    await expect(page.locator('#cv-continue')).toBeVisible();
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+  });
+
+  test('舊網址 /games/caravan 轉址到 /caravan', async ({ page }) => {
+    await page.goto('/games/caravan');
+    await expect(page).toHaveURL(/\/caravan\/?$/);
+    await expect(page.locator('.cv-title')).toBeVisible();
   });
 });
 
 test.describe('商隊與劍：訓練場戰鬥', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/games/caravan?seed=42');
+    await page.goto('/caravan/play?seed=42');
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -91,7 +118,7 @@ test.describe('商隊與劍：訓練場戰鬥', () => {
     // 因為 seed=42 訓練場首回合永遠輪到玩家、敵方 timer 從未排入——
     // 對「舊戰鬥敵方 timer 污染新戰鬥」的修復沒有鑑別力（還原修復仍會過，是假保護）。
     // seed=5 下訓練場開戰瞬間就輪到敵方 goblin-scout-1 先攻，敵方 timer 立即排入。
-    await page.goto('/games/caravan?seed=5');
+    await page.goto('/caravan/play?seed=5');
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -136,7 +163,7 @@ test.describe('商隊與劍：遠征系統', () => {
   // 第 2 層房卡 fight/rest，選 fight 進入 enc_mine_spiders 後立即撤退；
   // 結算 goldGained=35（70 折半無條件捨去）、xpGained=30。
   async function newGameWithSeed(page: import('@playwright/test').Page, seed: number): Promise<void> {
-    await page.goto(`/games/caravan?seed=${seed}`);
+    await page.goto(`/caravan/play?seed=${seed}`);
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -293,7 +320,7 @@ test.describe('商隊與劍：遠征系統', () => {
 
 test.describe('商隊與劍：經營系統', () => {
   async function newGameWithSeed(page: import('@playwright/test').Page, seed: number): Promise<void> {
-    await page.goto(`/games/caravan?seed=${seed}`);
+    await page.goto(`/caravan/play?seed=${seed}`);
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -544,7 +571,7 @@ test.describe('商隊與劍：經營系統', () => {
 
 test.describe('商隊與劍：裝備系統', () => {
   async function newGameWithSeed(page: import('@playwright/test').Page, seed: number): Promise<void> {
-    await page.goto(`/games/caravan?seed=${seed}`);
+    await page.goto(`/caravan/play?seed=${seed}`);
     await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
     await page.reload();
     await page.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
## Summary

《商隊與劍》從 arcade 小遊戲卡升格為獨立產品入口，一眼看出體量與小遊戲不同：

- **獨立入口 `/caravan`**：hero 大圖＋「長篇文字冒險 RPG」定位、內容量數字帶（42 事件卡／7 商路迷宮／4 城鎮／15 敵人／12 裝備／4 職業——build 時從 data 檔實算，內容擴充時自動更新）、世界觀引言、三大特色配事件插圖、職業立繪列、開始／繼續旅程 CTA
- **遊戲本體遷至 `/caravan/play`**（git mv 保留歷史），舊址 `/games/caravan` 由 astro.config redirects 轉址
- **遊戲廳分級**：caravan 自 220px 小卡牆抽出，改為全寬暖金旗艦橫幅卡（與青色霓虹 arcade 小卡視覺區隔），href 指向 landing

## Test plan
- [x] `npx vitest run` 1483 全綠
- [x] caravan e2e 24 綠（含新增 landing 數字帶／繼續旅程偵測／舊址轉址 3 條）＋ defense e2e 3 綠
- [x] `npm run build` 綠
- [x] 實機驗收：landing 全版面、遊戲廳旗艦卡對比、redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)