### PR TITLE
feat(caravan): M13 無盡遠路——契約制無盡模式

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -40,6 +40,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
           <li><b>接下委託</b>——到<em>委託板</em>選一條商路或迷宮出發；路程越遠越危險，報酬越高。</li>
           <li><b>遠征歷險</b>——沿途抽事件卡、擲骰做選擇；遇敵進入回合戰鬥。</li>
           <li><b>歸城結算</b>——獲得金幣、經驗與<em>聲望</em>；聲望推動商會階級，解鎖更遠的商路與迷宮。</li>
+          <li><b>無盡遠路</b>——聲望 40 後開放的契約商路：每完成一張契約，下一張更長更兇險、報酬更豐厚，<em>沒有盡頭</em>。</li>
         </ol>
         <p class="howto-tip">隨時可點右上角的「玩法」重看這份說明。</p>
         <div class="modal-actions">
@@ -333,6 +334,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   import {
     startExpedition, drawEvent, optionAvailable, resolveOption, drawRooms, chooseRoom,
     buildEncounter, applyPartyHp, finishCombat, settleExpedition, useItemOnExpedition,
+    endlessScaling,
   } from '@scripts/games/caravan/expedition';
   import type { ExpeditionState, EventCard, RoomKind, LocationDef } from '@scripts/games/caravan/expedition';
   import type { CheckResult } from '@scripts/games/caravan/check';
@@ -822,7 +824,10 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       const ratio = Math.min(1, progress.reputation.have / progress.reputation.need);
       barFill.style.width = `${Math.round(ratio * 100)}%`;
     } else {
-      nextEl.textContent = '你已登上商會的頂點——旅途仍在繼續。';
+      const tier = save.endlessTier ?? 0;
+      nextEl.textContent = tier > 0
+        ? `商會之主的傳說仍在書寫——無盡遠路已完成 ${tier} 張契約，下一張更兇險、更豐厚。`
+        : '你已登上商會的頂點——無盡遠路的契約，等著為你的傳說添頁。';
       bar.hidden = true;
     }
     const hudRank = document.getElementById('hud-rank');
@@ -1380,8 +1385,18 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       name.textContent = loc.name;
       const kind = document.createElement('p');
       kind.className = 'quest-kind';
-      kind.textContent =
-        loc.kind === 'dungeon' ? `迷宮．共 ${loc.floors} 層` : `商路．共 ${loc.legs} 段`;
+      if (loc.endless) {
+        const tier = save.endlessTier ?? 0;
+        const scaling = endlessScaling(tier);
+        kind.textContent = `無盡契約．共 ${(loc.legs ?? 1) + scaling.extraLegs} 段．戰利品 ×${scaling.goldFactor.toFixed(2)}`;
+        const badge = document.createElement('span');
+        badge.className = 'quest-endless-badge';
+        badge.textContent = `第 ${tier + 1} 張契約`;
+        name.appendChild(badge);
+      } else {
+        kind.textContent =
+          loc.kind === 'dungeon' ? `迷宮．共 ${loc.floors} 層` : `商路．共 ${loc.legs} 段`;
+      }
       div.append(name, kind);
       // 直接點整列＝沿用既有「立即出發（不押貨）」行為，保持向後相容
       // （舊 e2e 依賴此行為：點 .quest-item 後立刻進入 #screen-expedition，
@@ -1817,6 +1832,9 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       rankupEl.hidden = true;
     }
     const goalEl = document.getElementById('settle-goal')!;
+    const endlessLine = (finished.endlessTier !== undefined && !finished.retreated)
+      ? `無盡契約 第 ${finished.endlessTier + 1} 張完成——第 ${finished.endlessTier + 2} 張已開放！　`
+      : '';
     const progressAfter = rankProgress(save);
     if (progressAfter) {
       const nx = nextRank(save)!;
@@ -1824,9 +1842,9 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       if (progressAfter.bossClears) {
         text += `、魔窟 ${progressAfter.bossClears.have}/${progressAfter.bossClears.need}`;
       }
-      goalEl.textContent = text;
+      goalEl.textContent = endlessLine + text;
     } else {
-      goalEl.textContent = isFinalRank(save) ? '商會之主——你的名字已成為傳說。' : '';
+      goalEl.textContent = endlessLine + (isFinalRank(save) ? '商會之主——你的名字已成為傳說。' : '');
     }
     // 招募池輪替（M4）：每趟歸返結算後種子遞增，酒館下次渲染會抽到新一批人選
     save.tavernSeed += 1;
@@ -3256,5 +3274,14 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .settle-goal { font-size: 0.9rem; color: var(--gold-bright); letter-spacing: 0.05em; margin: 0.2rem 0 1rem; }
   @media (prefers-reduced-motion: reduce) {
     .rankup-banner { animation: none; }
+  }
+
+  /* ---- M13 無盡遠路 ---- */
+  .quest-endless-badge {
+    display: inline-block; margin-left: 0.5rem; padding: 0.1rem 0.55rem;
+    font-size: 0.72rem; font-weight: 700; letter-spacing: 0.1em;
+    color: #f7ece0; background: var(--seal);
+    border: 1px solid var(--seal-bright); border-radius: 999px;
+    vertical-align: 0.1em;
   }
 </style>

--- a/src/scripts/games/caravan/data/data.test.ts
+++ b/src/scripts/games/caravan/data/data.test.ts
@@ -80,8 +80,8 @@ describe('caravan content data integrity（M3 Task 4）', () => {
   // ---------------------------------------------------------------------
   // locations.ts
   // ---------------------------------------------------------------------
-  it('LOCATIONS 有計畫指定的 7 個地點（M3 4 + M5 內容擴充 3），其中 2 個為 hidden', () => {
-    expect(Object.keys(LOCATIONS).length).toBe(7);
+  it('LOCATIONS 有 8 個地點（M3 4 + M5 擴充 3 + M13 無盡遠路），其中 2 個為 hidden', () => {
+    expect(Object.keys(LOCATIONS).length).toBe(8);
     const hidden = Object.values(LOCATIONS).filter((l) => l.hidden);
     expect(hidden.length).toBe(2);
   });

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -8,6 +8,21 @@ import type { SaveData } from '../save';
  * 隱藏路線「古戰場」（旗標鏈 discover，見 data/events.ts ev_faded_banner→ev_mercenary_ruins）。
  */
 export const LOCATIONS: Record<string, LocationDef> = {
+  'endless-road': {
+    id: 'endless-road',
+    name: '無盡遠路',
+    kind: 'route',
+    legs: 4,
+    endless: true,
+    minReputation: 40,
+    destinationTownId: 'riverbend-town',
+    encounterTable: [
+      { weight: 35, encounterId: 'enc_wolf_pair' },
+      { weight: 30, encounterId: 'enc_bandit_raid' },
+      { weight: 20, encounterId: 'enc_goblin_raiders' },
+      { weight: 15, encounterId: 'enc_ridge_bandits' },
+    ],
+  },
   'riverside-road': {
     id: 'riverside-road',
     name: '臨水道',

--- a/src/scripts/games/caravan/expedition.test.ts
+++ b/src/scripts/games/caravan/expedition.test.ts
@@ -19,6 +19,7 @@ import {
   applyPartyHp,
   EXPEDITION_VERSION,
   useItemOnExpedition,
+  endlessScaling,
 } from './expedition';
 import type { EventCard, LocationDef, ExpeditionState } from './expedition';
 import { newGame } from './save';
@@ -1390,5 +1391,76 @@ describe('M11 羈絆遞增與遠征道具', () => {
     expect(() => useItemOnExpedition(state, save, 'herb', 'protagonist')).toThrow();
     save.inventory['iron-ore'] = 1;
     expect(() => useItemOnExpedition(state, save, 'iron-ore', 'protagonist')).toThrow();
+  });
+});
+
+describe('M13 無盡遠路（契約制無盡模式）', () => {
+  const ENDLESS_LOC: LocationDef = {
+    id: 'loc_endless', name: '無盡遠路', kind: 'route', legs: 4, endless: true,
+    encounterTable: [{ weight: 100, encounterId: 'enc_a' }],
+  };
+  const ENC_A_FACTORY = () => [makeEnemy({ id: 'endless-foe' })];
+  beforeEach(() => {
+    registerLocations({ loc_endless: ENDLESS_LOC, loc_route_a: LOC_ROUTE_A });
+    registerEvents([evUniversal]);
+    registerEncounters({ enc_a: ENC_A_FACTORY });
+  });
+
+  it('endlessScaling：tier 0 無加成；tier 4 段數+4、敵血+12、敵強化2、報酬×2、xp+20', () => {
+    expect(endlessScaling(0)).toEqual({ extraLegs: 0, enemyHpBonus: 0, enemyStrength: 0, goldFactor: 1, xpBonus: 0 });
+    expect(endlessScaling(4)).toEqual({ extraLegs: 4, enemyHpBonus: 12, enemyStrength: 2, goldFactor: 2, xpBonus: 20 });
+    expect(endlessScaling(9).extraLegs).toBe(6); // 段數成長封頂 +6
+  });
+
+  it('startExpedition：endless 地點快照 save.endlessTier 並加長段數', () => {
+    const save = newGame(1000);
+    const s0 = startExpedition(createRng(7), save, 'loc_endless');
+    expect(s0.endlessTier).toBe(0);
+    expect(s0.totalSteps).toBe(4);
+    save.endlessTier = 3;
+    const s3 = startExpedition(createRng(7), save, 'loc_endless');
+    expect(s3.endlessTier).toBe(3);
+    expect(s3.totalSteps).toBe(7);
+    // 非 endless 地點不帶 tier
+    expect(startExpedition(createRng(7), save, 'loc_route_a').endlessTier).toBeUndefined();
+  });
+
+  it('buildEncounter：tier 4 敵人 hp/maxHp +12 且帶常駐強化 potency 2；tier 0 不動', () => {
+    const save = newGame(1000);
+    save.endlessTier = 4;
+    const state = startExpedition(createRng(7), save, 'loc_endless');
+    const scaled = buildEncounter(createRng(7), state, 'enc_a');
+    const base = ENC_A_FACTORY();
+    expect(scaled[0].maxHp).toBe(base[0].maxHp + 12);
+    expect(scaled[0].hp).toBe(base[0].hp + 12);
+    expect(scaled[0].statuses).toEqual([{ kind: 'strength', remaining: 99, potency: 2 }]);
+
+    save.endlessTier = 0;
+    const flat = buildEncounter(createRng(7), startExpedition(createRng(7), save, 'loc_endless'), 'enc_a');
+    expect(flat[0].maxHp).toBe(base[0].maxHp);
+    expect(flat[0].statuses).toBeUndefined();
+  });
+
+  it('settleExpedition：tier 2 完成→戰利品 ×1.5、xp +10、endlessTier 2→3；撤退不升 tier', () => {
+    const save = newGame(1000);
+    save.endlessTier = 2;
+    const state = startExpedition(createRng(7), save, 'loc_endless');
+    state.step = state.totalSteps + 1;
+    state.phase = 'done';
+    state.loot.gold = 100;
+    const goldBefore = save.gold;
+    const result = settleExpedition(state, save);
+    expect(result.goldGained).toBe(150);
+    expect(save.gold).toBe(goldBefore + 150);
+    expect(save.endlessTier).toBe(3);
+    expect(result.xpGained).toBe(20 + (state.step - 1) * 5 + 5 + 10); // 基礎公式 + tier 2 加成
+
+    const save2 = newGame(1000);
+    save2.endlessTier = 2;
+    const retreatState = startExpedition(createRng(7), save2, 'loc_endless');
+    retreatState.retreated = true;
+    retreatState.phase = 'done';
+    settleExpedition(retreatState, save2);
+    expect(save2.endlessTier).toBe(2);
   });
 });

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -63,6 +63,8 @@ export interface LocationDef {
   destinationTownId?: string;
   /** 委託板可見門檻：save.reputation 未達此值時不列入 visibleLocations（M5，data/locations.ts） */
   minReputation?: number;
+  /** M13 無盡遠路：契約制無盡模式（每次完成 save.endlessTier +1，難度/報酬隨 tier 成長） */
+  endless?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,6 +128,8 @@ export interface ExpeditionState {
    * 「遠征受的傷會帶進戰鬥」，需額外決定要不要接上這裡。
    */
   partyHp: Record<string, number>;
+  /** M13 無盡遠路：出發當下的契約層數快照（非 endless 地點為 undefined） */
+  endlessTier?: number;
   /** 遠征快照結構版本（M4）；save.ts loadGame 用它判斷舊版遠征快照是否該丟棄 */
   expeditionVersion: number;
   /** route 抵達的目的城鎮（economy.ts TownDef.id）；從 LocationDef 帶入，dungeon 無此值（M4） */
@@ -179,6 +183,28 @@ function getLocation(locationId: string): LocationDef | undefined {
 // 狀態機
 // ---------------------------------------------------------------------------
 
+/**
+ * M13 無盡縮放：tier 越高段數越長（封頂 +6）、敵人更硬更痛、報酬與經驗越豐。
+ * 敵人強化沿用 boss 激怒的「常駐 strength」機制（combat.ts：出手傷害 +potency）。
+ */
+export interface EndlessScaling {
+  extraLegs: number;
+  enemyHpBonus: number;
+  enemyStrength: number;
+  goldFactor: number;
+  xpBonus: number;
+}
+
+export function endlessScaling(tier: number): EndlessScaling {
+  return {
+    extraLegs: Math.min(tier, 6),
+    enemyHpBonus: tier * 3,
+    enemyStrength: Math.ceil(tier / 2),
+    goldFactor: 1 + tier * 0.25,
+    xpBonus: tier * 5,
+  };
+}
+
 export function startExpedition(
   rng: Rng,
   save: SaveData,
@@ -217,7 +243,9 @@ export function startExpedition(
     stateCargo[itemId] = count;
   }
 
-  const totalSteps = loc.kind === 'dungeon' ? (loc.floors ?? 1) : (loc.legs ?? 1);
+  const endlessTier = loc.endless ? (save.endlessTier ?? 0) : undefined;
+  const baseSteps = loc.kind === 'dungeon' ? (loc.floors ?? 1) : (loc.legs ?? 1);
+  const totalSteps = baseSteps + (endlessTier !== undefined ? endlessScaling(endlessTier).extraLegs : 0);
 
   const partyHp: Record<string, number> = { [save.protagonist.id]: save.protagonist.maxHp };
   for (const companion of save.companions) {
@@ -240,6 +268,7 @@ export function startExpedition(
     retreated: false,
     conditionId: condition.id,
     partyHp,
+    ...(endlessTier !== undefined ? { endlessTier } : {}),
     expeditionVersion: EXPEDITION_VERSION,
     destinationTownId: loc.destinationTownId,
     cargo: stateCargo,
@@ -484,7 +513,9 @@ export function settleExpedition(
     tradeGold = Math.round(tradeGold * (conditionById(state.conditionId)?.tradeFactor ?? 1));
   }
 
-  const goldGained = state.loot.gold;
+  // M13 無盡遠路：戰利品金依 tier 放大；完成（未撤退）才升下一張契約
+  const scaling = state.endlessTier !== undefined ? endlessScaling(state.endlessTier) : null;
+  const goldGained = scaling ? Math.round(state.loot.gold * scaling.goldFactor) : state.loot.gold;
   const itemsGained = { ...state.loot.items };
 
   save.gold += goldGained + tradeGold;
@@ -498,7 +529,7 @@ export function settleExpedition(
 
   // 完賽時 step=totalSteps+1（advanceExpedition 遞增後才會把 phase 轉成 'done'），
   // 多出的那 5 xp 是完賽獎勵（刻意設計，非 bug——見 Task 2 report 的顧慮欄）。
-  const xpGained = 20 + state.step * 5;
+  const xpGained = 20 + state.step * 5 + (scaling?.xpBonus ?? 0);
   save.protagonist.xp += xpGained;
   // 主角的重傷趟數也要遞減——只寫不減會讓主角永久卡在重傷（M3 終審抓到的地雷）
   save.protagonist.injuredForTrips = Math.max(0, save.protagonist.injuredForTrips - 1);
@@ -513,6 +544,9 @@ export function settleExpedition(
 
   if (!state.retreated) {
     save.reputation += 5;
+    if (state.endlessTier !== undefined) {
+      save.endlessTier = state.endlessTier + 1; // 下一張契約
+    }
   }
 
   save.expedition = null;
@@ -646,6 +680,17 @@ export function buildEncounter(rng: Rng, state: ExpeditionState, encounterId: st
     throw new Error(`buildEncounter: 找不到遭遇「${encounterId}」（先呼叫 registerEncounters 登記）`);
   }
   const enemies = factory();
+  // M13 無盡縮放：tier > 0 時敵人更硬（+hp）更痛（常駐 strength，沿 boss 激怒機制）
+  if (state.endlessTier !== undefined && state.endlessTier > 0) {
+    const endless = endlessScaling(state.endlessTier);
+    for (const enemy of enemies) {
+      enemy.maxHp += endless.enemyHpBonus;
+      enemy.hp += endless.enemyHpBonus;
+      if (endless.enemyStrength > 0) {
+        enemy.statuses = [...(enemy.statuses ?? []), { kind: 'strength', remaining: 99, potency: endless.enemyStrength }];
+      }
+    }
+  }
   if (state.kind === 'dungeon') {
     const loc = getLocation(state.locationId);
     const bonus = (loc?.depthHpBonus ?? 0) * (state.step - 1);

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -93,6 +93,8 @@ export interface SaveDataV6 extends Omit<SaveDataV5, 'version'> {
   version: 6;
   /** 市場行情種子；每次歸返結算後遞增，各鎮物價隨之波動（M7） */
   marketSeed: number;
+  /** M13 無盡遠路契約層數；optional 不 bump 版本（舊檔視為 0） */
+  endlessTier?: number;
 }
 
 /** 對外別名，後續版本跟著改指向最新 schema */

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -630,6 +630,33 @@ test.describe('商隊與劍：經營系統', () => {
     await expect(page.locator('#rankup-name')).toHaveText('商會重鎮');
     await expect(page.locator('#settle-goal')).toContainText('距「商會之主」');
   });
+
+  test('M13 無盡遠路：聲望 40 開契約、tier 顯示縮放、完成後下一張開放', async ({ page }) => {
+    await newGameWithSeed(page, 55);
+    await page.evaluate(() => {
+      const data = JSON.parse(localStorage.getItem('caravan-save-v1')!);
+      data.reputation = 45;
+      data.endlessTier = 2;
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-continue');
+    await page.click('#btn-quest-board');
+
+    const endlessItem = page.locator('.quest-item[data-location-id="endless-road"]');
+    await expect(endlessItem.locator('.quest-endless-badge')).toHaveText('第 3 張契約');
+    await expect(endlessItem.locator('.quest-kind')).toContainText('共 6 段');
+    await expect(endlessItem.locator('.quest-kind')).toContainText('×1.50');
+
+    await endlessItem.click();
+    await advanceToSettlement(page);
+    await expect(page.locator('#settle-goal')).toContainText('第 3 張完成——第 4 張已開放');
+    const tier = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('caravan-save-v1')!).endlessTier
+    );
+    expect(tier).toBe(3);
+  });
 });
 
 test.describe('商隊與劍：裝備系統', () => {


### PR DESCRIPTION
## Summary

回應「預期是沒有盡頭的玩法、現在一下就玩完了」：新增可以永遠玩下去的核心循環（TDD）：

- **無盡遠路**（聲望 40 開放）：契約制商路——每完成一張契約 tier+1：下一張更長（+1 段/tier，封頂 +6）、敵人更硬更痛（+3 HP/tier＋常駐強化 ⌈tier/2⌉，沿 boss 激怒機制）、戰利品 ×(1+0.25·tier) 無上限、經驗 +5·tier
- **委託板**「第 N 張契約」硃砂徽章＋實算段數/倍率；**結算**「第 N 張完成——第 N+1 張已開放！」
- **頂階後目標卡**改敘無盡進度——目標線永遠有下一格
- 相容：endlessTier optional 不 bump 存檔版

## Test plan
- [x] `npx vitest run` 1547 全綠（endlessScaling/start/buildEncounter/settle 4 條新測試）
- [x] caravan e2e 37＋defense 3 全綠（契約徽章→出發→結算 tier+1 完整流程）
- [x] `npm run build` 綠
- [x] 實機：tier 4 契約走完一張（8 段、×2.00、第 5→第 6 張開放）

🤖 Generated with [Claude Code](https://claude.com/claude-code)