### PR TITLE
feat(caravan): M6 冒險編年史——圖鑑、成就、跨輪傳承

### DIFF
--- a/src/pages/caravan/index.astro
+++ b/src/pages/caravan/index.astro
@@ -10,6 +10,7 @@ import { TOWNS } from '@scripts/games/caravan/data/towns';
 import { JOBS } from '@scripts/games/caravan/data/jobs';
 import { ITEMS } from '@scripts/games/caravan/data/items';
 import { ENCOUNTERS, TRAINING_ENCOUNTER } from '@scripts/games/caravan/data/enemies';
+import { ACHIEVEMENTS } from '@scripts/games/caravan/chronicle';
 
 const allUnits = [...TRAINING_ENCOUNTER(), ...Object.values(ENCOUNTERS).flatMap((mk) => mk())];
 const stats = {
@@ -93,6 +94,27 @@ const jobList = Object.values(JOBS);
       ))}
     </section>
 
+    <!-- 冒險編年史（跨輪收集進度，client 從 localStorage 渲染狀態） -->
+    <section class="cv-chronicle" id="chronicle" aria-label="冒險編年史">
+      <h2 class="cv-section-title">冒險編年史</h2>
+      <p class="cv-chronicle-legacy" id="cv-legacy" hidden></p>
+      <p class="cv-chronicle-empty" id="cv-chronicle-empty">尚未啟程——你的旅途將在此留下足跡。</p>
+      <div class="cv-progress-grid" id="cv-progress" hidden>
+        <div class="cv-progress" data-kind="events"><span class="cv-progress-label">事件圖鑑</span><span class="cv-progress-num">0 / {stats.events}</span><div class="cv-progress-bar"><i></i></div></div>
+        <div class="cv-progress" data-kind="enemies"><span class="cv-progress-label">敵人圖鑑</span><span class="cv-progress-num">0 / {stats.enemies}</span><div class="cv-progress-bar"><i></i></div></div>
+        <div class="cv-progress" data-kind="locations"><span class="cv-progress-label">商路踏破</span><span class="cv-progress-num">0 / {stats.locations}</span><div class="cv-progress-bar"><i></i></div></div>
+        <div class="cv-progress" data-kind="equipment"><span class="cv-progress-label">裝備收集</span><span class="cv-progress-num">0 / {stats.equipment}</span><div class="cv-progress-bar"><i></i></div></div>
+      </div>
+      <div class="cv-achievements">
+        {ACHIEVEMENTS.map((a) => (
+          <div class="cv-achievement" data-ach={a.id}>
+            <b>{a.name}</b>
+            <span>{a.desc}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+
     <!-- 底部 CTA -->
     <footer class="cv-footer">
       <a class="cv-btn cv-btn-primary" href="/caravan/play">啟程</a>
@@ -106,10 +128,34 @@ const jobList = Object.values(JOBS);
 
 <script>
   import { SAVE_KEY } from '@scripts/games/caravan/save';
+  import { loadChronicle, collectionProgress, legacyBonusGold } from '@scripts/games/caravan/chronicle';
   // 有存檔才顯示「繼續旅程」
   try {
     if (localStorage.getItem(SAVE_KEY)) document.getElementById('cv-continue')?.removeAttribute('hidden');
   } catch { /* localStorage 不可用時僅顯示開始 */ }
+
+  // 編年史：讀 localStorage 填進度與成就狀態
+  try {
+    const chron = loadChronicle();
+    const progress = collectionProgress(chron);
+    const hasAny = chron.runs.started > 0 || chron.seenEvents.length > 0 || chron.defeatedEnemies.length > 0;
+    if (hasAny) {
+      document.getElementById('cv-chronicle-empty')?.setAttribute('hidden', '');
+      document.getElementById('cv-progress')?.removeAttribute('hidden');
+      for (const [kind, [got, total]] of Object.entries(progress)) {
+        const row = document.querySelector(`.cv-progress[data-kind="${kind}"]`);
+        if (!row) continue;
+        row.querySelector('.cv-progress-num')!.textContent = `${got} / ${total}`;
+        (row.querySelector('.cv-progress-bar i') as HTMLElement).style.width = `${total ? Math.round((got / total) * 100) : 0}%`;
+      }
+      const legacyEl = document.getElementById('cv-legacy')!;
+      legacyEl.textContent = `遠征 ${chron.runs.started} 次 · 歸來 ${chron.runs.won} 次 · 傳承 ${chron.legacyPoints} 點（新旅程起始金幣 +${legacyBonusGold(chron)} G）`;
+      legacyEl.removeAttribute('hidden');
+    }
+    for (const id of chron.unlockedAchievements) {
+      document.querySelector(`.cv-achievement[data-ach="${id}"]`)?.classList.add('unlocked');
+    }
+  } catch { /* 編年史讀取失敗時保持空狀態 */ }
 </script>
 
 <style>
@@ -184,6 +230,39 @@ const jobList = Object.values(JOBS);
     border: 1px solid #cfc6b0;
   }
   .cv-job figcaption { margin-top: 0.5rem; letter-spacing: 0.3em; font-size: 0.95rem; }
+
+  /* 冒險編年史 */
+  .cv-chronicle { max-width: 60rem; margin: 0 auto; padding: 1rem 1.5rem 2.6rem; text-align: center; }
+  .cv-section-title { font-size: 1.4rem; letter-spacing: 0.35em; margin: 0 0 0.9rem; color: #4a3420; }
+  .cv-chronicle-legacy { color: #8a3c1e; letter-spacing: 0.08em; margin: 0 0 1.2rem; font-size: 0.95rem; }
+  .cv-chronicle-legacy[hidden], .cv-chronicle-empty[hidden], .cv-progress-grid[hidden] { display: none; }
+  .cv-chronicle-empty { color: #8a7f6d; letter-spacing: 0.12em; margin: 0.4rem 0 1.4rem; }
+  .cv-progress-grid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    gap: 1rem 1.6rem; margin: 0 0 1.6rem; text-align: left;
+  }
+  .cv-progress-label { font-size: 0.88rem; letter-spacing: 0.2em; color: #6b5f4c; }
+  .cv-progress-num { float: right; font-size: 0.88rem; color: #8a3c1e; }
+  .cv-progress-bar {
+    margin-top: 0.35rem; height: 8px; background: #e2d8c0;
+    border: 1px solid #cfc6b0; overflow: hidden;
+  }
+  .cv-progress-bar i { display: block; height: 100%; width: 0; background: #b3552e; transition: width 0.6s ease; }
+  .cv-achievements {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(13.5rem, 1fr));
+    gap: 0.7rem; text-align: left;
+  }
+  .cv-achievement {
+    border: 1px solid #d5cab0; background: #efe8d6; padding: 0.6rem 0.85rem;
+    opacity: 0.55; filter: grayscale(0.6);
+  }
+  .cv-achievement.unlocked {
+    opacity: 1; filter: none; background: #fffdf6; border-color: #c9a35c;
+    box-shadow: 0 2px 10px rgba(179, 85, 46, 0.14);
+  }
+  .cv-achievement b { display: block; font-size: 0.95rem; letter-spacing: 0.1em; }
+  .cv-achievement.unlocked b::before { content: '🏆 '; }
+  .cv-achievement span { font-size: 0.8rem; color: #6b5f4c; line-height: 1.6; }
 
   /* Footer */
   .cv-footer {

--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -17,6 +17,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         <button id="btn-new-game" class="caravan-btn">新的旅程</button>
         <button id="btn-continue" class="caravan-btn" hidden>繼續旅程</button>
       </div>
+      <p id="title-legacy" class="title-legacy" hidden></p>
+      <a class="title-chronicle-link" href="/caravan#chronicle">冒險編年史 »</a>
     </section>
 
     <!-- 城鎮畫面（M4：市集/酒館/隊伍/馬車四分頁） -->
@@ -138,6 +140,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     <!-- 結算畫面（M3：遠征歸返） -->
     <section id="screen-settlement" class="screen" hidden>
       <h2 class="settle-title">遠征結算</h2>
+      <p id="settle-achievements" class="settle-achievements" hidden></p>
       <div id="settle-log" class="settle-log"></div>
       <dl class="settle-stats">
         <div class="settle-stat">
@@ -163,6 +166,10 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
 <script>
   import { newGame, saveGame, loadGame, SAVE_KEY } from '@scripts/games/caravan/save';
+  import {
+    loadChronicle, saveChronicle, recordEvent, recordEnemyDefeat, recordLocationVisit,
+    recordEquipment, recordExpedition, evaluateAchievements, legacyBonusGold, ACHIEVEMENTS,
+  } from '@scripts/games/caravan/chronicle';
   import type { SaveData, CompanionRecord } from '@scripts/games/caravan/save';
   import { createRng } from '@scripts/games/caravan/rng';
   import {
@@ -712,8 +719,27 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     expeditionExpiredOnLoad = false;
   }
 
+  const chron = loadChronicle();
+
+  /** 掃描存檔中的裝備（庫存＋成員身上），冪等收錄進編年史。 */
+  function syncEquipmentToChronicle(): void {
+    if (!save) return;
+    for (const id of Object.keys(save.inventory)) if (ITEMS[id]?.equip) recordEquipment(chron, id);
+    for (const m of [save.protagonist, ...save.companions]) {
+      for (const id of Object.values(m.equipment)) if (id && ITEMS[id]?.equip) recordEquipment(chron, id);
+    }
+  }
+
+  // 標題畫面：有傳承點才顯示加成
+  const titleLegacyEl = document.getElementById('title-legacy')!;
+  if (legacyBonusGold(chron) > 0) {
+    titleLegacyEl.textContent = `商會傳承：新旅程起始金幣 +${legacyBonusGold(chron)} G（傳承 ${chron.legacyPoints} 點）`;
+    titleLegacyEl.hidden = false;
+  }
+
   btnNew.addEventListener('click', () => {
     save = newGame();
+    save.gold += legacyBonusGold(chron); // 商會傳承：跨輪起始加成
     saveGame(save);
     expeditionExpiredOnLoad = false;
     showTown(save.gold);
@@ -926,6 +952,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     expedition = startExpedition(rng, save, locationId, cargo);
     save.expedition = expedition;
     saveGame(save);
+    recordLocationVisit(chron, locationId);
+    saveChronicle(chron);
     showScreen('expedition');
     dispatchPhase();
   }
@@ -976,6 +1004,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     checkResultEl.textContent = '';
     roomChoicesEl.innerHTML = '';
     eventCardEl.hidden = false;
+    if (recordEvent(chron, card.id)) saveChronicle(chron);
     eventArtEl.hidden = !card.art;
     if (card.art) eventArtEl.src = card.art;
     eventTitleEl.textContent = card.title;
@@ -1106,6 +1135,15 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     // 招募池輪替（M4）：每趟歸返結算後種子遞增，酒館下次渲染會抽到新一批人選
     save.tavernSeed += 1;
     saveGame(save);
+    recordExpedition(chron, finished.retreated ? 'retreat' : 'won');
+    syncEquipmentToChronicle();
+    const freshAchievements = evaluateAchievements(chron);
+    saveChronicle(chron);
+    const achEl = document.getElementById('settle-achievements')!;
+    achEl.hidden = freshAchievements.length === 0;
+    achEl.textContent = freshAchievements.length
+      ? `🏆 解鎖成就：${freshAchievements.map((id) => ACHIEVEMENTS.find((a) => a.id === id)?.name ?? id).join('、')}`
+      : '';
     renderSettlement(result, finished);
     showScreen('settlement');
     expedition = null;
@@ -1338,6 +1376,11 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   }
 
   function showResult(outcome: CombatState['outcome']): void {
+    if (outcome === 'victory' && state) {
+      for (const e of state.enemies) recordEnemyDefeat(chron, e.name);
+      evaluateAchievements(chron);
+      saveChronicle(chron);
+    }
     const text =
       outcome === 'victory'
         ? '勝利！敵人被擊潰了，商隊可以繼續前進。'
@@ -1426,6 +1469,12 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     padding-bottom: 96px;
   }
   .screen { text-align: center; padding: 2rem; max-width: 34rem; }
+  /* M6 編年史 */
+  .title-legacy { font-size: 0.85rem; color: #8a3c1e; letter-spacing: 0.08em; margin: 0.8rem 0 0; }
+  .title-chronicle-link { display: inline-block; margin-top: 0.7rem; font-size: 0.85rem; color: #6b5f4c; text-decoration: none; letter-spacing: 0.15em; }
+  .title-chronicle-link:hover { color: #8a3c1e; }
+  .settle-achievements { color: #8a3c1e; font-weight: 600; letter-spacing: 0.05em; margin: 0 0 0.6rem; }
+  .settle-achievements[hidden] { display: none; }
   .screen-wide { max-width: 46rem; width: 100%; }
   /* ---- M5 美術 ---- */
   .title-art {

--- a/src/scripts/games/caravan/chronicle.test.ts
+++ b/src/scripts/games/caravan/chronicle.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  CHRONICLE_KEY, emptyChronicle, loadChronicle, saveChronicle,
+  recordEvent, recordEnemyDefeat, recordLocationVisit, recordEquipment, recordExpedition,
+  ACHIEVEMENTS, evaluateAchievements, legacyBonusGold, collectionProgress,
+} from './chronicle';
+import { EVENTS } from './data/events';
+import { LOCATIONS } from './data/locations';
+import { ITEMS } from './data/items';
+
+describe('chronicle：跨輪編年史', () => {
+  beforeEach(() => localStorage.removeItem(CHRONICLE_KEY));
+
+  it('emptyChronicle：全空、零傳承', () => {
+    const c = emptyChronicle();
+    expect(c.seenEvents).toEqual([]);
+    expect(c.defeatedEnemies).toEqual([]);
+    expect(c.visitedLocations).toEqual([]);
+    expect(c.ownedEquipment).toEqual([]);
+    expect(c.runs).toEqual({ started: 0, won: 0 });
+    expect(c.legacyPoints).toBe(0);
+    expect(c.unlockedAchievements).toEqual([]);
+  });
+
+  it('load/save roundtrip；壞資料回空編年史', () => {
+    const c = emptyChronicle();
+    recordEvent(c, 'ev_merchant_map');
+    saveChronicle(c);
+    expect(loadChronicle().seenEvents).toEqual(['ev_merchant_map']);
+    localStorage.setItem(CHRONICLE_KEY, '{broken');
+    expect(loadChronicle().seenEvents).toEqual([]);
+  });
+
+  it('記錄冪等：同一 id 只收錄一次，回傳是否新收錄', () => {
+    const c = emptyChronicle();
+    expect(recordEvent(c, 'ev_merchant_map')).toBe(true);
+    expect(recordEvent(c, 'ev_merchant_map')).toBe(false);
+    expect(c.seenEvents.length).toBe(1);
+    expect(recordEnemyDefeat(c, '哥布林斥候')).toBe(true);
+    expect(recordEnemyDefeat(c, '哥布林斥候')).toBe(false);
+    expect(recordLocationVisit(c, 'riverside-road')).toBe(true);
+    expect(recordLocationVisit(c, 'riverside-road')).toBe(false);
+    expect(recordEquipment(c, 'salt-crystal-blade')).toBe(true);
+    expect(recordEquipment(c, 'salt-crystal-blade')).toBe(false);
+  });
+
+  it('遠征結算：won 得 1 傳承點並計入 runs；lost/retreat 只計 started', () => {
+    const c = emptyChronicle();
+    expect(recordExpedition(c, 'won')).toBe(1);
+    expect(recordExpedition(c, 'lost')).toBe(0);
+    expect(recordExpedition(c, 'retreat')).toBe(0);
+    expect(c.runs).toEqual({ started: 3, won: 1 });
+    expect(c.legacyPoints).toBe(1);
+  });
+
+  it('legacyBonusGold：每點 +10G、上限 100G', () => {
+    const c = emptyChronicle();
+    expect(legacyBonusGold(c)).toBe(0);
+    c.legacyPoints = 3;
+    expect(legacyBonusGold(c)).toBe(30);
+    c.legacyPoints = 25;
+    expect(legacyBonusGold(c)).toBe(100);
+  });
+
+  it('collectionProgress：分子=已收錄、分母=data 實數', () => {
+    const c = emptyChronicle();
+    recordEvent(c, 'ev_merchant_map');
+    recordLocationVisit(c, 'riverside-road');
+    const p = collectionProgress(c);
+    expect(p.events).toEqual([1, EVENTS.length]);
+    expect(p.locations).toEqual([1, Object.keys(LOCATIONS).length]);
+    expect(p.equipment[1]).toBe(Object.values(ITEMS).filter((i) => i.equip).length);
+    expect(p.enemies[1]).toBeGreaterThan(0);
+  });
+
+  it('成就：首次歸來／三大 boss／奇怪商人終章／傳承 5 點可解鎖，evaluateAchievements 回傳新解鎖且冪等', () => {
+    const c = emptyChronicle();
+    expect(evaluateAchievements(c)).toEqual([]);
+    recordExpedition(c, 'won');
+    expect(evaluateAchievements(c)).toContain('first-steps');
+    expect(evaluateAchievements(c)).not.toContain('first-steps'); // 已解鎖不重報
+    recordEnemyDefeat(c, '礦坑監工');
+    recordEnemyDefeat(c, '巢穴頭目');
+    recordEnemyDefeat(c, '鹽晶洞主');
+    expect(evaluateAchievements(c)).toContain('boss-slayer');
+    recordEvent(c, 'ev_strange_merchant_finale');
+    expect(evaluateAchievements(c)).toContain('strange-friend');
+    c.legacyPoints = 5;
+    expect(evaluateAchievements(c)).toContain('legacy-begins');
+    expect(c.unlockedAchievements.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('成就定義完備：id 唯一、都有名稱與描述', () => {
+    const ids = ACHIEVEMENTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ACHIEVEMENTS.length).toBeGreaterThanOrEqual(10);
+    for (const a of ACHIEVEMENTS) {
+      expect(a.name).toBeTruthy();
+      expect(a.desc).toBeTruthy();
+    }
+  });
+});

--- a/src/scripts/games/caravan/chronicle.ts
+++ b/src/scripts/games/caravan/chronicle.ts
@@ -1,0 +1,114 @@
+// 跨輪編年史（meta 層）：圖鑑收集、成就、傳承點。
+// 獨立於存檔 v5——newGame 不清除，永續累積；storage 注入同 save.ts 慣例。
+import { EVENTS } from './data/events';
+import { LOCATIONS } from './data/locations';
+import { ITEMS } from './data/items';
+import { ENCOUNTERS, TRAINING_ENCOUNTER } from './data/enemies';
+
+export const CHRONICLE_KEY = 'caravan-chronicle-v1';
+
+export interface Chronicle {
+  v: 1;
+  seenEvents: string[];
+  defeatedEnemies: string[]; // 以單位名去重（同名同種）
+  visitedLocations: string[];
+  ownedEquipment: string[]; // 曾擁有即收錄
+  runs: { started: number; won: number };
+  legacyPoints: number;
+  unlockedAchievements: string[];
+}
+
+export function emptyChronicle(): Chronicle {
+  return {
+    v: 1,
+    seenEvents: [], defeatedEnemies: [], visitedLocations: [], ownedEquipment: [],
+    runs: { started: 0, won: 0 },
+    legacyPoints: 0,
+    unlockedAchievements: [],
+  };
+}
+
+export function saveChronicle(c: Chronicle, storage: Storage = localStorage): void {
+  storage.setItem(CHRONICLE_KEY, JSON.stringify(c));
+}
+
+export function loadChronicle(storage: Storage = localStorage): Chronicle {
+  try {
+    const raw = storage.getItem(CHRONICLE_KEY);
+    if (!raw) return emptyChronicle();
+    const parsed = JSON.parse(raw) as Chronicle;
+    if (parsed.v !== 1 || !Array.isArray(parsed.seenEvents)) return emptyChronicle();
+    return { ...emptyChronicle(), ...parsed };
+  } catch {
+    return emptyChronicle();
+  }
+}
+
+/** 冪等收錄：新收錄回傳 true。 */
+const record = (list: string[], id: string): boolean => {
+  if (list.includes(id)) return false;
+  list.push(id);
+  return true;
+};
+
+export const recordEvent = (c: Chronicle, eventId: string): boolean => record(c.seenEvents, eventId);
+export const recordEnemyDefeat = (c: Chronicle, enemyName: string): boolean => record(c.defeatedEnemies, enemyName);
+export const recordLocationVisit = (c: Chronicle, locationId: string): boolean => record(c.visitedLocations, locationId);
+export const recordEquipment = (c: Chronicle, itemId: string): boolean => record(c.ownedEquipment, itemId);
+
+/** 遠征結束結算：won 得 1 傳承點；回傳新增傳承點。 */
+export function recordExpedition(c: Chronicle, outcome: 'won' | 'lost' | 'retreat'): number {
+  c.runs.started += 1;
+  if (outcome !== 'won') return 0;
+  c.runs.won += 1;
+  c.legacyPoints += 1;
+  return 1;
+}
+
+/** 傳承加成：新輪起始金幣，每點 +10G、上限 100G。 */
+export const legacyBonusGold = (c: Chronicle): number => Math.min(100, c.legacyPoints * 10);
+
+// ---- 收集進度（分母 build 時從 data 實算） ----
+const TOTAL_ENEMIES = new Set(
+  [...TRAINING_ENCOUNTER(), ...Object.values(ENCOUNTERS).flatMap((mk) => mk())].map((u) => u.name)
+).size;
+const TOTAL_EQUIPMENT = Object.values(ITEMS).filter((i) => i.equip).length;
+
+export function collectionProgress(c: Chronicle): {
+  events: [number, number]; enemies: [number, number]; locations: [number, number]; equipment: [number, number];
+} {
+  return {
+    events: [c.seenEvents.length, EVENTS.length],
+    enemies: [c.defeatedEnemies.length, TOTAL_ENEMIES],
+    locations: [c.visitedLocations.length, Object.keys(LOCATIONS).length],
+    equipment: [c.ownedEquipment.length, TOTAL_EQUIPMENT],
+  };
+}
+
+// ---- 成就 ----
+export interface AchievementDef { id: string; name: string; desc: string; check(c: Chronicle): boolean; }
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  { id: 'first-steps', name: '啟程者', desc: '首次遠征成功歸來', check: (c) => c.runs.won >= 1 },
+  { id: 'veteran-roads', name: '老練商隊長', desc: '遠征成功歸來 10 次', check: (c) => c.runs.won >= 10 },
+  { id: 'event-collector-half', name: '見多識廣', desc: '事件圖鑑收錄過半', check: (c) => c.seenEvents.length * 2 >= EVENTS.length },
+  { id: 'event-collector-full', name: '路上的百科', desc: '事件圖鑑全數收錄', check: (c) => c.seenEvents.length >= EVENTS.length },
+  { id: 'bestiary-complete', name: '獵人手冊', desc: '敵人圖鑑全數收錄', check: (c) => c.defeatedEnemies.length >= TOTAL_ENEMIES },
+  { id: 'world-walker', name: '踏遍邊陲', desc: '所有商路與迷宮都走過', check: (c) => c.visitedLocations.length >= Object.keys(LOCATIONS).length },
+  { id: 'quartermaster', name: '軍需官', desc: '所有裝備都曾入手', check: (c) => c.ownedEquipment.length >= TOTAL_EQUIPMENT },
+  { id: 'boss-slayer', name: '屠魔者', desc: '擊敗三大頭目', check: (c) => ['礦坑監工', '巢穴頭目', '鹽晶洞主'].every((n) => c.defeatedEnemies.includes(n)) },
+  { id: 'salt-pilgrim', name: '鹽路朝聖', desc: '走完霧嶺古道', check: (c) => c.visitedLocations.includes('misty-ridge-trail') },
+  { id: 'hidden-paths', name: '看不見的路', desc: '踏入古戰場', check: (c) => c.visitedLocations.includes('battlefield-ruins') },
+  { id: 'strange-friend', name: '奇怪的朋友', desc: '看完奇怪商人的終章', check: (c) => c.seenEvents.includes('ev_strange_merchant_finale') },
+  { id: 'legacy-begins', name: '商會的名聲', desc: '累積 5 點傳承', check: (c) => c.legacyPoints >= 5 },
+];
+
+/** 判定並收錄新解鎖成就；回傳本次新解鎖 id（已解鎖過的不重報）。 */
+export function evaluateAchievements(c: Chronicle): string[] {
+  const fresh: string[] = [];
+  for (const a of ACHIEVEMENTS) {
+    if (c.unlockedAchievements.includes(a.id)) continue;
+    if (a.check(c)) { c.unlockedAchievements.push(a.id); fresh.push(a.id); }
+  }
+  return fresh;
+}

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -674,3 +674,49 @@ test.describe('商隊與劍：裝備系統', () => {
     await expect(protagonistCard.locator('.roster-moves')).not.toContainText('重斬');
   });
 });
+
+test.describe('商隊與劍：冒險編年史（M6）', () => {
+  test('訓練場勝利寫入敵人圖鑑，landing 顯示收集進度', async ({ page }) => {
+    await page.goto('/caravan/play?seed=42');
+    await page.evaluate(() => {
+      localStorage.removeItem('caravan-save-v1');
+      localStorage.removeItem('caravan-chronicle-v1');
+    });
+    await page.reload();
+    await page.click('#btn-new-game');
+    await page.click('#btn-training');
+    for (let i = 0; i < 40; i++) {
+      if (await page.locator('#combat-result').isVisible()) break;
+      const move = page.locator('#combat-actions .move-btn').first();
+      if (await move.isVisible().catch(() => false)) await move.click();
+      await page.waitForTimeout(250);
+    }
+    await expect(page.locator('#combat-result')).toContainText('勝利');
+    const chron = await page.evaluate(() => JSON.parse(localStorage.getItem('caravan-chronicle-v1') ?? '{}'));
+    expect(chron.defeatedEnemies).toContain('哥布林斥候');
+    // landing 編年史區
+    await page.goto('/caravan');
+    await expect(page.locator('#cv-progress')).toBeVisible();
+    await expect(page.locator('.cv-progress[data-kind="enemies"] .cv-progress-num')).toHaveText(/^1 \//);
+    await page.evaluate(() => localStorage.removeItem('caravan-chronicle-v1'));
+  });
+
+  test('傳承點：landing 成就亮起、新旅程起始金幣 +30', async ({ page }) => {
+    await page.goto('/caravan');
+    await page.evaluate(() => localStorage.setItem('caravan-chronicle-v1', JSON.stringify({
+      v: 1, seenEvents: [], defeatedEnemies: [], visitedLocations: [], ownedEquipment: [],
+      runs: { started: 3, won: 3 }, legacyPoints: 3, unlockedAchievements: ['first-steps'],
+    })));
+    await page.reload();
+    await expect(page.locator('.cv-achievement[data-ach="first-steps"]')).toHaveClass(/unlocked/);
+    await expect(page.locator('#cv-legacy')).toContainText('傳承 3 點');
+    // 遊戲標題畫面顯示傳承、新旅程 200+30
+    await page.goto('/caravan/play');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await expect(page.locator('#title-legacy')).toContainText('+30 G');
+    await page.click('#btn-new-game');
+    await expect(page.locator('#town-gold')).toHaveText('230');
+    await page.evaluate(() => localStorage.removeItem('caravan-chronicle-v1'));
+  });
+});


### PR DESCRIPTION
## Summary

《商隊與劍》M6：把「體量」從展示做進機制——玩家隨時看得到「42 張事件卡我才收錄 17 張」，且每一輪遠征都為下一輪累積傳承：

- **編年史引擎 `chronicle.ts`**（TDD）：跨輪 meta 層（獨立 localStorage key，開新檔不清除）——事件／敵人／商路／裝備四本圖鑑冪等收錄、遠征統計、傳承點、12 個成就
- **遊戲內接線**：抽到事件即收錄、戰鬥勝利入獵人手冊、啟程記商路、結算同步裝備並顯示本趟新解鎖成就；標題畫面顯示傳承加成
- **傳承機制**：遠征成功歸來 +1 點 → 新旅程起始金幣 +10G/點（上限 100G）——「不斷遊玩」的第一個跨輪鉤子
- **landing 編年史區**：四條收集進度條＋12 格成就牆（解鎖亮金／未解鎖灰）＋遠征統計；成就內容 SSG、狀態 client 渲染

## Test plan
- [x] `npx vitest run` 1491 全綠（chronicle 8 條新測試）
- [x] caravan e2e 26 綠（新增：訓練場勝利→圖鑑→landing 進度、傳承點→成就亮＋起始金幣 +30 驗證）
- [x] `npm run build` 綠
- [x] 實機驗收：注入樣本編年史檢視進度條／成就牆／傳承顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)