### PR TITLE
feat(caravan): add M19 tactical trade contracts

### DIFF
--- a/src/scripts/games/caravan/data/locations.m19.test.ts
+++ b/src/scripts/games/caravan/data/locations.m19.test.ts
@@ -43,7 +43,8 @@ describe('M19 高階戰術契約', () => {
         ENCOUNTERS[entry.encounterId]().flatMap((enemy) => enemy.weaknesses ?? [])
       )
     );
-    expect(weaknesses).toEqual(expect.objectContaining(new Set(['holy', 'blunt'])));
+    expect(weaknesses.has('holy')).toBe(true);
+    expect(weaknesses.has('blunt')).toBe(true);
   });
 
   it('自由商旅環線與鹽晶護運的敵群及目的地不同，避免兩個按鈕實際上是同一關', () => {

--- a/src/scripts/games/caravan/data/locations.m19.test.ts
+++ b/src/scripts/games/caravan/data/locations.m19.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { newGame } from '../save';
+import { LOCATIONS, visibleLocations } from './locations';
+import { ENCOUNTERS } from './enemies';
+import { TOWNS } from './towns';
+
+const CONTRACT_IDS = ['guild-salt-convoy', 'free-trader-frontier'] as const;
+
+describe('M19 高階戰術契約', () => {
+  it('聲望 70 前不可見，達標後兩張契約同時出現在委託板', () => {
+    const save = newGame(1000);
+    save.reputation = 69;
+    expect(visibleLocations(save).map((loc) => loc.id)).not.toEqual(
+      expect.arrayContaining(CONTRACT_IDS)
+    );
+
+    save.reputation = 70;
+    expect(visibleLocations(save).map((loc) => loc.id)).toEqual(
+      expect.arrayContaining(CONTRACT_IDS)
+    );
+  });
+
+  it('兩張契約都是可完成的公開商路，且有有效目的地與遭遇引用', () => {
+    for (const id of CONTRACT_IDS) {
+      const loc = LOCATIONS[id];
+      expect(loc.kind).toBe('route');
+      expect(loc.hidden).not.toBe(true);
+      expect(loc.legs).toBeGreaterThanOrEqual(7);
+      expect(loc.destinationTownId).toBeTruthy();
+      expect(TOWNS[loc.destinationTownId!]).toBeDefined();
+      expect(loc.encounterTable.length).toBeGreaterThan(0);
+      for (const entry of loc.encounterTable) {
+        expect(entry.weight).toBeGreaterThan(0);
+        expect(ENCOUNTERS[entry.encounterId]).toBeDefined();
+      }
+    }
+  });
+
+  it('鹽晶護運確實要求聖與打擊覆蓋，不是只有名稱寫推薦', () => {
+    const loc = LOCATIONS['guild-salt-convoy'];
+    const weaknesses = new Set(
+      loc.encounterTable.flatMap((entry) =>
+        ENCOUNTERS[entry.encounterId]().flatMap((enemy) => enemy.weaknesses ?? [])
+      )
+    );
+    expect(weaknesses).toEqual(expect.objectContaining(new Set(['holy', 'blunt'])));
+  });
+
+  it('自由商旅環線與鹽晶護運的敵群及目的地不同，避免兩個按鈕實際上是同一關', () => {
+    const guild = LOCATIONS['guild-salt-convoy'];
+    const free = LOCATIONS['free-trader-frontier'];
+    const guildEncounters = new Set(guild.encounterTable.map((entry) => entry.encounterId));
+    const freeEncounters = new Set(free.encounterTable.map((entry) => entry.encounterId));
+
+    expect(free.destinationTownId).not.toBe(guild.destinationTownId);
+    expect(free.legs).not.toBe(guild.legs);
+    expect([...freeEncounters]).not.toEqual([...guildEncounters]);
+    expect(freeEncounters.has('enc_ruins_undead')).toBe(true);
+    expect(guildEncounters.has('enc_salt_crystals')).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -6,6 +6,7 @@ import type { SaveData } from '../save';
  * M3 首批地點：貿易路線 2 條、迷宮 1 座、隱藏迷宮 1 座（旗標鏈 discover）。
  * M5 擴充：第三路線「霧嶺古道」（reputation≥40）、高階迷宮「鹽晶洞窟」（reputation≥60）、
  * 隱藏路線「古戰場」（旗標鏈 discover，見 data/events.ts ev_faded_banner→ev_mercenary_ruins）。
+ * M19 擴充：兩張聲望 70 的高階戰術契約，讓戰技配置與押貨目的形成真正取捨。
  */
 export const LOCATIONS: Record<string, LocationDef> = {
   'endless-road': {
@@ -101,6 +102,33 @@ export const LOCATIONS: Record<string, LocationDef> = {
     hidden: true,
     legs: 3,
     encounterTable: [{ weight: 100, encounterId: 'enc_ruins_undead' }],
+  },
+
+  // ---- M19 高階戰術契約：目的地、敵情與推薦屬性都明確分流 -----------
+  'guild-salt-convoy': {
+    id: 'guild-salt-convoy',
+    name: '商會特許．鹽晶護運〔聖／打〕',
+    kind: 'route',
+    legs: 7,
+    minReputation: 70,
+    destinationTownId: 'salt-spring-city',
+    encounterTable: [
+      { weight: 65, encounterId: 'enc_salt_crystals' },
+      { weight: 35, encounterId: 'enc_ridge_bandits' },
+    ],
+  },
+  'free-trader-frontier': {
+    id: 'free-trader-frontier',
+    name: '自由商旅．邊境環線〔斬／刺〕',
+    kind: 'route',
+    legs: 8,
+    minReputation: 70,
+    destinationTownId: 'woodside-settlement',
+    encounterTable: [
+      { weight: 40, encounterId: 'enc_ridge_bandits' },
+      { weight: 35, encounterId: 'enc_ruins_undead' },
+      { weight: 25, encounterId: 'enc_goblin_raiders' },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary

- add two reputation-70 trade contracts that turn M18 loadouts into route-specific preparation decisions
- make the guild salt convoy favor holy/blunt coverage and terminate at Salt Spring City
- make the free-trader frontier circuit favor slash/pierce coverage, use a longer mixed enemy route, and terminate at Woodside Settlement
- surface the recommended damage coverage directly in each contract name so players can act on the information before departure
- add focused data-contract tests for visibility thresholds, valid destinations, encounter references, weakness coverage, and route differentiation

## Game-design intent

M18 introduced four-move loadouts, but existing routes did not create enough pressure to reconfigure those loadouts. M19 adds two high-rank contracts with different enemy ecosystems, lengths, and commercial destinations, so the player must choose both a tactical doctrine and a trading objective rather than always using one universal party setup.

## Player adversarial review

The implementation was reviewed from hostile but realistic player paths:

- reputation 69 cannot leak either high-rank contract; reputation 70 unlocks both simultaneously
- neither contract is hidden behind an undiscoverable flag
- every encounter reference resolves to a real encounter factory
- every route ends at a real town, preventing an unfinishable trade settlement
- the salt convoy's displayed holy/blunt recommendation is verified against actual enemy weaknesses
- the two contracts differ in destination, length, and encounter pool, preventing a false choice where two buttons lead to the same effective run

## Scope

- `src/scripts/games/caravan/data/locations.ts`
- `src/scripts/games/caravan/data/locations.m19.test.ts`

No dependency, lockfile, generated output, or asset changes.