### PR TITLE
feat(caravan): add M18 loadouts and campaign UI

### DIFF
--- a/src/pages/caravan/play.astro
+++ b/src/pages/caravan/play.astro
@@ -128,63 +128,95 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       </div>
     </section>
 
-    <!-- 城鎮畫面（M4：市集/酒館/隊伍/馬車四分頁） -->
+    <!-- 城鎮畫面（M18：戰役中樞，不再以長頁籤清單呈現） -->
     <section id="screen-town" class="screen screen-wide" hidden>
-      <img class="town-banner" src="/assets/games/caravan/town-starting-town.webp" alt="" width="1280" height="720" loading="lazy" />
-      <h2 class="town-name">啟程之鎮</h2>
-      <p class="town-status">金幣 <span id="town-gold">0</span> G</p>
-      <div id="goal-card" class="goal-card">
-        <span id="goal-rank" class="goal-rank"></span>
-        <div class="goal-body">
-          <p id="goal-desc" class="goal-desc"></p>
-          <p id="goal-next" class="goal-next"></p>
-          <div id="goal-bar" class="goal-bar"><i id="goal-bar-fill"></i></div>
+      <header class="town-scene">
+        <img class="town-banner" src="/assets/games/caravan/town-starting-town.webp" alt="" width="1280" height="720" loading="lazy" />
+        <div class="town-scene-shade" aria-hidden="true"></div>
+        <div class="town-scene-copy">
+          <span class="town-kicker">CARAVAN HEADQUARTERS</span>
+          <h2 class="town-name">啟程之鎮</h2>
+          <p class="town-status"><span>商隊資金</span><b><span id="town-gold">0</span> G</b></p>
         </div>
-      </div>
-      <p class="screen-guide">在此補給整備。準備好了就點<b>委託板</b>出發遠征、賺取財富。</p>
-      <div class="town-actions">
-        <button id="btn-quest-board" class="caravan-btn">委託板</button>
-        <button id="btn-training" class="caravan-btn">訓練場</button>
-        <button id="btn-resume-expedition" class="caravan-btn" hidden>繼續遠征</button>
+        <div id="goal-card" class="goal-card">
+          <span id="goal-rank" class="goal-rank"></span>
+          <div class="goal-body">
+            <p id="goal-desc" class="goal-desc"></p>
+            <p id="goal-next" class="goal-next"></p>
+            <div id="goal-bar" class="goal-bar"><i id="goal-bar-fill"></i></div>
+          </div>
+        </div>
+      </header>
+
+      <div class="town-actions" aria-label="主要行動">
+        <button id="btn-quest-board" class="town-action town-action-primary">
+          <span class="town-action-mark" aria-hidden="true">令</span>
+          <span><b>委託板</b><small>選擇商路或地下城</small></span>
+        </button>
+        <button id="btn-training" class="town-action">
+          <span class="town-action-mark" aria-hidden="true">鍊</span>
+          <span><b>訓練場</b><small>測試編隊與戰技</small></span>
+        </button>
+        <button id="btn-resume-expedition" class="town-action town-action-resume" hidden>
+          <span class="town-action-mark" aria-hidden="true">續</span>
+          <span><b>繼續遠征</b><small>返回未完成的旅途</small></span>
+        </button>
       </div>
       <p id="expedition-expired-note" class="expedition-expired-note" hidden>
         先前的遠征記錄已過期，已返回城鎮
       </p>
 
-      <nav id="town-tabs" class="town-tabs">
-        <button type="button" class="town-tab" data-town-tab="market">市集</button>
-        <button type="button" class="town-tab" data-town-tab="tavern">酒館</button>
-        <button type="button" class="town-tab" data-town-tab="roster">隊伍</button>
-        <button type="button" class="town-tab" data-town-tab="backpack">背包</button>
-        <button type="button" class="town-tab" data-town-tab="wagon">馬車</button>
-      </nav>
-
-      <section id="screen-market" class="town-panel" hidden>
-        <p class="panel-status">持有金幣 <span id="market-gold">0</span> G</p>
-        <div id="market-list" class="market-list"></div>
+      <section class="town-party-deck" aria-labelledby="town-party-title">
+        <div class="town-section-heading">
+          <span>
+            <small>EXPEDITION PARTY</small>
+            <b id="town-party-title">本次出征隊</b>
+          </span>
+          <em>前後排與職務會影響檢定、受擊與恢復</em>
+        </div>
+        <div id="town-party-ribbon" class="town-party-ribbon"></div>
       </section>
 
-      <section id="screen-tavern" class="town-panel" hidden>
-        <p class="panel-hint">花錢雇用旅人加入商隊（傭兵名冊上限 6 人；每趟含主角最多出征 4 人）。</p>
-        <div id="tavern-list" class="tavern-list"></div>
-      </section>
+      <div class="town-console">
+        <nav id="town-tabs" class="town-tabs" aria-label="城鎮設施">
+          <button type="button" class="town-tab" data-town-tab="market"><span aria-hidden="true">市</span><b>市集</b><small>補給交易</small></button>
+          <button type="button" class="town-tab" data-town-tab="tavern"><span aria-hidden="true">酒</span><b>酒館</b><small>招募旅伴</small></button>
+          <button type="button" class="town-tab" data-town-tab="roster"><span aria-hidden="true">隊</span><b>隊伍</b><small>構築整裝</small></button>
+          <button type="button" class="town-tab" data-town-tab="backpack"><span aria-hidden="true">囊</span><b>背包</b><small>物資收藏</small></button>
+          <button type="button" class="town-tab" data-town-tab="wagon"><span aria-hidden="true">車</span><b>馬車</b><small>運力升級</small></button>
+        </nav>
 
-      <section id="screen-roster" class="town-panel" hidden>
-        <div id="roster-list" class="roster-list"></div>
-      </section>
+        <div class="town-console-main">
+          <section id="screen-market" class="town-panel" hidden>
+            <div class="town-panel-head"><span><small>MARKET</small><b>市集行情</b></span><p class="panel-status">持有 <strong><span id="market-gold">0</span> G</strong></p></div>
+            <div id="market-list" class="market-list"></div>
+          </section>
 
-      <section id="screen-backpack" class="town-panel" hidden>
+          <section id="screen-tavern" class="town-panel" hidden>
+            <div class="town-panel-head"><span><small>TAVERN</small><b>旅人名冊</b></span></div>
+            <p class="panel-hint">名冊最多 6 人；每趟含主角最多出征 4 人。招募誰，會同時改變戰鬥與事件檢定。</p>
+            <div id="tavern-list" class="tavern-list"></div>
+          </section>
 
-        <p class="panel-hint">商隊目前持有的物品。裝備可在<b>隊伍</b>分頁為成員穿戴。</p>
+          <section id="screen-roster" class="town-panel" hidden>
+            <div class="town-panel-head"><span><small>ROSTER &amp; LOADOUT</small><b>隊伍與戰技構築</b></span></div>
+            <p class="panel-hint">每名角色最多攜帶 4 招戰技。裝備、技能、站位與遠征職務會共同定義他的用途。</p>
+            <div id="roster-list" class="roster-list"></div>
+          </section>
 
-        <div id="backpack-list" class="backpack-list"></div>
+          <section id="screen-backpack" class="town-panel" hidden>
+            <div class="town-panel-head"><span><small>INVENTORY</small><b>商隊背包</b></span></div>
+            <p class="panel-hint">消耗品可在旅途中救急；裝備則到<b>隊伍</b>為成員穿戴。</p>
+            <div id="backpack-list" class="backpack-list"></div>
+          </section>
 
-      </section>
-
-      <section id="wagon-panel" class="town-panel" hidden>
-        <p id="wagon-status" class="panel-status"></p>
-        <button id="btn-wagon-upgrade" type="button" class="caravan-btn"></button>
-      </section>
+          <section id="wagon-panel" class="town-panel" hidden>
+            <div class="town-panel-head"><span><small>WAGON</small><b>馬車工坊</b></span></div>
+            <p id="wagon-status" class="panel-status"></p>
+            <button id="btn-wagon-upgrade" type="button" class="caravan-btn"></button>
+          </section>
+        </div>
+      </div>
     </section>
 
     <!-- 屬性配點面板（M4：升級時彈出） -->
@@ -321,6 +353,7 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
       <button id="btn-settle-back" class="caravan-btn">返回城鎮</button>
     </section>
     </div>
+    <div id="game-toast" class="game-toast" role="status" aria-live="polite" hidden></div>
   </main>
   <ArcadeBgm track="/assets/games/bgm/caravan.mp3" />
 </BaseLayout>
@@ -358,7 +391,14 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   } from '@scripts/games/caravan/expedition';
   import type { ExpeditionState, EventCard, RoomKind, LocationDef } from '@scripts/games/caravan/expedition';
   import type { CheckResult } from '@scripts/games/caravan/check';
-  import { memberFromRecord, JOBS } from '@scripts/games/caravan/data/jobs';
+  import {
+    availableMovesFromRecord,
+    JOBS,
+    memberFromRecord,
+    MOVE_LOADOUT_CAP,
+    preparedMovesFromRecord,
+    setPreparedMoves,
+  } from '@scripts/games/caravan/data/jobs';
   import { TRAINING_ENCOUNTER } from '@scripts/games/caravan/data/enemies';
   import { visibleLocations, LOCATIONS } from '@scripts/games/caravan/data/locations';
   import { EVENTS } from '@scripts/games/caravan/data/events';
@@ -480,6 +520,23 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   const btnResumeExpedition = document.getElementById('btn-resume-expedition')!;
   const goldEl = document.getElementById('town-gold')!;
   const expeditionExpiredNoteEl = document.getElementById('expedition-expired-note')!;
+  const townPartyRibbonEl = document.getElementById('town-party-ribbon')!;
+  const gameToastEl = document.getElementById('game-toast')!;
+  let gameToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function showGameToast(message: string, tone: 'good' | 'info' = 'good'): void {
+    if (gameToastTimer) clearTimeout(gameToastTimer);
+    gameToastEl.textContent = message;
+    gameToastEl.dataset.tone = tone;
+    gameToastEl.hidden = false;
+    gameToastEl.classList.remove('toast-in');
+    void gameToastEl.offsetWidth;
+    gameToastEl.classList.add('toast-in');
+    gameToastTimer = setTimeout(() => {
+      gameToastEl.hidden = true;
+      gameToastEl.classList.remove('toast-in');
+    }, 2200);
+  }
 
   // ---- 城鎮分頁（M4：市集/酒館/隊伍/馬車） ----
   const townTabButtons = Array.from(
@@ -602,7 +659,9 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
   function switchTownTab(tab: string): void {
     for (const btn of townTabButtons) {
-      btn.classList.toggle('active', btn.dataset.townTab === tab);
+      const active = btn.dataset.townTab === tab;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-selected', String(active));
     }
     for (const [key, panel] of Object.entries(townPanels)) {
       panel.hidden = key !== tab;
@@ -935,6 +994,34 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     specPanelEl.hidden = false;
   }
 
+  function moveSummary(move: Move): string {
+    if (move.kind === 'guard') return '守勢．防禦 +4．攔截單體攻擊';
+    const parts: string[] = [];
+    if (move.area) parts.push('敵方全體');
+    else if (move.target === 'ally') parts.push('指定隊友');
+    else if (move.target === 'self') parts.push('自身');
+    else parts.push('單體敵人');
+    if (move.damage) {
+      const bonus = move.damage.bonusStat ? `＋${STAT_LABELS[move.damage.bonusStat]}` : '';
+      parts.push(`傷害 ${move.damage.dice}d${move.damage.sides}${bonus}`);
+    }
+    if (move.heal) {
+      const bonus = move.heal.bonusStat ? `＋${STAT_LABELS[move.heal.bonusStat]}` : '';
+      parts.push(`恢復 ${move.heal.dice}d${move.heal.sides}${bonus}`);
+    }
+    if (move.hitBonus) parts.push(`命中 +${move.hitBonus}`);
+    if (move.element) parts.push(ELEMENT_LABELS[move.element]);
+    if (move.applyStatus) {
+      const statusLabel = {
+        poison: '中毒',
+        stun: '暈眩',
+        strength: '強化',
+      }[move.applyStatus.kind];
+      parts.push(statusLabel);
+    }
+    return parts.join('．');
+  }
+
   function renderRoster(): void {
     if (!save) return;
     const members: CompanionRecord[] = [save.protagonist, ...save.companions];
@@ -1059,12 +1146,48 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
 
       const moves = document.createElement('div');
       moves.className = 'roster-moves';
-      for (const move of effective.moves) {
-        const chip = document.createElement('span');
-        chip.className = `move-chip move-${move.kind}`;
-        chip.textContent = move.name;
-        moves.appendChild(chip);
+      const knownMoves = availableMovesFromRecord(record);
+      const preparedIds = new Set(preparedMovesFromRecord(record).map((move) => move.id));
+      const movesHead = document.createElement('div');
+      movesHead.className = 'roster-moves-head';
+      const movesTitle = document.createElement('b');
+      movesTitle.textContent = `戰技配置 ${preparedIds.size}/${MOVE_LOADOUT_CAP}`;
+      const movesHint = document.createElement('span');
+      movesHint.textContent = '點選戰技切換攜帶狀態';
+      movesHead.append(movesTitle, movesHint);
+      moves.appendChild(movesHead);
+      const movesGrid = document.createElement('div');
+      movesGrid.className = 'move-loadout-grid';
+      for (const move of knownMoves) {
+        const selected = preparedIds.has(move.id);
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = `move-chip move-${move.kind} ${selected ? 'prepared' : 'unprepared'}`;
+        chip.dataset.moveId = move.id;
+        chip.setAttribute('aria-pressed', String(selected));
+        chip.disabled = (selected && preparedIds.size === 1) || (!selected && preparedIds.size >= MOVE_LOADOUT_CAP);
+
+        const moveState = document.createElement('span');
+        moveState.className = 'move-state';
+        moveState.textContent = selected ? '已攜帶' : '候補';
+        const moveName = document.createElement('b');
+        moveName.textContent = move.name;
+        const moveDetail = document.createElement('small');
+        moveDetail.textContent = moveSummary(move);
+        chip.append(moveState, moveName, moveDetail);
+        chip.addEventListener('click', () => {
+          if (!save) return;
+          const next = new Set(preparedMovesFromRecord(record).map((known) => known.id));
+          if (next.has(move.id)) next.delete(move.id);
+          else next.add(move.id);
+          setPreparedMoves(record, [...next]);
+          saveGame(save);
+          renderTownPanels();
+          showGameToast(next.has(move.id) ? `已裝備戰技「${move.name}」` : `已卸下戰技「${move.name}」`, 'info');
+        });
+        movesGrid.appendChild(chip);
       }
+      moves.appendChild(movesGrid);
 
       sheet.append(name, xp, stats, hp, moves);
       // M14 冒險技能區
@@ -1227,10 +1350,57 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
     }
   }
 
+  function renderTownPartyRibbon(): void {
+    if (!save) return;
+    const plan = normalizeExpeditionPlan(save);
+    const members = [save.protagonist, ...save.companions];
+    townPartyRibbonEl.innerHTML = '';
+    for (const memberId of plan.activeIds) {
+      const record = members.find((member) => member.id === memberId);
+      if (!record) continue;
+      const effective = memberFromRecord(record);
+      const row = plan.positions[record.id] === 'back' ? '後排' : '前排';
+      const role = memberRole(plan, record.id);
+      const card = document.createElement('article');
+      card.className = `town-party-card party-${record.job}`;
+      card.dataset.memberId = record.id;
+      card.dataset.row = plan.positions[record.id] ?? 'front';
+
+      const portrait = document.createElement('img');
+      portrait.src = record.id === 'protagonist'
+        ? '/assets/games/caravan/job-protagonist.webp'
+        : (JOBS[record.job].art ?? '');
+      portrait.alt = '';
+      portrait.width = 600;
+      portrait.height = 800;
+      portrait.loading = 'lazy';
+
+      const copy = document.createElement('div');
+      const name = document.createElement('b');
+      name.textContent = record.name;
+      const job = document.createElement('small');
+      job.textContent = `${JOBS[record.job].name} · Lv${record.level}`;
+      const assignment = document.createElement('span');
+      assignment.textContent = `${row}${role ? ` · ${EXPEDITION_ROLES[role].name}` : ''}`;
+      const hp = document.createElement('em');
+      hp.textContent = `HP ${effective.maxHp}`;
+      copy.append(name, job, assignment, hp);
+      card.append(portrait, copy);
+      townPartyRibbonEl.appendChild(card);
+    }
+
+    const reserveCount = members.filter((member) => !plan.activeIds.includes(member.id)).length;
+    const summary = document.createElement('div');
+    summary.className = 'town-party-summary';
+    summary.innerHTML = `<b>${plan.activeIds.length}/${EXPEDITION_PARTY_CAP}</b><span>出征</span><small>${reserveCount} 名後備</small>`;
+    townPartyRibbonEl.appendChild(summary);
+  }
+
   function renderTownPanels(): void {
     if (!save) return;
     goldEl.textContent = String(save.gold);
     refreshHud('');
+    renderTownPartyRibbon();
     renderMarket();
     renderTavern();
     renderRoster();
@@ -3816,4 +3986,346 @@ const pageTitle = '商隊與劍 | CARAVAN & SWORD';
   .move-element-fire { color: #e07a4e; }
   .move-element-frost { color: #8fb8d8; }
   .move-element-holy { color: #ecd98f; }
+
+  /* ---- M18：戰役中樞與角色構築 UI ---- */
+  .caravan-root { padding: 3.25rem 0.75rem 0.75rem; }
+  .game-frame {
+    width: min(1240px, 98vw);
+    height: calc(100dvh - 4rem);
+    margin: 0 auto;
+  }
+  #screen-town {
+    --town-line: rgba(232, 200, 126, 0.2);
+    padding: 0 0 96px;
+    text-align: left;
+    background:
+      radial-gradient(circle at 50% 0, rgba(139, 75, 34, 0.16), transparent 38rem),
+      linear-gradient(180deg, rgba(13, 9, 5, 0.25), rgba(13, 9, 5, 0.7));
+  }
+  .town-scene {
+    position: relative;
+    min-height: 236px;
+    overflow: hidden;
+    border-bottom: 1px solid var(--gold);
+    isolation: isolate;
+  }
+  .town-scene .town-banner {
+    position: absolute; inset: 0;
+    width: 100%; height: 100%; max-height: none;
+    margin: 0; border: 0; border-radius: 0;
+    object-fit: cover; object-position: center 52%;
+    filter: saturate(0.92) contrast(1.04);
+    transform: scale(1.015);
+  }
+  .town-scene-shade {
+    position: absolute; inset: 0; z-index: 1;
+    background:
+      linear-gradient(90deg, rgba(10, 7, 4, 0.92) 0, rgba(10, 7, 4, 0.56) 42%, rgba(10, 7, 4, 0.18) 70%),
+      linear-gradient(180deg, rgba(10, 7, 4, 0.12), rgba(10, 7, 4, 0.86));
+  }
+  .town-scene-copy {
+    position: absolute; z-index: 2; left: clamp(1.4rem, 4vw, 3rem); bottom: 2rem;
+    display: flex; flex-direction: column; align-items: flex-start;
+  }
+  .town-kicker {
+    color: var(--seal-bright); font-family: 'Cinzel', serif;
+    font-size: 0.72rem; font-weight: 700; letter-spacing: 0.35em;
+  }
+  .town-scene .town-name {
+    margin: 0.3rem 0 0.6rem;
+    font-family: 'Ma Shan Zheng', 'Noto Serif TC', serif;
+    font-size: clamp(2.5rem, 5vw, 4.2rem); font-weight: 400; line-height: 1;
+    letter-spacing: 0.15em; color: #f5e7c1;
+    text-shadow: 0 3px 14px rgba(0, 0, 0, 0.9);
+  }
+  .town-scene .town-status {
+    display: inline-flex; align-items: baseline; gap: 0.75rem;
+    margin: 0; color: #c9bda5; font-size: 0.78rem; letter-spacing: 0.18em;
+  }
+  .town-scene .town-status b { color: var(--gold-bright); font-size: 1.2rem; letter-spacing: 0.05em; }
+  .town-scene .goal-card {
+    position: absolute; z-index: 2; right: clamp(1.4rem, 4vw, 3rem); bottom: 1.6rem;
+    width: min(31rem, 48%); max-width: none; margin: 0;
+    background: linear-gradient(135deg, rgba(24, 16, 9, 0.95), rgba(42, 27, 14, 0.82));
+    border: 1px solid rgba(232, 200, 126, 0.48);
+    border-left: 4px solid var(--seal);
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.42), inset 0 1px rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(9px);
+  }
+  .town-scene .goal-rank { writing-mode: horizontal-tb; min-width: 5.5rem; text-align: center; }
+  .town-scene .goal-desc, .town-scene .goal-next { color: #d3c6ad; }
+  .town-scene .goal-next { color: var(--gold-bright); }
+
+  .town-actions {
+    display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.8rem;
+    margin: 0; padding: 1rem clamp(1rem, 3vw, 2rem);
+    background: linear-gradient(180deg, rgba(5, 3, 2, 0.72), rgba(21, 14, 8, 0.76));
+    border-bottom: 1px solid var(--town-line);
+  }
+  .town-action {
+    min-width: 0; min-height: 76px;
+    display: flex; align-items: center; gap: 0.85rem;
+    padding: 0.75rem 1rem; text-align: left;
+    font: inherit; color: var(--text); cursor: pointer;
+    background:
+      linear-gradient(120deg, rgba(232, 200, 126, 0.08), transparent 54%),
+      rgba(24, 16, 9, 0.86);
+    border: 1px solid var(--gold-dim); border-radius: 4px;
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0.05), 0 6px 16px rgba(0, 0, 0, 0.28);
+    transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+  }
+  .town-action:hover {
+    transform: translateY(-2px); border-color: var(--gold-bright);
+    background: linear-gradient(120deg, rgba(232, 200, 126, 0.14), transparent 60%), rgba(37, 24, 12, 0.94);
+  }
+  .town-action-primary {
+    border-color: var(--seal-bright);
+    background: linear-gradient(120deg, rgba(181, 52, 43, 0.34), transparent 62%), rgba(32, 17, 10, 0.95);
+  }
+  .town-action-resume { border-color: var(--forest); }
+  .town-action-mark {
+    flex: none; width: 2.8rem; height: 2.8rem; display: grid; place-items: center;
+    color: #f7ece0; background: var(--seal);
+    border: 1px solid var(--seal-bright); border-radius: 3px;
+    font-size: 1.05rem; font-weight: 900;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+  }
+  .town-action > span:last-child { display: flex; flex-direction: column; gap: 0.18rem; min-width: 0; }
+  .town-action b { color: var(--gold-bright); font-size: 1rem; letter-spacing: 0.14em; }
+  .town-action small { color: #c2b49a; font-size: 0.76rem; letter-spacing: 0.04em; }
+
+  .town-party-deck { padding: 1.1rem clamp(1rem, 3vw, 2rem); border-bottom: 1px solid var(--town-line); }
+  .town-section-heading, .town-panel-head {
+    display: flex; align-items: end; justify-content: space-between; gap: 1rem;
+    margin-bottom: 0.8rem;
+  }
+  .town-section-heading > span, .town-panel-head > span { display: flex; flex-direction: column; gap: 0.1rem; }
+  .town-section-heading small, .town-panel-head small {
+    color: var(--seal-bright); font-family: 'Cinzel', serif;
+    font-size: 0.64rem; font-weight: 700; letter-spacing: 0.28em;
+  }
+  .town-section-heading b, .town-panel-head b { color: var(--gold-bright); font-size: 1.05rem; letter-spacing: 0.14em; }
+  .town-section-heading em { color: #bcae92; font-size: 0.76rem; font-style: normal; }
+  .town-party-ribbon {
+    display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)) 5.8rem; gap: 0.55rem;
+  }
+  .town-party-card {
+    --party-color: var(--gold);
+    min-width: 0; display: grid; grid-template-columns: 3.1rem 1fr; gap: 0.6rem; align-items: center;
+    padding: 0.55rem; overflow: hidden;
+    background: linear-gradient(110deg, color-mix(in srgb, var(--party-color) 16%, transparent), transparent 60%), rgba(13, 9, 5, 0.84);
+    border: 1px solid var(--town-line); border-top: 2px solid var(--party-color); border-radius: 4px;
+  }
+  .town-party-card.party-swordsman { --party-color: #c55f4b; }
+  .town-party-card.party-ranger { --party-color: #72a774; }
+  .town-party-card.party-mage { --party-color: #7695bd; }
+  .town-party-card.party-cleric { --party-color: #d0ab67; }
+  .town-party-card img { width: 3.1rem; height: 3.7rem; object-fit: cover; object-position: top; border: 1px solid var(--party-color); border-radius: 3px; }
+  .town-party-card > div { min-width: 0; display: flex; flex-direction: column; gap: 0.08rem; }
+  .town-party-card b { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .town-party-card small { color: #b9ad95; font-size: 0.68rem; }
+  .town-party-card span { color: var(--party-color); font-size: 0.7rem; font-weight: 700; }
+  .town-party-card em { color: #d7ccb7; font-size: 0.66rem; font-style: normal; }
+  .town-party-summary {
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    background: rgba(13, 9, 5, 0.78); border: 1px solid var(--town-line); border-radius: 4px;
+  }
+  .town-party-summary b { color: var(--gold-bright); font-size: 1.2rem; }
+  .town-party-summary span { color: #c8baa0; font-size: 0.68rem; letter-spacing: 0.15em; }
+  .town-party-summary small { color: var(--forest); font-size: 0.64rem; margin-top: 0.2rem; }
+
+  .town-console {
+    display: grid; grid-template-columns: 168px minmax(0, 1fr);
+    gap: 0; margin: 0 clamp(1rem, 3vw, 2rem) 2rem;
+    border: 1px solid var(--town-line); border-radius: 5px; overflow: hidden;
+    background: rgba(12, 8, 4, 0.64);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+  }
+  .town-tabs {
+    display: flex; flex-direction: column; flex-wrap: nowrap; justify-content: flex-start; gap: 0;
+    margin: 0; padding: 0.65rem 0;
+    border: 0; border-right: 1px solid var(--town-line);
+    background: linear-gradient(180deg, rgba(45, 29, 14, 0.84), rgba(16, 10, 5, 0.88));
+  }
+  .town-tab {
+    position: relative; transform: none;
+    display: grid; grid-template-columns: 2.15rem 1fr; grid-template-rows: auto auto;
+    column-gap: 0.65rem; align-items: center;
+    padding: 0.72rem 0.8rem; text-align: left;
+    border: 0; border-left: 3px solid transparent; border-radius: 0;
+    background: transparent; color: #b7aa91;
+  }
+  .town-tab > span {
+    grid-row: 1 / 3; width: 2.1rem; height: 2.1rem; display: grid; place-items: center;
+    color: var(--gold); background: rgba(0, 0, 0, 0.28);
+    border: 1px solid var(--gold-dim); border-radius: 3px;
+    font-size: 0.88rem; font-weight: 900;
+  }
+  .town-tab b { font-size: 0.88rem; letter-spacing: 0.12em; color: inherit; }
+  .town-tab small { font-size: 0.62rem; letter-spacing: 0.04em; opacity: 0.72; }
+  .town-tab:hover { color: #f1dfb5; background: rgba(232, 200, 126, 0.06); }
+  .town-tab.active {
+    transform: none; padding-top: 0.72rem;
+    color: #f7ece0; background: linear-gradient(90deg, rgba(181, 52, 43, 0.26), transparent);
+    border: 0; border-left: 3px solid var(--seal-bright);
+  }
+  .town-tab.active > span { color: #fff; background: var(--seal); border-color: var(--seal-bright); }
+  .town-console-main { min-width: 0; padding: 1.2rem; }
+  .town-panel { min-width: 0; text-align: left; }
+  .town-panel-head { padding-bottom: 0.75rem; border-bottom: 1px solid var(--town-line); }
+  .town-panel-head .panel-status { margin: 0; color: #c4b79d; }
+  .town-panel-head .panel-status strong { color: var(--gold-bright); font-size: 1.05rem; }
+  .town-panel .panel-hint { color: #c2b49a; opacity: 1; line-height: 1.7; font-size: 0.82rem; }
+
+  .town-console .market-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.55rem; }
+  .town-console .market-row {
+    align-content: center; min-height: 64px; padding: 0.65rem 0.75rem;
+    background: linear-gradient(120deg, rgba(232, 200, 126, 0.05), transparent), rgba(11, 7, 4, 0.74);
+    border-left-width: 2px;
+  }
+  .town-console .market-name { color: #e2d7c2; font-size: 0.87rem; }
+  .town-console .buy-btn, .town-console .sell-btn { padding: 0.3rem 0.6rem; font-size: 0.74rem; }
+  .town-console .tavern-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.7rem; }
+  .town-console .recruit-card {
+    display: grid; grid-template-columns: 4.1rem 1fr auto; grid-template-rows: auto 1fr;
+    align-items: center; column-gap: 0.75rem; padding: 0.75rem;
+  }
+  .town-console .recruit-art { grid-row: 1 / 3; width: 4.1rem; height: 5.2rem; }
+  .town-console .recruit-name { grid-column: 2 / 4; }
+  .town-console .recruit-info { grid-column: 2; min-width: 0; }
+  .town-console .hire-btn { grid-column: 3; padding: 0.35rem 0.8rem; }
+
+  .town-console .roster-list { gap: 0.9rem; }
+  .town-console .roster-card {
+    position: relative;
+    grid-template-columns: 7.4rem minmax(0, 1fr); gap: 1rem;
+    padding: 1rem; border-left-width: 4px;
+    background:
+      radial-gradient(circle at 0 0, color-mix(in srgb, var(--job) 18%, transparent), transparent 18rem),
+      linear-gradient(135deg, rgba(34, 22, 12, 0.94), rgba(12, 8, 4, 0.9));
+    box-shadow: inset 0 1px rgba(255, 255, 255, 0.05), 0 12px 28px rgba(0, 0, 0, 0.28);
+  }
+  .town-console .roster-portrait .roster-art { width: 7.4rem; height: 9.7rem; }
+  .town-console .roster-name { font-size: 1.25rem; }
+  .town-console .roster-stats { grid-template-columns: repeat(5, minmax(6rem, 1fr)); }
+  .town-console .roster-hp { color: #d3c7b0; }
+  .roster-moves { margin: 0.7rem 0 0.35rem; }
+  .roster-moves-head {
+    display: flex; justify-content: space-between; align-items: baseline; gap: 0.6rem;
+    margin-bottom: 0.45rem;
+  }
+  .roster-moves-head b { color: var(--gold-bright); font-size: 0.82rem; letter-spacing: 0.1em; }
+  .roster-moves-head span { color: #a99c84; font-size: 0.7rem; }
+  .move-loadout-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.4rem; }
+  .move-loadout-grid .move-chip {
+    position: relative; min-width: 0;
+    display: grid; grid-template-columns: 1fr auto; gap: 0.12rem 0.5rem;
+    padding: 0.52rem 0.62rem; text-align: left; cursor: pointer;
+    font: inherit; background: rgba(7, 5, 3, 0.62);
+    border: 1px solid var(--gold-dim); border-left-width: 3px; border-radius: 3px;
+    transition: opacity 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+  }
+  .move-loadout-grid .move-chip:hover:not(:disabled) { transform: translateY(-1px); border-color: var(--gold-bright); }
+  .move-loadout-grid .move-chip.prepared {
+    background: linear-gradient(110deg, rgba(181, 52, 43, 0.17), transparent), rgba(9, 6, 3, 0.82);
+    box-shadow: inset 0 0 0 1px rgba(232, 200, 126, 0.05);
+  }
+  .move-loadout-grid .move-chip.unprepared { opacity: 0.48; filter: saturate(0.65); }
+  .move-loadout-grid .move-chip:disabled { cursor: not-allowed; }
+  .move-loadout-grid .move-chip b { grid-column: 1; color: #eee1c9; font-size: 0.86rem; }
+  .move-loadout-grid .move-chip small { grid-column: 1 / 3; color: #b7aa91; font-size: 0.68rem; line-height: 1.45; }
+  .move-state {
+    grid-column: 2; grid-row: 1;
+    color: var(--forest); font-size: 0.62rem; font-weight: 700; letter-spacing: 0.08em;
+  }
+  .move-chip.unprepared .move-state { color: #a99c84; }
+  .town-console .roster-card .equip-slots { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .town-console .roster-card .equip-slot {
+    min-width: 0; border-style: solid;
+    background: linear-gradient(145deg, rgba(232, 200, 126, 0.05), transparent), rgba(5, 3, 2, 0.38);
+  }
+
+  .game-toast {
+    position: fixed; z-index: 40; left: 50%; bottom: 1.4rem;
+    transform: translate(-50%, 12px);
+    min-width: min(24rem, calc(100vw - 2rem)); padding: 0.7rem 1rem;
+    text-align: center; color: #f7ece0; background: rgba(24, 15, 8, 0.96);
+    border: 1px solid var(--gold); border-left: 4px solid var(--forest); border-radius: 4px;
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.62);
+    pointer-events: none;
+  }
+  .game-toast[data-tone='info'] { border-left-color: var(--gold-bright); }
+  .game-toast.toast-in { animation: toastRise 2.2s ease both; }
+  @keyframes toastRise {
+    0% { opacity: 0; transform: translate(-50%, 14px); }
+    12%, 82% { opacity: 1; transform: translate(-50%, 0); }
+    100% { opacity: 0; transform: translate(-50%, -8px); }
+  }
+
+  @media (max-width: 900px) {
+    .town-scene { min-height: 300px; }
+    .town-scene .goal-card { left: 1rem; right: 1rem; bottom: 1rem; width: auto; }
+    .town-scene-copy { top: 1.4rem; bottom: auto; }
+    .town-party-ribbon { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .town-party-summary { min-height: 64px; }
+    .town-console { grid-template-columns: 1fr; }
+    .town-tabs {
+      display: grid; grid-template-columns: repeat(5, minmax(0, 1fr));
+      padding: 0; border-right: 0; border-bottom: 1px solid var(--town-line);
+    }
+    .town-tab {
+      display: flex; flex-direction: column; gap: 0.25rem; text-align: center;
+      padding: 0.6rem 0.25rem; border-left: 0; border-bottom: 3px solid transparent;
+    }
+    .town-tab > span { width: 1.8rem; height: 1.8rem; }
+    .town-tab small { display: none; }
+    .town-tab.active { padding-top: 0.6rem; border-left: 0; border-bottom: 3px solid var(--seal-bright); }
+    .town-console .market-list, .town-console .tavern-list { grid-template-columns: 1fr; }
+    .town-console .roster-stats { grid-template-columns: repeat(2, minmax(7rem, 1fr)); }
+  }
+
+  @media (max-width: 620px) {
+    .caravan-root { padding: 2.9rem 0 0; }
+    .game-frame { width: 100vw; height: calc(100dvh - 2.9rem); margin: 0; border-left: 0; border-right: 0; border-radius: 0; }
+    .game-hud { gap: 0.4rem; padding: 0 0.55rem; }
+    .hud-scene { font-size: 1rem; }
+    .hud-right { gap: 0.38rem; }
+    .hud-label, .hud-sep, .hud-rank { display: none; }
+    #screen-town { padding-bottom: 72px; }
+    .town-scene { min-height: 332px; }
+    .town-scene-copy { left: 1rem; top: 1.2rem; }
+    .town-kicker { font-size: 0.58rem; }
+    .town-scene .town-name { font-size: 2.6rem; }
+    .town-scene .goal-card { align-items: flex-start; padding: 0.65rem; }
+    .town-scene .goal-rank { min-width: auto; padding: 0.3rem 0.5rem; font-size: 0.8rem; }
+    .town-scene .goal-desc { display: none; }
+    .town-actions { grid-template-columns: 1fr; padding: 0.75rem; }
+    .town-action { min-height: 60px; }
+    .town-party-deck { padding: 0.9rem 0.75rem; }
+    .town-section-heading { align-items: flex-start; }
+    .town-section-heading em { max-width: 10rem; text-align: right; }
+    .town-party-ribbon { grid-template-columns: 1fr 1fr; gap: 0.4rem; }
+    .town-party-card { grid-template-columns: 2.6rem 1fr; }
+    .town-party-card img { width: 2.6rem; height: 3.2rem; }
+    .town-party-summary { min-height: 58px; }
+    .town-console { margin: 0 0.65rem 1rem; }
+    .town-tab b { font-size: 0.72rem; }
+    .town-console-main { padding: 0.85rem; }
+    .town-panel-head { align-items: flex-start; }
+    .town-console .roster-card { display: block; padding: 0.8rem; }
+    .town-console .roster-portrait { float: left; margin: 0 0.8rem 0.5rem 0; }
+    .town-console .roster-portrait .roster-art { width: 5.2rem; height: 6.8rem; }
+    .town-console .roster-stats { clear: both; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .move-loadout-grid { grid-template-columns: 1fr; }
+    .town-console .roster-card .equip-slots { grid-template-columns: 1fr; }
+    .town-console .recruit-card { grid-template-columns: 3.4rem 1fr; }
+    .town-console .recruit-art { width: 3.4rem; height: 4.4rem; }
+    .town-console .recruit-name, .town-console .recruit-info { grid-column: 2; }
+    .town-console .hire-btn { grid-column: 1 / 3; justify-self: stretch; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .town-action, .move-loadout-grid .move-chip { transition: none; }
+    .game-toast.toast-in { animation: none; }
+  }
 </style>

--- a/src/scripts/games/caravan/data/jobs.test.ts
+++ b/src/scripts/games/caravan/data/jobs.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { JOBS, memberFromRecord } from './jobs';
+import {
+  JOBS,
+  MOVE_LOADOUT_CAP,
+  availableMovesFromRecord,
+  memberFromRecord,
+  preparedMovesFromRecord,
+  setPreparedMoves,
+} from './jobs';
 import { ITEMS, type ItemDef } from './items';
 import type { CompanionRecord } from '../save';
 import type { Move } from '../combat';
@@ -28,6 +35,35 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
     const aimedShot = JOBS.ranger.moves.find((move) => move.id === 'aimed-shot');
     expect(aimedShot?.hitBonus).toBe(3);
     expect(aimedShot?.area).not.toBe(true);
+  });
+
+  describe('M18 戰技配置', () => {
+    it('舊存檔在已知招式超過上限時預設攜帶前四招', () => {
+      const record = makeRecord({ level: 3 });
+      expect(availableMovesFromRecord(record)).toHaveLength(5);
+      expect(MOVE_LOADOUT_CAP).toBe(4);
+      expect(preparedMovesFromRecord(record).map((move) => move.id))
+        .toEqual(['heavy-slash', 'guard', 'whirlwind-slash', 'breaking-combo']);
+      expect(record.preparedMoveIds).toBeUndefined();
+    });
+
+    it('玩家可在已解鎖招式中配置一至四招，戰鬥成員只帶入該配置', () => {
+      const record = makeRecord({ level: 3 });
+      expect(setPreparedMoves(record, ['guard', 'strike'])).toEqual(['guard', 'strike']);
+      expect(memberFromRecord(record).moves.map((move) => move.id)).toEqual(['guard', 'strike']);
+    });
+
+    it('未知、空白或超量配置會拒絕且不修改既有配置', () => {
+      const record = makeRecord({ level: 3, preparedMoveIds: ['guard', 'strike'] });
+      for (const invalid of [
+        [],
+        ['guard', 'not-a-move'],
+        ['heavy-slash', 'guard', 'whirlwind-slash', 'breaking-combo', 'strike'],
+      ]) {
+        expect(() => setPreparedMoves(record, invalid)).toThrow();
+        expect(record.preparedMoveIds).toEqual(['guard', 'strike']);
+      }
+    });
   });
 
   describe('memberFromRecord 裝備整合', () => {
@@ -65,6 +101,16 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
       const member = memberFromRecord(record);
       expect(member.moves[0].id).toBe('test-weapon-move');
       expect(member.moves.slice(1).map((m) => m.id)).toEqual(withoutWeapon.slice(1));
+    });
+
+    it('已配置職業首招時，換上帶招式武器會以武器招平滑取代', () => {
+      const record = makeRecord({
+        level: 3,
+        preparedMoveIds: ['heavy-slash', 'guard', 'strike'],
+        equipment: { weapon: 'test-weapon', armor: null, trinket: null },
+      });
+      expect(memberFromRecord(record).moves.map((move) => move.id))
+        .toEqual(['test-weapon-move', 'guard', 'strike']);
     });
 
     it('武器無 move 欄位時 moves[0] 維持職業原招（僅套用屬性加成）', () => {

--- a/src/scripts/games/caravan/data/jobs.test.ts
+++ b/src/scripts/games/caravan/data/jobs.test.ts
@@ -53,16 +53,26 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
       expect(memberFromRecord(record).moves.map((move) => move.id)).toEqual(['guard', 'strike']);
     });
 
-    it('未知、空白或超量配置會拒絕且不修改既有配置', () => {
+    it('未知、重複、空白或超量配置會拒絕且不修改既有配置', () => {
       const record = makeRecord({ level: 3, preparedMoveIds: ['guard', 'strike'] });
       for (const invalid of [
         [],
+        ['guard', 'guard'],
         ['guard', 'not-a-move'],
         ['heavy-slash', 'guard', 'whirlwind-slash', 'breaking-combo', 'strike'],
       ]) {
         expect(() => setPreparedMoves(record, invalid)).toThrow();
         expect(record.preparedMoveIds).toEqual(['guard', 'strike']);
       }
+    });
+
+    it('毀損或已過期配置不會讓角色空手進戰鬥，而是退回安全預設', () => {
+      const damaged = makeRecord({
+        level: 3,
+        preparedMoveIds: ['removed-move', 'removed-move'],
+      });
+      expect(preparedMovesFromRecord(damaged).map((move) => move.id))
+        .toEqual(['heavy-slash', 'guard', 'whirlwind-slash', 'breaking-combo']);
     });
   });
 
@@ -72,9 +82,18 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
       damage: { dice: 1, sides: 4, bonusStat: 'str' },
       narration: '{actor}揮動測試武器擊向{target}，造成 {amount} 點傷害！',
     };
+    const SECOND_WEAPON_MOVE: Move = {
+      id: 'second-weapon-move', name: '第二武器技', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 8, bonusStat: 'str' },
+      narration: '{actor}使出第二武器技擊向{target}，造成 {amount} 點傷害！',
+    };
     const TEST_WEAPON: ItemDef = {
       id: 'test-weapon', name: '測試武器', desc: '測試用武器。', value: 20,
       equip: { slot: 'weapon', bonus: { str: 2 }, move: TEST_WEAPON_MOVE },
+    };
+    const SECOND_WEAPON: ItemDef = {
+      id: 'second-weapon', name: '第二武器', desc: '另一把測試武器。', value: 30,
+      equip: { slot: 'weapon', move: SECOND_WEAPON_MOVE },
     };
     const TEST_ARMOR: ItemDef = {
       id: 'test-armor', name: '測試護甲', desc: '測試用護甲。', value: 20,
@@ -83,10 +102,12 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
 
     beforeEach(() => {
       ITEMS['test-weapon'] = TEST_WEAPON;
+      ITEMS['second-weapon'] = SECOND_WEAPON;
       ITEMS['test-armor'] = TEST_ARMOR;
     });
     afterEach(() => {
       delete ITEMS['test-weapon'];
+      delete ITEMS['second-weapon'];
       delete ITEMS['test-armor'];
     });
 
@@ -111,6 +132,36 @@ describe('jobs（武器招約定與 memberFromRecord 裝備整合，M5 Task 1）
       });
       expect(memberFromRecord(record).moves.map((move) => move.id))
         .toEqual(['test-weapon-move', 'guard', 'strike']);
+    });
+
+    it('已配置武器招時換另一把武器，保留槽位並改成新武器技', () => {
+      const record = makeRecord({
+        level: 3,
+        preparedMoveIds: ['test-weapon-move', 'guard', 'strike'],
+        equipment: { weapon: 'second-weapon', armor: null, trinket: null },
+      });
+      expect(memberFromRecord(record).moves.map((move) => move.id))
+        .toEqual(['second-weapon-move', 'guard', 'strike']);
+    });
+
+    it('卸下武器後，原武器招槽恢復為職業首招，不會讓角色無預警少一招', () => {
+      const record = makeRecord({
+        level: 3,
+        preparedMoveIds: ['test-weapon-move', 'guard', 'strike'],
+        equipment: { weapon: null, armor: null, trinket: null },
+      });
+      expect(memberFromRecord(record).moves.map((move) => move.id))
+        .toEqual(['heavy-slash', 'guard', 'strike']);
+    });
+
+    it('玩家刻意不攜帶武器招時，換裝不會擅自加入武器技', () => {
+      const record = makeRecord({
+        level: 3,
+        preparedMoveIds: ['guard', 'whirlwind-slash', 'strike'],
+        equipment: { weapon: 'test-weapon', armor: null, trinket: null },
+      });
+      expect(memberFromRecord(record).moves.map((move) => move.id))
+        .toEqual(['guard', 'whirlwind-slash', 'strike']);
     });
 
     it('武器無 move 欄位時 moves[0] 維持職業原招（僅套用屬性加成）', () => {

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -25,6 +25,9 @@ export interface JobDef {
   art?: string;
 }
 
+/** M18：每名角色最多攜帶四招，讓升級後的技能選擇形成構築取捨。 */
+export const MOVE_LOADOUT_CAP = 4;
+
 /** 通用「揮擊」：所有職業都會的基礎武器攻擊，備用招式 */
 const universalStrike: Move = {
   id: 'strike', element: 'blunt', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str',
@@ -140,10 +143,66 @@ export const JOBS: Record<JobId, JobDef> = {
   },
 };
 
+/** 包含等級解鎖、武器招式與專精招式的完整已知戰技清單。 */
+export function availableMovesFromRecord(record: CompanionRecord): Move[] {
+  const moves = unlockedMoves(record);
+  const weaponId = record.equipment.weapon;
+  const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
+  const baseMoves = weaponMove ? [weaponMove, ...moves.slice(1)] : moves;
+  const spec = specById(record.specialization);
+  // 專屬招放在兩招職業核心技之後，讓舊存檔的預設四招必定能體現專精身分。
+  return spec
+    ? [...baseMoves.slice(0, 2), spec.move, ...baseMoves.slice(2)]
+    : baseMoves;
+}
+
 /**
- * 用 JOBS[record.job] 的 moves/defense，配上 record 自己的 stats/maxHp（含成長），
- * 再疊上裝備三欄的效果（M5）：stats/defense/maxHp 加成；weapon 若帶 move 則取代
- * moves[0]（武器招約定——JOBS 每職業 moves[0] 恆為 kind==='attack'，見 jobs.test.ts 資料鎖定）。
+ * 依已知戰技整理實際攜帶配置。
+ * 舊存檔採前四招；裝上帶招式的武器時，若原本配置了職業首招，會平滑替換成武器招。
+ */
+export function preparedMovesFromRecord(record: CompanionRecord): Move[] {
+  const available = availableMovesFromRecord(record);
+  if (available.length === 0) return [];
+  if (!record.preparedMoveIds) return available.slice(0, MOVE_LOADOUT_CAP);
+
+  const requested = new Set(record.preparedMoveIds);
+  const weaponId = record.equipment.weapon;
+  const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
+  const originalWeaponMove = unlockedMoves(record)[0];
+  if (
+    weaponMove &&
+    originalWeaponMove &&
+    requested.has(originalWeaponMove.id) &&
+    !available.some((move) => move.id === originalWeaponMove.id)
+  ) {
+    requested.delete(originalWeaponMove.id);
+    requested.add(weaponMove.id);
+  }
+  const prepared = available
+    .filter((move) => requested.has(move.id))
+    .slice(0, MOVE_LOADOUT_CAP);
+  return prepared.length > 0 ? prepared : available.slice(0, 1);
+}
+
+/** 寫入一組合法戰技配置；未知招式、空配置與超過四招都拒絕且不修改角色。 */
+export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): string[] {
+  const known = availableMovesFromRecord(record);
+  const requested = new Set(moveIds);
+  const prepared = known.filter((move) => requested.has(move.id));
+  if (
+    prepared.length === 0 ||
+    prepared.length > MOVE_LOADOUT_CAP ||
+    prepared.length !== requested.size
+  ) {
+    throw new Error(`戰技配置必須是 1～${MOVE_LOADOUT_CAP} 個已解鎖招式`);
+  }
+  record.preparedMoveIds = prepared.map((move) => move.id);
+  return [...record.preparedMoveIds];
+}
+
+/**
+ * 將角色成長、裝備、特質、專精與戰技配置整合成實際戰鬥成員。
+ * 武器招式替換與出戰招式上限都已在 preparedMovesFromRecord 內處理。
  */
 export function memberFromRecord(record: CompanionRecord): PartyMember {
   const job = JOBS[record.job];
@@ -158,15 +217,6 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
   const bondHp = bondTier(record.bond) * BOND_HP_PER_TIER;
   const maxHp = record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0) + (spec?.maxHp ?? 0) + bondHp;
 
-  const moves = unlockedMoves(record);
-  const weaponId = record.equipment.weapon;
-  const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
-  const baseMoves = weaponMove ? [weaponMove, ...moves.slice(1)] : moves;
-  // 專屬招插在通用「揮擊」之前（揮擊恆為最後一招）
-  const finalMoves = spec
-    ? [...baseMoves.slice(0, -1), spec.move, baseMoves[baseMoves.length - 1]]
-    : baseMoves;
-
   return {
     id: record.id,
     name: record.name,
@@ -174,7 +224,7 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     maxHp,
     hp: maxHp,
     defense: job.defense + bonus.defense + (spec?.defense ?? 0),
-    moves: finalMoves,
+    moves: preparedMovesFromRecord(record),
     damageBonus: bonus.damageBonus,
     isProtagonist: record.id === 'protagonist',
   };

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -156,45 +156,74 @@ export function availableMovesFromRecord(record: CompanionRecord): Move[] {
     : baseMoves;
 }
 
+function weaponMoveIds(): Set<string> {
+  const ids = new Set<string>();
+  for (const item of Object.values(ITEMS)) {
+    if (item.equip?.slot === 'weapon' && item.equip.move) ids.add(item.equip.move.id);
+  }
+  return ids;
+}
+
+/**
+ * 將存檔中的「武器招式槽」對齊目前裝備：
+ * - 換武器時，舊武器招平滑換成新武器招。
+ * - 卸下武器時，恢復職業原本的首招。
+ * - 玩家本來就沒攜帶武器招時，不會擅自塞回去。
+ */
+function normalizePreparedMoveIds(record: CompanionRecord): Set<string> {
+  const raw = record.preparedMoveIds;
+  if (!Array.isArray(raw)) return new Set<string>();
+  const requested = new Set(raw.filter((id): id is string => typeof id === 'string'));
+  const classWeaponMove = unlockedMoves(record)[0];
+  const equippedWeaponId = record.equipment.weapon;
+  const equippedWeaponMove = equippedWeaponId ? ITEMS[equippedWeaponId]?.equip?.move : undefined;
+  const allWeaponMoveIds = weaponMoveIds();
+  const hadWeaponSlot = !!classWeaponMove && (
+    requested.has(classWeaponMove.id) ||
+    [...requested].some((id) => allWeaponMoveIds.has(id))
+  );
+
+  if (hadWeaponSlot) {
+    requested.delete(classWeaponMove.id);
+    for (const id of allWeaponMoveIds) requested.delete(id);
+    const replacement = equippedWeaponMove ?? classWeaponMove;
+    if (replacement) requested.add(replacement.id);
+  }
+  return requested;
+}
+
 /**
  * 依已知戰技整理實際攜帶配置。
- * 舊存檔採前四招；裝上帶招式的武器時，若原本配置了職業首招，會平滑替換成武器招。
+ * 舊存檔採前四招；武器替換與卸下都會保留原本佔用的武器招式槽。
+ * 毀損或已過期的配置退回安全預設，不讓玩家帶著空配置進入戰鬥。
  */
 export function preparedMovesFromRecord(record: CompanionRecord): Move[] {
   const available = availableMovesFromRecord(record);
   if (available.length === 0) return [];
-  if (!record.preparedMoveIds) return available.slice(0, MOVE_LOADOUT_CAP);
-
-  const requested = new Set(record.preparedMoveIds);
-  const weaponId = record.equipment.weapon;
-  const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
-  const originalWeaponMove = unlockedMoves(record)[0];
-  if (
-    weaponMove &&
-    originalWeaponMove &&
-    requested.has(originalWeaponMove.id) &&
-    !available.some((move) => move.id === originalWeaponMove.id)
-  ) {
-    requested.delete(originalWeaponMove.id);
-    requested.add(weaponMove.id);
+  if (!Array.isArray(record.preparedMoveIds) || record.preparedMoveIds.length === 0) {
+    return available.slice(0, MOVE_LOADOUT_CAP);
   }
+
+  const requested = normalizePreparedMoveIds(record);
   const prepared = available
     .filter((move) => requested.has(move.id))
     .slice(0, MOVE_LOADOUT_CAP);
-  return prepared.length > 0 ? prepared : available.slice(0, 1);
+  return prepared.length > 0 ? prepared : available.slice(0, MOVE_LOADOUT_CAP);
 }
 
-/** 寫入一組合法戰技配置；未知招式、空配置與超過四招都拒絕且不修改角色。 */
+/** 寫入一組合法戰技配置；未知、重複、空配置與超過四招都拒絕且不修改角色。 */
 export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): string[] {
   const known = availableMovesFromRecord(record);
   const requested = new Set(moveIds);
   const prepared = known.filter((move) => requested.has(move.id));
   if (
+    moveIds.some((id) => typeof id !== 'string') ||
+    moveIds.length !== requested.size ||
     prepared.length === 0 ||
     prepared.length > MOVE_LOADOUT_CAP ||
     prepared.length !== requested.size
   ) {
-    throw new Error(`戰技配置必須是 1～${MOVE_LOADOUT_CAP} 個已解鎖招式`);
+    throw new Error(`戰技配置必須是 1～${MOVE_LOADOUT_CAP} 個不重複的已解鎖招式`);
   }
   record.preparedMoveIds = prepared.map((move) => move.id);
   return [...record.preparedMoveIds];

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -39,6 +39,11 @@ export interface CompanionRecord {
   skillPoints?: number;
   /** M14 鐵匠強化：各裝備欄的 +N（0-3），跟人走（換裝保留） */
   equipmentPlus?: { weapon: number; armor: number; trinket: number };
+  /**
+   * M18 戰技配置：本角色帶入戰鬥的招式 id（最多 4 招）。
+   * optional 讓既有 v6 存檔自動採用預設配置，不需要清檔或升版。
+   */
+  preparedMoveIds?: string[];
 }
 
 export interface SaveDataV2 {

--- a/tests/e2e/caravan.spec.ts
+++ b/tests/e2e/caravan.spec.ts
@@ -157,6 +157,50 @@ test.describe('商隊與劍：訓練場戰鬥', () => {
     await expect(aimed.locator('.move-hit')).toHaveText('命中+3');
   });
 
+  test('M18：城鎮戰役中樞呈現出征隊，四格戰技配置會實際限制戰鬥指令', async ({ page }) => {
+    await page.evaluate(() => {
+      const raw = localStorage.getItem('caravan-save-v1');
+      if (!raw) throw new Error('測試存檔不存在');
+      const data = JSON.parse(raw);
+      data.protagonist.job = 'mage';
+      data.protagonist.level = 3;
+      data.protagonist.xp = 120;
+      data.protagonist.stats = { str: 8, dex: 100, int: 16, cha: 10, con: 8 };
+      data.protagonist.maxHp = 16;
+      delete data.protagonist.preparedMoveIds;
+      localStorage.setItem('caravan-save-v1', JSON.stringify(data));
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.click('#btn-continue');
+
+    await expect(page.locator('.town-scene')).toBeVisible();
+    await expect(page.locator('.town-console')).toBeVisible();
+    await expect(page.locator('#town-party-ribbon .town-party-card')).toHaveCount(1);
+    await expect(page.locator('#town-party-ribbon')).toContainText('後排');
+
+    await page.click('.town-tab[data-town-tab="roster"]');
+    const card = page.locator('.roster-card[data-member-id="protagonist"]');
+    await expect(card.locator('.move-chip.prepared')).toHaveCount(4);
+    await expect(card.locator('.move-chip.unprepared')).toHaveCount(2);
+    await card.locator('.move-chip[data-move-id="frost-bind"]').click();
+    await card.locator('.move-chip[data-move-id="meteor-fall"]').click();
+    await expect(card.locator('.move-chip[data-move-id="meteor-fall"]')).toHaveClass(/prepared/);
+    await expect(page.locator('#game-toast')).toContainText('隕石墜');
+
+    const prepared = await page.evaluate(() => {
+      const raw = localStorage.getItem('caravan-save-v1');
+      if (!raw) throw new Error('測試存檔不存在');
+      return JSON.parse(raw).protagonist.preparedMoveIds as string[];
+    });
+    expect(prepared).toHaveLength(4);
+    expect(prepared).toContain('meteor-fall');
+    expect(prepared).not.toContain('frost-bind');
+
+    await page.click('#btn-training');
+    await expect(page.locator('#combat-actions [data-move-id="meteor-fall"]')).toBeVisible();
+    await expect(page.locator('#combat-actions [data-move-id="frost-bind"]')).toHaveCount(0);
+  });
+
   test('打到分出勝負：點招式推進、log 累積、結果面板出現、可返回城鎮', async ({ page }) => {
     await page.click('#btn-training');
     await expect(page.locator('#screen-combat')).toBeVisible();


### PR DESCRIPTION
## Summary

- turn the town screen into a cinematic campaign hub with primary actions, expedition party status, and a dedicated facility console
- add persistent 1–4 move loadouts that combine level unlocks, weapon moves, and specialization moves
- make the selected loadout drive the actual combat action set while preserving old v6 saves
- redesign roster and preparation surfaces with richer character cards, move details, responsive layout, and in-game feedback
- harden loadouts against weapon swaps, weapon removal, stale save data, and duplicate move IDs

## Why

M16–M17 established team tactics and expedition roles, but the interface still read like a long HTML form and characters automatically carried every unlocked move. M18 adds a real build decision and presents town preparation as a game screen instead of a website settings page.

## Player adversarial review

The final review deliberately tested hostile but realistic player paths rather than only the happy path:

- **Equip a weapon after preparing the class weapon move:** the prepared slot now changes to the equipped weapon move.
- **Swap from one weapon-move weapon to another:** the slot follows the new weapon instead of silently disappearing.
- **Unequip a weapon:** the slot returns to the class weapon move, so a character does not unexpectedly lose a core action.
- **Intentionally omit the weapon move:** equipment changes respect that choice and do not force the weapon action back in.
- **Load stale or corrupted prepared move IDs:** the character falls back to a safe default loadout rather than entering combat empty-handed.
- **Submit duplicate move IDs:** the configuration is rejected without modifying the existing valid loadout.

These cases close the largest player-facing failure mode in a persistent build system: a valid-looking save becoming weaker or unusable because equipment and loadout state drift apart.

## Validation

- original full Vitest suite: 114 files, 1,581 tests passed
- original focused Caravan tests: 158 tests passed
- added focused regression coverage for weapon swap, weapon removal, stale loadouts, deliberate weapon omission, and duplicate IDs
- latest Vercel preview deployment for head `b1c6a76f` passed
- Astro production build passed through the latest Vercel deployment
- original connected-browser walkthrough: new game → town → tavern hire → three-member expedition ribbon → roster → remove move → reload → continue → loadout persisted
- preview application console had no warnings or errors during the original walkthrough

## Scope

Five files only; no dependency, lockfile, generated output, or asset churn.