### PR TITLE
feat(caravan): M7 系統深度——市場行情波動、旅伴特質、戰鬥狀態效果

### DIFF
--- a/src/pages/caravan/index.astro
+++ b/src/pages/caravan/index.astro
@@ -70,12 +70,12 @@ const jobList = Object.values(JOBS);
       <article class="cv-feature">
         <img src="/assets/games/caravan/event-rare-treasure-map.webp" alt="" width="960" height="720" loading="lazy" />
         <h2>擲骰決定命運</h2>
-        <p>d20 檢定驅動每個抉擇——說服、潛行、強攻或繞路。nat20 的奇蹟與 nat1 的災難都會寫進你的旅途，回合制戰鬥有意圖預示與架盾反擊。</p>
+        <p>d20 檢定驅動每個抉擇——說服、潛行、強攻或繞路。回合制戰鬥有意圖預示、架盾反擊與狀態效果：蜘蛛的毒會慢慢侵蝕，洞主的重壓會讓人眼冒金星。</p>
       </article>
       <article class="cv-feature">
         <img src="/assets/games/caravan/town-riverbend-town.webp" alt="" width="1280" height="720" loading="lazy" />
         <h2>商隊經營</h2>
-        <p>四鎮物價各異：礦石在河灣鎮翻倍、香料在林邊聚落搶手。升級馬車、招募旅伴、押貨跨鎮套利——薪餉與傷勢都是帳本上的真實成本。</p>
+        <p>四鎮物價隨行情波動，每趟歸來市場都會重新洗牌——沒有永遠的套利路線。招募帶著特質的旅伴（老練、貪財、硬朗……），升級馬車押貨跨鎮，薪餉與傷勢都是帳本上的真實成本。</p>
       </article>
       <article class="cv-feature">
         <img src="/assets/games/caravan/event-mercenary-ruins.webp" alt="" width="960" height="720" loading="lazy" />

--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -166,6 +166,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
 <script>
   import { newGame, saveGame, loadGame, SAVE_KEY } from '@scripts/games/caravan/save';
+  import { applyMarket } from '@scripts/games/caravan/economy';
+  import { traitById } from '@scripts/games/caravan/roster';
   import {
     loadChronicle, saveChronicle, recordEvent, recordEnemyDefeat, recordLocationVisit,
     recordEquipment, recordExpedition, evaluateAchievements, legacyBonusGold, ACHIEVEMENTS,
@@ -350,7 +352,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   function renderMarket(): void {
     if (!save) return;
     marketGoldEl.textContent = String(save.gold);
-    const town = STARTING_TOWN;
+    const town = applyMarket(STARTING_TOWN, save.marketSeed); // M7 行情
     const ownedIds = Object.keys(save.inventory).filter((id) => (save!.inventory[id] ?? 0) > 0);
     const ids = Array.from(new Set([...town.stock, ...ownedIds]));
     marketListEl.innerHTML = '';
@@ -365,6 +367,16 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       const name = document.createElement('span');
       name.className = 'market-name';
       name.textContent = `${item.name}（持有 ${owned}）`;
+      // M7 行情箭頭：與基準價比較
+      const baseMod = STARTING_TOWN.priceModifiers[itemId] ?? 1;
+      const nowMod = town.priceModifiers[itemId] ?? 1;
+      if (Math.abs(nowMod - baseMod) > 0.02) {
+        const arrow = document.createElement('i');
+        arrow.className = nowMod > baseMod ? 'market-trend up' : 'market-trend down';
+        arrow.textContent = nowMod > baseMod ? '▲' : '▼';
+        arrow.title = '市場行情';
+        name.appendChild(arrow);
+      }
       row.appendChild(name);
 
       if (town.stock.includes(itemId)) {
@@ -443,7 +455,14 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
       const info = document.createElement('p');
       info.className = 'recruit-info';
+      const trait = traitById(record.trait);
       info.textContent = `雇用費 ${cost} G．每趟薪餉 ${wage} G`;
+      if (trait) {
+        const tag = document.createElement('span');
+        tag.className = 'trait-tag';
+        tag.textContent = `${trait.name}：${trait.desc}`;
+        info.appendChild(tag);
+      }
 
       const hireBtn = document.createElement('button');
       hireBtn.type = 'button';
@@ -562,6 +581,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       const xp = document.createElement('p');
       xp.className = 'roster-xp';
       xp.textContent = `經驗值 ${record.xp} XP`;
+      const rTrait = traitById(record.trait);
+      if (rTrait) xp.textContent += `．特質「${rTrait.name}」（${rTrait.desc}）`;
 
       const stats = document.createElement('p');
       stats.className = 'roster-stats';
@@ -1134,6 +1155,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     const result = settleExpedition(finished, save, tradeSales);
     // 招募池輪替（M4）：每趟歸返結算後種子遞增，酒館下次渲染會抽到新一批人選
     save.tavernSeed += 1;
+    save.marketSeed += 1; // M7：歸返後各鎮行情輪動
     saveGame(save);
     recordExpedition(chron, finished.retreated ? 'retreat' : 'won');
     syncEquipmentToChronicle();
@@ -1161,7 +1183,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   function enterTradePhase(): void {
     if (!expedition || !save) return;
     const townId = expedition.destinationTownId!;
-    tradeTown = TOWNS[townId] ?? null;
+    tradeTown = TOWNS[townId] ? applyMarket(TOWNS[townId], save!.marketSeed) : null;
     tradeSoldIds = new Set();
     tradeCombined = {};
     for (const [itemId, count] of Object.entries(expedition.cargo)) {
@@ -1304,7 +1326,14 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       intent.className = 'unit-intent';
       intent.textContent = showIntent ? unitIntentText(unit) : '';
 
-      card.append(name, hp, intent);
+      const status = document.createElement('p');
+      status.className = 'unit-status';
+      const icons = { poison: '☠', stun: '💫', strength: '💪' } as const;
+      status.textContent = (unit.statuses ?? [])
+        .map((s) => `${icons[s.kind]}${s.remaining}`)
+        .join(' ');
+
+      card.append(name, hp, intent, status);
       container.appendChild(card);
     }
   }
@@ -1475,6 +1504,11 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .title-chronicle-link:hover { color: #8a3c1e; }
   .settle-achievements { color: #8a3c1e; font-weight: 600; letter-spacing: 0.05em; margin: 0 0 0.6rem; }
   .settle-achievements[hidden] { display: none; }
+  /* M7 行情與特質 */
+  .market-trend { font-style: normal; margin-left: 0.35rem; font-size: 0.8rem; }
+  .market-trend.up { color: #a4453a; }
+  .market-trend.down { color: #3a7a4e; }
+  .trait-tag { display: block; margin-top: 0.2rem; font-size: 0.8rem; color: #6b5f4c; }
   .screen-wide { max-width: 46rem; width: 100%; }
   /* ---- M5 美術 ---- */
   .title-art {
@@ -1728,6 +1762,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .unit-name { font-weight: 600; margin: 0 0 0.15rem; }
   .unit-hp { font-size: 0.85rem; color: #5c5344; margin: 0; }
   .unit-intent { font-size: 0.75rem; font-style: italic; color: #8a7f6d; margin: 0.15rem 0 0; min-height: 1em; }
+  .unit-status { font-size: 0.8rem; color: #7a4b9d; margin: 0.15rem 0 0; min-height: 1em; }
   .combat-targets {
     display: flex;
     flex-wrap: wrap;

--- a/src/scripts/games/caravan/combat.test.ts
+++ b/src/scripts/games/caravan/combat.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { statMod } from './check';
 import { startCombat, currentActor, advanceTurn, partyAct, enemyAct, attemptRetreat, resolveCasualties } from './combat';
-import type { PartyMember, EnemyUnit, Move } from './combat';
+import type { PartyMember, EnemyUnit, Move, CombatState } from './combat';
+import { createRng } from './rng';
 import type { Rng } from './rng';
 
 /** 依序回傳指定骰值的假 RNG（骰完循環）；next 固定 0（weightedPick 取第一個非零權重項） */
@@ -237,5 +238,103 @@ describe('動作結算', () => {
       { id: 'm1', fate: 'injured' },
       { id: 'm2', fate: 'dead' },
     ]);
+  });
+});
+
+describe('戰鬥狀態效果（M7）', () => {
+  const poisonMove: Move = {
+    id: 'venom', name: '毒牙', kind: 'attack', target: 'enemy', hitStat: 'str',
+    damage: { dice: 1, sides: 4 },
+    applyStatus: { kind: 'poison', duration: 2, potency: 2 },
+    narration: '{actor}咬中{target}，造成 {amount} 點傷害！',
+  };
+  const stunMove: Move = {
+    id: 'slam', name: '重壓', kind: 'attack', target: 'enemy', hitStat: 'str',
+    damage: { dice: 1, sides: 4 },
+    applyStatus: { kind: 'stun', duration: 1 },
+    narration: '{actor}重壓{target}，造成 {amount} 點傷害！',
+  };
+
+  const mkParty = (): PartyMember[] => [{
+    id: 'hero', name: '英雄', stats: { str: 14, dex: 20, int: 10, cha: 10, con: 14 },
+    maxHp: 30, hp: 30, defense: 5, isProtagonist: true,
+    moves: [{ id: 'hit', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str', damage: { dice: 1, sides: 4 }, narration: '{actor}攻擊{target}，{amount} 傷害' }],
+  }];
+  const mkEnemy = (moves: Move[], hp = 20): EnemyUnit => ({
+    id: 'foe', name: '敵人', stats: { str: 14, dex: 1, int: 8, cha: 8, con: 10 },
+    maxHp: hp, hp, defense: 1, moves,
+    intents: moves.map((m) => ({ weight: 1, moveId: m.id })),
+  });
+
+  function freshState(enemyMoves: Move[]): CombatState {
+    // dex 20 vs 1：hero 必先攻
+    return startCombat(createRng(7), mkParty(), [mkEnemy(enemyMoves)]);
+  }
+
+  it('攻擊命中附加中毒；中毒者行動前發作扣血、持續遞減、歸零解除', () => {
+    const rng = createRng(3);
+    const state = freshState([poisonMove]);
+    // 敵人對英雄上毒（直接 performMove 路徑：敵人行動）
+    state.turnIndex = state.order.indexOf('foe');
+    enemyAct(rng, state, 'foe');
+    const hero = state.party[0];
+    expect(hero.statuses?.some((s) => s.kind === 'poison')).toBe(true);
+    const hpAfterBite = hero.hp;
+    // 英雄行動：毒發作 -2
+    partyAct(rng, state, 'hero', 'hit', 'foe');
+    expect(hero.hp).toBe(hpAfterBite - 2);
+    expect(hero.statuses?.find((s) => s.kind === 'poison')?.remaining).toBe(1);
+    expect(state.log.some((l) => l.text.includes('毒'))).toBe(true);
+    // 第二次行動：再 -2 且解除
+    state.turnIndex = state.order.indexOf('hero');
+    partyAct(rng, state, 'hero', 'hit', 'foe');
+    expect(hero.hp).toBe(hpAfterBite - 4);
+    expect(hero.statuses?.some((s) => s.kind === 'poison')).toBe(false);
+  });
+
+  it('暈眩：行動被跳過（不出招），輪替照常、狀態解除', () => {
+    const rng = createRng(3);
+    const state = freshState([stunMove]);
+    state.turnIndex = state.order.indexOf('foe');
+    enemyAct(rng, state, 'foe');
+    const hero = state.party[0];
+    expect(hero.statuses?.some((s) => s.kind === 'stun')).toBe(true);
+    const foeHpBefore = state.enemies[0].hp;
+    partyAct(rng, state, 'hero', 'hit', 'foe');
+    expect(state.enemies[0].hp).toBe(foeHpBefore); // 沒出招
+    expect(state.log.some((l) => l.text.includes('暈'))).toBe(true);
+    expect(hero.statuses?.some((s) => s.kind === 'stun')).toBe(false);
+    expect(state.order[state.turnIndex]).not.toBe('hero'); // 輪替發生
+  });
+
+  it('強化：出手傷害 +potency、次數遞減歸零解除', () => {
+    const rng = scriptedRng([10, 3]); // d20=10 必中（defense 1）、傷害骰 3
+    const state = freshState([poisonMove]);
+    const hero = state.party[0];
+    hero.statuses = [{ kind: 'strength', remaining: 1, potency: 5 }];
+    const foeHpBefore = state.enemies[0].hp;
+    partyAct(rng, state, 'hero', 'hit', 'foe');
+    const dealt = foeHpBefore - state.enemies[0].hp;
+    expect(dealt).toBe(3 + 5); // 傷害骰 3（hit 招無 bonusStat）+ 強化 5
+    expect(hero.statuses.some((s) => s.kind === 'strength')).toBe(false);
+  });
+
+  it('毒可以致死並觸發倒下與勝負判定', () => {
+    const rng = createRng(3);
+    const state = freshState([poisonMove]);
+    const hero = state.party[0];
+    hero.hp = 2;
+    hero.statuses = [{ kind: 'poison', remaining: 3, potency: 2 }];
+    partyAct(rng, state, 'hero', 'hit', 'foe');
+    expect(hero.hp).toBe(0);
+    expect(state.outcome).toBe('defeat');
+  });
+
+  it('蜘蛛毒牙與鹽晶洞主重壓帶狀態（資料接線）', async () => {
+    const { ENCOUNTERS } = await import('./data/enemies');
+    const spider = ENCOUNTERS.enc_mine_spiders()[0];
+    expect(spider.moves.some((m) => m.applyStatus?.kind === 'poison')).toBe(true);
+    const boss = ENCOUNTERS.enc_salt_cavern_boss()[0];
+    expect(boss.moves.some((m) => m.applyStatus?.kind === 'stun')).toBe(true);
   });
 });

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -9,14 +9,21 @@ export interface Move {
   hitStat: Stat;
   damage?: { dice: number; sides: number; bonusStat?: Stat };
   heal?: { dice: number; sides: number; bonusStat?: Stat };
+  /** 命中後附加狀態（M7）：poison 每回合行動前扣 potency；stun 跳過一次行動；strength 出手傷害 +potency */
+  applyStatus?: { kind: StatusKind; duration: number; potency?: number };
   narration: string; // 例：「{actor}的巨劍劈向{target}，造成 {amount} 點傷害！」
   /** 解鎖所需等級；未標＝Lv1 起就會（M4 roster.ts unlockedMoves 依此過濾） */
   minLevel?: number;
 }
 
+export type StatusKind = 'poison' | 'stun' | 'strength';
+export interface StatusEffect { kind: StatusKind; remaining: number; potency: number; }
+
 export interface CombatantBase {
   id: string; name: string; stats: StatBlock;
   maxHp: number; hp: number; defense: number; moves: Move[];
+  /** 進行中狀態效果（M7，戰鬥 runtime） */
+  statuses?: StatusEffect[];
   /** 立繪路徑（M5 美術） */
   art?: string;
 }
@@ -123,6 +130,27 @@ function applyDamage(state: CombatState, target: CombatantBase, amount: number):
   if (target.hp === 0) state.log.push({ kind: 'down', text: `${target.name}倒下了！` });
 }
 
+const STATUS_LABEL: Record<StatusKind, string> = { poison: '中毒', stun: '暈眩', strength: '強化' };
+
+/** 行動前狀態結算（M7）：毒發作扣血、暈眩跳過本次行動。回傳 false＝本次行動被取消。 */
+function tickStatuses(state: CombatState, actor: CombatantBase): boolean {
+  if (!actor.statuses?.length) return true;
+  let canAct = true;
+  for (const st of actor.statuses) {
+    if (st.kind === 'poison') {
+      state.log.push({ kind: 'damage', text: `${actor.name}毒素發作，損失 ${st.potency} 點生命！` });
+      applyDamage(state, actor, st.potency);
+      st.remaining -= 1;
+    } else if (st.kind === 'stun') {
+      state.log.push({ kind: 'info', text: `${actor.name}暈眩中，無法行動！` });
+      st.remaining -= 1;
+      canAct = false;
+    }
+  }
+  actor.statuses = actor.statuses.filter((st) => st.remaining > 0);
+  return canAct && actor.hp > 0;
+}
+
 function performMove(rng: Rng, state: CombatState, actor: CombatantBase, move: Move, target: CombatantBase): void {
   if (move.kind === 'guard') {
     state.guarding[actor.id] = true;
@@ -146,10 +174,26 @@ function performMove(rng: Rng, state: CombatState, actor: CombatantBase, move: M
     return;
   }
   const dmgSpec = move.damage ?? { dice: 1, sides: 4 };
+  // M7 強化：出手傷害 +potency，用一次遞減
+  const strength = actor.statuses?.find((s) => s.kind === 'strength');
+  const strengthBonus = strength?.potency ?? 0;
+  if (strength) {
+    strength.remaining -= 1;
+    actor.statuses = actor.statuses!.filter((s) => s.remaining > 0);
+  }
   const amount = Math.max(1, rollDice(rng, dmgSpec.dice, dmgSpec.sides)
-    + (dmgSpec.bonusStat ? statMod(actor.stats[dmgSpec.bonusStat]) : 0));
+    + (dmgSpec.bonusStat ? statMod(actor.stats[dmgSpec.bonusStat]) : 0) + strengthBonus);
   state.log.push({ kind: 'damage', text: fillNarration(move.narration, actor.name, target.name, amount) });
   applyDamage(state, target, amount);
+  // M7 命中附加狀態（同類刷新為較長持續）
+  if (move.applyStatus && target.hp > 0) {
+    const spec = move.applyStatus;
+    target.statuses ??= [];
+    const existing = target.statuses.find((s) => s.kind === spec.kind);
+    if (existing) existing.remaining = Math.max(existing.remaining, spec.duration);
+    else target.statuses.push({ kind: spec.kind, remaining: spec.duration, potency: spec.potency ?? 0 });
+    state.log.push({ kind: 'info', text: `${target.name}陷入${STATUS_LABEL[spec.kind]}狀態！` });
+  }
 }
 
 export function partyAct(rng: Rng, state: CombatState, actorId: string, moveId: string, targetId: string): void {
@@ -157,6 +201,11 @@ export function partyAct(rng: Rng, state: CombatState, actorId: string, moveId: 
   const move = actor?.moves.find((m) => m.id === moveId);
   const targetFound = [...state.party, ...state.enemies].find((c) => c.id === targetId);
   if (!actor || !move || !targetFound || state.outcome !== 'ongoing') return;
+  if (!tickStatuses(state, actor)) {
+    checkOutcome(state);
+    if (state.outcome === 'ongoing') advanceTurn(state);
+    return;
+  }
   performMove(rng, state, actor, move, targetFound);
   checkOutcome(state);
   if (state.outcome === 'ongoing') advanceTurn(state);
@@ -165,6 +214,14 @@ export function partyAct(rng: Rng, state: CombatState, actorId: string, moveId: 
 export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
   const enemy = state.enemies.find((e) => e.id === enemyId);
   if (!enemy || state.outcome !== 'ongoing') return;
+  if (!tickStatuses(state, enemy)) {
+    state.enemyIntents[enemyId] = rng.weightedPick(
+      enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
+    );
+    checkOutcome(state);
+    if (state.outcome === 'ongoing') advanceTurn(state);
+    return;
+  }
   const moveId = state.enemyIntents[enemyId] ?? enemy.moves[0].id;
   const move = enemy.moves.find((m) => m.id === moveId) ?? enemy.moves[0];
   let target: CombatantBase;

--- a/src/scripts/games/caravan/data/enemies.ts
+++ b/src/scripts/games/caravan/data/enemies.ts
@@ -100,6 +100,7 @@ function makeBanditMedic(id: string): EnemyUnit {
 const spiderBite: Move = {
   id: 'spider-bite', name: '毒牙', kind: 'attack', target: 'enemy', hitStat: 'dex',
   damage: { dice: 1, sides: 6, bonusStat: 'dex' },
+  applyStatus: { kind: 'poison', duration: 2, potency: 2 }, // M7：毒牙見血封喉
   narration: '{actor}以毒牙刺向{target}，造成 {amount} 點傷害！',
 };
 
@@ -306,6 +307,7 @@ function makeRuinsArcher(id: string): EnemyUnit {
 const sovereignCrystalCrush: Move = {
   id: 'sovereign-crystal-crush', name: '鹽晶碎壓', kind: 'attack', target: 'enemy', hitStat: 'str',
   damage: { dice: 2, sides: 8, bonusStat: 'str' },
+  applyStatus: { kind: 'stun', duration: 1 }, // M7：碎壓震得人眼冒金星
   narration: '{actor}雙拳凝聚鹽晶之力，重重砸向{target}，造成 {amount} 點傷害！',
 };
 

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -1,7 +1,7 @@
 import type { Move, PartyMember } from '../combat';
 import type { CompanionRecord } from '../save';
 import type { StatBlock } from '../types';
-import { unlockedMoves, equipmentBonus } from '../roster';
+import { unlockedMoves, equipmentBonus, traitById } from '../roster';
 import { ITEMS } from './items';
 
 export type JobId = 'swordsman' | 'ranger' | 'mage' | 'cleric';
@@ -131,7 +131,14 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
   for (const key of Object.keys(bonus.stats) as Array<keyof StatBlock>) {
     stats[key] += bonus.stats[key] ?? 0;
   }
-  const maxHp = record.maxHp + bonus.maxHp;
+  // M7 特質加成
+  const trait = traitById(record.trait);
+  if (trait?.statBonus) {
+    for (const key of Object.keys(trait.statBonus) as Array<keyof StatBlock>) {
+      stats[key] += trait.statBonus[key] ?? 0;
+    }
+  }
+  const maxHp = record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0);
 
   const moves = unlockedMoves(record);
   const weaponId = record.equipment.weapon;

--- a/src/scripts/games/caravan/economy.test.ts
+++ b/src/scripts/games/caravan/economy.test.ts
@@ -3,6 +3,9 @@ import {
   buyPrice, sellPrice, tradeSellPrice, cargoCapacity, wagonUpgradeCost, totalWage,
 } from './economy';
 import type { TownDef } from './economy';
+import { applyMarket } from './economy';
+import { TOWNS } from './data/towns';
+import { ITEMS } from './data/items';
 import { newGame } from './save';
 import type { CompanionRecord } from './save';
 
@@ -135,5 +138,49 @@ describe('economy（經濟系統）', () => {
       save.companions = [makeCompanion({ level: 2, injuredForTrips: 2 })];
       expect(totalWage(save)).toBe(0);
     });
+  });
+});
+
+describe('市場行情波動（M7）', () => {
+  const base = TOWNS['riverbend-town'];
+
+  it('同 seed 決定性；不同 seed 產生不同行情', () => {
+    const a1 = applyMarket(base, 7);
+    const a2 = applyMarket(base, 7);
+    expect(a1.priceModifiers).toEqual(a2.priceModifiers);
+    const b = applyMarket(base, 8);
+    expect(JSON.stringify(a1.priceModifiers)).not.toBe(JSON.stringify(b.priceModifiers));
+  });
+
+  it('行情係數把基準乘上 0.75-1.35 浮動，且不動原物件', () => {
+    const m = applyMarket(base, 3);
+    expect(m).not.toBe(base);
+    for (const [itemId, mod] of Object.entries(m.priceModifiers)) {
+      const baseMod = base.priceModifiers[itemId] ?? 1;
+      const ratio = mod / baseMod;
+      expect(ratio, `${itemId} 行情比例超界`).toBeGreaterThanOrEqual(0.75);
+      expect(ratio, `${itemId} 行情比例超界`).toBeLessThanOrEqual(1.35);
+    }
+    expect(base.priceModifiers.ore).toBe(1.5); // 原 town 不被改
+  });
+
+  it('裝備物品不吃行情（套利裁決延伸）；一般 stock 品項有行情', () => {
+    const salt = TOWNS['salt-spring-city'];
+    const m = applyMarket(salt, 11);
+    for (const itemId of Object.keys(m.priceModifiers)) {
+      if (ITEMS[itemId]?.equip) {
+        expect(m.priceModifiers[itemId], `裝備 ${itemId} 不應浮動`).toBe(salt.priceModifiers[itemId] ?? 1);
+      }
+    }
+    // 非裝備 stock 品項應獲得行情條目（即使基準為 1）
+    expect(m.priceModifiers.herb).toBeDefined();
+  });
+
+  it('newGame 有 marketSeed；行情 town 可直接餵 buyPrice/sellPrice', () => {
+    const save = newGame();
+    expect(typeof save.marketSeed).toBe('number');
+    const m = applyMarket(base, save.marketSeed);
+    expect(buyPrice(m, 'ore')).toBeGreaterThan(0);
+    expect(sellPrice(m, 'ore')).toBeGreaterThan(0);
   });
 });

--- a/src/scripts/games/caravan/economy.ts
+++ b/src/scripts/games/caravan/economy.ts
@@ -14,6 +14,31 @@ export interface TownDef {
   art?: string;
 }
 
+/**
+ * 市場行情（M7）：以 marketSeed 對鎮上「非裝備」品項的價格係數做 0.75-1.35 決定性浮動，
+ * 回傳新 TownDef（不改原物件）。裝備不吃行情（延伸 M5 套利裁決）。
+ * 浮動對象＝priceModifiers 既有品項 ∪ stock 品項。
+ */
+export function applyMarket(town: TownDef, marketSeed: number): TownDef {
+  // 每鎮每品項各自可重現的偽隨機：字串雜湊 + seed（mulberry32 一步）
+  const swing = (key: string): number => {
+    let h = marketSeed >>> 0;
+    for (let i = 0; i < key.length; i++) h = Math.imul(h ^ key.charCodeAt(i), 2654435761);
+    h = Math.imul(h ^ (h >>> 13), 1597334677);
+    const unit = ((h ^ (h >>> 16)) >>> 0) / 4294967296; // 0-1
+    return 0.75 + unit * 0.6; // 0.75-1.35
+  };
+  const itemIds = new Set([...Object.keys(town.priceModifiers), ...town.stock]);
+  const priceModifiers: Record<string, number> = {};
+  for (const itemId of itemIds) {
+    const base = town.priceModifiers[itemId] ?? 1;
+    priceModifiers[itemId] = ITEMS[itemId]?.equip
+      ? base // 裝備維持基準
+      : Math.round(base * swing(`${town.id}:${itemId}`) * 100) / 100;
+  }
+  return { ...town, priceModifiers };
+}
+
 function priceModifier(town: TownDef, itemId: string): number {
   return town.priceModifiers[itemId] ?? 1;
 }

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -3,6 +3,7 @@ import type { Stat } from './types';
 import type { SaveData } from './save';
 import type { CheckResult } from './check';
 import { resolveCheck, statMod } from './check';
+import { partyCheckBonus } from './roster';
 import type { CombatState, EnemyUnit, PartyMember } from './combat';
 import type { JobId } from './data/jobs';
 import type { TownDef } from './economy';
@@ -327,7 +328,7 @@ export function resolveOption(
   let check: CheckResult | null = null;
   let effects: EffectSpec[];
   if (opt.check) {
-    const modifier = statMod(save.protagonist.stats[opt.check.stat]);
+    const modifier = statMod(save.protagonist.stats[opt.check.stat]) + partyCheckBonus(save);
     check = resolveCheck(rng, { stat: opt.check.stat, dc: opt.check.dc, modifier });
     effects = check.success ? opt.success : (opt.failure ?? []);
   } else {

--- a/src/scripts/games/caravan/roster.test.ts
+++ b/src/scripts/games/caravan/roster.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   XP_TABLE, levelFromXp, pendingLevelUps, applyLevelUp, unlockedMoves,
   generateRecruitPool, hireCost, wagePerTrip, equipItem, unequipItem, equipmentBonus,
+  TRAITS, partyCheckBonus,
 } from './roster';
 import { createRng } from './rng';
 import { newGame, type SaveData, type CompanionRecord } from './save';
 import type { StatBlock } from './types';
-import { JOBS } from './data/jobs';
+import { JOBS, memberFromRecord } from './data/jobs';
 import { ITEMS, type ItemDef } from './data/items';
 
 function makeCompanion(overrides: Partial<CompanionRecord> = {}): CompanionRecord {
@@ -422,5 +423,45 @@ describe('roster（成長系統）', () => {
         delete ITEMS['test-charm'];
       });
     });
+  });
+});
+
+describe('旅伴特質（M7）', () => {
+  it('TRAITS：至少 8 種、id 唯一、皆有名稱與描述', () => {
+    expect(TRAITS.length).toBeGreaterThanOrEqual(8);
+    expect(new Set(TRAITS.map((t: { id: string }) => t.id)).size).toBe(TRAITS.length);
+    for (const t of TRAITS) { expect(t.name).toBeTruthy(); expect(t.desc).toBeTruthy(); }
+  });
+
+  it('招募池每人帶特質；主角無特質', () => {
+    const pool = generateRecruitPool(createRng(99), 99, 0);
+    for (const r of pool) {
+      expect(r.trait, `${r.name} 缺特質`).toBeTruthy();
+      expect(TRAITS.some((t: { id: string }) => t.id === r.trait)).toBe(true);
+    }
+    expect(newGame().protagonist.trait).toBeNull();
+  });
+
+  it('特質影響薪餉與雇用費（greedy：便宜請、養得貴）', () => {
+    const r = generateRecruitPool(createRng(1), 1, 0)[0];
+    const asTrait = (trait: string | null) => ({ ...r, trait });
+    const baseWage = wagePerTrip(asTrait(null));
+    expect(wagePerTrip(asTrait('greedy'))).toBe(baseWage + 3);
+    expect(wagePerTrip(asTrait('frugal'))).toBe(baseWage - 2);
+    expect(hireCost(asTrait('greedy'))).toBe(hireCost(asTrait(null)) - 10);
+  });
+
+  it('特質屬性/HP 加成進入 memberFromRecord；partyCheckBonus 加總老練', () => {
+    const r = generateRecruitPool(createRng(2), 2, 0)[0];
+    const brawny = memberFromRecord({ ...r, trait: 'brawny' });
+    const plain = memberFromRecord({ ...r, trait: null });
+    expect(brawny.stats.str).toBe(plain.stats.str + 2);
+    const tough = memberFromRecord({ ...r, trait: 'tough' });
+    expect(tough.maxHp).toBe(plain.maxHp + 4);
+
+    const save = newGame();
+    expect(partyCheckBonus(save)).toBe(0);
+    save.companions.push({ ...r, trait: 'seasoned' }, { ...r, id: 'x2', trait: 'seasoned' });
+    expect(partyCheckBonus(save)).toBe(2);
   });
 });

--- a/src/scripts/games/caravan/roster.ts
+++ b/src/scripts/games/caravan/roster.ts
@@ -6,6 +6,43 @@ import { statMod } from './check';
 import { JOBS, type JobId } from './data/jobs';
 import { ITEMS } from './data/items';
 
+// -----------------------------------------------------------------------
+// 旅伴特質（M7）：招募池人物隨機帶 1 種，影響檢定/薪餉/屬性——招誰變成決策
+// -----------------------------------------------------------------------
+
+export interface TraitDef {
+  id: string; name: string; desc: string;
+  /** 全隊事件檢定加成（老練旅伴的建議） */
+  checkBonus?: number;
+  /** 每趟薪餉增減 */
+  wageDelta?: number;
+  /** 雇用費增減（負值＝便宜） */
+  hireDelta?: number;
+  /** 戰鬥屬性加成（memberFromRecord 整合） */
+  statBonus?: Partial<StatBlock>;
+  maxHpBonus?: number;
+}
+
+export const TRAITS: TraitDef[] = [
+  { id: 'seasoned', name: '老練', desc: '旅途檢定 +1（全隊）', checkBonus: 1 },
+  { id: 'greedy', name: '貪財', desc: '雇用費 -10，但每趟薪餉 +3', wageDelta: 3, hireDelta: -10 },
+  { id: 'frugal', name: '儉樸', desc: '每趟薪餉 -2', wageDelta: -2 },
+  { id: 'brawny', name: '強壯', desc: '力量 +2', statBonus: { str: 2 } },
+  { id: 'nimble', name: '靈巧', desc: '敏捷 +2', statBonus: { dex: 2 } },
+  { id: 'learned', name: '博學', desc: '智力 +2', statBonus: { int: 2 } },
+  { id: 'charming', name: '迷人', desc: '魅力 +2', statBonus: { cha: 2 } },
+  { id: 'tough', name: '硬朗', desc: '生命上限 +4', maxHpBonus: 4 },
+];
+
+export const traitById = (id: string | null | undefined): TraitDef | undefined =>
+  id ? TRAITS.find((t) => t.id === id) : undefined;
+
+/** 全隊事件檢定加成：加總所有成員特質的 checkBonus（M7） */
+export function partyCheckBonus(save: SaveData): number {
+  return [save.protagonist, ...save.companions]
+    .reduce((sum, m) => sum + (traitById(m.trait)?.checkBonus ?? 0), 0);
+}
+
 /** 升級累積 XP 門檻；index=level（1-based，index 0 廢棄）；Lv5 為封頂（M4） */
 export const XP_TABLE: number[] = [0, 0, 50, 120, 210, 320];
 
@@ -52,14 +89,14 @@ export function unlockedMoves(record: CompanionRecord): Move[] {
   return JOBS[record.job].moves.filter((move) => (move.minLevel ?? 1) <= record.level);
 }
 
-/** 雇用花費：30 + level×20 */
+/** 雇用花費：30 + level×20 + 特質增減（M7） */
 export function hireCost(record: CompanionRecord): number {
-  return 30 + record.level * 20;
+  return 30 + record.level * 20 + (traitById(record.trait)?.hireDelta ?? 0);
 }
 
-/** 每趟薪餉：8 + level×4（M3 終審給定的經濟基準——一趟路線覆蓋 2-3 趟小隊薪餉） */
+/** 每趟薪餉：8 + level×4 + 特質增減（M3 經濟基準；M7 特質） */
 export function wagePerTrip(record: CompanionRecord): number {
-  return 8 + record.level * 4;
+  return 8 + record.level * 4 + (traitById(record.trait)?.wageDelta ?? 0);
 }
 
 const JOB_IDS: JobId[] = ['swordsman', 'ranger', 'mage', 'cleric'];
@@ -101,6 +138,7 @@ export function generateRecruitPool(rng: Rng, tavernSeed: number, reputation: nu
       stats,
       maxHp: jobDef.baseMaxHp + (isVeteran ? VETERAN_MAX_HP_BONUS : 0),
       injuredForTrips: 0,
+      trait: rng.pick(TRAITS).id, // M7：每位旅伴一種特質
       equipment: { weapon: null, armor: null, trinket: null },
     });
   }

--- a/src/scripts/games/caravan/save.test.ts
+++ b/src/scripts/games/caravan/save.test.ts
@@ -6,9 +6,9 @@ import { EXPEDITION_VERSION } from './expedition';
 beforeEach(() => localStorage.clear());
 
 describe('save（版本化存檔）', () => {
-  it('newGame 產出 v5：含預設主角、空傭兵清單、空背包、無進行中遠征、經營層預設值、裝備三欄皆空（M5）', () => {
+  it('newGame 產出 v6：含預設主角、空傭兵清單、空背包、無進行中遠征、經營層預設值、裝備三欄皆空（M5）', () => {
     const s = newGame(1000);
-    expect(s.version).toBe(5);
+    expect(s.version).toBe(6);
     expect(s.protagonist.name).toBe('你');
     expect(s.protagonist.job).toBe('swordsman');
     expect(s.protagonist.equipment).toEqual({ weapon: null, armor: null, trinket: null });
@@ -22,10 +22,10 @@ describe('save（版本化存檔）', () => {
     expect(s.visitedBossDungeons).toEqual([]);
   });
 
-  it('v1 舊檔 loadGame 一路遷移到 v5 且保留原金幣與旗標，tavernSeed 取 createdAt', () => {
+  it('v1 舊檔 loadGame 一路遷移到 v6 且保留原金幣與旗標，tavernSeed 取 createdAt、marketSeed 取 createdAt+1', () => {
     localStorage.setItem(SAVE_KEY, JSON.stringify({ version: 1, createdAt: 5, gold: 777, flags: { met: true } }));
     const s = loadGame();
-    expect(s?.version).toBe(5);
+    expect(s?.version).toBe(6);
     expect(s?.gold).toBe(777);
     expect(s?.flags).toEqual({ met: true });
     expect(s?.protagonist.id).toBe('protagonist');
@@ -34,11 +34,13 @@ describe('save（版本化存檔）', () => {
     expect(s?.expedition).toBeNull();
     expect(s?.wagonLevel).toBe(0);
     expect(s?.tavernSeed).toBe(5);
+    expect(s?.marketSeed).toBe(6); // createdAt+1（M7）
+    expect(s?.protagonist.trait).toBeNull(); // M7 舊成員無特質
     expect(s?.reputation).toBe(0);
     expect(s?.visitedBossDungeons).toEqual([]);
   });
 
-  it('v2 舊檔 loadGame 遷移為 v5：補上 inventory/expedition/經營層/裝備欄位，其餘欄位不變', () => {
+  it('v2 舊檔 loadGame 遷移為 v6：補上 inventory/expedition/經營層/裝備欄位，其餘欄位不變', () => {
     localStorage.setItem(
       SAVE_KEY,
       JSON.stringify({
@@ -52,7 +54,7 @@ describe('save（版本化存檔）', () => {
       })
     );
     const s = loadGame();
-    expect(s?.version).toBe(5);
+    expect(s?.version).toBe(6);
     expect(s?.gold).toBe(300);
     expect(s?.inventory).toEqual({});
     expect(s?.expedition).toBeNull();
@@ -63,7 +65,7 @@ describe('save（版本化存檔）', () => {
     expect(s?.protagonist.equipment).toEqual({ weapon: null, armor: null, trinket: null });
   });
 
-  it('v3 舊檔 loadGame 遷移為 v5：補上 wagonLevel/tavernSeed/reputation/visitedBossDungeons/裝備欄位', () => {
+  it('v3 舊檔 loadGame 遷移為 v6：補上 wagonLevel/tavernSeed/reputation/visitedBossDungeons/裝備欄位', () => {
     localStorage.setItem(
       SAVE_KEY,
       JSON.stringify({
@@ -79,7 +81,7 @@ describe('save（版本化存檔）', () => {
       })
     );
     const s = loadGame();
-    expect(s?.version).toBe(5);
+    expect(s?.version).toBe(6);
     expect(s?.gold).toBe(150);
     expect(s?.inventory).toEqual({ herb: 2 });
     expect(s?.wagonLevel).toBe(0);
@@ -89,7 +91,7 @@ describe('save（版本化存檔）', () => {
     expect(s?.protagonist.equipment).toEqual({ weapon: null, armor: null, trinket: null });
   });
 
-  it('v4 舊檔 loadGame 遷移為 v5：主角與全部傭兵補上 equipment 預設（weapon/armor/trinket 皆 null，M5）', () => {
+  it('v4 舊檔 loadGame 遷移為 v6：主角與全部傭兵補上 equipment 預設與 trait null（M5/M7）', () => {
     localStorage.setItem(
       SAVE_KEY,
       JSON.stringify({
@@ -114,7 +116,7 @@ describe('save（版本化存檔）', () => {
       })
     );
     const s = loadGame();
-    expect(s?.version).toBe(5);
+    expect(s?.version).toBe(6);
     expect(s?.gold).toBe(500);
     expect(s?.protagonist.equipment).toEqual({ weapon: null, armor: null, trinket: null });
     expect(s?.companions).toHaveLength(2);
@@ -172,10 +174,10 @@ describe('save（版本化存檔）', () => {
     expect(loadGame()).toBeNull();
   });
 
-  it('importSave 對 v1 字串也會遷移到 v5（與 loadGame 同路徑）', () => {
+  it('importSave 對 v1 字串也會遷移到 v6（與 loadGame 同路徑）', () => {
     const v1 = btoa(encodeURIComponent(JSON.stringify({ version: 1, createdAt: 5, gold: 42, flags: {} })));
     const s = importSave(v1);
-    expect(s?.version).toBe(5);
+    expect(s?.version).toBe(6);
     expect(s?.gold).toBe(42);
     expect(s?.inventory).toEqual({});
     expect(s?.tavernSeed).toBe(5);

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -14,6 +14,8 @@ export interface CompanionRecord {
   maxHp: number;
   /** >0 表示重傷缺席剩餘趟數 */
   injuredForTrips: number;
+  /** 旅伴特質 id（roster.ts TRAITS）；主角與 M7 前的舊成員為 null */
+  trait?: string | null;
   /** 裝備三欄：itemId 或 null（M5，roster.ts equipItem/unequipItem 維護） */
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
 }
@@ -82,10 +84,16 @@ export interface SaveDataV5 {
   visitedBossDungeons: string[];
 }
 
-/** 對外別名，後續版本跟著改指向最新 schema */
-export type SaveData = SaveDataV5;
+export interface SaveDataV6 extends Omit<SaveDataV5, 'version'> {
+  version: 6;
+  /** 市場行情種子；每次歸返結算後遞增，各鎮物價隨之波動（M7） */
+  marketSeed: number;
+}
 
-const CURRENT_VERSION = 5;
+/** 對外別名，後續版本跟著改指向最新 schema */
+export type SaveData = SaveDataV6;
+
+const CURRENT_VERSION = 6;
 
 const defaultEquipment = (): CompanionRecord['equipment'] => ({ weapon: null, armor: null, trinket: null });
 
@@ -99,6 +107,7 @@ function defaultProtagonist(): CompanionRecord {
     stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 },
     maxHp: 22,
     injuredForTrips: 0,
+    trait: null,
     equipment: defaultEquipment(),
   };
 }
@@ -125,9 +134,20 @@ const MIGRATIONS: Record<number, (old: Record<string, unknown>) => Record<string
       companions: companions.map((c) => ({ ...c, equipment: defaultEquipment() })),
     };
   },
+  5: (old) => {
+    const protagonist = old.protagonist as Record<string, unknown>;
+    const companions = (old.companions as Array<Record<string, unknown>>) ?? [];
+    return {
+      ...old,
+      version: 6,
+      marketSeed: (old.createdAt as number) + 1,
+      protagonist: { ...protagonist, trait: null },
+      companions: companions.map((c) => ({ ...c, trait: c.trait ?? null })),
+    };
+  },
 };
 
-/** 驗證物件是否符合 SaveDataV5 的完整 shape（含 protagonist/companions/inventory/expedition/wagonLevel/tavernSeed/reputation/visitedBossDungeons/equipment）*/
+/** 驗證物件是否符合 SaveDataV6 的完整 shape（含 marketSeed；v5 及更早由 MIGRATIONS 先升版再驗）*/
 function isValidSaveShape(value: unknown): value is SaveData {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
@@ -145,6 +165,7 @@ function isValidSaveShape(value: unknown): value is SaveData {
     (v.expedition !== null && typeof v.expedition !== 'object') ||
     typeof v.wagonLevel !== 'number' ||
     typeof v.tavernSeed !== 'number' ||
+    typeof v.marketSeed !== 'number' ||
     typeof v.reputation !== 'number' ||
     !Array.isArray(v.visitedBossDungeons)
   ) {
@@ -178,7 +199,7 @@ function parseAndMigrate(raw: unknown): SaveData | null {
 
 export function newGame(now: number = Date.now()): SaveData {
   return {
-    version: 5,
+    version: 6,
     createdAt: now,
     gold: 200,
     flags: {},
@@ -188,6 +209,7 @@ export function newGame(now: number = Date.now()): SaveData {
     expedition: null,
     wagonLevel: 0,
     tavernSeed: now,
+    marketSeed: now + 1,
     reputation: 0,
     visitedBossDungeons: [],
   };

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -412,19 +412,23 @@ test.describe('商隊與劍：經營系統', () => {
     throw new Error('advanceToSettlement: 超過 200 步仍未抵達結算畫面');
   }
 
-  test('市集買賣：買 2 繃帶扣款、賣 1 回收半價，金幣與庫存精確同步', async ({ page }) => {
+  test('市集買賣：扣款與 UI 標價一致、賣出回收標示價，金幣與庫存精確同步', async ({ page }) => {
     await newGameWithSeed(page, 101);
-    // buyPrice(starting-town, bandage)=round(8×1)=8；sellPrice=round(8×0.5)=4（economy.ts 公式）。
+    // M7 行情波動後價格隨 marketSeed 浮動——改從 UI 標價動態驗證（意圖不變：標價=實扣=庫存同步）。
     const bandageRow = page.locator('.market-row[data-item-id="bandage"]');
+    const buyPriceNow = Number((await bandageRow.locator('.buy-btn').textContent())!.match(/\d+/)![0]);
+    expect(buyPriceNow).toBeGreaterThan(0);
     await bandageRow.locator('.buy-btn').click();
     await bandageRow.locator('.buy-btn').click();
-    await expect(page.locator('#market-gold')).toHaveText('184');
-    await expect(page.locator('#town-gold')).toHaveText('184');
+    const afterBuy = 200 - buyPriceNow * 2;
+    await expect(page.locator('#market-gold')).toHaveText(String(afterBuy));
+    await expect(page.locator('#town-gold')).toHaveText(String(afterBuy));
     await expect(bandageRow.locator('.market-name')).toContainText('持有 2');
 
+    const sellPriceNow = Number((await bandageRow.locator('.sell-btn').textContent())!.match(/\d+/)![0]);
     await bandageRow.locator('.sell-btn').click();
-    await expect(page.locator('#market-gold')).toHaveText('188');
-    await expect(page.locator('#town-gold')).toHaveText('188');
+    await expect(page.locator('#market-gold')).toHaveText(String(afterBuy + sellPriceNow));
+    await expect(page.locator('#town-gold')).toHaveText(String(afterBuy + sellPriceNow));
     await expect(bandageRow.locator('.market-name')).toContainText('持有 1');
   });
 
@@ -488,12 +492,13 @@ test.describe('商隊與劍：經營系統', () => {
     expect(goldAtStart).toBe(200);
 
     const oreRow = page.locator('.market-row[data-item-id="ore"]');
+    // M7 行情：礦石買價隨 marketSeed 浮動，從 UI 標價動態計算
+    const orePrice = Number((await oreRow.locator('.buy-btn').textContent())!.match(/\d+/)![0]);
     for (let i = 0; i < 6; i++) {
       await oreRow.locator('.buy-btn').click();
     }
     const goldBeforeDepart = (await readSave(page)).gold;
-    // buyPrice(starting-town, ore)=round(12×1)=12；買 6 個＝72。
-    expect(goldBeforeDepart).toBe(goldAtStart - 72);
+    expect(goldBeforeDepart).toBe(goldAtStart - orePrice * 6);
 
     await page.click('#btn-quest-board');
     await page.click('.quest-outfit-btn[data-location-id="riverside-road"]');
@@ -508,16 +513,17 @@ test.describe('商隊與劍：經營系統', () => {
 
     await advanceToSettlement(page, { sellAll: true });
     await expect(page.locator('#screen-settlement')).toBeVisible();
-    // seed=91 臨水道已知確定結果：loot.gold=25、無戰利品物品、勝利未撤退——
-    // 押貨 6 礦石全額到帳。tradeSellPrice(riverbend-town, ore)=round(12×1.5×0.9)=16，6 個＝96。
+    // seed=91 臨水道已知確定結果：loot.gold=25、無戰利品物品、勝利未撤退。
+    // M7 行情：異鎮賣價浮動——貿易收入從結算畫面讀出後驗算帳一致與淨利為正。
     await expect(page.locator('#settle-gold')).toHaveText('25');
-    await expect(page.locator('#settle-trade-gold')).toHaveText('96');
+    const tradeGold = Number(await page.locator('#settle-trade-gold').textContent());
+    expect(tradeGold).toBeGreaterThan(0);
 
     await page.click('#btn-settle-back');
     await expect(page.locator('#screen-town')).toBeVisible();
     const finalGold = (await readSave(page)).gold;
-    expect(finalGold).toBe(goldBeforeDepart + 25 + 96);
-    expect(finalGold).toBeGreaterThan(goldAtStart);
+    expect(finalGold).toBe(goldBeforeDepart + 25 + tradeGold);
+    expect(finalGold, '押貨淨利應為正').toBeGreaterThan(goldAtStart);
   });
 
   test('升級：xp 達 Lv2 門檻後配 2 點力量，卡片顯示 Lv2 與屬性變化', async ({ page }) => {


### PR DESCRIPTION
## Summary

《商隊與劍》M7：把三個核心系統做深，讓每一輪遊玩都不同：

- **市場行情波動**：各鎮物價以 marketSeed 決定性浮動（0.75-1.35），每次遠征歸來行情輪動——套利路線每輪重新洗牌，跑商不再有標準答案；市集與異鎮交易顯示 ▲▼ 行情箭頭；裝備不吃行情（延伸套利裁決）
- **旅伴特質**：酒館人選隨機帶特質（老練＝全隊檢定 +1、貪財＝便宜請養得貴、硬朗＝HP+4 等 8 種），影響檢定/薪餉/雇用費/戰鬥面板——招募從撿人變成決策
- **戰鬥狀態效果**：中毒（行動前發作）/暈眩（跳過行動）/強化（傷害加成）三種機制；蜘蛛毒牙見血封喉、鹽晶洞主重壓令人眼冒金星；戰鬥卡顯示 ☠💫💪 狀態圖示
- 存檔 v5→v6 遷移（marketSeed＋trait，不清檔）；e2e 金額斷言改讀 UI 標價動態驗證

## Test plan
- [x] `npx vitest run` 1504 全綠（M7 新測試 13 條：行情 4／特質 4／狀態 5）
- [x] caravan e2e 26 綠＋defense 3 綠
- [x] `npm run build` 綠
- [x] 實機驗收：市集行情箭頭（4▲2▼）、酒館特質標籤、v6 新檔

🤖 Generated with [Claude Code](https://claude.com/claude-code)