### PR TITLE
feat(caravan): M14 角色深度——創角擲骰＋冒險技能＋鐵匠強化

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -110,6 +110,11 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
         <div class="create-col">
           <h3 class="create-subtitle">天賦點 · 剩餘 <span id="create-points">3</span></h3>
           <div id="create-alloc-rows" class="alloc-rows"></div>
+          <div class="create-roll-row">
+            <button id="btn-roll-stats" type="button" class="caravan-btn caravan-btn-ghost">🎲 擲骰天賦</button>
+            <button id="btn-roll-reset" type="button" class="caravan-btn caravan-btn-ghost" hidden>還原基準</button>
+          </div>
+          <p class="create-roll-hint">命運的骰子：每項屬性在基準 −2 ～ +3 之間浮動，不滿意可以再擲。</p>
         </div>
         <div class="create-col">
           <h3 class="create-subtitle">出身特性</h3>
@@ -351,6 +356,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     pendingLevelUps, applyLevelUp, unlockedMoves, generateRecruitPool, hireCost, wagePerTrip,
     equipItem, unequipItem, SPECIALIZATIONS, SPECIALIZATION_LEVEL, chooseSpecialization, specById,
     bondTier, BOND_TIER_NAMES, XP_TABLE,
+    SKILLS, SKILL_RANK_CAP, spendSkillPoint, smithCost, SMITH_PLUS_CAP, upgradeEquipment, rollStats,
   } from '@scripts/games/caravan/roster';
   import {
     buyPrice, sellPrice, tradeSellPrice, cargoCapacity, wagonUpgradeCost, totalWage,
@@ -758,6 +764,13 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       slotEl.appendChild(label);
 
       if (equippedItem) {
+        const plus = record.equipmentPlus?.[slot] ?? 0;
+        if (plus > 0) {
+          const plusTag = document.createElement('span');
+          plusTag.className = 'smith-plus-tag';
+          plusTag.textContent = `+${plus}`;
+          label.appendChild(plusTag);
+        }
         const unequipBtn = document.createElement('button');
         unequipBtn.type = 'button';
         unequipBtn.className = 'caravan-btn unequip-btn';
@@ -769,6 +782,23 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
           renderTownPanels();
         });
         slotEl.appendChild(unequipBtn);
+        // M14 鐵匠強化
+        if (plus < SMITH_PLUS_CAP) {
+          const cost = smithCost(plus);
+          const smithBtn = document.createElement('button');
+          smithBtn.type = 'button';
+          smithBtn.className = 'caravan-btn smith-btn';
+          smithBtn.dataset.slot = slot;
+          smithBtn.textContent = `強化 +${plus + 1}（${cost.gold}G＋礦石×${cost.ore}）`;
+          smithBtn.disabled = save.gold < cost.gold || (save.inventory['ore'] ?? 0) < cost.ore;
+          smithBtn.addEventListener('click', () => {
+            if (!save) return;
+            upgradeEquipment(save, record.id, slot);
+            saveGame(save);
+            renderTownPanels();
+          });
+          slotEl.appendChild(smithBtn);
+        }
       }
 
       const candidates = Object.values(ITEMS).filter(
@@ -981,6 +1011,40 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       }
 
       sheet.append(name, xp, stats, hp, moves);
+      // M14 冒險技能區
+      const skillsWrap = document.createElement('div');
+      skillsWrap.className = 'roster-skills';
+      const points = record.skillPoints ?? 0;
+      const skillsTitle = document.createElement('p');
+      skillsTitle.className = 'roster-skills-title';
+      skillsTitle.textContent = points > 0 ? `冒險技能（可用點數 ${points}）` : '冒險技能';
+      skillsWrap.appendChild(skillsTitle);
+      const skillRow = document.createElement('div');
+      skillRow.className = 'skill-chips';
+      for (const skill of SKILLS) {
+        const rank = record.skills?.[skill.id] ?? 0;
+        const chip = document.createElement('span');
+        chip.className = 'skill-chip' + (rank > 0 ? ' learned' : '');
+        chip.title = skill.desc;
+        chip.textContent = `${skill.name} ${'●'.repeat(rank)}${'○'.repeat(SKILL_RANK_CAP - rank)}`;
+        if (points > 0 && rank < SKILL_RANK_CAP) {
+          const plus = document.createElement('button');
+          plus.type = 'button';
+          plus.className = 'skill-plus';
+          plus.dataset.skillId = skill.id;
+          plus.textContent = '＋';
+          plus.addEventListener('click', () => {
+            if (!save) return;
+            spendSkillPoint(record, skill.id);
+            saveGame(save);
+            renderTownPanels();
+          });
+          chip.appendChild(plus);
+        }
+        skillRow.appendChild(chip);
+      }
+      skillsWrap.appendChild(skillRow);
+      sheet.appendChild(skillsWrap);
       card.appendChild(sheet);
       renderEquipSlots(sheet, record);
 
@@ -1225,6 +1289,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   let createJob: typeof JOB_IDS[number] = 'swordsman';
   let createAlloc: Partial<Record<Stat, number>> = {};
   let createTrait: string | null = null;
+  let rolledStats: Record<Stat, number> | null = null; // M14 擲骰結果；null=職業基準
 
   function createAllocTotal(): number {
     return (Object.values(createAlloc) as number[]).reduce((a, b) => a + (b ?? 0), 0);
@@ -1243,14 +1308,15 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       const nm = document.createElement('b'); nm.textContent = JOBS[job].name;
       const desc = document.createElement('span'); desc.textContent = JOB_BLURB[job];
       card.append(art, nm, desc);
-      card.addEventListener('click', () => { createJob = job; createAlloc = {}; renderCreate(); });
+      card.addEventListener('click', () => { createJob = job; createAlloc = {}; rolledStats = null; renderCreate(); });
       createJobsEl.appendChild(card);
     }
     // 配點
     const remaining = CREATION_BONUS_POINTS - createAllocTotal();
     createPointsEl.textContent = String(remaining);
     createAllocRowsEl.innerHTML = '';
-    const base = STARTING_PROFILE[createJob].stats;
+    const base = rolledStats ?? STARTING_PROFILE[createJob].stats;
+    document.getElementById('btn-roll-reset')!.hidden = rolledStats === null;
     for (const stat of Object.keys(STAT_LABELS) as Stat[]) {
       const row = document.createElement('div'); row.className = 'alloc-row';
       const label = document.createElement('span'); label.className = 'alloc-label';
@@ -1310,10 +1376,21 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   }
 
   function enterCreation(): void {
-    createJob = 'swordsman'; createAlloc = {}; createTrait = null;
+    createJob = 'swordsman'; createAlloc = {}; createTrait = null; rolledStats = null;
     renderCreate();
     showScreen('create');
   }
+
+  document.getElementById('btn-roll-stats')?.addEventListener('click', () => {
+    rolledStats = rollStats(rng, createJob);
+    createAlloc = {};
+    renderCreate();
+  });
+  document.getElementById('btn-roll-reset')?.addEventListener('click', () => {
+    rolledStats = null;
+    createAlloc = {};
+    renderCreate();
+  });
 
   btnNew.addEventListener('click', () => {
     prologueIndex = 0;
@@ -1328,7 +1405,10 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   document.getElementById('btn-prologue-skip')?.addEventListener('click', enterCreation);
   document.getElementById('btn-create-cancel')?.addEventListener('click', () => showScreen('title'));
   document.getElementById('btn-create-confirm')?.addEventListener('click', () => {
-    const choice: CharacterChoice = { job: createJob, allocation: createAlloc, trait: createTrait };
+    const choice: CharacterChoice = {
+      job: createJob, allocation: createAlloc, trait: createTrait,
+      ...(rolledStats ? { statRoll: rolledStats } : {}),
+    };
     save = newGame(Date.now(), choice);
     // ?seed= 同時固定 marketSeed 與 tavernSeed（e2e 決定性依賴）
     if (seedParam) {
@@ -3284,4 +3364,32 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     border: 1px solid var(--seal-bright); border-radius: 999px;
     vertical-align: 0.1em;
   }
+
+  /* ---- M14：擲骰／技能／鐵匠 ---- */
+  .create-roll-row { display: flex; gap: 0.6rem; margin-top: 0.8rem; }
+  .create-roll-hint { font-size: 0.78rem; color: var(--text-dim); margin: 0.45rem 0 0; line-height: 1.6; }
+  .roster-skills { margin: 0.1rem 0 0.4rem; }
+  .roster-skills-title { font-size: 0.8rem; letter-spacing: 0.08em; color: var(--gold-bright); margin: 0 0 0.3rem; }
+  .skill-chips { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+  .skill-chip {
+    display: inline-flex; align-items: center; gap: 0.35rem;
+    padding: 0.12rem 0.55rem; font-size: 0.76rem; letter-spacing: 0.04em;
+    color: var(--text-dim); background: var(--panel-deep);
+    border: 1px solid var(--gold-dim); border-radius: 3px;
+  }
+  .skill-chip.learned { color: var(--text); border-color: var(--gold); }
+  .skill-plus {
+    font: inherit; cursor: pointer; line-height: 1;
+    width: 1.15rem; height: 1.15rem; display: grid; place-items: center;
+    color: #f7ece0; background: var(--seal);
+    border: 1px solid var(--seal-bright); border-radius: 3px;
+  }
+  .skill-plus:hover { background: var(--seal-bright); }
+  .smith-plus-tag {
+    margin-left: 0.4rem; padding: 0 0.4rem;
+    font-size: 0.72rem; font-weight: 700;
+    color: #f7ece0; background: var(--seal); border-radius: 3px;
+  }
+  .smith-btn { font-size: 0.78rem; padding: 0.25rem 0.7rem; margin-top: 0.3rem; }
+  .smith-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 </style>

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -22,6 +22,8 @@ export interface StatusEffect { kind: StatusKind; remaining: number; potency: nu
 export interface CombatantBase {
   id: string; name: string; stats: StatBlock;
   maxHp: number; hp: number; defense: number; moves: Move[];
+  /** M14 鐵匠強化：武器 +N 固定傷害加值 */
+  damageBonus?: number;
   /** 進行中狀態效果（M7，戰鬥 runtime） */
   statuses?: StatusEffect[];
   /** 立繪路徑（M5 美術） */
@@ -205,7 +207,8 @@ function performMove(rng: Rng, state: CombatState, actor: CombatantBase, move: M
     actor.statuses = actor.statuses!.filter((s) => s.remaining > 0);
   }
   const amount = Math.max(1, rollDice(rng, dmgSpec.dice, dmgSpec.sides)
-    + (dmgSpec.bonusStat ? statMod(actor.stats[dmgSpec.bonusStat]) : 0) + strengthBonus);
+    + (dmgSpec.bonusStat ? statMod(actor.stats[dmgSpec.bonusStat]) : 0) + strengthBonus
+    + (actor.damageBonus ?? 0));
   state.log.push({ kind: 'damage', text: fillNarration(move.narration, actor.name, target.name, amount) });
   applyDamage(state, target, amount);
   // M7 命中附加狀態（同類刷新為較長持續）

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -180,6 +180,7 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     hp: maxHp,
     defense: job.defense + bonus.defense + (spec?.defense ?? 0),
     moves: finalMoves,
+    damageBonus: bonus.damageBonus,
     isProtagonist: record.id === 'protagonist',
   };
 }

--- a/src/scripts/games/caravan/expedition.ts
+++ b/src/scripts/games/caravan/expedition.ts
@@ -3,7 +3,7 @@ import type { Stat } from './types';
 import type { SaveData } from './save';
 import type { CheckResult } from './check';
 import { resolveCheck, statMod } from './check';
-import { partyCheckBonus } from './roster';
+import { partyCheckBonus, skillCheckBonus } from './roster';
 import type { CombatState, EnemyUnit, PartyMember } from './combat';
 import type { JobId } from './data/jobs';
 import { ITEMS } from './data/items';
@@ -401,7 +401,7 @@ export function resolveOption(
   let check: CheckResult | null = null;
   let effects: EffectSpec[];
   if (opt.check) {
-    const modifier = statMod(save.protagonist.stats[opt.check.stat]) + partyCheckBonus(save)
+    const modifier = statMod(save.protagonist.stats[opt.check.stat]) + partyCheckBonus(save) + skillCheckBonus(save.protagonist, opt.check.stat)
       + (conditionById(state.conditionId)?.checkDelta ?? 0); // M8 旅況
     check = resolveCheck(rng, { stat: opt.check.stat, dc: opt.check.dc, modifier });
     effects = check.success ? opt.success : (opt.failure ?? []);

--- a/src/scripts/games/caravan/roster.test.ts
+++ b/src/scripts/games/caravan/roster.test.ts
@@ -3,11 +3,12 @@ import {
   XP_TABLE, levelFromXp, pendingLevelUps, applyLevelUp, unlockedMoves,
   generateRecruitPool, hireCost, wagePerTrip, equipItem, unequipItem, equipmentBonus,
   SPECIALIZATIONS, chooseSpecialization, bondTier, partyCheckBonus,
+  SKILLS, spendSkillPoint, skillCheckBonus, smithCost, upgradeEquipment, rollStats,
   TRAITS, partyCheckBonus,
 } from './roster';
 import { memberFromRecord } from './data/jobs';
 import { createRng } from './rng';
-import { newGame, type SaveData, type CompanionRecord } from './save';
+import { newGame, STARTING_PROFILE as STARTING_PROFILE_REF, type SaveData, type CompanionRecord } from './save';
 import type { StatBlock } from './types';
 import { JOBS, memberFromRecord } from './data/jobs';
 import { ITEMS, type ItemDef } from './data/items';
@@ -400,7 +401,7 @@ describe('roster（成長系統）', () => {
     describe('equipmentBonus', () => {
       it('無裝備回全 0/空', () => {
         const record = makeCompanion();
-        expect(equipmentBonus(record)).toEqual({ stats: {}, defense: 0, maxHp: 0 });
+        expect(equipmentBonus(record)).toEqual({ stats: {}, defense: 0, maxHp: 0, damageBonus: 0 });
       });
 
       it('三個 slot 的 bonus/defense/maxHp 各自加總', () => {
@@ -552,5 +553,118 @@ describe('M11 旅伴羈絆', () => {
     const noBond = memberFromRecord(rec);
     const bonded = memberFromRecord({ ...rec, bond: 9 }); // tier 3
     expect(bonded.maxHp).toBe(noBond.maxHp + 6);
+  });
+});
+
+describe('M14 冒險技能', () => {
+  const mkRec = (over: Partial<CompanionRecord> = {}): CompanionRecord => ({
+    id: 'protagonist', name: '你', job: 'swordsman', level: 1, xp: 0,
+    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22,
+    injuredForTrips: 0, trait: null,
+    equipment: { weapon: null, armor: null, trinket: null },
+    ...over,
+  });
+
+  it('SKILLS：五技能一一對應五屬性', () => {
+    expect(SKILLS).toHaveLength(5);
+    const stats = SKILLS.map((sk) => sk.stat).sort();
+    expect(stats).toEqual(['cha', 'con', 'dex', 'int', 'str']);
+  });
+
+  it('applyLevelUp 升級同時獲得 1 技能點', () => {
+    const r = mkRec({ xp: 60 });
+    applyLevelUp(r, { str: 2 });
+    expect(r.skillPoints).toBe(1);
+  });
+
+  it('spendSkillPoint：消耗點數升 rank；無點數/滿 rank(5) 丟錯', () => {
+    const r = mkRec({ skillPoints: 2 });
+    spendSkillPoint(r, 'negotiation');
+    expect(r.skills?.negotiation).toBe(1);
+    expect(r.skillPoints).toBe(1);
+    expect(() => spendSkillPoint(mkRec(), 'negotiation')).toThrow();
+    const maxed = mkRec({ skillPoints: 1, skills: { negotiation: 5 } });
+    expect(() => spendSkillPoint(maxed, 'negotiation')).toThrow();
+    expect(() => spendSkillPoint(mkRec({ skillPoints: 1 }), 'nope')).toThrow();
+  });
+
+  it('skillCheckBonus：回傳該屬性對應技能的 rank；未學為 0', () => {
+    const r = mkRec({ skills: { negotiation: 3, survival: 1 } });
+    expect(skillCheckBonus(r, 'cha')).toBe(3);
+    expect(skillCheckBonus(r, 'con')).toBe(1);
+    expect(skillCheckBonus(r, 'str')).toBe(0);
+    expect(skillCheckBonus(mkRec(), 'cha')).toBe(0);
+  });
+});
+
+describe('M14 鐵匠強化', () => {
+  const mkRec = (over: Partial<CompanionRecord> = {}): CompanionRecord => ({
+    id: 'protagonist', name: '你', job: 'swordsman', level: 1, xp: 0,
+    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22,
+    injuredForTrips: 0, trait: null,
+    equipment: { weapon: 'salt-crystal-blade', armor: 'ridgeleather-vest', trinket: 'den-idol' },
+    ...over,
+  });
+
+  it('smithCost：+1=40G+1礦、+2=80G+2礦、+3=120G+3礦', () => {
+    expect(smithCost(0)).toEqual({ gold: 40, ore: 1 });
+    expect(smithCost(1)).toEqual({ gold: 80, ore: 2 });
+    expect(smithCost(2)).toEqual({ gold: 120, ore: 3 });
+  });
+
+  it('upgradeEquipment：扣金幣與礦石、slot plus +1；封頂 +3、無裝備/資源不足丟錯', () => {
+    const save = newGame(1000);
+    save.protagonist = mkRec();
+    save.gold = 200; save.inventory['ore'] = 2;
+    upgradeEquipment(save, 'protagonist', 'weapon');
+    expect(save.protagonist.equipmentPlus?.weapon).toBe(1);
+    expect(save.gold).toBe(160);
+    expect(save.inventory['ore']).toBe(1);
+
+    const capped = newGame(1000);
+    capped.protagonist = mkRec({ equipmentPlus: { weapon: 3, armor: 0, trinket: 0 } });
+    capped.gold = 999; capped.inventory['ore'] = 9;
+    expect(() => upgradeEquipment(capped, 'protagonist', 'weapon')).toThrow();
+
+    const bare = newGame(1000);
+    bare.gold = 999; bare.inventory['ore'] = 9;
+    expect(() => upgradeEquipment(bare, 'protagonist', 'weapon')).toThrow(); // 未裝備
+
+    const poor = newGame(1000);
+    poor.protagonist = mkRec();
+    poor.gold = 10; poor.inventory['ore'] = 9;
+    expect(() => upgradeEquipment(poor, 'protagonist', 'weapon')).toThrow();
+  });
+
+  it('equipmentBonus：armor plus → 防禦 +N、trinket plus → 生命 +2N、weapon plus → damageBonus +N', () => {
+    const plain = equipmentBonus(mkRec());
+    const plused = equipmentBonus(mkRec({ equipmentPlus: { weapon: 2, armor: 3, trinket: 1 } }));
+    expect(plused.defense).toBe(plain.defense + 3);
+    expect(plused.maxHp).toBe(plain.maxHp + 2);
+    expect(plused.damageBonus).toBe(2);
+    expect(plain.damageBonus).toBe(0);
+    // 空 slot 的 plus 不生效
+    const empty = equipmentBonus(mkRec({ equipment: { weapon: null, armor: null, trinket: null }, equipmentPlus: { weapon: 3, armor: 3, trinket: 3 } }));
+    expect(empty.damageBonus).toBe(0);
+    expect(empty.defense).toBe(0);
+  });
+
+  it('memberFromRecord：weapon plus 轉為 PartyMember.damageBonus', () => {
+    const m = memberFromRecord(mkRec({ equipmentPlus: { weapon: 2, armor: 0, trinket: 0 } }));
+    expect(m.damageBonus).toBe(2);
+  });
+});
+
+describe('M14 創角擲骰', () => {
+  it('rollStats：每項屬性落在 [base-2, base+3]；同種子可重現', () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const rolled = rollStats(createRng(seed), 'mage');
+      const base = STARTING_PROFILE_REF.mage.stats;
+      for (const key of Object.keys(base) as Array<keyof StatBlock>) {
+        expect(rolled[key]).toBeGreaterThanOrEqual(base[key] - 2);
+        expect(rolled[key]).toBeLessThanOrEqual(base[key] + 3);
+      }
+    }
+    expect(rollStats(createRng(9), 'ranger')).toEqual(rollStats(createRng(9), 'ranger'));
   });
 });

--- a/src/scripts/games/caravan/roster.ts
+++ b/src/scripts/games/caravan/roster.ts
@@ -1,5 +1,6 @@
 import type { Rng } from './rng';
 import type { CompanionRecord, SaveData } from './save';
+import { STARTING_PROFILE, STAT_ROLL_MIN, STAT_ROLL_MAX } from './save';
 import type { StatBlock } from './types';
 import type { Move } from './combat';
 import { statMod } from './check';
@@ -135,6 +136,76 @@ export const SPECIALIZATIONS: Record<CompanionRecord['job'], SpecializationDef[]
   ],
 };
 
+// ---------------------------------------------------------------------------
+// M14 冒險技能：五技能一一對應五屬性，rank 加成遠征檢定（expedition resolveOption）
+// ---------------------------------------------------------------------------
+
+export interface SkillDef { id: string; name: string; stat: keyof StatBlock; desc: string; }
+
+export const SKILL_RANK_CAP = 5;
+
+export const SKILLS: SkillDef[] = [
+  { id: 'martial', name: '武藝', stat: 'str', desc: '刀劍拳腳的功底——力量檢定 +rank' },
+  { id: 'scouting', name: '偵查', stat: 'dex', desc: '先一步察覺危險——敏捷檢定 +rank' },
+  { id: 'lore', name: '博識', stat: 'int', desc: '商路見聞與古籍知識——智力檢定 +rank' },
+  { id: 'negotiation', name: '交涉', stat: 'cha', desc: '討價還價與談判——魅力檢定 +rank' },
+  { id: 'survival', name: '生存', stat: 'con', desc: '風餐露宿的本領——體質檢定 +rank' },
+];
+
+export function spendSkillPoint(record: CompanionRecord, skillId: string): void {
+  const skill = SKILLS.find((sk) => sk.id === skillId);
+  if (!skill) throw new Error(`未知技能「${skillId}」`);
+  if ((record.skillPoints ?? 0) <= 0) throw new Error('沒有可用的技能點');
+  const rank = record.skills?.[skillId] ?? 0;
+  if (rank >= SKILL_RANK_CAP) throw new Error(`「${skill.name}」已達最高 rank ${SKILL_RANK_CAP}`);
+  record.skills = { ...(record.skills ?? {}), [skillId]: rank + 1 };
+  record.skillPoints = (record.skillPoints ?? 0) - 1;
+}
+
+/** 該屬性對應技能的 rank（遠征檢定加成） */
+export function skillCheckBonus(record: CompanionRecord, stat: keyof StatBlock): number {
+  const skill = SKILLS.find((sk) => sk.stat === stat);
+  if (!skill) return 0;
+  return record.skills?.[skill.id] ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// M14 鐵匠強化：per-slot +N（跟人走），weapon=+N 傷害、armor=+N 防禦、trinket=+2N 生命
+// ---------------------------------------------------------------------------
+
+export const SMITH_PLUS_CAP = 3;
+
+export function smithCost(currentPlus: number): { gold: number; ore: number } {
+  return { gold: 40 * (currentPlus + 1), ore: currentPlus + 1 };
+}
+
+export function upgradeEquipment(save: SaveData, memberId: string, slot: EquipSlot): void {
+  const record = memberId === save.protagonist.id
+    ? save.protagonist
+    : save.companions.find((c) => c.id === memberId);
+  if (!record) throw new Error(`找不到成員「${memberId}」`);
+  if (!record.equipment[slot]) throw new Error('該欄位沒有裝備，無法強化');
+  const plus = record.equipmentPlus?.[slot] ?? 0;
+  if (plus >= SMITH_PLUS_CAP) throw new Error(`已達強化上限 +${SMITH_PLUS_CAP}`);
+  const cost = smithCost(plus);
+  if (save.gold < cost.gold) throw new Error(`金幣不足（需 ${cost.gold}）`);
+  if ((save.inventory['ore'] ?? 0) < cost.ore) throw new Error(`礦石不足（需 ${cost.ore}）`);
+  save.gold -= cost.gold;
+  save.inventory['ore'] -= cost.ore;
+  record.equipmentPlus = { weapon: 0, armor: 0, trinket: 0, ...(record.equipmentPlus ?? {}), [slot]: plus + 1 };
+}
+
+/** M14 創角擲骰：每項屬性 = 職業基準 + [STAT_ROLL_MIN, STAT_ROLL_MAX] 均勻隨機 */
+export function rollStats(rng: Rng, job: JobId): StatBlock {
+  const profile = STARTING_PROFILE[job];
+  const rolled = { ...profile.stats };
+  const span = STAT_ROLL_MAX - STAT_ROLL_MIN + 1;
+  for (const key of Object.keys(rolled) as Array<keyof StatBlock>) {
+    rolled[key] = profile.stats[key] + STAT_ROLL_MIN + (rng.roll(span) - 1);
+  }
+  return rolled;
+}
+
 export function specById(id: string | null | undefined): SpecializationDef | null {
   if (!id) return null;
   for (const specs of Object.values(SPECIALIZATIONS)) {
@@ -194,6 +265,7 @@ export function applyLevelUp(record: CompanionRecord, allocate: Partial<StatBloc
   }
   record.level += 1;
   record.maxHp += 3 + statMod(record.stats.con);
+  record.skillPoints = (record.skillPoints ?? 0) + 1; // M14 冒險技能
 }
 
 /** 依 record.level 過濾 JOBS[record.job].moves；招式無 minLevel 視為 Lv1 起就會 */
@@ -315,10 +387,11 @@ export function unequipItem(save: SaveData, memberId: string, slot: EquipSlot): 
 }
 
 /** 加總成員三個裝備欄位的效果：屬性加值/防禦/生命上限（memberFromRecord 整合用） */
-export function equipmentBonus(record: CompanionRecord): { stats: Partial<StatBlock>; defense: number; maxHp: number } {
+export function equipmentBonus(record: CompanionRecord): { stats: Partial<StatBlock>; defense: number; maxHp: number; damageBonus: number } {
   const stats: Partial<StatBlock> = {};
   let defense = 0;
   let maxHp = 0;
+  let damageBonus = 0;
   for (const slot of EQUIP_SLOTS) {
     const itemId = record.equipment[slot];
     if (!itemId) continue;
@@ -331,6 +404,13 @@ export function equipmentBonus(record: CompanionRecord): { stats: Partial<StatBl
     }
     if (equip.defense) defense += equip.defense;
     if (equip.maxHp) maxHp += equip.maxHp;
+    // M14 鐵匠強化（slot 有裝備才生效）
+    const plus = record.equipmentPlus?.[slot] ?? 0;
+    if (plus > 0) {
+      if (slot === 'weapon') damageBonus += plus;
+      if (slot === 'armor') defense += plus;
+      if (slot === 'trinket') maxHp += plus * 2;
+    }
   }
-  return { stats, defense, maxHp };
+  return { stats, defense, maxHp, damageBonus };
 }

--- a/src/scripts/games/caravan/save.test.ts
+++ b/src/scripts/games/caravan/save.test.ts
@@ -338,3 +338,15 @@ describe('創角系統（createProtagonist / newGame config）', () => {
     expect(newGame(2000).protagonist.job).toBe('swordsman');
   });
 });
+
+describe('M14 創角擲骰（createProtagonist statRoll）', () => {
+  it('statRoll 在允許範圍內作為配點基底；超出範圍丟錯', () => {
+    const base = STARTING_PROFILE.swordsman.stats;
+    const roll = { ...base, str: base.str + 3, con: base.con - 2 };
+    const created = createProtagonist({ job: 'swordsman', statRoll: roll, allocation: { str: 1 } });
+    expect(created.stats.str).toBe(base.str + 4); // 骰 +3 再配 1
+    expect(created.stats.con).toBe(base.con - 2);
+    expect(() => createProtagonist({ job: 'swordsman', statRoll: { ...base, str: base.str + 4 } })).toThrow();
+    expect(() => createProtagonist({ job: 'swordsman', statRoll: { ...base, dex: base.dex - 3 } })).toThrow();
+  });
+});

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -23,6 +23,12 @@ export interface CompanionRecord {
   specialization?: string | null;
   /** M11 旅伴羈絆：與主角同行完成的遠征趟數（主角自身不使用此欄） */
   bond?: number;
+  /** M14 冒險技能 rank（skillId -> 0-5）；主角使用 */
+  skills?: Record<string, number>;
+  /** M14 未分配技能點（升級 +1） */
+  skillPoints?: number;
+  /** M14 鐵匠強化：各裝備欄的 +N（0-3），跟人走（換裝保留） */
+  equipmentPlus?: { weapon: number; armor: number; trinket: number };
 }
 
 export interface SaveDataV2 {
@@ -115,12 +121,18 @@ export const STARTING_PROFILE: Record<JobId, { stats: StatBlock; maxHp: number }
   cleric: { stats: { str: 10, dex: 9, int: 11, cha: 14, con: 12 }, maxHp: 21 },
 };
 
+/** M14 創角擲骰：每項屬性允許偏離職業基準的範圍 */
+export const STAT_ROLL_MIN = -2;
+export const STAT_ROLL_MAX = 3;
+
 export interface CharacterChoice {
   job: JobId;
   /** 額外配點（總和 ≤ CREATION_BONUS_POINTS，每項非負整數） */
   allocation?: Partial<StatBlock>;
   /** 起始特性 id（roster.ts TRAITS）；未選為 null */
   trait?: string | null;
+  /** M14 擲骰結果：每項須落在 [base+STAT_ROLL_MIN, base+STAT_ROLL_MAX]；未帶＝職業基準 */
+  statRoll?: StatBlock;
 }
 
 /** 依創角選擇建立主角記錄。劍士＋0 配點＋無特性 === defaultProtagonist()。 */
@@ -138,7 +150,16 @@ export function createProtagonist(choice: CharacterChoice): CompanionRecord {
   if (total > CREATION_BONUS_POINTS) {
     throw new Error(`創角配點總和不可超過 ${CREATION_BONUS_POINTS}`);
   }
-  const stats: StatBlock = { ...profile.stats };
+  const base = choice.statRoll ?? profile.stats;
+  if (choice.statRoll) {
+    for (const key of Object.keys(profile.stats) as Array<keyof StatBlock>) {
+      const offset = choice.statRoll[key] - profile.stats[key];
+      if (offset < STAT_ROLL_MIN || offset > STAT_ROLL_MAX) {
+        throw new Error(`擲骰屬性超出允許範圍（${String(key)} 偏離 ${offset}）`);
+      }
+    }
+  }
+  const stats: StatBlock = { ...base };
   for (const key of Object.keys(alloc) as Array<keyof StatBlock>) {
     stats[key] += alloc[key] ?? 0;
   }

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -1076,3 +1076,78 @@ test.describe('商隊與劍：序章演出', () => {
     await expect(page.locator('#screen-create')).toBeVisible();
   });
 });
+
+test.describe('商隊與劍：M14 角色深度', () => {
+  async function freshCreate(page: import('@playwright/test').Page): Promise<void> {
+    await page.goto('/caravan/play?seed=77');
+    await page.evaluate(() => localStorage.removeItem('caravan-save-v1'));
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-new-game');
+    await page.click('#btn-prologue-skip'); // 序章演出：e2e 一律跳過
+  }
+
+  test('創角擲骰：擲骰後屬性在基準 ±範圍內變動、確認後入檔；還原鈕回基準', async ({ page }) => {
+    await freshCreate(page);
+    await page.click('#btn-roll-stats');
+    await expect(page.locator('#btn-roll-reset')).toBeVisible();
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    const stats = await page.evaluate(
+      () => JSON.parse(localStorage.getItem('caravan-save-v1')!).protagonist.stats
+    );
+    const base = { str: 12, dex: 12, int: 10, cha: 12, con: 12 };
+    for (const key of Object.keys(base) as Array<keyof typeof base>) {
+      expect(stats[key]).toBeGreaterThanOrEqual(base[key] - 2);
+      expect(stats[key]).toBeLessThanOrEqual(base[key] + 3);
+    }
+  });
+
+  test('冒險技能：有技能點時 roster 可加點、rank 點點顯示、點數遞減', async ({ page }) => {
+    await freshCreate(page);
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await page.evaluate(() => {
+      const data = JSON.parse(localStorage.getItem('caravan-save-v1')!);
+      data.protagonist.skillPoints = 1;
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-continue');
+    await page.click('.town-tab[data-town-tab="roster"]');
+
+    await page.click('.skill-plus[data-skill-id="scouting"]');
+    const card = page.locator('.roster-card[data-member-id="protagonist"]');
+    await expect(card.locator('.skill-chip', { hasText: '偵查' })).toContainText('●');
+    const data = await page.evaluate(() => JSON.parse(localStorage.getItem('caravan-save-v1')!));
+    expect(data.protagonist.skills.scouting).toBe(1);
+    expect(data.protagonist.skillPoints).toBe(0);
+  });
+
+  test('鐵匠強化：花 40G+1 礦把武器強化到 +1，標籤與下一級費用更新', async ({ page }) => {
+    await freshCreate(page);
+    await page.click('#btn-create-confirm');
+    await expect(page.locator('#screen-town')).toBeVisible();
+    await page.evaluate(() => {
+      const data = JSON.parse(localStorage.getItem('caravan-save-v1')!);
+      data.protagonist.equipment.weapon = 'salt-crystal-blade';
+      data.gold = 100;
+      data.inventory = { ore: 1 };
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.click('#btn-continue');
+    await page.click('.town-tab[data-town-tab="roster"]');
+
+    const card = page.locator('.roster-card[data-member-id="protagonist"]');
+    await card.locator('.smith-btn[data-slot="weapon"]').click();
+    await expect(card.locator('.smith-plus-tag')).toHaveText('+1');
+    await expect(card.locator('.smith-btn[data-slot="weapon"]')).toContainText('80G');
+    const data = await page.evaluate(() => JSON.parse(localStorage.getItem('caravan-save-v1')!));
+    expect(data.protagonist.equipmentPlus.weapon).toBe(1);
+    expect(data.gold).toBe(60);
+    expect(data.inventory.ore).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

回應「裝備太簡單、屬性太簡單、開局該能骰隨機屬性、沒有技能系統」（TDD）：

- **創角擲骰**：🎲 每項屬性在職業基準 −2～+3 擲骰、可無限重擲/還原，配點疊在骰出基底上
- **冒險技能**：五技能對應五屬性（武藝/偵查/博識/交涉/生存），升級 +1 技能點、rank 0-5 直接加成遠征檢定；roster ●○ 顯示＋加點
- **鐵匠強化**：裝備欄 +N（0-3 跟人走）——武器 +N 傷害（新 damageBonus 通道）、護甲 +N 防禦、飾品 +2N 生命；40G×(N+1)＋礦石×(N+1)，礦石從交易品變強化資源
- 相容：新欄位皆 optional 不 bump 存檔版；不擲骰＝職業基準（既有 e2e 不動）

## Test plan
- [x] `npx vitest run` 1557 全綠（10 條新引擎測試）
- [x] caravan e2e 40＋defense 3 全綠（擲骰/技能/鐵匠 3 條新測試）
- [x] `npm run build` 綠
- [x] 實機：骰天賦入檔、學交涉 ●、武器強化 +1（資源扣減與下一級費用正確）

🤖 Generated with [Claude Code](https://claude.com/claude-code)