### PR TITLE
feat(caravan): enforce M20 elite contract difficulty

### DIFF
--- a/src/scripts/games/caravan/data/locations.m20.test.ts
+++ b/src/scripts/games/caravan/data/locations.m20.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { ENCOUNTERS } from './enemies';
+import { LOCATIONS } from './locations';
+
+const ELITE_ENCOUNTERS = [
+  'enc_elite_salt_convoy',
+  'enc_elite_frontier_raiders',
+  'enc_elite_frontier_horde',
+] as const;
+
+describe('M20 高階契約難度誠信', () => {
+  it('聲望 70 契約只引用專屬精英遭遇，不再混入早期兩人遭遇', () => {
+    for (const id of ['guild-salt-convoy', 'free-trader-frontier'] as const) {
+      const loc = LOCATIONS[id];
+      expect(loc.minReputation).toBe(70);
+      expect(loc.encounterTable.length).toBeGreaterThan(0);
+      for (const entry of loc.encounterTable) {
+        expect(entry.encounterId).toMatch(/^enc_elite_/);
+        expect(ELITE_ENCOUNTERS).toContain(entry.encounterId);
+      }
+    }
+  });
+
+  it.each(ELITE_ENCOUNTERS)('%s 每場固定三名精英，且 id 唯一', (encounterId) => {
+    const units = ENCOUNTERS[encounterId]();
+    expect(units).toHaveLength(3);
+    expect(new Set(units.map((unit) => unit.id)).size).toBe(3);
+    for (const unit of units) {
+      expect(unit.name.startsWith('精英')).toBe(true);
+      expect(unit.maxHp).toBeGreaterThanOrEqual(14);
+      expect(unit.defense).toBeGreaterThanOrEqual(13);
+      expect(unit.maxPoise).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it('精英遭遇每次建立全新可變物件，不會因上一場受傷或中狀態污染下一場', () => {
+    const first = ENCOUNTERS.enc_elite_salt_convoy();
+    const second = ENCOUNTERS.enc_elite_salt_convoy();
+
+    first[0].hp = 1;
+    first[0].statuses = [{ kind: 'poison', remaining: 2, potency: 3 }];
+    first[0].moves[0].name = '被污染的招式';
+
+    expect(second[0].hp).toBe(second[0].maxHp);
+    expect(second[0].statuses).toEqual([]);
+    expect(second[0].moves[0].name).not.toBe('被污染的招式');
+  });
+
+  it('精英契約不偷渡地下城 Boss 規則或 Boss 級一次性掉落', () => {
+    for (const encounterId of ELITE_ENCOUNTERS) {
+      for (const unit of ENCOUNTERS[encounterId]()) {
+        expect(unit.enrage).toBeUndefined();
+        expect(unit.loot?.itemChance ?? 0).toBeLessThan(0.8);
+        expect(unit.maxHp).toBeLessThan(38);
+      }
+    }
+  });
+
+  it('契約名稱宣告的推薦屬性確實覆蓋專屬精英池', () => {
+    const saltWeaknesses = new Set(
+      ENCOUNTERS.enc_elite_salt_convoy().flatMap((unit) => unit.weaknesses ?? [])
+    );
+    expect(saltWeaknesses.has('holy')).toBe(true);
+    expect(saltWeaknesses.has('blunt')).toBe(true);
+
+    const frontierWeaknesses = new Set(
+      [
+        ...ENCOUNTERS.enc_elite_frontier_raiders(),
+        ...ENCOUNTERS.enc_elite_frontier_horde(),
+      ].flatMap((unit) => unit.weaknesses ?? [])
+    );
+    expect(frontierWeaknesses.has('slash')).toBe(true);
+    expect(frontierWeaknesses.has('pierce')).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -1,13 +1,73 @@
+import type { EnemyUnit } from '../combat';
 import type { LocationDef } from '../expedition';
 import { registerLocations } from '../expedition';
 import type { SaveData } from '../save';
+import { ENCOUNTERS } from './enemies';
 
 /**
  * M3 首批地點：貿易路線 2 條、迷宮 1 座、隱藏迷宮 1 座（旗標鏈 discover）。
  * M5 擴充：第三路線「霧嶺古道」（reputation≥40）、高階迷宮「鹽晶洞窟」（reputation≥60）、
  * 隱藏路線「古戰場」（旗標鏈 discover，見 data/events.ts ev_faded_banner→ev_mercenary_ruins）。
  * M19 擴充：兩張聲望 70 的高階戰術契約，讓戰技配置與押貨目的形成真正取捨。
+ * M20 修正：高階契約改用三人精英編成，不再重用早期兩人遭遇造成難度倒退。
  */
+
+/**
+ * 將既有敵人提升為高階契約精英：保留原招式、弱點與美術，只提高耐久、護勢、
+ * 防禦與掉落。複製所有可變欄位，避免精英遭遇污染一般路線的工廠產物。
+ */
+function elite(unit: EnemyUnit, suffix: string): EnemyUnit {
+  const hpBonus = Math.max(5, Math.ceil(unit.maxHp * 0.35));
+  return {
+    ...unit,
+    id: `${unit.id}-${suffix}`,
+    name: `精英${unit.name}`,
+    stats: { ...unit.stats },
+    maxHp: unit.maxHp + hpBonus,
+    hp: unit.maxHp + hpBonus,
+    defense: unit.defense + 1,
+    moves: unit.moves.map((move) => ({ ...move })),
+    intents: unit.intents.map((intent) => ({ ...intent })),
+    weaknesses: unit.weaknesses ? [...unit.weaknesses] : undefined,
+    resists: unit.resists ? [...unit.resists] : undefined,
+    maxPoise: Math.max(3, (unit.maxPoise ?? 2) + 1),
+    poise: undefined,
+    statuses: [],
+    loot: unit.loot
+      ? {
+          ...unit.loot,
+          gold: [Math.ceil(unit.loot.gold[0] * 1.5), Math.ceil(unit.loot.gold[1] * 1.5)],
+        }
+      : undefined,
+  };
+}
+
+function encounterUnits(id: string): EnemyUnit[] {
+  const factory = ENCOUNTERS[id];
+  if (!factory) throw new Error(`高階契約引用不存在的遭遇「${id}」`);
+  return factory();
+}
+
+/** 鹽晶護運：亡魂＋傀儡＋山賊，聖／打可覆蓋主力威脅。 */
+ENCOUNTERS.enc_elite_salt_convoy = () => {
+  const salt = encounterUnits('enc_salt_crystals');
+  const ridge = encounterUnits('enc_ridge_bandits');
+  return [elite(salt[0], 'convoy'), elite(salt[1], 'convoy'), elite(ridge[0], 'convoy')];
+};
+
+/** 邊境環線：山賊＋亡靈＋哥布林，斬／刺可處理三種不同位置與防禦型態。 */
+ENCOUNTERS.enc_elite_frontier_raiders = () => {
+  const ridge = encounterUnits('enc_ridge_bandits');
+  const ruins = encounterUnits('enc_ruins_undead');
+  return [elite(ridge[0], 'frontier'), elite(ridge[1], 'frontier'), elite(ruins[1], 'frontier')];
+};
+
+ENCOUNTERS.enc_elite_frontier_horde = () => {
+  const ruins = encounterUnits('enc_ruins_undead');
+  const goblins = encounterUnits('enc_goblin_raiders');
+  return [elite(ruins[1], 'horde'), elite(goblins[0], 'horde'), elite(goblins[1], 'horde')];
+};
+
 export const LOCATIONS: Record<string, LocationDef> = {
   'endless-road': {
     id: 'endless-road',
@@ -104,7 +164,7 @@ export const LOCATIONS: Record<string, LocationDef> = {
     encounterTable: [{ weight: 100, encounterId: 'enc_ruins_undead' }],
   },
 
-  // ---- M19 高階戰術契約：目的地、敵情與推薦屬性都明確分流 -----------
+  // ---- M19/M20 高階戰術契約：專屬三人精英編成 -------------------------
   'guild-salt-convoy': {
     id: 'guild-salt-convoy',
     name: '商會特許．鹽晶護運〔聖／打〕',
@@ -112,10 +172,7 @@ export const LOCATIONS: Record<string, LocationDef> = {
     legs: 7,
     minReputation: 70,
     destinationTownId: 'salt-spring-city',
-    encounterTable: [
-      { weight: 65, encounterId: 'enc_salt_crystals' },
-      { weight: 35, encounterId: 'enc_ridge_bandits' },
-    ],
+    encounterTable: [{ weight: 100, encounterId: 'enc_elite_salt_convoy' }],
   },
   'free-trader-frontier': {
     id: 'free-trader-frontier',
@@ -125,9 +182,8 @@ export const LOCATIONS: Record<string, LocationDef> = {
     minReputation: 70,
     destinationTownId: 'woodside-settlement',
     encounterTable: [
-      { weight: 40, encounterId: 'enc_ridge_bandits' },
-      { weight: 35, encounterId: 'enc_ruins_undead' },
-      { weight: 25, encounterId: 'enc_goblin_raiders' },
+      { weight: 55, encounterId: 'enc_elite_frontier_raiders' },
+      { weight: 45, encounterId: 'enc_elite_frontier_horde' },
     ],
   },
 };


### PR DESCRIPTION
## Summary

- replace the reputation-70 contracts' reused early-game two-enemy encounters with dedicated three-enemy elite formations
- promote existing enemies without duplicating their art, moves, weaknesses, or behavior data
- raise elite HP, defense, poise, and gold rewards while keeping route encounters below boss scale
- preserve the advertised holy/blunt and slash/pierce preparation doctrines
- add regression tests for party size, elite durability, unique IDs, fresh factory state, boss-rule exclusion, and weakness coverage

## Game-design intent

M19 gave high-rank players two tactically distinct contracts, but those contracts still reused ordinary two-enemy encounters originally tuned for much earlier progression. From a player's perspective, the label said "high-rank contract" while the combat often became easier than content already cleared at reputation 60. M20 restores difficulty integrity: the contracts now test four-person formations and prepared loadouts with three-unit elite enemy compositions.

## Player adversarial review

The implementation explicitly covers hostile but realistic failure cases:

- every reputation-70 contract references only dedicated elite encounters
- every elite encounter contains exactly three enemies with unique IDs
- elite factories return fresh mutable objects, so damage, statuses, and move mutations cannot leak into later battles
- elite enemies receive meaningful durability and poise increases rather than cosmetic name changes
- route encounters do not inherit boss enrage rules, boss HP scale, or high-probability one-time boss loot
- the salt convoy still exposes both holy and blunt weaknesses
- the frontier pools still expose both slash and pierce weaknesses

## Scope

- `src/scripts/games/caravan/data/locations.ts`
- `src/scripts/games/caravan/data/locations.m20.test.ts`

No dependency, lockfile, generated output, or asset changes.