### PR TITLE
feat(caravan): M11 RPG 深度——職業專精＋消耗品＋旅伴羈絆

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -45,6 +45,18 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         </div>
       </div>
     </div>
+
+    <!-- M11 職業專精選擇面板 -->
+    <div id="spec-panel" class="modal-overlay" hidden>
+      <div class="modal-box spec-box">
+        <h3 class="modal-title">選擇專精</h3>
+        <p class="spec-hint">Lv4 的抉擇將定義這名成員的戰鬥之道——<b>選定後不可更改</b>。</p>
+        <div id="spec-options" class="spec-options"></div>
+        <div class="modal-actions">
+          <button id="btn-spec-cancel" type="button" class="caravan-btn caravan-btn-ghost">再想想</button>
+        </div>
+      </div>
+    </div>
     <!-- 遊戲畫面框：所有場景在此固定框內切換（全螢幕遊戲視窗，非置中卡片） -->
     <div class="game-frame">
     <!-- 標題畫面 -->
@@ -186,7 +198,12 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       </div>
       <div id="room-choices" class="room-choices"></div>
       <p id="check-result" class="check-result" hidden></p>
-      <button id="btn-exp-continue" class="caravan-btn" hidden>繼續前進</button>
+      <div id="exp-party" class="exp-party"></div>
+      <div class="exp-actions">
+        <button id="btn-exp-continue" class="caravan-btn" hidden>繼續前進</button>
+        <button id="btn-exp-item" class="caravan-btn caravan-btn-ghost" hidden>使用道具</button>
+      </div>
+      <div id="exp-item-list" class="exp-item-list" hidden></div>
     </section>
 
     <!-- 戰鬥畫面（M2：訓練場入口；M3 併入遠征遭遇） -->
@@ -267,12 +284,13 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   import type { SaveData, CompanionRecord } from '@scripts/games/caravan/save';
   import { createRng } from '@scripts/games/caravan/rng';
   import {
-    startCombat, partyAct, enemyAct, attemptRetreat, currentActor, resolveCasualties,
+    startCombat, partyAct, enemyAct, attemptRetreat, currentActor, resolveCasualties, useItemInCombat,
   } from '@scripts/games/caravan/combat';
+  import type { ItemCombatUse } from '@scripts/games/caravan/combat';
   import type { CombatState, CombatantBase, Move, PartyMember } from '@scripts/games/caravan/combat';
   import {
     startExpedition, drawEvent, optionAvailable, resolveOption, drawRooms, chooseRoom,
-    buildEncounter, applyPartyHp, finishCombat, settleExpedition,
+    buildEncounter, applyPartyHp, finishCombat, settleExpedition, useItemOnExpedition,
   } from '@scripts/games/caravan/expedition';
   import type { ExpeditionState, EventCard, RoomKind, LocationDef } from '@scripts/games/caravan/expedition';
   import type { CheckResult } from '@scripts/games/caravan/check';
@@ -287,7 +305,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   import type { TownDef } from '@scripts/games/caravan/economy';
   import {
     pendingLevelUps, applyLevelUp, unlockedMoves, generateRecruitPool, hireCost, wagePerTrip,
-    equipItem, unequipItem,
+    equipItem, unequipItem, SPECIALIZATIONS, SPECIALIZATION_LEVEL, chooseSpecialization, specById,
+    bondTier, BOND_TIER_NAMES,
   } from '@scripts/games/caravan/roster';
   import {
     buyPrice, sellPrice, tradeSellPrice, cargoCapacity, wagonUpgradeCost, totalWage,
@@ -735,6 +754,35 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     card.appendChild(wrap);
   }
 
+  // ---- M11 專精面板 ----
+  const specPanelEl = document.getElementById('spec-panel')!;
+  const specOptionsEl = document.getElementById('spec-options')!;
+  document.getElementById('btn-spec-cancel')?.addEventListener('click', () => { specPanelEl.hidden = true; });
+
+  function openSpecPanel(record: CompanionRecord): void {
+    specOptionsEl.innerHTML = '';
+    for (const spec of SPECIALIZATIONS[record.job]) {
+      const card = document.createElement('button');
+      card.type = 'button';
+      card.className = 'spec-option';
+      card.dataset.specId = spec.id;
+      const nm = document.createElement('b');
+      nm.textContent = spec.name;
+      const desc = document.createElement('span');
+      desc.textContent = spec.desc;
+      card.append(nm, desc);
+      card.addEventListener('click', () => {
+        if (!save) return;
+        chooseSpecialization(record, spec.id);
+        saveGame(save);
+        specPanelEl.hidden = true;
+        renderTownPanels();
+      });
+      specOptionsEl.appendChild(card);
+    }
+    specPanelEl.hidden = false;
+  }
+
   function renderRoster(): void {
     if (!save) return;
     const members: CompanionRecord[] = [save.protagonist, ...save.companions];
@@ -763,6 +811,12 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       xp.textContent = `經驗值 ${record.xp} XP`;
       const rTrait = traitById(record.trait);
       if (rTrait) xp.textContent += `．特質「${rTrait.name}」（${rTrait.desc}）`;
+      const rSpec = specById(record.specialization);
+      if (rSpec) xp.textContent += `．專精「${rSpec.name}」`;
+      if (record.id !== 'protagonist') {
+        const tier = bondTier(record.bond);
+        if (tier > 0) xp.textContent += `．羈絆「${BOND_TIER_NAMES[tier]}」（同行 ${record.bond} 趟）`;
+      }
 
       const stats = document.createElement('p');
       stats.className = 'roster-stats';
@@ -795,6 +849,15 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         levelupBtn.textContent = '升級！';
         levelupBtn.addEventListener('click', () => openLevelupPanel(record));
         card.appendChild(levelupBtn);
+      }
+
+      if (record.level >= SPECIALIZATION_LEVEL && !record.specialization) {
+        const specBtn = document.createElement('button');
+        specBtn.type = 'button';
+        specBtn.className = 'caravan-btn spec-btn';
+        specBtn.textContent = '選擇專精';
+        specBtn.addEventListener('click', () => openSpecPanel(record));
+        card.appendChild(specBtn);
       }
 
       if (record.id !== save.protagonist.id) {
@@ -877,6 +940,11 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         tag.className = 'backpack-tag';
         const slotLabel: Record<string, string> = { weapon: '武器', armor: '護甲', trinket: '飾品' };
         tag.textContent = slotLabel[item.equip.slot] ?? '裝備';
+        head.append(nm, tag, ct);
+      } else if (item.use) {
+        const tag = document.createElement('span');
+        tag.className = 'backpack-tag backpack-tag-use';
+        tag.textContent = '可使用';
         head.append(nm, tag, ct);
       } else {
         head.append(nm, ct);
@@ -1313,6 +1381,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     if (!expedition) return;
     const unit = expedition.kind === 'dungeon' ? '層' : '段';
     expProgressEl.textContent = `第 ${expedition.step}/${expedition.totalSteps} ${unit}`;
+    renderExpParty();
   }
 
   function renderCheckResult(check: CheckResult | null): void {
@@ -1338,6 +1407,85 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     }
     renderEventCard(card);
   }
+
+  // ---- M11 消耗品 ----
+  const expPartyEl = document.getElementById('exp-party')!;
+  const btnExpItem = document.getElementById('btn-exp-item')! as HTMLButtonElement;
+  const expItemListEl = document.getElementById('exp-item-list')!;
+
+  function usableItems(): Array<{ id: string; name: string; count: number }> {
+    if (!save) return [];
+    return Object.entries(save.inventory)
+      .filter(([id, n]) => (n ?? 0) > 0 && ITEMS[id]?.use)
+      .map(([id, n]) => ({ id, name: ITEMS[id].name, count: n }));
+  }
+
+  /** 遠征隊伍狀態帶：每位成員名字＋HP 條（損耗可視化） */
+  function renderExpParty(): void {
+    if (!save || !expedition) return;
+    expPartyEl.innerHTML = '';
+    const members = [save.protagonist, ...save.companions.filter((c) => c.id in expedition!.partyHp)];
+    for (const member of members) {
+      if (!(member.id in expedition.partyHp)) continue;
+      const chip = document.createElement('div');
+      chip.className = 'exp-member';
+      chip.dataset.memberId = member.id;
+      const nm = document.createElement('span');
+      nm.className = 'exp-member-name';
+      nm.textContent = member.name;
+      const hpText = document.createElement('span');
+      hpText.className = 'exp-member-hp';
+      hpText.textContent = `${expedition.partyHp[member.id]}/${member.maxHp}`;
+      const bar = document.createElement('div');
+      bar.className = 'hp-bar exp-member-bar';
+      const fill = document.createElement('i');
+      fill.style.width = `${Math.round((expedition.partyHp[member.id] / member.maxHp) * 100)}%`;
+      bar.appendChild(fill);
+      chip.append(nm, hpText, bar);
+      expPartyEl.appendChild(chip);
+    }
+    // 道具鈕：有可用治療品且隊伍有損耗才亮
+    const anyHeal = usableItems().some((it) => ITEMS[it.id].use!.kind === 'heal');
+    const anyHurt = members.some((m) => m.id in expedition!.partyHp && expedition!.partyHp[m.id] < m.maxHp);
+    btnExpItem.hidden = !(anyHeal && anyHurt);
+    if (btnExpItem.hidden) { expItemListEl.hidden = true; expItemListEl.innerHTML = ''; }
+  }
+
+  /** 遠征途中用藥：治療目前 HP 比例最低的成員 */
+  function lowestHpMemberId(): string | null {
+    if (!save || !expedition) return null;
+    let worst: { id: string; ratio: number } | null = null;
+    for (const member of [save.protagonist, ...save.companions]) {
+      const hp = expedition.partyHp[member.id];
+      if (hp === undefined || hp >= member.maxHp) continue;
+      const ratio = hp / member.maxHp;
+      if (!worst || ratio < worst.ratio) worst = { id: member.id, ratio };
+    }
+    return worst?.id ?? null;
+  }
+
+  btnExpItem.addEventListener('click', () => {
+    expItemListEl.hidden = !expItemListEl.hidden;
+    if (expItemListEl.hidden) return;
+    expItemListEl.innerHTML = '';
+    for (const it of usableItems().filter((x) => ITEMS[x.id].use!.kind === 'heal')) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'caravan-btn exp-item-btn';
+      btn.dataset.itemId = it.id;
+      btn.textContent = `${it.name} ×${it.count}`;
+      btn.addEventListener('click', () => {
+        if (!save || !expedition) return;
+        const targetId = lowestHpMemberId();
+        if (!targetId) return;
+        useItemOnExpedition(expedition, save, it.id, targetId);
+        saveGame(save);
+        expItemListEl.hidden = true;
+        renderExpParty();
+      });
+      expItemListEl.appendChild(btn);
+    }
+  });
 
   function renderEventCard(card: EventCard): void {
     if (!save) return;
@@ -1796,6 +1944,56 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     }
   }
 
+  /** M11 戰鬥道具：ItemDef.use → 引擎 ItemCombatUse */
+  function toCombatUse(itemId: string): ItemCombatUse | null {
+    const item = ITEMS[itemId];
+    if (!item?.use) return null;
+    if (item.use.kind === 'heal') return { kind: 'heal', amount: item.use.amount, name: item.name };
+    if (item.use.kind === 'cure') return { kind: 'cure', name: item.name };
+    return { kind: 'buff', status: item.use.status, name: item.name };
+  }
+
+  /** 道具目標：治療/解毒選 HP 比例最低（或中毒）的存活隊友；強化給行動者 */
+  function itemTargetId(actorId: string, use: ItemCombatUse): string {
+    if (!state) return actorId;
+    if (use.kind === 'buff') return actorId;
+    const alive = state.party.filter((u) => u.hp > 0);
+    if (use.kind === 'cure') {
+      const poisoned = alive.find((u) => (u.statuses ?? []).some((st) => st.kind === 'poison'));
+      if (poisoned) return poisoned.id;
+    }
+    let worst = alive[0];
+    for (const u of alive) if (u.hp / u.maxHp < worst.hp / worst.maxHp) worst = u;
+    return worst?.id ?? actorId;
+  }
+
+  function renderItemMenu(actorId: string): void {
+    if (!state) return;
+    combatActionsEl.innerHTML = '';
+    for (const it of usableItems()) {
+      const btn = document.createElement('button');
+      btn.className = 'caravan-btn move-btn item-btn';
+      btn.dataset.itemId = it.id;
+      btn.textContent = `${it.name} ×${it.count}`;
+      btn.addEventListener('click', () => {
+        if (!state || !save) return;
+        const use = toCombatUse(it.id);
+        if (!use) return;
+        useItemInCombat(state, actorId, use, itemTargetId(actorId, use));
+        save.inventory[it.id] -= 1;
+        saveGame(save);
+        selectedTargetId = null;
+        render();
+      });
+      combatActionsEl.appendChild(btn);
+    }
+    const back = document.createElement('button');
+    back.className = 'caravan-btn move-btn item-back-btn';
+    back.textContent = '返回';
+    back.addEventListener('click', () => renderActions(actorId));
+    combatActionsEl.appendChild(back);
+  }
+
   function renderActions(actorId: string): void {
     if (!state) return;
     combatActionsEl.innerHTML = '';
@@ -1815,6 +2013,13 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         render();
       });
       combatActionsEl.appendChild(btn);
+    }
+    if (usableItems().length > 0) {
+      const itemBtn = document.createElement('button');
+      itemBtn.className = 'caravan-btn move-btn combat-item-toggle';
+      itemBtn.textContent = '道具';
+      itemBtn.addEventListener('click', () => renderItemMenu(actorId));
+      combatActionsEl.appendChild(itemBtn);
     }
   }
 
@@ -2585,4 +2790,37 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .backpack-count { margin-left: auto; color: var(--gold-bright); font-weight: 700; letter-spacing: 0.05em; }
   .backpack-tag { font-size: 0.72rem; letter-spacing: 0.12em; color: #241505; background: var(--gold); border-radius: 3px; padding: 0.05rem 0.5rem; }
   .backpack-desc { margin: 0.35rem 0 0; font-size: 0.85rem; color: var(--text-dim); line-height: 1.7; }
+
+  /* ---- M11：遠征隊伍帶／道具／專精 ---- */
+  .exp-party { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem; margin: 0.4rem 0 0.7rem; }
+  .exp-member {
+    display: flex; align-items: center; gap: 0.45rem;
+    padding: 0.3rem 0.7rem;
+    background: var(--panel-deep); border: 1px solid var(--gold-dim); border-radius: 3px;
+    font-size: 0.85rem;
+  }
+  .exp-member-name { color: var(--text); font-weight: 700; }
+  .exp-member-hp { color: var(--text-dim); font-size: 0.8rem; }
+  .exp-member-bar { width: 4.5rem; }
+  .exp-actions { display: flex; justify-content: center; gap: 0.7rem; }
+  .exp-item-list { display: flex; flex-wrap: wrap; justify-content: center; gap: 0.5rem; margin-top: 0.6rem; }
+  .exp-item-btn, .item-btn { letter-spacing: 0.08em; }
+  .combat-item-toggle { border-style: dashed; }
+  .spec-box { max-width: 30rem; }
+  .spec-hint { color: var(--text-dim); line-height: 1.7; margin: 0 0 1rem; }
+  .spec-hint b { color: var(--seal-bright); }
+  .spec-options { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: 0.8rem; margin-bottom: 1rem; }
+  .spec-option {
+    font: inherit; cursor: pointer; text-align: left;
+    display: flex; flex-direction: column; gap: 0.4rem;
+    padding: 0.9rem;
+    background: var(--panel-deep); color: var(--text);
+    border: 1px solid var(--gold-dim); border-radius: 4px;
+    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  }
+  .spec-option b { color: var(--gold-bright); letter-spacing: 0.1em; font-size: 1.05rem; }
+  .spec-option span { font-size: 0.85rem; color: var(--text-dim); line-height: 1.7; }
+  .spec-option:hover { border-color: var(--seal); box-shadow: 0 0 14px rgba(181, 52, 43, 0.3); }
+  .spec-btn { margin: 0.6rem 0.6rem 0 0; padding: 0.35rem 1.1rem; font-size: 0.85rem; background: var(--seal); border-color: var(--seal-bright); color: #f7ece0; }
+  .backpack-tag-use { background: var(--forest); color: #10201a; }
 </style>

--- a/src/scripts/games/caravan/combat.test.ts
+++ b/src/scripts/games/caravan/combat.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { statMod } from './check';
-import { startCombat, currentActor, advanceTurn, partyAct, enemyAct, attemptRetreat, resolveCasualties } from './combat';
+import { startCombat, currentActor, advanceTurn, partyAct, enemyAct, attemptRetreat, resolveCasualties, useItemInCombat } from './combat';
 import type { PartyMember, EnemyUnit, Move, CombatState } from './combat';
 import { createRng } from './rng';
 import type { Rng } from './rng';
@@ -376,5 +376,66 @@ describe('Boss 激怒機制（M10）', () => {
       expect(ENCOUNTERS[encId]()[0].enrage, `${encId} 缺 enrage`).toBeDefined();
     }
     expect(ENCOUNTERS.enc_wolf_pair()[0].enrage).toBeUndefined();
+  });
+});
+
+describe('M11 戰鬥道具（useItemInCombat）', () => {
+  const healer = (): PartyMember => ({
+    id: 'p1', name: '你', stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 },
+    maxHp: 22, hp: 10, defense: 14, isProtagonist: true,
+    moves: [{ id: 'strike', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}攻擊{target}造成{amount}點傷害' }],
+  });
+  const foe = (): EnemyUnit => ({
+    id: 'e1', name: '哥布林', stats: { str: 10, dex: 10, int: 8, cha: 6, con: 10 },
+    maxHp: 8, hp: 8, defense: 10, xp: 10,
+    moves: [{ id: 'stab', name: '短刀', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 4, bonusStat: 'str' }, narration: '{actor}刺向{target}造成{amount}點傷害' }],
+    intents: [{ moveId: 'stab', weight: 1 }],
+  });
+
+  it('治療道具：目標回血不超過 maxHp、消耗行動（輪到下一位）、寫入 log', () => {
+    const state = startCombat(scriptedRng([20, 1]), [healer()], [foe()]);
+    useItemInCombat(state, 'p1', { kind: 'heal', amount: 6, name: '藥草' }, 'p1');
+    const unit = state.party[0];
+    expect(unit.hp).toBe(16);
+    expect(state.log.some((e) => e.text.includes('藥草'))).toBe(true);
+    expect(currentActor(state)?.side).toBe('enemy'); // 行動已消耗
+  });
+
+  it('治療不溢出 maxHp', () => {
+    const member = healer(); member.hp = 20;
+    const state = startCombat(scriptedRng([20, 1]), [member], [foe()]);
+    useItemInCombat(state, 'p1', { kind: 'heal', amount: 12, name: '繃帶' }, 'p1');
+    expect(state.party[0].hp).toBe(22);
+  });
+
+  it('解毒道具：清除目標身上的 poison，保留其他狀態', () => {
+    const member = healer();
+    member.statuses = [
+      { kind: 'poison', remaining: 2, potency: 2 },
+      { kind: 'strength', remaining: 2, potency: 3 },
+    ];
+    const state = startCombat(scriptedRng([20, 1]), [member], [foe()]);
+    useItemInCombat(state, 'p1', { kind: 'cure', name: '解毒劑' }, 'p1');
+    const statuses = state.party[0].statuses ?? [];
+    expect(statuses.some((st) => st.kind === 'poison')).toBe(false);
+    expect(statuses.some((st) => st.kind === 'strength')).toBe(true);
+  });
+
+  it('強化道具：附加 strength 狀態', () => {
+    const state = startCombat(scriptedRng([20, 1]), [healer()], [foe()]);
+    useItemInCombat(state, 'p1', { kind: 'buff', status: { kind: 'strength', duration: 2, potency: 2 }, name: '行軍補劑' }, 'p1');
+    const statuses = state.party[0].statuses ?? [];
+    expect(statuses.some((st) => st.kind === 'strength' && st.potency === 2)).toBe(true);
+  });
+
+  it('對倒下的隊友使用丟錯；戰鬥已結束丟錯', () => {
+    const member = healer(); member.hp = 0;
+    const ally = healer(); ally.id = 'p2'; ally.name = '甲';
+    const state = startCombat(scriptedRng([20, 1]), [ally, member], [foe()]);
+    expect(() => useItemInCombat(state, 'p2', { kind: 'heal', amount: 6, name: '藥草' }, 'p1')).toThrow();
+    state.outcome = 'victory';
+    expect(() => useItemInCombat(state, 'p2', { kind: 'heal', amount: 6, name: '藥草' }, 'p2')).toThrow();
   });
 });

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -268,6 +268,37 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
   if (state.outcome === 'ongoing') advanceTurn(state);
 }
 
+/** M11 戰鬥道具效果（資料層 ItemDef.use 轉譯後傳入） */
+export type ItemCombatUse =
+  | { kind: 'heal'; amount: number; name: string }
+  | { kind: 'cure'; name: string }
+  | { kind: 'buff'; status: { kind: StatusKind; duration: number; potency?: number }; name: string };
+
+/**
+ * M11 戰鬥中使用道具：治療/解毒/強化目標隊友。
+ * 消耗使用者的行動（advanceTurn）；背包扣減由呼叫端（UI/遠征層）負責。
+ */
+export function useItemInCombat(state: CombatState, actorId: string, use: ItemCombatUse, targetId: string): void {
+  if (state.outcome !== 'ongoing') throw new Error('useItemInCombat: 戰鬥已結束');
+  const actor = state.party.find((u) => u.id === actorId);
+  const target = state.party.find((u) => u.id === targetId);
+  if (!actor || actor.hp <= 0) throw new Error('useItemInCombat: 使用者不存在或已倒下');
+  if (!target || target.hp <= 0) throw new Error('useItemInCombat: 目標不存在或已倒下');
+  if (use.kind === 'heal') {
+    const healed = Math.min(use.amount, target.maxHp - target.hp);
+    target.hp += healed;
+    state.log.push({ kind: 'heal', text: `${actor.name}使用${use.name}，${target.name}恢復 ${healed} 點生命。` });
+  } else if (use.kind === 'cure') {
+    target.statuses = (target.statuses ?? []).filter((st) => st.kind !== 'poison');
+    state.log.push({ kind: 'info', text: `${actor.name}使用${use.name}，${target.name}的毒被清除了。` });
+  } else {
+    target.statuses = target.statuses ?? [];
+    target.statuses.push({ kind: use.status.kind, remaining: use.status.duration, potency: use.status.potency ?? 0 });
+    state.log.push({ kind: 'info', text: `${actor.name}使用${use.name}，${target.name}獲得強化！` });
+  }
+  advanceTurn(state);
+}
+
 export function attemptRetreat(rng: Rng, state: CombatState): void {
   if (state.outcome !== 'ongoing') return;
   const aliveParty = state.party.filter((p) => p.hp > 0);

--- a/src/scripts/games/caravan/data/data.test.ts
+++ b/src/scripts/games/caravan/data/data.test.ts
@@ -36,8 +36,8 @@ describe('caravan content data integrity（M3 Task 4）', () => {
   // ---------------------------------------------------------------------
   // items.ts
   // ---------------------------------------------------------------------
-  it('ITEMS 有 29 種（M3 12 + M5 11 + M10 稀有裝 6），且 ore 存在（Task 3 寶箱房寫死給 ore）', () => {
-    expect(Object.keys(ITEMS).length).toBe(29);
+  it('ITEMS 有 31 種（M3 12 + M5 11 + M10 稀有裝 6 + M11 消耗品 2），且 ore 存在（Task 3 寶箱房寫死給 ore）', () => {
+    expect(Object.keys(ITEMS).length).toBe(31);
     expect(ITEMS.ore).toBeDefined();
     for (const item of Object.values(ITEMS)) {
       expect(item.id).toBeTruthy();

--- a/src/scripts/games/caravan/data/items.ts
+++ b/src/scripts/games/caravan/data/items.ts
@@ -8,6 +8,11 @@ export interface ItemDef {
   value: number;
   /** 裝備 icon 路徑（M10 美術統一，裝備限定） */
   art?: string;
+  /** M11 消耗品效果：戰鬥與遠征中可使用；未設定＝純交易品 */
+  use?:
+    | { kind: 'heal'; amount: number }
+    | { kind: 'cure' }
+    | { kind: 'buff'; status: { kind: 'strength'; duration: number; potency: number } };
   /** 可裝備物品的效果設定（M5 裝備三欄系統）；未設定＝純消耗/交易品 */
   equip?: {
     slot: 'weapon' | 'armor' | 'trinket';
@@ -33,12 +38,28 @@ export const ITEMS: Record<string, ItemDef> = {
   herb: {
     id: 'herb',
     name: '藥草',
-    desc: '山野常見的藥草，搗碎外敷可止血鎮痛，旅人隨身必備。',
+    desc: '山野常見的藥草，搗碎外敷可止血鎮痛。使用後恢復 6 點生命。',
     value: 5,
+    use: { kind: 'heal', amount: 6 },
+  },
+  antidote: {
+    id: 'antidote',
+    name: '解毒劑',
+    desc: '以蛇膽與苦艾熬成的藥劑，入喉極苦。使用後清除中毒狀態。',
+    value: 12,
+    use: { kind: 'cure' },
+  },
+  'war-tonic': {
+    id: 'war-tonic',
+    name: '行軍補劑',
+    desc: '傭兵間流傳的濃烈藥酒，飲下後血氣翻湧。使用後短暫提升攻擊力。',
+    value: 20,
+    use: { kind: 'buff', status: { kind: 'strength', duration: 2, potency: 2 } },
   },
   bandage: {
     id: 'bandage',
     name: '繃帶',
+    use: { kind: 'heal', amount: 12 },
     desc: '浸過藥水的紗布，是戰場急救的最後一道防線。',
     value: 8,
   },

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -1,7 +1,7 @@
 import type { Move, PartyMember } from '../combat';
 import type { CompanionRecord } from '../save';
 import type { StatBlock } from '../types';
-import { unlockedMoves, equipmentBonus, traitById } from '../roster';
+import { unlockedMoves, equipmentBonus, traitById, specById, bondTier, BOND_HP_PER_TIER } from '../roster';
 import { ITEMS } from './items';
 
 export type JobId = 'swordsman' | 'ranger' | 'mage' | 'cleric';
@@ -152,12 +152,25 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
       stats[key] += trait.statBonus[key] ?? 0;
     }
   }
-  const maxHp = record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0);
+  // M11 專精被動
+  const spec = specById(record.specialization);
+  if (spec?.statBonus) {
+    for (const key of Object.keys(spec.statBonus) as Array<keyof StatBlock>) {
+      stats[key] += spec.statBonus[key] ?? 0;
+    }
+  }
+  // M11 羈絆：旅伴 tier 每階 +BOND_HP_PER_TIER 生命上限（主角無 bond 欄自然為 0）
+  const bondHp = bondTier(record.bond) * BOND_HP_PER_TIER;
+  const maxHp = record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0) + (spec?.maxHp ?? 0) + bondHp;
 
   const moves = unlockedMoves(record);
   const weaponId = record.equipment.weapon;
   const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
-  const finalMoves = weaponMove ? [weaponMove, ...moves.slice(1)] : moves;
+  const baseMoves = weaponMove ? [weaponMove, ...moves.slice(1)] : moves;
+  // 專屬招插在通用「揮擊」之前（揮擊恆為最後一招）
+  const finalMoves = spec
+    ? [...baseMoves.slice(0, -1), spec.move, baseMoves[baseMoves.length - 1]]
+    : baseMoves;
 
   return {
     id: record.id,
@@ -165,7 +178,7 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     stats,
     maxHp,
     hp: maxHp,
-    defense: job.defense + bonus.defense,
+    defense: job.defense + bonus.defense + (spec?.defense ?? 0),
     moves: finalMoves,
     isProtagonist: record.id === 'protagonist',
   };

--- a/src/scripts/games/caravan/data/towns.ts
+++ b/src/scripts/games/caravan/data/towns.ts
@@ -18,7 +18,7 @@ export const TOWNS: Record<string, TownDef> = {
     name: '啟程之鎮',
     desc: '商隊由此啟程，青石廣場終年人聲鼎沸，鐵匠爐火不熄，貨棧招牌層層疊疊，是踏上未知路途前最後一次安穩補給。',
     priceModifiers: {},
-    stock: ['herb', 'bandage', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest'],
+    stock: ['herb', 'bandage', 'antidote', 'war-tonic', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest'],
   },
   'riverbend-town': {
     id: 'riverbend-town',

--- a/src/scripts/games/caravan/expedition.test.ts
+++ b/src/scripts/games/caravan/expedition.test.ts
@@ -18,6 +18,7 @@ import {
   finishCombat,
   applyPartyHp,
   EXPEDITION_VERSION,
+  useItemOnExpedition,
 } from './expedition';
 import type { EventCard, LocationDef, ExpeditionState } from './expedition';
 import { newGame } from './save';
@@ -1352,5 +1353,42 @@ describe('M8 玩家狀態招', () => {
     const buffed = state.party.find((p) => p.id === 'p2')!;
     expect(buffed.statuses?.some((s) => s.kind === 'strength')).toBe(true);
     expect(state.log.some((l) => l.text.includes('強化'))).toBe(true);
+  });
+});
+
+describe('M11 羈絆遞增與遠征道具', () => {
+  it('settleExpedition：參戰（未重傷）旅伴 bond +1，重傷者不加', () => {
+    const save = newGame(1000);
+    const mkComp = (id: string, injured: number): CompanionRecord => ({
+      id, name: id, job: 'ranger', level: 1, xp: 0,
+      stats: { str: 10, dex: 14, int: 10, cha: 10, con: 11 }, maxHp: 20,
+      injuredForTrips: injured, trait: null,
+      equipment: { weapon: null, armor: null, trinket: null },
+    });
+    save.companions.push(mkComp('c-ok', 0), mkComp('c-hurt', 2));
+    const state = startExpedition(createRng(7), save, 'loc_route_a');
+    state.step = state.totalSteps + 1;
+    state.phase = 'done';
+    settleExpedition(state, save);
+    expect(save.companions.find((c) => c.id === 'c-ok')?.bond).toBe(1);
+    expect(save.companions.find((c) => c.id === 'c-hurt')?.bond ?? 0).toBe(0);
+  });
+
+  it('useItemOnExpedition：治療目標 partyHp（clamp maxHp）並扣背包', () => {
+    const save = newGame(1000);
+    save.inventory['herb'] = 2;
+    const state = startExpedition(createRng(7), save, 'loc_route_a');
+    state.partyHp['protagonist'] = 10;
+    useItemOnExpedition(state, save, 'herb', 'protagonist');
+    expect(state.partyHp['protagonist']).toBe(16); // herb 回 6
+    expect(save.inventory['herb']).toBe(1);
+  });
+
+  it('useItemOnExpedition：背包沒有該道具/道具不可用 → 丟錯', () => {
+    const save = newGame(1000);
+    const state = startExpedition(createRng(7), save, 'loc_route_a');
+    expect(() => useItemOnExpedition(state, save, 'herb', 'protagonist')).toThrow();
+    save.inventory['iron-ore'] = 1;
+    expect(() => useItemOnExpedition(state, save, 'iron-ore', 'protagonist')).toThrow();
   });
 });

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -6,6 +6,7 @@ import { resolveCheck, statMod } from './check';
 import { partyCheckBonus } from './roster';
 import type { CombatState, EnemyUnit, PartyMember } from './combat';
 import type { JobId } from './data/jobs';
+import { ITEMS } from './data/items';
 import type { TownDef } from './economy';
 import { tradeSellPrice, totalWage, cargoCapacity, applyMarket } from './economy';
 
@@ -423,6 +424,29 @@ export function advanceExpedition(rng: Rng, state: ExpeditionState): void {
  * 未售出的 cargo 一律退回 save.inventory（含被 finishCombat 撤退/戰敗折半後的殘餘）。
  * 完成遠征（!state.retreated）聲望 +5。
  */
+/**
+ * M11 遠征途中使用消耗品：治療類作用於 partyHp（clamp 至該成員 maxHp），
+ * cure/buff 為戰鬥限定效果、途中使用視為無效丟錯。扣減 save.inventory。
+ */
+export function useItemOnExpedition(
+  state: ExpeditionState,
+  save: SaveData,
+  itemId: string,
+  targetId: string
+): void {
+  if ((save.inventory[itemId] ?? 0) <= 0) throw new Error(`背包沒有「${itemId}」`);
+  const item = ITEMS[itemId];
+  if (!item?.use) throw new Error(`「${itemId}」不是可使用的道具`);
+  if (item.use.kind !== 'heal') throw new Error(`「${item.name}」只能在戰鬥中使用`);
+  if (!(targetId in state.partyHp)) throw new Error(`目標「${targetId}」不在遠征隊伍中`);
+  const maxHp =
+    targetId === save.protagonist.id
+      ? save.protagonist.maxHp
+      : (save.companions.find((c) => c.id === targetId)?.maxHp ?? 0);
+  state.partyHp[targetId] = Math.min(maxHp, state.partyHp[targetId] + item.use.amount);
+  save.inventory[itemId] -= 1;
+}
+
 export function settleExpedition(
   state: ExpeditionState,
   save: SaveData,
@@ -481,6 +505,7 @@ export function settleExpedition(
   for (const companion of save.companions) {
     if (companion.injuredForTrips === 0) {
       companion.xp += xpGained;
+      companion.bond = (companion.bond ?? 0) + 1; // M11 羈絆：同行完成一趟
     } else {
       companion.injuredForTrips = Math.max(0, companion.injuredForTrips - 1);
     }

--- a/src/scripts/games/caravan/roster.test.ts
+++ b/src/scripts/games/caravan/roster.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   XP_TABLE, levelFromXp, pendingLevelUps, applyLevelUp, unlockedMoves,
   generateRecruitPool, hireCost, wagePerTrip, equipItem, unequipItem, equipmentBonus,
+  SPECIALIZATIONS, chooseSpecialization, bondTier, partyCheckBonus,
   TRAITS, partyCheckBonus,
 } from './roster';
+import { memberFromRecord } from './data/jobs';
 import { createRng } from './rng';
 import { newGame, type SaveData, type CompanionRecord } from './save';
 import type { StatBlock } from './types';
@@ -463,5 +465,92 @@ describe('旅伴特質（M7）', () => {
     expect(partyCheckBonus(save)).toBe(0);
     save.companions.push({ ...r, trait: 'seasoned' }, { ...r, id: 'x2', trait: 'seasoned' });
     expect(partyCheckBonus(save)).toBe(2);
+  });
+});
+
+describe('M11 職業專精（Lv4 二選一）', () => {
+  const mk = (over: Partial<CompanionRecord> = {}): CompanionRecord => ({
+    id: 'protagonist', name: '你', job: 'swordsman', level: 4, xp: 210,
+    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22,
+    injuredForTrips: 0, trait: null,
+    equipment: { weapon: null, armor: null, trinket: null },
+    ...over,
+  });
+
+  it('SPECIALIZATIONS：每職業恰 2 個選項，各有名稱/說明/專屬招', () => {
+    for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
+      const specs = SPECIALIZATIONS[job];
+      expect(specs).toHaveLength(2);
+      for (const spec of specs) {
+        expect(spec.name.length).toBeGreaterThan(0);
+        expect(spec.desc.length).toBeGreaterThan(0);
+        expect(spec.move.id.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('chooseSpecialization：Lv4 可選；選後寫入 record.specialization', () => {
+    const r = mk();
+    chooseSpecialization(r, 'berserker');
+    expect(r.specialization).toBe('berserker');
+  });
+
+  it('chooseSpecialization：Lv<4 丟錯；已有專精再選丟錯；非本職業選項丟錯', () => {
+    expect(() => chooseSpecialization(mk({ level: 3 }), 'berserker')).toThrow();
+    const chosen = mk({ specialization: 'berserker' });
+    expect(() => chooseSpecialization(chosen, 'bulwark')).toThrow();
+    expect(() => chooseSpecialization(mk(), 'hawkeye')).toThrow(); // 游俠專精配劍士
+  });
+
+  it('memberFromRecord：專精被動疊上（狂戰士 +2 力量）且專屬招入列', () => {
+    const base = memberFromRecord(mk());
+    const spec = memberFromRecord(mk({ specialization: 'berserker' }));
+    expect(spec.stats.str).toBe(base.stats.str + 2);
+    expect(spec.moves.some((m) => m.id === SPECIALIZATIONS.swordsman[0].move.id)).toBe(true);
+    expect(base.moves.some((m) => m.id === SPECIALIZATIONS.swordsman[0].move.id)).toBe(false);
+  });
+
+  it('memberFromRecord：鐵壁衛防禦與生命被動生效', () => {
+    const base = memberFromRecord(mk());
+    const spec = memberFromRecord(mk({ specialization: 'bulwark' }));
+    expect(spec.defense).toBeGreaterThan(base.defense);
+    expect(spec.maxHp).toBeGreaterThan(base.maxHp);
+  });
+});
+
+describe('M11 旅伴羈絆', () => {
+  it('bondTier：0-1 趟=0、2-4=1、5-8=2、9+=3', () => {
+    expect(bondTier(0)).toBe(0);
+    expect(bondTier(1)).toBe(0);
+    expect(bondTier(2)).toBe(1);
+    expect(bondTier(4)).toBe(1);
+    expect(bondTier(5)).toBe(2);
+    expect(bondTier(8)).toBe(2);
+    expect(bondTier(9)).toBe(3);
+    expect(bondTier(undefined)).toBe(0);
+  });
+
+  it('partyCheckBonus 計入旅伴羈絆 tier 總和', () => {
+    const save = newGame(1000);
+    const base = partyCheckBonus(save);
+    save.companions.push({
+      id: 'c1', name: '甲', job: 'ranger', level: 1, xp: 0,
+      stats: { str: 10, dex: 14, int: 10, cha: 10, con: 11 }, maxHp: 20,
+      injuredForTrips: 0, trait: null, bond: 5,
+      equipment: { weapon: null, armor: null, trinket: null },
+    });
+    expect(partyCheckBonus(save)).toBe(base + 2); // bond 5 → tier 2
+  });
+
+  it('memberFromRecord：羈絆 tier 每階 +2 maxHp（主角無羈絆不加）', () => {
+    const rec: CompanionRecord = {
+      id: 'c1', name: '甲', job: 'ranger', level: 1, xp: 0,
+      stats: { str: 10, dex: 14, int: 10, cha: 10, con: 11 }, maxHp: 20,
+      injuredForTrips: 0, trait: null,
+      equipment: { weapon: null, armor: null, trinket: null },
+    };
+    const noBond = memberFromRecord(rec);
+    const bonded = memberFromRecord({ ...rec, bond: 9 }); // tier 3
+    expect(bonded.maxHp).toBe(noBond.maxHp + 6);
   });
 });

--- a/src/scripts/games/caravan/roster.ts
+++ b/src/scripts/games/caravan/roster.ts
@@ -39,8 +39,120 @@ export const traitById = (id: string | null | undefined): TraitDef | undefined =
 
 /** 全隊事件檢定加成：加總所有成員特質的 checkBonus（M7） */
 export function partyCheckBonus(save: SaveData): number {
-  return [save.protagonist, ...save.companions]
+  const traitSum = [save.protagonist, ...save.companions]
     .reduce((sum, m) => sum + (traitById(m.trait)?.checkBonus ?? 0), 0);
+  // M11 羈絆：旅伴 tier 總和（主角無羈絆欄）
+  const bondSum = save.companions.reduce((sum, c) => sum + bondTier(c.bond), 0);
+  return traitSum + bondSum;
+}
+
+// ---------------------------------------------------------------------------
+// M11 旅伴羈絆：同行完成遠征的趟數 → tier（檢定與生命加成）
+// ---------------------------------------------------------------------------
+
+/** 羈絆 tier：0-1 趟=0、2-4=1（同行）、5-8=2（信賴）、9+=3（莫逆） */
+export function bondTier(bond: number | undefined): number {
+  const b = bond ?? 0;
+  if (b >= 9) return 3;
+  if (b >= 5) return 2;
+  if (b >= 2) return 1;
+  return 0;
+}
+
+export const BOND_TIER_NAMES = ['', '同行', '信賴', '莫逆'] as const;
+/** 每 tier 的 maxHp 加成（jobs.ts memberFromRecord 套用） */
+export const BOND_HP_PER_TIER = 2;
+
+// ---------------------------------------------------------------------------
+// M11 職業專精：Lv4 二選一進階（被動加成＋專屬招式）
+// ---------------------------------------------------------------------------
+
+export interface SpecializationDef {
+  id: string;
+  name: string;
+  desc: string;
+  /** 被動：屬性/防禦/生命上限加成 */
+  statBonus?: Partial<StatBlock>;
+  defense?: number;
+  maxHp?: number;
+  /** 專屬招式（入列於職業招式之後） */
+  move: Move;
+}
+
+export const SPECIALIZATION_LEVEL = 4;
+
+export const SPECIALIZATIONS: Record<CompanionRecord['job'], SpecializationDef[]> = {
+  swordsman: [
+    { id: 'berserker', name: '狂戰士', desc: '捨守取攻的戰場猛獸。力量 +2，習得「血怒斬」。',
+      statBonus: { str: 2 },
+      move: { id: 'blood-rage-slash', name: '血怒斬', kind: 'attack', target: 'enemy', hitStat: 'str',
+        damage: { dice: 2, sides: 10, bonusStat: 'str' },
+        narration: '{actor}雙目赤紅，狂嘯著將全身之力灌入一斬，劈向{target}，造成 {amount} 點傷害！' } },
+    { id: 'bulwark', name: '鐵壁衛', desc: '隊伍的不動壁壘。防禦 +2、生命上限 +6，習得「盾牆猛擊」。',
+      defense: 2, maxHp: 6,
+      move: { id: 'shield-bash', name: '盾牆猛擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+        damage: { dice: 1, sides: 8, bonusStat: 'con' },
+        applyStatus: { kind: 'stun', duration: 1 },
+        narration: '{actor}舉盾撞向{target}，造成 {amount} 點傷害並將其震得暈頭轉向！' } },
+  ],
+  ranger: [
+    { id: 'hawkeye', name: '鷹眼', desc: '百步穿楊的神射手。敏捷 +2，習得「奪命狙擊」。',
+      statBonus: { dex: 2 },
+      move: { id: 'deadeye-shot', name: '奪命狙擊', kind: 'attack', target: 'enemy', hitStat: 'dex',
+        damage: { dice: 2, sides: 8, bonusStat: 'dex' },
+        narration: '{actor}屏息凝神，一箭破空而出，貫穿{target}，造成 {amount} 點傷害！' } },
+    { id: 'trapper', name: '陷阱師', desc: '荒野的獵人智者。體質 +1、防禦 +1，習得「絆足陷阱」。',
+      statBonus: { con: 1 }, defense: 1,
+      move: { id: 'snare-trap', name: '絆足陷阱', kind: 'attack', target: 'enemy', hitStat: 'dex',
+        damage: { dice: 1, sides: 6, bonusStat: 'dex' },
+        applyStatus: { kind: 'stun', duration: 1 },
+        narration: '{actor}拋出鐵絆索纏住{target}，造成 {amount} 點傷害並使其動彈不得！' } },
+  ],
+  mage: [
+    { id: 'elementalist', name: '元素使', desc: '駕馭風暴的天災法師。智力 +2，習得「連鎖閃電」。',
+      statBonus: { int: 2 },
+      move: { id: 'chain-lightning', name: '連鎖閃電', kind: 'attack', target: 'enemy', hitStat: 'int',
+        damage: { dice: 2, sides: 10, bonusStat: 'int' },
+        narration: '{actor}指尖迸出蛛網般的紫電，轟向{target}，造成 {amount} 點傷害！' } },
+    { id: 'occultist', name: '秘術師', desc: '窺探禁忌的暗影學者。智力 +1、生命上限 +4，習得「腐蝕詛咒」。',
+      statBonus: { int: 1 }, maxHp: 4,
+      move: { id: 'corrosive-curse', name: '腐蝕詛咒', kind: 'attack', target: 'enemy', hitStat: 'int',
+        damage: { dice: 1, sides: 6, bonusStat: 'int' },
+        applyStatus: { kind: 'poison', duration: 3, potency: 2 },
+        narration: '{actor}低聲唸出禁咒，黑霧纏上{target}，造成 {amount} 點傷害並持續侵蝕！' } },
+  ],
+  cleric: [
+    { id: 'hierophant', name: '大祭司', desc: '聖光的化身。魅力 +2，習得「神聖賜福」。',
+      statBonus: { cha: 2 },
+      move: { id: 'divine-blessing', name: '神聖賜福', kind: 'support', target: 'ally', hitStat: 'cha',
+        heal: { dice: 3, sides: 6, bonusStat: 'cha' },
+        narration: '{actor}張開雙臂引下天光，{target}沐浴其中，恢復 {amount} 點生命。' } },
+    { id: 'inquisitor', name: '審判官', desc: '揮舞聖裁之錘的戰鬥祭司。力量 +1、防禦 +1，習得「聖裁之錘」。',
+      statBonus: { str: 1 }, defense: 1,
+      move: { id: 'judgement-hammer', name: '聖裁之錘', kind: 'attack', target: 'enemy', hitStat: 'cha',
+        damage: { dice: 2, sides: 8, bonusStat: 'cha' },
+        narration: '{actor}高舉聖錘宣告裁決，重重砸向{target}，造成 {amount} 點傷害！' } },
+  ],
+};
+
+export function specById(id: string | null | undefined): SpecializationDef | null {
+  if (!id) return null;
+  for (const specs of Object.values(SPECIALIZATIONS)) {
+    const found = specs.find((sp) => sp.id === id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Lv4 起可選、僅能選一次、僅限本職業的選項 */
+export function chooseSpecialization(record: CompanionRecord, specId: string): void {
+  if (record.level < SPECIALIZATION_LEVEL) {
+    throw new Error(`專精需 Lv${SPECIALIZATION_LEVEL}（目前 Lv${record.level}）`);
+  }
+  if (record.specialization) throw new Error('已選定專精，不可更改');
+  const spec = SPECIALIZATIONS[record.job].find((sp) => sp.id === specId);
+  if (!spec) throw new Error(`職業「${record.job}」沒有專精「${specId}」`);
+  record.specialization = specId;
 }
 
 /** 升級累積 XP 門檻；index=level（1-based，index 0 廢棄）；Lv5 為封頂（M4） */

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -19,6 +19,10 @@ export interface CompanionRecord {
   trait?: string | null;
   /** 裝備三欄：itemId 或 null（M5，roster.ts equipItem/unequipItem 維護） */
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
+  /** M11 職業專精 id（roster.ts SPECIALIZATIONS）；Lv4 起可選，未選＝undefined/null */
+  specialization?: string | null;
+  /** M11 旅伴羈絆：與主角同行完成的遠征趟數（主角自身不使用此欄） */
+  bond?: number;
 }
 
 export interface SaveDataV2 {

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -867,3 +867,86 @@ test.describe('商隊與劍：創角與背包', () => {
     await expect(gearRow.locator('.backpack-tag')).toHaveText('護甲');
   });
 });
+
+test.describe('商隊與劍：M11 RPG 深度', () => {
+  test('專精：Lv4 主角選狂戰士 → 力量 +2、血怒斬入列、選後鎖定', async ({ page }) => {
+    await page.goto('/caravan/play');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-new-game');
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await page.evaluate(() => {
+      const data = JSON.parse(localStorage.getItem('caravan-save-v1')!);
+      data.protagonist.level = 4;
+      data.protagonist.xp = 210;
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-continue');
+    await page.click('.town-tab[data-town-tab="roster"]');
+
+    const card = page.locator('.roster-card[data-member-id="protagonist"]');
+    await card.locator('.spec-btn').click();
+    await expect(page.locator('#spec-panel')).toBeVisible();
+    await page.click('.spec-option[data-spec-id="berserker"]');
+    await expect(page.locator('#spec-panel')).toBeHidden();
+
+    await expect(card.locator('.roster-xp')).toContainText('專精「狂戰士」');
+    await expect(card.locator('.roster-stats')).toContainText('力量 14'); // 12 + 2
+    await expect(card.locator('.roster-moves')).toContainText('血怒斬');
+    await expect(card.locator('.spec-btn')).toHaveCount(0);
+  });
+
+  test('戰鬥道具：買藥草進訓練場 → 道具選單使用 → 背包扣減且寫入戰鬥記錄', async ({ page }) => {
+    await page.goto('/caravan/play');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-new-game');
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+
+    await page.locator('.market-row[data-item-id="herb"] .buy-btn').click();
+    await page.click('#btn-training');
+    await expect(page.locator('#screen-combat')).toBeVisible();
+
+    await page.locator('.combat-item-toggle').click();
+    await page.locator('.item-btn[data-item-id="herb"]').click();
+    await expect(page.locator('#combat-log')).toContainText('使用藥草');
+    const herbLeft = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('caravan-save-v1')!).inventory.herb
+    );
+    expect(herbLeft).toBe(0);
+  });
+
+  test('羈絆：bond=5 的旅伴顯示「信賴」且生命上限 +4', async ({ page }) => {
+    await page.goto('/caravan/play');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-new-game');
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await page.evaluate(() => {
+      const data = JSON.parse(localStorage.getItem('caravan-save-v1')!);
+      data.companions.push({
+        id: 'bond-ally', name: '老友', job: 'ranger', level: 1, xp: 0,
+        stats: { str: 10, dex: 14, int: 10, cha: 10, con: 11 }, maxHp: 20,
+        injuredForTrips: 0, trait: null, bond: 5,
+        equipment: { weapon: null, armor: null, trinket: null },
+      });
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-continue');
+    await page.click('.town-tab[data-town-tab="roster"]');
+
+    const ally = page.locator('.roster-card[data-member-id="bond-ally"]');
+    await expect(ally.locator('.roster-xp')).toContainText('羈絆「信賴」（同行 5 趟）');
+    await expect(ally.locator('.roster-hp')).toHaveText('生命上限 24'); // 20 + tier2×2
+  });
+});


### PR DESCRIPTION
## Summary

回應「系統深度遠遠不足以支撐完整的 RPG 探險遊戲」，補上三個核心成長循環（TDD）：

- **職業專精**：Lv4 二選一進階，每職業 2 選項＝被動加成＋專屬招式（狂戰士/鐵壁衛、鷹眼/陷阱師、元素使/秘術師、大祭司/審判官），選定不可改
- **消耗品系統**：藥草/繃帶＋新道具解毒劑/行軍補劑；戰鬥「道具」子選單（耗行動、治療 clamp、解毒、強化）；遠征途中「使用道具」（作用 partyHp、扣背包）
- **旅伴羈絆**：同行完成遠征 bond+1 → 同行/信賴/莫逆 tier → 全隊檢定加成＋每階 +2 生命上限
- **遠征損耗可視化**：隊伍 HP 狀態帶（partyHp 一直存在但玩家從未看得見）
- 相容：新欄位皆 optional，不 bump 存檔版本

## Test plan
- [x] `npx vitest run` 1539 全綠（16 條新引擎測試）
- [x] caravan e2e 32＋defense 3 綠（新增專精/戰鬥道具/羈絆 3 條）
- [x] `npm run build` 綠
- [x] 實機：選狂戰士（力量+2、血怒斬入列、鎖定）／戰鬥用藥草（扣背包+log）／遠征用藥（8/22→14/22）／羈絆「信賴」（+4 生命上限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)