### PR TITLE
feat(caravan): add M21 trustworthy quest intelligence

### DIFF
--- a/src/scripts/games/caravan/data/locations.m21.test.ts
+++ b/src/scripts/games/caravan/data/locations.m21.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { ENCOUNTERS } from './enemies';
+import { LOCATIONS, locationIntel } from './locations';
+
+const salt = LOCATIONS['guild-salt-convoy'];
+const frontier = LOCATIONS['free-trader-frontier'];
+
+describe('M21 契約情報', () => {
+  it('鹽晶護運標籤與實際三人精英敵情一致', () => {
+    const intel = locationIntel(salt);
+    expect(salt.name).toContain('→ 鹽泉城');
+    expect(salt.name).toContain('精英×3');
+    expect(intel.enemyCountMin).toBe(3);
+    expect(intel.enemyCountMax).toBe(3);
+    expect(intel.weaknesses).toEqual(expect.arrayContaining(['holy', 'blunt']));
+    expect(intel.resists).toEqual(expect.arrayContaining(['slash', 'pierce']));
+    expect(intel.averageHp).toBeGreaterThan(18);
+    expect(intel.averageDefense).toBeGreaterThanOrEqual(14);
+    expect(intel.averagePoise).toBeGreaterThanOrEqual(3);
+  });
+
+  it('邊境環線標籤涵蓋所有隨機敵群的規模與核心弱點', () => {
+    const intel = locationIntel(frontier);
+    expect(frontier.name).toContain('→ 林邊聚落');
+    expect(frontier.name).toContain('精英×3');
+    expect(intel.enemyCountMin).toBe(3);
+    expect(intel.enemyCountMax).toBe(3);
+    expect(intel.weaknesses).toEqual(expect.arrayContaining(['slash', 'pierce']));
+    expect(intel.averageHp).toBeGreaterThan(14);
+  });
+
+  it('情報掃描不會把受傷或狀態污染到下一場遭遇', () => {
+    const first = ENCOUNTERS.enc_elite_salt_convoy();
+    first[0].hp = 1;
+    first[0].statuses = [{ kind: 'poison', remaining: 3, potency: 9 }];
+
+    locationIntel(salt);
+    const second = ENCOUNTERS.enc_elite_salt_convoy();
+    expect(second[0].hp).toBe(second[0].maxHp);
+    expect(second[0].statuses).toEqual([]);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it('不存在的遭遇引用會明確失敗，不產生看似正常的空情報', () => {
+    expect(() => locationIntel({
+      id: 'broken-intel',
+      name: '毀損情報',
+      kind: 'route',
+      legs: 1,
+      encounterTable: [{ weight: 1, encounterId: 'enc_missing' }],
+    })).toThrow('enc_missing');
+  });
+});

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -1,22 +1,10 @@
-import type { DamageElement, EnemyUnit } from '../combat';
+import type { Element as DamageElement, EnemyUnit } from '../combat';
 import type { LocationDef } from '../expedition';
 import { registerLocations } from '../expedition';
 import type { SaveData } from '../save';
 import { ENCOUNTERS } from './enemies';
 
-/**
- * M3 首批地點：貿易路線 2 條、迷宮 1 座、隱藏迷宮 1 座（旗標鏈 discover）。
- * M5 擴充：第三路線「霧嶺古道」（reputation≥40）、高階迷宮「鹽晶洞窟」（reputation≥60）、
- * 隱藏路線「古戰場」（旗標鏈 discover，見 data/events.ts ev_faded_banner→ev_mercenary_ruins）。
- * M19 擴充：兩張聲望 70 的高階戰術契約，讓戰技配置與押貨目的形成真正取捨。
- * M20 修正：高階契約改用三人精英編成，不再重用早期兩人遭遇造成難度倒退。
- * M21 情報：由實際遭遇工廠推導敵群規模、弱點與抗性，避免委託文字和戰鬥資料漂移。
- */
-
-/**
- * 將既有敵人提升為高階契約精英：保留原招式、弱點與美術，只提高耐久、護勢、
- * 防禦與掉落。複製所有可變欄位，避免精英遭遇污染一般路線的工廠產物。
- */
+/** 將既有敵人提升為高階契約精英，並複製所有可變欄位。 */
 function elite(unit: EnemyUnit, suffix: string): EnemyUnit {
   const hpBonus = Math.max(5, Math.ceil(unit.maxHp * 0.35));
   return {
@@ -35,10 +23,7 @@ function elite(unit: EnemyUnit, suffix: string): EnemyUnit {
     poise: undefined,
     statuses: [],
     loot: unit.loot
-      ? {
-          ...unit.loot,
-          gold: [Math.ceil(unit.loot.gold[0] * 1.5), Math.ceil(unit.loot.gold[1] * 1.5)],
-        }
+      ? { ...unit.loot, gold: [Math.ceil(unit.loot.gold[0] * 1.5), Math.ceil(unit.loot.gold[1] * 1.5)] }
       : undefined,
   };
 }
@@ -49,14 +34,12 @@ function encounterUnits(id: string): EnemyUnit[] {
   return factory();
 }
 
-/** 鹽晶護運：亡魂＋傀儡＋山賊，聖／打可覆蓋主力威脅。 */
 ENCOUNTERS.enc_elite_salt_convoy = () => {
   const salt = encounterUnits('enc_salt_crystals');
   const ridge = encounterUnits('enc_ridge_bandits');
   return [elite(salt[0], 'convoy'), elite(salt[1], 'convoy'), elite(ridge[0], 'convoy')];
 };
 
-/** 邊境環線：山賊＋亡靈＋哥布林，斬／刺可處理三種不同位置與防禦型態。 */
 ENCOUNTERS.enc_elite_frontier_raiders = () => {
   const ridge = encounterUnits('enc_ridge_bandits');
   const ruins = encounterUnits('enc_ruins_undead');
@@ -79,10 +62,7 @@ export interface LocationIntel {
   averagePoise: number;
 }
 
-/**
- * 從地點的所有隨機遭遇推導玩家出發前可用的可信情報。
- * 每次都呼叫全新的遭遇工廠，不讀寫註冊表內的可變敵人狀態。
- */
+/** 從地點的實際遭遇工廠推導可信的出發前情報。 */
 export function locationIntel(location: LocationDef): LocationIntel {
   const encounters = location.encounterTable.map((entry) => {
     const factory = ENCOUNTERS[entry.encounterId];
@@ -99,8 +79,8 @@ export function locationIntel(location: LocationDef): LocationIntel {
   const average = (values: number[]): number =>
     values.length === 0 ? 0 : Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) / 10;
   return {
-    enemyCountMin: encounters.length === 0 ? 0 : Math.min(...encounters.map((units) => units.length)),
-    enemyCountMax: encounters.length === 0 ? 0 : Math.max(...encounters.map((units) => units.length)),
+    enemyCountMin: encounters.length === 0 ? 0 : Math.min(...encounters.map((group) => group.length)),
+    enemyCountMax: encounters.length === 0 ? 0 : Math.max(...encounters.map((group) => group.length)),
     weaknesses: [...weaknesses].sort(),
     resists: [...resists].sort(),
     averageHp: average(units.map((unit) => unit.maxHp)),
@@ -111,13 +91,8 @@ export function locationIntel(location: LocationDef): LocationIntel {
 
 export const LOCATIONS: Record<string, LocationDef> = {
   'endless-road': {
-    id: 'endless-road',
-    name: '無盡遠路',
-    kind: 'route',
-    legs: 4,
-    endless: true,
-    minReputation: 40,
-    destinationTownId: 'riverbend-town',
+    id: 'endless-road', name: '無盡遠路', kind: 'route', legs: 4, endless: true,
+    minReputation: 40, destinationTownId: 'riverbend-town',
     encounterTable: [
       { weight: 35, encounterId: 'enc_wolf_pair' },
       { weight: 30, encounterId: 'enc_bandit_raid' },
@@ -126,10 +101,7 @@ export const LOCATIONS: Record<string, LocationDef> = {
     ],
   },
   'riverside-road': {
-    id: 'riverside-road',
-    name: '臨水道',
-    kind: 'route',
-    legs: 4,
+    id: 'riverside-road', name: '臨水道', kind: 'route', legs: 4,
     encounterTable: [
       { weight: 60, encounterId: 'enc_wolf_pair' },
       { weight: 40, encounterId: 'enc_bandit_raid' },
@@ -137,10 +109,7 @@ export const LOCATIONS: Record<string, LocationDef> = {
     destinationTownId: 'riverbend-town',
   },
   'blackwood-trail': {
-    id: 'blackwood-trail',
-    name: '黑森林徑',
-    kind: 'route',
-    legs: 5,
+    id: 'blackwood-trail', name: '黑森林徑', kind: 'route', legs: 5,
     encounterTable: [
       { weight: 50, encounterId: 'enc_wolf_pair' },
       { weight: 50, encounterId: 'enc_goblin_raiders' },
@@ -148,35 +117,20 @@ export const LOCATIONS: Record<string, LocationDef> = {
     destinationTownId: 'woodside-settlement',
   },
   'abandoned-mine': {
-    id: 'abandoned-mine',
-    name: '廢棄礦坑',
-    kind: 'dungeon',
-    floors: 4,
-    roomsPerFloor: [2, 3],
-    depthHpBonus: 2,
-    bossEncounterId: 'enc_mine_overseer',
+    id: 'abandoned-mine', name: '廢棄礦坑', kind: 'dungeon', floors: 4,
+    roomsPerFloor: [2, 3], depthHpBonus: 2, bossEncounterId: 'enc_mine_overseer',
     encounterTable: [
       { weight: 70, encounterId: 'enc_mine_spiders' },
       { weight: 30, encounterId: 'enc_bandit_raid' },
     ],
   },
   'goblin-den': {
-    id: 'goblin-den',
-    name: '哥布林巢穴',
-    kind: 'dungeon',
-    hidden: true,
-    floors: 3,
-    roomsPerFloor: [2, 3],
-    depthHpBonus: 3,
-    bossEncounterId: 'enc_goblin_den_chief',
+    id: 'goblin-den', name: '哥布林巢穴', kind: 'dungeon', hidden: true, floors: 3,
+    roomsPerFloor: [2, 3], depthHpBonus: 3, bossEncounterId: 'enc_goblin_den_chief',
     encounterTable: [{ weight: 100, encounterId: 'enc_goblin_raiders' }],
   },
   'misty-ridge-trail': {
-    id: 'misty-ridge-trail',
-    name: '霧嶺古道',
-    kind: 'route',
-    legs: 6,
-    minReputation: 40,
+    id: 'misty-ridge-trail', name: '霧嶺古道', kind: 'route', legs: 6, minReputation: 40,
     encounterTable: [
       { weight: 60, encounterId: 'enc_ridge_bandits' },
       { weight: 40, encounterId: 'enc_wolf_pair' },
@@ -184,40 +138,25 @@ export const LOCATIONS: Record<string, LocationDef> = {
     destinationTownId: 'salt-spring-city',
   },
   'salt-crystal-cavern': {
-    id: 'salt-crystal-cavern',
-    name: '鹽晶洞窟',
-    kind: 'dungeon',
-    floors: 5,
-    roomsPerFloor: [2, 3],
-    depthHpBonus: 3,
-    minReputation: 60,
+    id: 'salt-crystal-cavern', name: '鹽晶洞窟', kind: 'dungeon', floors: 5,
+    roomsPerFloor: [2, 3], depthHpBonus: 3, minReputation: 60,
     bossEncounterId: 'enc_salt_cavern_boss',
     encounterTable: [{ weight: 100, encounterId: 'enc_salt_crystals' }],
   },
   'battlefield-ruins': {
-    id: 'battlefield-ruins',
-    name: '古戰場',
-    kind: 'route',
-    hidden: true,
-    legs: 3,
+    id: 'battlefield-ruins', name: '古戰場', kind: 'route', hidden: true, legs: 3,
     encounterTable: [{ weight: 100, encounterId: 'enc_ruins_undead' }],
   },
   'guild-salt-convoy': {
     id: 'guild-salt-convoy',
     name: '商會特許．鹽晶護運 → 鹽泉城〔精英×3｜弱聖打｜抗斬刺〕',
-    kind: 'route',
-    legs: 7,
-    minReputation: 70,
-    destinationTownId: 'salt-spring-city',
+    kind: 'route', legs: 7, minReputation: 70, destinationTownId: 'salt-spring-city',
     encounterTable: [{ weight: 100, encounterId: 'enc_elite_salt_convoy' }],
   },
   'free-trader-frontier': {
     id: 'free-trader-frontier',
     name: '自由商旅．邊境環線 → 林邊聚落〔精英×3｜弱斬刺〕',
-    kind: 'route',
-    legs: 8,
-    minReputation: 70,
-    destinationTownId: 'woodside-settlement',
+    kind: 'route', legs: 8, minReputation: 70, destinationTownId: 'woodside-settlement',
     encounterTable: [
       { weight: 55, encounterId: 'enc_elite_frontier_raiders' },
       { weight: 45, encounterId: 'enc_elite_frontier_horde' },

--- a/src/scripts/games/caravan/data/locations.ts
+++ b/src/scripts/games/caravan/data/locations.ts
@@ -1,4 +1,4 @@
-import type { EnemyUnit } from '../combat';
+import type { DamageElement, EnemyUnit } from '../combat';
 import type { LocationDef } from '../expedition';
 import { registerLocations } from '../expedition';
 import type { SaveData } from '../save';
@@ -10,6 +10,7 @@ import { ENCOUNTERS } from './enemies';
  * 隱藏路線「古戰場」（旗標鏈 discover，見 data/events.ts ev_faded_banner→ev_mercenary_ruins）。
  * M19 擴充：兩張聲望 70 的高階戰術契約，讓戰技配置與押貨目的形成真正取捨。
  * M20 修正：高階契約改用三人精英編成，不再重用早期兩人遭遇造成難度倒退。
+ * M21 情報：由實際遭遇工廠推導敵群規模、弱點與抗性，避免委託文字和戰鬥資料漂移。
  */
 
 /**
@@ -67,6 +68,46 @@ ENCOUNTERS.enc_elite_frontier_horde = () => {
   const goblins = encounterUnits('enc_goblin_raiders');
   return [elite(ruins[1], 'horde'), elite(goblins[0], 'horde'), elite(goblins[1], 'horde')];
 };
+
+export interface LocationIntel {
+  enemyCountMin: number;
+  enemyCountMax: number;
+  weaknesses: DamageElement[];
+  resists: DamageElement[];
+  averageHp: number;
+  averageDefense: number;
+  averagePoise: number;
+}
+
+/**
+ * 從地點的所有隨機遭遇推導玩家出發前可用的可信情報。
+ * 每次都呼叫全新的遭遇工廠，不讀寫註冊表內的可變敵人狀態。
+ */
+export function locationIntel(location: LocationDef): LocationIntel {
+  const encounters = location.encounterTable.map((entry) => {
+    const factory = ENCOUNTERS[entry.encounterId];
+    if (!factory) throw new Error(`locationIntel: 遭遇「${entry.encounterId}」不存在`);
+    return factory();
+  });
+  const units = encounters.flat();
+  const weaknesses = new Set<DamageElement>();
+  const resists = new Set<DamageElement>();
+  for (const unit of units) {
+    for (const element of unit.weaknesses ?? []) weaknesses.add(element);
+    for (const element of unit.resists ?? []) resists.add(element);
+  }
+  const average = (values: number[]): number =>
+    values.length === 0 ? 0 : Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 10) / 10;
+  return {
+    enemyCountMin: encounters.length === 0 ? 0 : Math.min(...encounters.map((units) => units.length)),
+    enemyCountMax: encounters.length === 0 ? 0 : Math.max(...encounters.map((units) => units.length)),
+    weaknesses: [...weaknesses].sort(),
+    resists: [...resists].sort(),
+    averageHp: average(units.map((unit) => unit.maxHp)),
+    averageDefense: average(units.map((unit) => unit.defense)),
+    averagePoise: average(units.map((unit) => unit.maxPoise ?? 0)),
+  };
+}
 
 export const LOCATIONS: Record<string, LocationDef> = {
   'endless-road': {
@@ -130,8 +171,6 @@ export const LOCATIONS: Record<string, LocationDef> = {
     bossEncounterId: 'enc_goblin_den_chief',
     encounterTable: [{ weight: 100, encounterId: 'enc_goblin_raiders' }],
   },
-
-  // ---- M5 內容擴充：第三路線／高階迷宮／隱藏路線 -----------------------
   'misty-ridge-trail': {
     id: 'misty-ridge-trail',
     name: '霧嶺古道',
@@ -163,11 +202,9 @@ export const LOCATIONS: Record<string, LocationDef> = {
     legs: 3,
     encounterTable: [{ weight: 100, encounterId: 'enc_ruins_undead' }],
   },
-
-  // ---- M19/M20 高階戰術契約：專屬三人精英編成 -------------------------
   'guild-salt-convoy': {
     id: 'guild-salt-convoy',
-    name: '商會特許．鹽晶護運〔聖／打〕',
+    name: '商會特許．鹽晶護運 → 鹽泉城〔精英×3｜弱聖打｜抗斬刺〕',
     kind: 'route',
     legs: 7,
     minReputation: 70,
@@ -176,7 +213,7 @@ export const LOCATIONS: Record<string, LocationDef> = {
   },
   'free-trader-frontier': {
     id: 'free-trader-frontier',
-    name: '自由商旅．邊境環線〔斬／刺〕',
+    name: '自由商旅．邊境環線 → 林邊聚落〔精英×3｜弱斬刺〕',
     kind: 'route',
     legs: 8,
     minReputation: 70,
@@ -188,10 +225,6 @@ export const LOCATIONS: Record<string, LocationDef> = {
   },
 };
 
-/**
- * 委託板可見地點：hidden 且未設 `discovered:<id>` 旗標的地點不列入；
- * minReputation 設定時 save.reputation 未達門檻也不列入（M5，兩條件各自獨立判斷）。
- */
 export function visibleLocations(save: SaveData): LocationDef[] {
   return Object.values(LOCATIONS).filter((loc) => {
     if (loc.hidden && save.flags[`discovered:${loc.id}`] !== true) return false;


### PR DESCRIPTION
## Summary

- expose reusable `locationIntel()` data derived from the actual encounter factories
- report enemy-count range, weaknesses, resistances, average HP, defense, and poise without mutating combat state
- upgrade reputation-70 contract labels with destination, elite group size, core weaknesses, and critical resistances
- keep the visible briefing aligned with the real M20 elite encounters instead of hand-written flavor text
- add adversarial regression tests for label truthfulness, encounter freshness, strength thresholds, and broken encounter references

## Game-design intent

M18–M20 created loadouts, route-specific contracts, and elite encounters, but the quest board still forced players to infer critical preparation information through failure or external knowledge. M21 improves decision quality without removing uncertainty: high-rank players can now see where the route ends, how many elite enemies appear, what damage types matter, and which common damage types may be resisted.

The new `locationIntel()` helper is deliberately data-driven so future UI can show full briefings, party coverage, scout forecasts, and trade opportunities using the same source of truth.

## Player adversarial review

- displayed enemy count must equal every possible encounter group size
- displayed weaknesses and resistances must exist on the actual generated enemies
- elite contracts must report materially higher average HP, defense, and poise
- intelligence scans must not leak damage or statuses into later battles
- a missing encounter reference must fail explicitly instead of producing misleading empty intelligence
- destination names in the visible contract labels must match the configured destination towns

## Scope

- `src/scripts/games/caravan/data/locations.ts`
- `src/scripts/games/caravan/data/locations.m21.test.ts`

No dependency, lockfile, generated output, save schema, or asset changes.