### PR TITLE
feat(caravan): 角色卡重製為 RPG 面板＋介面 juice

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -306,7 +306,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   import {
     pendingLevelUps, applyLevelUp, unlockedMoves, generateRecruitPool, hireCost, wagePerTrip,
     equipItem, unequipItem, SPECIALIZATIONS, SPECIALIZATION_LEVEL, chooseSpecialization, specById,
-    bondTier, BOND_TIER_NAMES,
+    bondTier, BOND_TIER_NAMES, XP_TABLE,
   } from '@scripts/games/caravan/roster';
   import {
     buyPrice, sellPrice, tradeSellPrice, cargoCapacity, wagonUpgradeCost, totalWage,
@@ -793,47 +793,116 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       card.dataset.memberId = record.id;
 
       const effective = memberFromRecord(record);
+      card.dataset.job = record.job;
 
+      // 左欄：立繪＋等級章
+      const portraitWrap = document.createElement('div');
+      portraitWrap.className = 'roster-portrait';
       const portrait = document.createElement('img');
       portrait.className = 'roster-art';
       portrait.src = record.id === 'protagonist' ? '/assets/games/caravan/job-protagonist.webp' : (JOBS[record.job].art ?? '');
       portrait.alt = '';
       portrait.width = 600; portrait.height = 800;
       portrait.loading = 'lazy';
-      card.appendChild(portrait);
+      const levelBadge = document.createElement('span');
+      levelBadge.className = 'roster-level';
+      levelBadge.textContent = `Lv${record.level}`;
+      portraitWrap.append(portrait, levelBadge);
+      card.appendChild(portraitWrap);
+
+      // 右欄：角色面板
+      const sheet = document.createElement('div');
+      sheet.className = 'roster-sheet';
 
       const name = document.createElement('p');
       name.className = 'roster-name';
-      name.textContent = `${record.name}．${JOBS[record.job].name}（Lv${record.level}）`;
+      name.textContent = record.name;
+      const jobTag = document.createElement('span');
+      jobTag.className = 'roster-job';
+      jobTag.textContent = `${JOBS[record.job].name}（Lv${record.level}）`;
+      name.appendChild(jobTag);
 
-      const xp = document.createElement('p');
+      // 身分徽章列（e2e 契約：容器 class 維持 roster-xp、含既有文字子串）
+      const xp = document.createElement('div');
       xp.className = 'roster-xp';
-      xp.textContent = `經驗值 ${record.xp} XP`;
+      const xpChip = document.createElement('span');
+      xpChip.className = 'meta-chip meta-xp';
+      if (record.level < XP_TABLE.length - 1) {
+        const floor = XP_TABLE[record.level];
+        const ceil = XP_TABLE[record.level + 1];
+        const ratio = Math.max(0, Math.min(1, (record.xp - floor) / (ceil - floor)));
+        xpChip.textContent = `經驗值 ${record.xp} XP`;
+        const xpBar = document.createElement('span');
+        xpBar.className = 'xp-mini-bar';
+        const xpFill = document.createElement('i');
+        xpFill.style.width = `${Math.round(ratio * 100)}%`;
+        xpBar.appendChild(xpFill);
+        xpChip.appendChild(xpBar);
+      } else {
+        xpChip.textContent = `經驗值 ${record.xp} XP．滿級`;
+      }
+      xp.appendChild(xpChip);
       const rTrait = traitById(record.trait);
-      if (rTrait) xp.textContent += `．特質「${rTrait.name}」（${rTrait.desc}）`;
+      if (rTrait) {
+        const chip = document.createElement('span');
+        chip.className = 'meta-chip';
+        chip.textContent = `特質「${rTrait.name}」（${rTrait.desc}）`;
+        xp.appendChild(chip);
+      }
       const rSpec = specById(record.specialization);
-      if (rSpec) xp.textContent += `．專精「${rSpec.name}」`;
+      if (rSpec) {
+        const chip = document.createElement('span');
+        chip.className = 'meta-chip meta-spec';
+        chip.textContent = `專精「${rSpec.name}」`;
+        xp.appendChild(chip);
+      }
       if (record.id !== 'protagonist') {
         const tier = bondTier(record.bond);
-        if (tier > 0) xp.textContent += `．羈絆「${BOND_TIER_NAMES[tier]}」（同行 ${record.bond} 趟）`;
+        if (tier > 0) {
+          const chip = document.createElement('span');
+          chip.className = 'meta-chip meta-bond';
+          chip.textContent = `${'♥'.repeat(tier)} 羈絆「${BOND_TIER_NAMES[tier]}」（同行 ${record.bond} 趟）`;
+          xp.appendChild(chip);
+        }
       }
 
-      const stats = document.createElement('p');
+      // 屬性條（e2e 契約：label 帶尾空格讓 textContent 串成「力量 14」）
+      const stats = document.createElement('div');
       stats.className = 'roster-stats';
-      stats.textContent = (Object.keys(STAT_LABELS) as Stat[])
-        .map((k) => `${STAT_LABELS[k]} ${effective.stats[k]}`)
-        .join('　');
+      for (const k of Object.keys(STAT_LABELS) as Stat[]) {
+        const row = document.createElement('div');
+        row.className = 'stat-row';
+        const label = document.createElement('span');
+        label.className = 'stat-label';
+        label.textContent = `${STAT_LABELS[k]} `;
+        const value = document.createElement('b');
+        value.className = 'stat-value';
+        value.textContent = String(effective.stats[k]);
+        const bar = document.createElement('span');
+        bar.className = 'stat-bar';
+        const fill = document.createElement('i');
+        fill.style.width = `${Math.min(100, Math.round((effective.stats[k] / 20) * 100))}%`;
+        bar.appendChild(fill);
+        row.append(label, value, bar);
+        stats.appendChild(row);
+      }
 
       const hp = document.createElement('p');
       hp.className = 'roster-hp';
       hp.textContent = `生命上限 ${effective.maxHp}`;
 
-      const moves = document.createElement('p');
+      const moves = document.createElement('div');
       moves.className = 'roster-moves';
-      moves.textContent = `招式：${effective.moves.map((m) => m.name).join('、')}`;
+      for (const move of effective.moves) {
+        const chip = document.createElement('span');
+        chip.className = `move-chip move-${move.kind}`;
+        chip.textContent = move.name;
+        moves.appendChild(chip);
+      }
 
-      card.append(name, xp, stats, hp, moves);
-      renderEquipSlots(card, record);
+      sheet.append(name, xp, stats, hp, moves);
+      card.appendChild(sheet);
+      renderEquipSlots(sheet, record);
 
       if (record.injuredForTrips > 0) {
         const injury = document.createElement('p');
@@ -1105,6 +1174,12 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       const row = document.createElement('div'); row.className = 'alloc-row';
       const label = document.createElement('span'); label.className = 'alloc-label';
       label.textContent = `${STAT_LABELS[stat]} ${base[stat] + (createAlloc[stat] ?? 0)}`;
+      const bar = document.createElement('span'); bar.className = 'stat-bar alloc-bar';
+      const fill = document.createElement('i');
+      const statTotal = base[stat] + (createAlloc[stat] ?? 0);
+      fill.style.width = `${Math.min(100, Math.round((statTotal / 20) * 100))}%`;
+      if ((createAlloc[stat] ?? 0) > 0) fill.classList.add('boosted');
+      bar.appendChild(fill);
       const minus = document.createElement('button');
       minus.type = 'button'; minus.className = 'caravan-btn alloc-plus'; minus.textContent = '－';
       minus.disabled = (createAlloc[stat] ?? 0) <= 0;
@@ -1113,7 +1188,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       plus.type = 'button'; plus.className = 'caravan-btn alloc-plus'; plus.textContent = '＋';
       plus.disabled = remaining <= 0;
       plus.addEventListener('click', () => { createAlloc[stat] = (createAlloc[stat] ?? 0) + 1; renderCreate(); });
-      row.append(label, minus, plus);
+      row.append(label, bar, minus, plus);
       createAllocRowsEl.appendChild(row);
     }
     // 特性
@@ -2823,4 +2898,84 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .spec-option:hover { border-color: var(--seal); box-shadow: 0 0 14px rgba(181, 52, 43, 0.3); }
   .spec-btn { margin: 0.6rem 0.6rem 0 0; padding: 0.35rem 1.1rem; font-size: 0.85rem; background: var(--seal); border-color: var(--seal-bright); color: #f7ece0; }
   .backpack-tag-use { background: var(--forest); color: #10201a; }
+
+  /* ---- 角色面板（RPG character sheet）---- */
+  .roster-card {
+    display: grid; grid-template-columns: 6.2rem 1fr; gap: 0.9rem;
+    align-items: start; text-align: left;
+    border-left: 3px solid var(--job, var(--gold));
+  }
+  .roster-card[data-job='swordsman'] { --job: #a84b3a; }
+  .roster-card[data-job='ranger'] { --job: #5c8a5a; }
+  .roster-card[data-job='mage'] { --job: #4e6b8f; }
+  .roster-card[data-job='cleric'] { --job: #b98d4f; }
+  .roster-card > .caravan-btn, .roster-card > .roster-injury { grid-column: 2; justify-self: start; }
+  .roster-portrait { position: relative; }
+  .roster-portrait .roster-art {
+    width: 6.2rem; height: 8.2rem; object-fit: cover; display: block;
+    border: 1px solid var(--gold-dim); border-radius: 3px;
+    box-shadow: inset 0 0 0 2px rgba(10, 6, 3, 0.4), 0 3px 10px rgba(0, 0, 0, 0.45);
+  }
+  .roster-level {
+    position: absolute; bottom: -0.5rem; left: 50%; transform: translateX(-50%);
+    padding: 0.08rem 0.55rem;
+    font-size: 0.72rem; font-weight: 700; letter-spacing: 0.1em;
+    color: #f7ece0; background: var(--job, var(--seal));
+    border: 1px solid rgba(247, 236, 224, 0.35); border-radius: 999px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  }
+  .roster-sheet { min-width: 0; }
+  .roster-name { font-size: 1.08rem; display: flex; align-items: baseline; gap: 0.55rem; flex-wrap: wrap; }
+  .roster-job { font-size: 0.8rem; font-weight: 400; color: var(--job, var(--text-dim)); letter-spacing: 0.1em; }
+  .roster-xp { display: flex; flex-wrap: wrap; gap: 0.35rem; margin: 0.3rem 0 0.55rem; }
+  .meta-chip {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    padding: 0.14rem 0.6rem; font-size: 0.76rem; letter-spacing: 0.04em;
+    color: var(--text-dim); background: var(--panel-deep);
+    border: 1px solid var(--gold-dim); border-radius: 999px;
+  }
+  .meta-chip.meta-spec { color: #f7ece0; background: var(--seal); border-color: var(--seal-bright); }
+  .meta-chip.meta-bond { color: var(--seal-bright); }
+  .xp-mini-bar {
+    display: inline-block; width: 3.2rem; height: 4px; border-radius: 2px;
+    background: rgba(0, 0, 0, 0.5); overflow: hidden;
+  }
+  .xp-mini-bar i { display: block; height: 100%; background: var(--gold-bright); }
+  .roster-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr)); gap: 0.25rem 1rem; margin: 0.2rem 0 0.45rem; }
+  .stat-row { display: flex; align-items: center; gap: 0.45rem; font-size: 0.85rem; }
+  .stat-label { color: var(--text-dim); white-space: pre; }
+  .stat-value { color: var(--gold-bright); min-width: 1.4rem; text-align: right; }
+  .stat-bar {
+    flex: 1; height: 5px; border-radius: 2px;
+    background: rgba(0, 0, 0, 0.5); overflow: hidden;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.6);
+  }
+  .stat-bar i { display: block; height: 100%; background: linear-gradient(90deg, var(--job, var(--gold)), var(--gold-bright)); }
+  .roster-hp { font-size: 0.85rem; color: var(--text-dim); margin: 0 0 0.4rem; }
+  .roster-moves { display: flex; flex-wrap: wrap; gap: 0.3rem; margin: 0 0 0.2rem; }
+  .move-chip {
+    padding: 0.12rem 0.55rem; font-size: 0.76rem; letter-spacing: 0.06em;
+    color: var(--text); background: var(--panel-deep);
+    border: 1px solid var(--gold-dim); border-radius: 3px;
+    border-left-width: 3px;
+  }
+  .move-chip.move-attack { border-left-color: var(--seal); }
+  .move-chip.move-support { border-left-color: var(--forest); }
+  .move-chip.move-guard { border-left-color: var(--gold); }
+  /* 卡片進場：階梯浮現 */
+  @keyframes cardRise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+  .roster-card { animation: cardRise 0.35s ease both; }
+  .roster-card:nth-child(2) { animation-delay: 0.06s; }
+  .roster-card:nth-child(3) { animation-delay: 0.12s; }
+  .roster-card:nth-child(4) { animation-delay: 0.18s; }
+  .roster-card:nth-child(n+5) { animation-delay: 0.24s; }
+  /* 全域按壓回饋 */
+  .caravan-btn:active, .town-tab:active { transform: translateY(1px); }
+  .alloc-bar { max-width: 9rem; }
+  .alloc-bar i.boosted { background: linear-gradient(90deg, var(--seal), var(--seal-bright)); }
+  .alloc-row { display: flex; align-items: center; gap: 0.6rem; }
+  .alloc-row .alloc-label { min-width: 4.6rem; }
+  @media (prefers-reduced-motion: reduce) {
+    .roster-card { animation: none; }
+  }
 </style>


### PR DESCRIPTION
## Summary

回應「角色的部分太無聊、介面也很無趣」，roster 純文字段落重製為 RPG 角色面板：

- **版面**：立繪欄（職業色 Lv 徽章）＋面板欄 grid；卡片職業色左框（劍士赭紅/游俠松綠/法師黛藍/教士杏金）
- **屬性條**：文字串改五條職業色漸層屬性條
- **身分徽章**：XP chip（升級進度 mini bar）、特質、專精硃砂印、羈絆 ♥×tier
- **招式徽章**：攻擊硃砂/輔助青玉/防禦茶褐
- **創角配點**同步屬性條（加點硃砂 boosted）
- **juice**：卡片階梯浮現、按鈕按壓回饋、reduced-motion 全停

e2e 契約保全：roster-hp 精確文字、roster-stats textContent 串接、chip 容器 containText、equip-slot 結構全部不動。

## Test plan
- [x] vitest 全套 1538/1539（唯一失敗＝tetris Pixi import smoke 既知 flaky、單跑綠、與本改動無關）
- [x] caravan e2e 32＋defense 3 全綠
- [x] `npm run build` 綠
- [x] 實機截圖：三職業色角色面板／專精章／羈絆♥／招式徽章／創角屬性條

🤖 Generated with [Claude Code](https://claude.com/claude-code)