### PR TITLE
feat(caravan): 入口重製——電影化標題＋序章演出＋商會登記

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -63,23 +63,47 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     <div class="game-frame">
     <!-- 標題畫面 -->
     <section id="screen-title" class="screen">
-      <img class="title-art" src="/assets/games/caravan/title-banner.webp" alt="" width="1280" height="720" loading="eager" />
-      <h1 class="game-title">商隊與劍</h1>
-      <p class="game-subtitle">CARAVAN &amp; SWORD</p>
-      <p class="title-premise">一輛馬車、一袋銅幣——目標，<b>商會之主</b>。</p>
-      <div class="title-actions">
-        <button id="btn-new-game" class="caravan-btn">新的旅程</button>
-        <button id="btn-continue" class="caravan-btn" hidden>繼續旅程</button>
-        <button id="btn-howto-title" class="caravan-btn caravan-btn-ghost">怎麼玩？</button>
+      <div class="title-stage" aria-hidden="true">
+        <img class="title-stage-art" src="/assets/games/caravan/title-banner.webp" alt="" width="1280" height="720" loading="eager" />
+        <div class="title-vignette"></div>
+        <div class="title-embers">
+          <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+        </div>
       </div>
-      <p id="title-legacy" class="title-legacy" hidden></p>
-      <a class="title-chronicle-link" href="/caravan#chronicle">冒險編年史 »</a>
+      <div class="title-content">
+        <h1 class="game-title"><span>商</span><span>隊</span><span>與</span><span>劍</span></h1>
+        <p class="game-subtitle">CARAVAN &amp; SWORD</p>
+        <p class="title-premise">一輛馬車、一袋銅幣——目標，<b>商會之主</b>。</p>
+        <div class="title-actions">
+          <button id="btn-new-game" class="caravan-btn">新的旅程</button>
+          <button id="btn-continue" class="caravan-btn" hidden>繼續旅程</button>
+          <button id="btn-howto-title" class="caravan-btn caravan-btn-ghost">怎麼玩？</button>
+        </div>
+        <p id="title-legacy" class="title-legacy" hidden></p>
+        <a class="title-chronicle-link" href="/caravan#chronicle">冒險編年史 »</a>
+      </div>
+    </section>
+
+    <!-- 序章演出（新的旅程 → 三拍敘事 → 商會登記/創角） -->
+    <section id="screen-prologue" class="screen" hidden>
+      <div class="prologue-stage" aria-hidden="true">
+        <img class="title-stage-art" src="/assets/games/caravan/title-banner.webp" alt="" width="1280" height="720" loading="eager" />
+        <div class="prologue-vignette"></div>
+      </div>
+      <div class="prologue-box">
+        <p id="prologue-text" class="prologue-text"></p>
+        <div class="prologue-actions">
+          <button id="btn-prologue-next" type="button" class="caravan-btn">▸ 繼續</button>
+          <button id="btn-prologue-skip" type="button" class="caravan-btn caravan-btn-ghost">跳過序章</button>
+        </div>
+      </div>
     </section>
 
     <!-- 創角畫面 -->
     <section id="screen-create" class="screen" hidden>
-      <h2 class="create-title">創建你的隊長</h2>
-      <p class="screen-guide">選擇職業、分配天賦點、挑一個出身特性，然後啟程。</p>
+      <h2 class="create-title">商會登記</h2>
+      <p class="create-registrar">登記官蘸了蘸墨，抬眼打量你：「說吧——你是誰？」</p>
+      <p class="screen-guide">選擇職業、分配天賦點、挑一個出身特性，然後在名冊上按下手印。</p>
       <div id="create-jobs" class="create-jobs"></div>
       <div class="create-cols">
         <div class="create-col">
@@ -332,6 +356,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   import type { Stat, StatBlock } from '@scripts/games/caravan/types';
 
   const titleScreen = document.getElementById('screen-title')!;
+  const prologueScreen = document.getElementById('screen-prologue')!;
   const createScreen = document.getElementById('screen-create')!;
   const townScreen = document.getElementById('screen-town')!;
   const questScreen = document.getElementById('screen-quest')!;
@@ -342,6 +367,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
   const screens = {
     title: titleScreen,
+    prologue: prologueScreen,
     create: createScreen,
     town: townScreen,
     quest: questScreen,
@@ -359,7 +385,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   const hudRepEl = document.getElementById('hud-rep')!;
   const BACKDROP: Record<keyof typeof screens, { img: string; mood: string; scene: string }> = {
     title: { img: 'title-banner', mood: '', scene: '' },
-    create: { img: 'title-banner', mood: '', scene: '創建隊長' },
+    prologue: { img: 'title-banner', mood: '', scene: '' },
+    create: { img: 'title-banner', mood: '', scene: '商會登記' },
     town: { img: 'town-starting-town', mood: '', scene: '啟程之鎮' },
     quest: { img: 'title-banner', mood: 'road', scene: '委託板' },
     expedition: { img: 'title-banner', mood: 'road', scene: '遠征途中' },
@@ -405,8 +432,8 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     backdropEl.style.backgroundImage = `url('/assets/games/caravan/${b.img}.webp')`;
     backdropEl.dataset.mood = b.mood;
     // HUD：標題畫面外常駐
-    hudEl.hidden = name === 'title' || name === 'create';
-    if (name !== 'title' && name !== 'create') refreshHud(b.scene);
+    hudEl.hidden = name === 'title' || name === 'create' || name === 'prologue';
+    if (!hudEl.hidden) refreshHud(b.scene);
     // 轉場入場動畫（重新觸發）
     const el = screens[name];
     el.classList.remove('screen-enter');
@@ -1258,11 +1285,42 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     createTraitDescEl.textContent = cur ? cur.desc : '';
   }
 
-  btnNew.addEventListener('click', () => {
+  // ---- 序章演出 ----
+  const PROLOGUE_BEATS = [
+    '暮色壓低了官道。你數過行囊——幾枚銀幣、半袋鹽，和一輛吱呀作響的舊馬車。這就是你的全部了。',
+    '城門邊的老商人瞇眼打量你：「又一個想走商路的？狼群、盜匪、還有山裡那些東西……銅幣可不會自己滾進口袋，小子。」',
+    '他嗤笑一聲，朝商會的方向努了努嘴。「去登記吧。從行腳商做起——要是你能活著把名聲攢起來，商會之主的位子，誰說不能是你的？」',
+  ];
+  let prologueIndex = 0;
+  const prologueTextEl = document.getElementById('prologue-text')!;
+
+  function renderPrologueBeat(): void {
+    prologueTextEl.textContent = PROLOGUE_BEATS[prologueIndex];
+    // 重新觸發淡入
+    prologueTextEl.classList.remove('beat-in');
+    void (prologueTextEl as HTMLElement).offsetWidth;
+    prologueTextEl.classList.add('beat-in');
+    document.getElementById('btn-prologue-next')!.textContent =
+      prologueIndex === PROLOGUE_BEATS.length - 1 ? '▸ 前往商會' : '▸ 繼續';
+  }
+
+  function enterCreation(): void {
     createJob = 'swordsman'; createAlloc = {}; createTrait = null;
     renderCreate();
     showScreen('create');
+  }
+
+  btnNew.addEventListener('click', () => {
+    prologueIndex = 0;
+    renderPrologueBeat();
+    showScreen('prologue');
   });
+  document.getElementById('btn-prologue-next')?.addEventListener('click', () => {
+    if (prologueIndex >= PROLOGUE_BEATS.length - 1) { enterCreation(); return; }
+    prologueIndex += 1;
+    renderPrologueBeat();
+  });
+  document.getElementById('btn-prologue-skip')?.addEventListener('click', enterCreation);
   document.getElementById('btn-create-cancel')?.addEventListener('click', () => showScreen('title'));
   document.getElementById('btn-create-confirm')?.addEventListener('click', () => {
     const choice: CharacterChoice = { job: createJob, allocation: createAlloc, trait: createTrait };
@@ -2384,18 +2442,122 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   #screen-title { justify-content: center; }
   .screen-wide, .town-panel { width: 100%; }
 
-  /* ---- 標題畫面 ---- */
+  /* ---- 標題畫面：電影化舞台 ---- */
+  #screen-title { padding: 0; overflow: hidden; }
+  .title-stage, .prologue-stage { position: absolute; inset: 0; }
+  .title-stage-art {
+    width: 100%; height: 100%; object-fit: cover; display: block;
+    animation: titleDrift 36s ease-in-out infinite alternate;
+  }
+  @keyframes titleDrift {
+    from { transform: scale(1.02) translateX(-0.6%); }
+    to { transform: scale(1.1) translateX(0.8%); }
+  }
+  .title-vignette, .prologue-vignette {
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(ellipse 90% 70% at 50% 38%, transparent 40%, rgba(12, 8, 4, 0.55) 78%, rgba(12, 8, 4, 0.9)),
+      linear-gradient(180deg, rgba(12, 8, 4, 0.35), transparent 30%, transparent 52%, rgba(12, 8, 4, 0.92) 86%);
+  }
+  .prologue-vignette { background: rgba(10, 6, 3, 0.68); backdrop-filter: blur(2px); }
+  /* 餘燼：緩慢上飄的暖光點 */
+  .title-embers { position: absolute; inset: 0; overflow: hidden; }
+  .title-embers i {
+    position: absolute; bottom: -2%;
+    width: 4px; height: 4px; border-radius: 50%;
+    background: radial-gradient(circle, #ffd9a0, rgba(232, 150, 80, 0.7) 55%, transparent 75%);
+    opacity: 0;
+    animation: emberRise linear infinite;
+  }
+  @keyframes emberRise {
+    0% { transform: translate(0, 0) scale(1); opacity: 0; }
+    8% { opacity: 0.9; }
+    60% { opacity: 0.55; }
+    100% { transform: translate(var(--sway, 24px), -108vh) scale(0.4); opacity: 0; }
+  }
+  .title-embers i:nth-child(1)  { left: 6%;  animation-duration: 13s; animation-delay: 0s;   --sway: 30px; }
+  .title-embers i:nth-child(2)  { left: 14%; animation-duration: 17s; animation-delay: 3.2s; --sway: -22px; }
+  .title-embers i:nth-child(3)  { left: 22%; animation-duration: 15s; animation-delay: 7s;   --sway: 18px; width: 3px; height: 3px; }
+  .title-embers i:nth-child(4)  { left: 30%; animation-duration: 19s; animation-delay: 1.4s; --sway: -34px; }
+  .title-embers i:nth-child(5)  { left: 38%; animation-duration: 14s; animation-delay: 9s;   --sway: 26px; width: 5px; height: 5px; }
+  .title-embers i:nth-child(6)  { left: 46%; animation-duration: 18s; animation-delay: 4.6s; --sway: -16px; }
+  .title-embers i:nth-child(7)  { left: 54%; animation-duration: 13.5s; animation-delay: 11s; --sway: 32px; width: 3px; height: 3px; }
+  .title-embers i:nth-child(8)  { left: 62%; animation-duration: 16s; animation-delay: 2.2s; --sway: -28px; }
+  .title-embers i:nth-child(9)  { left: 70%; animation-duration: 20s; animation-delay: 6.4s; --sway: 20px; }
+  .title-embers i:nth-child(10) { left: 78%; animation-duration: 14.5s; animation-delay: 10s; --sway: -24px; width: 5px; height: 5px; }
+  .title-embers i:nth-child(11) { left: 86%; animation-duration: 17.5s; animation-delay: 0.8s; --sway: 16px; }
+  .title-embers i:nth-child(12) { left: 93%; animation-duration: 15.5s; animation-delay: 8s;  --sway: -30px; width: 3px; height: 3px; }
+  .title-embers i:nth-child(13) { left: 50%; animation-duration: 21s; animation-delay: 13s;  --sway: 36px; }
+  .title-embers i:nth-child(14) { left: 10%; animation-duration: 16.5s; animation-delay: 12s; --sway: -18px; width: 5px; height: 5px; }
+
+  .title-content {
+    position: relative; z-index: 1;
+    height: 100%;
+    display: flex; flex-direction: column; justify-content: flex-end; align-items: center;
+    padding: 0 1rem 3.4rem;
+  }
   .game-title {
     font-family: 'Ma Shan Zheng', 'Noto Serif TC', serif;
-    font-size: 4.2rem; font-weight: 400; letter-spacing: 0.14em; margin: 0.5rem 0 0.1rem;
+    font-size: 4.6rem; font-weight: 400; letter-spacing: 0.14em; margin: 0 0 0.1rem;
     color: var(--gold-bright);
     text-shadow: 0 0 30px rgba(201, 163, 92, 0.5), 0 3px 6px rgba(0, 0, 0, 0.85);
   }
+  /* 題字逐字浮現：墨滴落定 */
+  .game-title span {
+    display: inline-block;
+    animation: inkDrop 0.7s cubic-bezier(0.2, 1.2, 0.4, 1) both;
+  }
+  .game-title span:nth-child(1) { animation-delay: 0.15s; }
+  .game-title span:nth-child(2) { animation-delay: 0.34s; }
+  .game-title span:nth-child(3) { animation-delay: 0.53s; }
+  .game-title span:nth-child(4) { animation-delay: 0.72s; }
+  @keyframes inkDrop {
+    from { opacity: 0; transform: translateY(-14px) scale(1.25); filter: blur(6px); }
+    to { opacity: 1; transform: none; filter: blur(0); }
+  }
   .game-subtitle {
     font-family: 'Cinzel', serif; font-weight: 500;
-    letter-spacing: 0.42em; color: var(--text-dim); margin-bottom: 2.2rem; font-size: 0.95rem;
+    letter-spacing: 0.42em; color: var(--text-dim); margin-bottom: 1.6rem; font-size: 0.95rem;
+    animation: beatFade 0.9s ease 1.1s both;
   }
-  .title-actions { display: flex; flex-direction: column; gap: 0.8rem; align-items: center; }
+  .title-premise { animation: beatFade 0.9s ease 1.4s both; }
+  .title-actions {
+    display: flex; flex-direction: column; gap: 0.8rem; align-items: center;
+    animation: beatFade 0.9s ease 1.7s both;
+  }
+  @keyframes beatFade { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+
+  /* ---- 序章演出 ---- */
+  #screen-prologue { padding: 0; overflow: hidden; }
+  .prologue-box {
+    position: absolute; left: 50%; bottom: 3rem; transform: translateX(-50%);
+    z-index: 1; width: min(34rem, 88%);
+    background:
+      repeating-linear-gradient(0deg, rgba(36, 28, 18, 0.018) 0 2px, transparent 2px 4px),
+      linear-gradient(178deg, #f1e8d4, var(--page));
+    color: var(--ink);
+    border: 1px solid var(--seal); border-radius: 3px;
+    padding: 1.4rem 1.5rem 1.1rem; text-align: left;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6), inset 0 0 0 3px rgba(236, 226, 204, 0.7);
+  }
+  .prologue-text { margin: 0 0 1.1rem; font-size: 1.05rem; line-height: 2.1; color: var(--ink); min-height: 6.3em; }
+  .prologue-text.beat-in { animation: beatFade 0.6s ease both; }
+  .prologue-actions { display: flex; justify-content: space-between; align-items: center; gap: 0.8rem; }
+  .prologue-box .caravan-btn {
+    background: var(--seal); border-color: var(--seal-bright); color: #f7ece0;
+  }
+  .prologue-box .caravan-btn:hover { background: var(--seal-bright); }
+  .prologue-box .caravan-btn-ghost {
+    background: transparent; border-color: var(--ink-soft); color: var(--ink-soft);
+    font-size: 0.82rem; padding: 0.35rem 1rem;
+  }
+  .prologue-box .caravan-btn-ghost:hover { color: var(--seal); border-color: var(--seal); background: transparent; }
+  .create-registrar { font-size: 0.95rem; color: var(--gold-bright); letter-spacing: 0.05em; margin: 0 0 0.3rem; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .title-stage-art, .title-embers i, .game-title span, .game-subtitle, .title-premise, .title-actions, .prologue-text.beat-in { animation: none; }
+    .game-title span { opacity: 1; }
+  }
   .title-legacy { font-size: 0.85rem; color: var(--gold); letter-spacing: 0.08em; margin: 0.9rem 0 0; }
   .title-chronicle-link { display: inline-block; margin-top: 0.7rem; font-size: 0.85rem; color: var(--text-dim); text-decoration: none; letter-spacing: 0.15em; }
   .title-chronicle-link:hover { color: var(--gold-bright); }
@@ -2769,11 +2931,6 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   #trade-buy-section[hidden] { display: none; }
 
   /* ---- 圖片：金框窗 ---- */
-  .title-art {
-    display: block; width: 100%; height: auto; max-height: 300px; object-fit: cover;
-    border: 1px solid var(--gold); border-radius: 4px; margin: 0 auto 1.4rem;
-    box-shadow: inset 0 0 0 3px rgba(10, 6, 3, 0.4), 0 10px 30px rgba(0, 0, 0, 0.6);
-  }
   .town-banner {
     display: block; width: 100%; height: auto; max-height: 200px; object-fit: cover;
     border: 1px solid var(--gold); border-radius: 4px; margin: 0 auto 1rem;

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -16,6 +16,7 @@ test.describe('商隊與劍：外殼流程', () => {
 
   test('開新檔 → 城鎮畫面顯示初始金幣 200', async ({ page }) => {
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
     await expect(page.locator('#screen-title')).toBeHidden();
@@ -24,6 +25,7 @@ test.describe('商隊與劍：外殼流程', () => {
 
   test('開新檔後重新整理 → 「繼續旅程」可見且回到城鎮', async ({ page }) => {
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
@@ -76,6 +78,7 @@ test.describe('商隊與劍：訓練場戰鬥', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
   });
@@ -126,6 +129,7 @@ test.describe('商隊與劍：訓練場戰鬥', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
     await page.click('#btn-training');
@@ -172,6 +176,7 @@ test.describe('商隊與劍：遠征系統', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
   }
@@ -330,6 +335,7 @@ test.describe('商隊與劍：經營系統', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
   }
@@ -633,6 +639,7 @@ test.describe('商隊與劍：裝備系統', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#screen-town')).toBeVisible();
   }
@@ -742,6 +749,7 @@ test.describe('商隊與劍：冒險編年史（M6）', () => {
     });
     await page.reload();
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await page.click('#btn-training');
     for (let i = 0; i < 40; i++) {
@@ -775,6 +783,7 @@ test.describe('商隊與劍：冒險編年史（M6）', () => {
     await page.reload();
     await expect(page.locator('#title-legacy')).toContainText('+30 G');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm'); // 創角：預設劍士＋0 配點＝舊版主角
     await expect(page.locator('#town-gold')).toHaveText('230');
     await page.evaluate(() => localStorage.removeItem('caravan-chronicle-v1'));
@@ -847,6 +856,7 @@ test.describe('商隊與劍：創角與背包', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await expect(page.locator('#screen-create')).toBeVisible();
 
     await page.click('.create-job[data-job="mage"]');
@@ -872,6 +882,7 @@ test.describe('商隊與劍：創角與背包', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
 
@@ -894,6 +905,7 @@ test.describe('商隊與劍：M11 RPG 深度', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
     await page.evaluate(() => {
@@ -925,6 +937,7 @@ test.describe('商隊與劍：M11 RPG 深度', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
 
@@ -947,6 +960,7 @@ test.describe('商隊與劍：M11 RPG 深度', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
     await page.evaluate(() => {
@@ -977,6 +991,7 @@ test.describe('商隊與劍：M12 商會目標', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
 
@@ -992,6 +1007,7 @@ test.describe('商隊與劍：M12 商會目標', () => {
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
     await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
     await page.click('#btn-create-confirm');
     await expect(page.locator('#screen-town')).toBeVisible();
     await page.evaluate(() => {
@@ -1005,5 +1021,31 @@ test.describe('商隊與劍：M12 商會目標', () => {
 
     await expect(page.locator('#goal-rank')).toHaveText('特許商人');
     await expect(page.locator('#goal-next')).toContainText('聲望 45/60');
+  });
+});
+
+test.describe('商隊與劍：序章演出', () => {
+  test('新的旅程 → 序章三拍 → 前往商會進入商會登記；跳過鈕直達', async ({ page }) => {
+    await page.goto('/caravan/play');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.click('#btn-new-game');
+    await expect(page.locator('#screen-prologue')).toBeVisible();
+    await expect(page.locator('#prologue-text')).toContainText('暮色');
+    await page.click('#btn-prologue-next');
+    await expect(page.locator('#prologue-text')).toContainText('老商人');
+    await page.click('#btn-prologue-next');
+    await expect(page.locator('#btn-prologue-next')).toHaveText('▸ 前往商會');
+    await page.click('#btn-prologue-next');
+    await expect(page.locator('#screen-create')).toBeVisible();
+    await expect(page.locator('.create-title')).toHaveText('商會登記');
+
+    // 跳過路徑
+    await page.click('#btn-create-cancel');
+    await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip');
+    await expect(page.locator('#screen-create')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

回應「從入口就整個錯了、非常無聊」：舊入口＝靜態橫幅＋按鈕列，點下去直接是表單。重做整條進場鏈：

- **標題電影化**：滿版舞台圖（Ken Burns 漂移）＋vignette＋餘燼上飄（純 CSS）；書法題字逐字墨滴落定、選單依序浮現
- **序章演出**：新的旅程 → 三拍 VN 敘事（暮色官道→老商人→指向商會）→「▸ 前往商會」入創角；可隨時跳過
- **商會登記**：創角框成故事場景（登記官開場白），填表成為劇情一部分

## Test plan
- [x] `npx vitest run` 1543 全綠
- [x] caravan e2e 36＋defense 3 全綠（16 處 new-game 流程補跳過一步；新增序章流程測試）
- [x] `npm run build` 綠
- [x] 實機截圖：滿版電影化標題／宣紙序章敘事框

🤖 Generated with [Claude Code](https://claude.com/claude-code)