### PR TITLE
feat(caravan): add M22 character genesis matrix

### DIFF
--- a/src/scripts/games/caravan/data/genesis.test.ts
+++ b/src/scripts/games/caravan/data/genesis.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from './items';
+import {
+  GENESIS_APTITUDES,
+  GENESIS_BURDENS,
+  GENESIS_LIFEPATHS,
+  genesisName,
+  resolveCharacterGenesis,
+  type GenesisTraitId,
+} from './genesis';
+import { newGame, STARTING_PROFILE, type CharacterChoice } from '../save';
+import type { StatBlock } from '../types';
+
+const JOBS = ['swordsman', 'ranger', 'mage', 'cleric'] as const;
+const TRAITS = Object.keys(GENESIS_LIFEPATHS) as GenesisTraitId[];
+const STATS = ['str', 'dex', 'int', 'cha', 'con'] as const;
+
+function statShape(high: keyof StatBlock, low: keyof StatBlock): StatBlock {
+  const stats: StatBlock = { str: 10, dex: 10, int: 10, cha: 10, con: 10 };
+  stats[high] = 15;
+  stats[low] = high === low ? 15 : 6;
+  return stats;
+}
+
+function choice(job: typeof JOBS[number], trait: GenesisTraitId): CharacterChoice {
+  return { job, trait };
+}
+
+describe('M22 角色命運矩陣', () => {
+  it('無出身特性維持舊版開局，不偷偷改動金幣、聲望、物資或命運欄位', () => {
+    const save = newGame(1000, { job: 'swordsman' });
+    expect(save.gold).toBe(200);
+    expect(save.reputation).toBe(0);
+    expect(save.inventory).toEqual({});
+    expect(save.protagonist.genesis).toBeUndefined();
+    expect(save.protagonist.skills).toBeUndefined();
+    expect(save.protagonist.skillPoints).toBeUndefined();
+  });
+
+  it('四職業 × 六出身全部能安全開局，且所有物資與技能資料有效', () => {
+    for (const job of JOBS) {
+      for (const trait of TRAITS) {
+        const save = newGame(1000, choice(job, trait));
+        expect(save.protagonist.genesis?.lifepathId).toBe(trait);
+        expect(save.gold, `${job}/${trait} 資金死局`).toBeGreaterThanOrEqual(50);
+        expect(save.protagonist.maxHp, `${job}/${trait} 生命死局`).toBeGreaterThanOrEqual(8);
+        expect(save.reputation).toBeGreaterThanOrEqual(0);
+        expect(save.reputation).toBeLessThan(10);
+        for (const [itemId, count] of Object.entries(save.inventory)) {
+          expect(ITEMS[itemId], `${job}/${trait} 引用未知物品 ${itemId}`).toBeDefined();
+          expect(count).toBeGreaterThan(0);
+        }
+        for (const rank of Object.values(save.protagonist.skills ?? {})) {
+          expect(rank).toBeGreaterThanOrEqual(1);
+          expect(rank).toBeLessThanOrEqual(2);
+        }
+        expect(save.protagonist.skillPoints ?? 0).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  it('最強屬性與最弱屬性各有五種可推導結果，平手採固定順序並可重現', () => {
+    for (const high of STATS) {
+      for (const low of STATS) {
+        if (high === low) continue;
+        const stats = statShape(high, low);
+        const first = resolveCharacterGenesis(stats, 'seasoned');
+        const second = resolveCharacterGenesis({ ...stats }, 'seasoned');
+        expect(first?.profile.aptitudeId).toBe(high);
+        expect(first?.profile.burdenId).toBe(low);
+        expect(second).toEqual(first);
+      }
+    }
+
+    const tied = resolveCharacterGenesis({ str: 12, dex: 12, int: 10, cha: 10, con: 10 }, 'nimble');
+    expect(tied?.profile.aptitudeId).toBe('str');
+    expect(tied?.profile.burdenId).toBe('con');
+  });
+
+  it('擲骰與配點後的實際數值會改變命運方向，而不是被職業模板寫死', () => {
+    const base = STARTING_PROFILE.mage.stats;
+    const ordinary = newGame(1000, { job: 'mage', trait: 'learned' });
+    const transformed = newGame(1000, {
+      job: 'mage', trait: 'learned',
+      statRoll: { ...base, str: base.str + 3, int: base.int - 2, con: base.con + 3 },
+      allocation: { str: 3 },
+    });
+    expect(ordinary.protagonist.genesis?.aptitudeId).toBe('int');
+    expect(transformed.protagonist.genesis?.aptitudeId).toBe('str');
+    expect(transformed.protagonist.genesis).not.toEqual(ordinary.protagonist.genesis);
+  });
+
+  it('每條出身都有優勢與代價，沒有單一選項同時擁有最高資金、聲望、生命與技能', () => {
+    const outcomes = TRAITS.map((trait) => {
+      const save = newGame(1000, { job: 'swordsman', trait });
+      return {
+        trait,
+        gold: save.gold,
+        reputation: save.reputation,
+        hp: save.protagonist.maxHp,
+        skillPower: Object.values(save.protagonist.skills ?? {}).reduce((sum, rank) => sum + rank, 0)
+          + (save.protagonist.skillPoints ?? 0),
+        items: Object.values(save.inventory).reduce((sum, count) => sum + count, 0),
+      };
+    });
+    const maxima = {
+      gold: Math.max(...outcomes.map((x) => x.gold)),
+      reputation: Math.max(...outcomes.map((x) => x.reputation)),
+      hp: Math.max(...outcomes.map((x) => x.hp)),
+      skillPower: Math.max(...outcomes.map((x) => x.skillPower)),
+      items: Math.max(...outcomes.map((x) => x.items)),
+    };
+    expect(outcomes.some((x) =>
+      x.gold === maxima.gold && x.reputation === maxima.reputation && x.hp === maxima.hp &&
+      x.skillPower === maxima.skillPower && x.items === maxima.items
+    )).toBe(false);
+  });
+
+  it('命運名稱完整揭露出身、天賦與缺陷三個軸', () => {
+    const result = resolveCharacterGenesis(statShape('cha', 'con'), 'charming');
+    expect(result).not.toBeNull();
+    const name = genesisName(result!.profile);
+    expect(name).toContain(GENESIS_LIFEPATHS.charming.name);
+    expect(name).toContain(GENESIS_APTITUDES.cha.name);
+    expect(name).toContain(GENESIS_BURDENS.con.name);
+  });
+
+  it('未知或空特性不啟動命運矩陣，避免毀損存檔取得未驗證資源', () => {
+    const stats = statShape('str', 'con');
+    expect(resolveCharacterGenesis(stats, null)).toBeNull();
+    expect(resolveCharacterGenesis(stats, 'not-a-trait')).toBeNull();
+  });
+});

--- a/src/scripts/games/caravan/data/genesis.ts
+++ b/src/scripts/games/caravan/data/genesis.ts
@@ -1,0 +1,193 @@
+import type { StatBlock } from '../types';
+
+export type GenesisTraitId = 'seasoned' | 'brawny' | 'nimble' | 'learned' | 'charming' | 'tough';
+export type GenesisAptitudeId = keyof StatBlock;
+export type GenesisBurdenId = keyof StatBlock;
+export type GenesisSkillId = 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+
+export interface GenesisEffects {
+  goldDelta: number;
+  reputationDelta: number;
+  maxHpDelta: number;
+  inventory: Record<string, number>;
+  skills: Partial<Record<GenesisSkillId, number>>;
+  skillPoints: number;
+}
+
+export interface GenesisPathDef extends GenesisEffects {
+  id: string;
+  name: string;
+  desc: string;
+}
+
+export interface CharacterGenesis {
+  lifepathId: GenesisTraitId;
+  aptitudeId: GenesisAptitudeId;
+  burdenId: GenesisBurdenId;
+}
+
+const emptyEffects = (): GenesisEffects => ({
+  goldDelta: 0,
+  reputationDelta: 0,
+  maxHpDelta: 0,
+  inventory: {},
+  skills: {},
+  skillPoints: 0,
+});
+
+/**
+ * M22 出身道路：直接沿用創角既有六種「出身特性」，不增加一個只換皮的選單。
+ * 每條道路都同時影響經濟、聲望、技能、物資或生命，讓特性成為完整開局策略。
+ */
+export const GENESIS_LIFEPATHS: Record<GenesisTraitId, GenesisPathDef> = {
+  seasoned: {
+    id: 'seasoned', name: '流浪老手',
+    desc: '熟悉商路與人情：聲望 +4、博識 1、破損地圖與乾糧各 1。',
+    goldDelta: 0, reputationDelta: 4, maxHpDelta: 0,
+    inventory: { 'tattered-map': 1, 'dried-rations': 1 },
+    skills: { lore: 1 }, skillPoints: 0,
+  },
+  brawny: {
+    id: 'brawny', name: '苦役鬥士',
+    desc: '用傷痕換來力量：生命 +2、武藝 1、行軍補劑 1，但起始金幣 -20。',
+    goldDelta: -20, reputationDelta: 0, maxHpDelta: 2,
+    inventory: { 'war-tonic': 1 },
+    skills: { martial: 1 }, skillPoints: 0,
+  },
+  nimble: {
+    id: 'nimble', name: '邊境跑商',
+    desc: '懂得找路與避險：偵查 1、火把 1、乾糧 2，但起始金幣 -10。',
+    goldDelta: -10, reputationDelta: 0, maxHpDelta: 0,
+    inventory: { torch: 1, 'dried-rations': 2 },
+    skills: { scouting: 1 }, skillPoints: 0,
+  },
+  learned: {
+    id: 'learned', name: '失學書吏',
+    desc: '帶著知識重新起步：聲望 +1、博識 1、自由技能點 1、地圖與藥草各 1，但金幣 -15。',
+    goldDelta: -15, reputationDelta: 1, maxHpDelta: 0,
+    inventory: { 'tattered-map': 1, herb: 1 },
+    skills: { lore: 1 }, skillPoints: 1,
+  },
+  charming: {
+    id: 'charming', name: '市井掮客',
+    desc: '人脈就是本錢：金幣 +35、聲望 +1、交涉 1、香料包 1，但生命 -1。',
+    goldDelta: 35, reputationDelta: 1, maxHpDelta: -1,
+    inventory: { 'spice-pouch': 1 },
+    skills: { negotiation: 1 }, skillPoints: 0,
+  },
+  tough: {
+    id: 'tough', name: '礦難倖存者',
+    desc: '撐過地底災難：生命 +3、生存 1、繃帶 2，但起始金幣 -25。',
+    goldDelta: -25, reputationDelta: 0, maxHpDelta: 3,
+    inventory: { bandage: 2 },
+    skills: { survival: 1 }, skillPoints: 0,
+  },
+};
+
+/** 最強屬性形成的天賦方向；玩家可透過擲骰與配點主動改變。 */
+export const GENESIS_APTITUDES: Record<GenesisAptitudeId, GenesisPathDef> = {
+  str: {
+    id: 'str', name: '武勇天賦', desc: '生命 +1、武藝 +1、行軍補劑 1，金幣 -5。',
+    goldDelta: -5, reputationDelta: 0, maxHpDelta: 1,
+    inventory: { 'war-tonic': 1 }, skills: { martial: 1 }, skillPoints: 0,
+  },
+  dex: {
+    id: 'dex', name: '機敏天賦', desc: '偵查 +1、火把 1。',
+    goldDelta: 0, reputationDelta: 0, maxHpDelta: 0,
+    inventory: { torch: 1 }, skills: { scouting: 1 }, skillPoints: 0,
+  },
+  int: {
+    id: 'int', name: '求知天賦', desc: '博識 +1、自由技能點 1、破損地圖 1，金幣 -5。',
+    goldDelta: -5, reputationDelta: 0, maxHpDelta: 0,
+    inventory: { 'tattered-map': 1 }, skills: { lore: 1 }, skillPoints: 1,
+  },
+  cha: {
+    id: 'cha', name: '領袖天賦', desc: '金幣 +20、聲望 +1、交涉 +1、香料包 1。',
+    goldDelta: 20, reputationDelta: 1, maxHpDelta: 0,
+    inventory: { 'spice-pouch': 1 }, skills: { negotiation: 1 }, skillPoints: 0,
+  },
+  con: {
+    id: 'con', name: '韌性天賦', desc: '生命 +3、生存 +1、繃帶 1，金幣 -10。',
+    goldDelta: -10, reputationDelta: 0, maxHpDelta: 3,
+    inventory: { bandage: 1 }, skills: { survival: 1 }, skillPoints: 0,
+  },
+};
+
+/** 最弱屬性形成的開局缺陷；只增加壓力，不會鎖死任何職業。 */
+export const GENESIS_BURDENS: Record<GenesisBurdenId, GenesisPathDef> = {
+  str: {
+    id: 'str', name: '人手不足', desc: '搬運與護衛必須外包，起始金幣 -15。',
+    ...emptyEffects(), goldDelta: -15,
+  },
+  dex: {
+    id: 'dex', name: '舊傷遲滯', desc: '生命 -1、起始金幣 -5。',
+    ...emptyEffects(), goldDelta: -5, maxHpDelta: -1,
+  },
+  int: {
+    id: 'int', name: '帳目生疏', desc: '為錯誤採購付出代價，起始金幣 -10。',
+    ...emptyEffects(), goldDelta: -10,
+  },
+  cha: {
+    id: 'cha', name: '名聲不佳', desc: '議價與擔保成本較高，起始金幣 -20。',
+    ...emptyEffects(), goldDelta: -20,
+  },
+  con: {
+    id: 'con', name: '體弱多病', desc: '生命 -3。',
+    ...emptyEffects(), maxHpDelta: -3,
+  },
+};
+
+const STAT_ORDER: Array<keyof StatBlock> = ['str', 'dex', 'int', 'cha', 'con'];
+
+function extremeStat(stats: StatBlock, direction: 'high' | 'low'): keyof StatBlock {
+  const order = direction === 'high' ? STAT_ORDER : [...STAT_ORDER].reverse();
+  return order.reduce((best, stat) => {
+    if (direction === 'high') return stats[stat] > stats[best] ? stat : best;
+    return stats[stat] < stats[best] ? stat : best;
+  }, order[0]);
+}
+
+function mergeEffects(...effects: GenesisEffects[]): GenesisEffects {
+  const merged = emptyEffects();
+  for (const effect of effects) {
+    merged.goldDelta += effect.goldDelta;
+    merged.reputationDelta += effect.reputationDelta;
+    merged.maxHpDelta += effect.maxHpDelta;
+    merged.skillPoints += effect.skillPoints;
+    for (const [itemId, count] of Object.entries(effect.inventory)) {
+      merged.inventory[itemId] = (merged.inventory[itemId] ?? 0) + count;
+    }
+    for (const [skillId, rank] of Object.entries(effect.skills) as Array<[GenesisSkillId, number]>) {
+      merged.skills[skillId] = (merged.skills[skillId] ?? 0) + rank;
+    }
+  }
+  return merged;
+}
+
+export function isGenesisTraitId(value: unknown): value is GenesisTraitId {
+  return typeof value === 'string' && value in GENESIS_LIFEPATHS;
+}
+
+/**
+ * 「無特性」維持舊版完全相容；六種可選出身才啟動命運矩陣。
+ * 最強／最弱屬性由擲骰與配點後的實際數值決定，平手採固定順序，確保存檔可重現。
+ */
+export function resolveCharacterGenesis(
+  stats: StatBlock,
+  trait: string | null | undefined,
+): { profile: CharacterGenesis; effects: GenesisEffects } | null {
+  if (!isGenesisTraitId(trait)) return null;
+  const aptitudeId = extremeStat(stats, 'high');
+  const burdenId = extremeStat(stats, 'low');
+  const profile: CharacterGenesis = { lifepathId: trait, aptitudeId, burdenId };
+  const effects = mergeEffects(
+    GENESIS_LIFEPATHS[trait],
+    GENESIS_APTITUDES[aptitudeId],
+    GENESIS_BURDENS[burdenId],
+  );
+  return { profile, effects };
+}
+
+export function genesisName(profile: CharacterGenesis): string {
+  return `${GENESIS_LIFEPATHS[profile.lifepathId].name}／${GENESIS_APTITUDES[profile.aptitudeId].name}／${GENESIS_BURDENS[profile.burdenId].name}`;
+}

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -2,10 +2,10 @@ import type { StatBlock } from './types';
 import type { JobId } from './data/jobs';
 import type { ExpeditionState } from './expedition';
 import { EXPEDITION_VERSION } from './expedition';
+import { resolveCharacterGenesis } from './data/genesis';
+import type { CharacterGenesis } from './data/genesis';
 
 export const SAVE_KEY = 'caravan-save-v1';
-
-/** M17 編隊：每次遠征最多四人，主角必定出征。 */
 export type FormationRow = 'front' | 'back';
 export type ExpeditionRole = 'captain' | 'scout' | 'quartermaster' | 'medic';
 
@@ -23,355 +23,194 @@ export interface CompanionRecord {
   xp: number;
   stats: StatBlock;
   maxHp: number;
-  /** >0 表示重傷缺席剩餘趟數 */
   injuredForTrips: number;
-  /** 旅伴特質 id（roster.ts TRAITS）；主角與 M7 前的舊成員為 null */
   trait?: string | null;
-  /** 裝備三欄：itemId 或 null（M5，roster.ts equipItem/unequipItem 維護） */
+  genesis?: CharacterGenesis;
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
-  /** M11 職業專精 id（roster.ts SPECIALIZATIONS）；Lv4 起可選，未選＝undefined/null */
   specialization?: string | null;
-  /** M11 旅伴羈絆：與主角同行完成的遠征趟數（主角自身不使用此欄） */
   bond?: number;
-  /** M14 冒險技能 rank（skillId -> 0-5）；主角使用 */
   skills?: Record<string, number>;
-  /** M14 未分配技能點（升級 +1） */
   skillPoints?: number;
-  /** M14 鐵匠強化：各裝備欄的 +N（0-3），跟人走（換裝保留） */
   equipmentPlus?: { weapon: number; armor: number; trinket: number };
-  /**
-   * M18 戰技配置：本角色帶入戰鬥的招式 id（最多 4 招）。
-   * optional 讓既有 v6 存檔自動採用預設配置，不需要清檔或升版。
-   */
   preparedMoveIds?: string[];
 }
 
-export interface SaveDataV2 {
-  version: 2;
+interface SaveBase {
   createdAt: number;
   gold: number;
   flags: Record<string, boolean>;
   protagonist: CompanionRecord;
   companions: CompanionRecord[];
 }
-
-export interface SaveDataV3 {
+export interface SaveDataV2 extends SaveBase { version: 2; }
+export interface SaveDataV3 extends SaveBase {
   version: 3;
-  createdAt: number;
-  gold: number;
-  flags: Record<string, boolean>;
-  protagonist: CompanionRecord;
-  companions: CompanionRecord[];
-  /** 背包：itemId -> 持有數量 */
   inventory: Record<string, number>;
-  /** 進行中的遠征快照；重整頁面靠這個接續，非遠征中為 null */
   expedition: ExpeditionState | null;
 }
-
-export interface SaveDataV4 {
-  version: 4;
-  createdAt: number;
-  gold: number;
-  flags: Record<string, boolean>;
-  protagonist: CompanionRecord;
-  companions: CompanionRecord[];
-  /** 背包：itemId -> 持有數量 */
-  inventory: Record<string, number>;
-  /** 進行中的遠征快照；重整頁面靠這個接續，非遠征中為 null */
-  expedition: ExpeditionState | null;
-  /** 馬車升級等級：economy.ts cargoCapacity 依此計算載貨上限（M4） */
+interface SaveManaged extends SaveDataV3 {
   wagonLevel: number;
-  /** 酒館招募池種子；每次歸返結算後遞增以輪替名單（M4） */
   tavernSeed: number;
-  /** 聲望：M4 唯一效果——達門檻時酒館池首位出現 Lv2 精英傭兵 */
   reputation: number;
-  /** 已擊殺過的隱藏迷宮 boss（locationId），用於再殺遞減報酬（M4） */
   visitedBossDungeons: string[];
 }
-
-export interface SaveDataV5 {
-  version: 5;
-  createdAt: number;
-  gold: number;
-  flags: Record<string, boolean>;
-  protagonist: CompanionRecord;
-  companions: CompanionRecord[];
-  /** 背包：itemId -> 持有數量 */
-  inventory: Record<string, number>;
-  /** 進行中的遠征快照；重整頁面靠這個接續，非遠征中為 null */
-  expedition: ExpeditionState | null;
-  /** 馬車升級等級：economy.ts cargoCapacity 依此計算載貨上限（M4） */
-  wagonLevel: number;
-  /** 酒館招募池種子；每次歸返結算後遞增以輪替名單（M4） */
-  tavernSeed: number;
-  /** 聲望：M4 唯一效果——達門檻時酒館池首位出現 Lv2 精英傭兵 */
-  reputation: number;
-  /** 已擊殺過的隱藏迷宮 boss（locationId），用於再殺遞減報酬（M4） */
-  visitedBossDungeons: string[];
-}
-
+export interface SaveDataV4 extends Omit<SaveManaged, 'version'> { version: 4; }
+export interface SaveDataV5 extends Omit<SaveManaged, 'version'> { version: 5; }
 export interface SaveDataV6 extends Omit<SaveDataV5, 'version'> {
   version: 6;
-  /** 市場行情種子；每次歸返結算後遞增，各鎮物價隨之波動（M7） */
   marketSeed: number;
-  /** M13 無盡遠路契約層數；optional 不 bump 版本（舊檔視為 0） */
   endlessTier?: number;
-  /**
-   * M17 編隊計畫；optional 以相容既有 v6 存檔。
-   * 缺少時由 roster.ts normalizeExpeditionPlan 依現有健康成員建立預設編隊。
-   */
   expeditionPlan?: ExpeditionPlan;
 }
-
-/** 對外別名，後續版本跟著改指向最新 schema */
 export type SaveData = SaveDataV6;
 
 const CURRENT_VERSION = 6;
-
 const defaultEquipment = (): CompanionRecord['equipment'] => ({ weapon: null, armor: null, trinket: null });
-
-/** 創角配點池：職業起始屬性之外可額外分配的點數 */
 export const CREATION_BONUS_POINTS = 3;
-
-/** 每職業的主角起始屬性與生命上限。劍士＝舊版預設（e2e 相容鐵則）。 */
 export const STARTING_PROFILE: Record<JobId, { stats: StatBlock; maxHp: number }> = {
   swordsman: { stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22 },
   ranger: { stats: { str: 10, dex: 14, int: 10, cha: 10, con: 11 }, maxHp: 20 },
   mage: { stats: { str: 8, dex: 10, int: 14, cha: 11, con: 9 }, maxHp: 17 },
   cleric: { stats: { str: 10, dex: 9, int: 11, cha: 14, con: 12 }, maxHp: 21 },
 };
-
-/** M14 創角擲骰：每項屬性允許偏離職業基準的範圍 */
 export const STAT_ROLL_MIN = -2;
 export const STAT_ROLL_MAX = 3;
 
 export interface CharacterChoice {
   job: JobId;
-  /** 額外配點（總和 ≤ CREATION_BONUS_POINTS，每項非負整數） */
   allocation?: Partial<StatBlock>;
-  /** 起始特性 id（roster.ts TRAITS）；未選為 null */
   trait?: string | null;
-  /** M14 擲骰結果：每項須落在 [base+STAT_ROLL_MIN, base+STAT_ROLL_MAX]；未帶＝職業基準 */
   statRoll?: StatBlock;
 }
 
-/** 依創角選擇建立主角記錄。劍士＋0 配點＋無特性 === defaultProtagonist()。 */
 export function createProtagonist(choice: CharacterChoice): CompanionRecord {
   const profile = STARTING_PROFILE[choice.job];
   if (!profile) throw new Error(`createProtagonist: 未知職業「${choice.job}」`);
-  const alloc = choice.allocation ?? {};
+  const allocation = choice.allocation ?? {};
   let total = 0;
-  for (const value of Object.values(alloc)) {
+  for (const value of Object.values(allocation)) {
     if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
       throw new Error('創角配點每項必須為非負整數');
     }
     total += value ?? 0;
   }
-  if (total > CREATION_BONUS_POINTS) {
-    throw new Error(`創角配點總和不可超過 ${CREATION_BONUS_POINTS}`);
-  }
+  if (total > CREATION_BONUS_POINTS) throw new Error(`創角配點總和不可超過 ${CREATION_BONUS_POINTS}`);
   const base = choice.statRoll ?? profile.stats;
   if (choice.statRoll) {
-    for (const key of Object.keys(profile.stats) as Array<keyof StatBlock>) {
-      const offset = choice.statRoll[key] - profile.stats[key];
+    for (const stat of Object.keys(profile.stats) as Array<keyof StatBlock>) {
+      const offset = choice.statRoll[stat] - profile.stats[stat];
       if (offset < STAT_ROLL_MIN || offset > STAT_ROLL_MAX) {
-        throw new Error(`擲骰屬性超出允許範圍（${String(key)} 偏離 ${offset}）`);
+        throw new Error(`擲骰屬性超出允許範圍（${String(stat)} 偏離 ${offset}）`);
       }
     }
   }
-  const stats: StatBlock = { ...base };
-  for (const key of Object.keys(alloc) as Array<keyof StatBlock>) {
-    stats[key] += alloc[key] ?? 0;
-  }
+  const stats = { ...base };
+  for (const stat of Object.keys(allocation) as Array<keyof StatBlock>) stats[stat] += allocation[stat] ?? 0;
   return {
-    id: 'protagonist',
-    name: '你',
-    job: choice.job,
-    level: 1,
-    xp: 0,
-    stats,
-    maxHp: profile.maxHp,
-    injuredForTrips: 0,
-    trait: choice.trait ?? null,
+    id: 'protagonist', name: '你', job: choice.job, level: 1, xp: 0, stats,
+    maxHp: profile.maxHp, injuredForTrips: 0, trait: choice.trait ?? null,
     equipment: defaultEquipment(),
   };
 }
 
 function defaultProtagonist(): CompanionRecord {
   return {
-    id: 'protagonist',
-    name: '你',
-    job: 'swordsman',
-    level: 1,
-    xp: 0,
-    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 },
-    maxHp: 22,
-    injuredForTrips: 0,
-    trait: null,
-    equipment: defaultEquipment(),
+    id: 'protagonist', name: '你', job: 'swordsman', level: 1, xp: 0,
+    stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 }, maxHp: 22,
+    injuredForTrips: 0, trait: null, equipment: defaultEquipment(),
   };
 }
 
-/** 逐版遷移表：M2+ 擴充 schema 時在此補 (v) => v+1 的轉換，玩家不清檔 */
 const MIGRATIONS: Record<number, (old: Record<string, unknown>) => Record<string, unknown>> = {
   1: (old) => ({ ...old, version: 2, protagonist: defaultProtagonist(), companions: [] }),
   2: (old) => ({ ...old, version: 3, inventory: {}, expedition: null }),
-  3: (old) => ({
-    ...old,
-    version: 4,
-    wagonLevel: 0,
-    tavernSeed: old.createdAt,
-    reputation: 0,
-    visitedBossDungeons: [],
-  }),
+  3: (old) => ({ ...old, version: 4, wagonLevel: 0, tavernSeed: old.createdAt, reputation: 0, visitedBossDungeons: [] }),
   4: (old) => {
     const protagonist = old.protagonist as Record<string, unknown>;
     const companions = (old.companions as Array<Record<string, unknown>>) ?? [];
-    return {
-      ...old,
-      version: 5,
-      protagonist: { ...protagonist, equipment: defaultEquipment() },
-      companions: companions.map((c) => ({ ...c, equipment: defaultEquipment() })),
-    };
+    return { ...old, version: 5, protagonist: { ...protagonist, equipment: defaultEquipment() }, companions: companions.map((c) => ({ ...c, equipment: defaultEquipment() })) };
   },
   5: (old) => {
     const protagonist = old.protagonist as Record<string, unknown>;
     const companions = (old.companions as Array<Record<string, unknown>>) ?? [];
-    return {
-      ...old,
-      version: 6,
-      marketSeed: (old.createdAt as number) + 1,
-      protagonist: { ...protagonist, trait: null },
-      companions: companions.map((c) => ({ ...c, trait: c.trait ?? null })),
-    };
+    return { ...old, version: 6, marketSeed: (old.createdAt as number) + 1, protagonist: { ...protagonist, trait: null }, companions: companions.map((c) => ({ ...c, trait: c.trait ?? null })) };
   },
 };
 
-/** 驗證物件是否符合 SaveDataV6 的完整 shape（含 marketSeed；v5 及更早由 MIGRATIONS 先升版再驗）*/
 function isValidSaveShape(value: unknown): value is SaveData {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
-  if (
-    typeof v.version !== 'number' ||
-    typeof v.createdAt !== 'number' ||
-    typeof v.gold !== 'number' ||
-    typeof v.flags !== 'object' ||
-    v.flags === null ||
-    typeof v.protagonist !== 'object' ||
-    v.protagonist === null ||
-    !Array.isArray(v.companions) ||
-    typeof v.inventory !== 'object' ||
-    v.inventory === null ||
-    (v.expedition !== null && typeof v.expedition !== 'object') ||
-    typeof v.wagonLevel !== 'number' ||
-    typeof v.tavernSeed !== 'number' ||
-    typeof v.marketSeed !== 'number' ||
-    typeof v.reputation !== 'number' ||
-    !Array.isArray(v.visitedBossDungeons)
-  ) {
-    return false;
-  }
+  if (typeof v.version !== 'number' || typeof v.createdAt !== 'number' || typeof v.gold !== 'number' ||
+      typeof v.flags !== 'object' || v.flags === null || typeof v.protagonist !== 'object' || v.protagonist === null ||
+      !Array.isArray(v.companions) || typeof v.inventory !== 'object' || v.inventory === null ||
+      (v.expedition !== null && typeof v.expedition !== 'object') || typeof v.wagonLevel !== 'number' ||
+      typeof v.tavernSeed !== 'number' || typeof v.marketSeed !== 'number' || typeof v.reputation !== 'number' ||
+      !Array.isArray(v.visitedBossDungeons)) return false;
   const protagonist = v.protagonist as Record<string, unknown>;
-  if (typeof protagonist.stats !== 'object' || protagonist.stats === null) return false;
-  return typeof protagonist.equipment === 'object' && protagonist.equipment !== null;
+  return typeof protagonist.stats === 'object' && protagonist.stats !== null && typeof protagonist.equipment === 'object' && protagonist.equipment !== null;
 }
 
 function isValidExpeditionPlan(value: unknown): value is ExpeditionPlan {
   if (typeof value !== 'object' || value === null) return false;
   const plan = value as Record<string, unknown>;
-  if (
-    !Array.isArray(plan.activeIds) ||
-    !plan.activeIds.every((id) => typeof id === 'string') ||
-    typeof plan.positions !== 'object' ||
-    plan.positions === null ||
-    typeof plan.roles !== 'object' ||
-    plan.roles === null
-  ) {
-    return false;
-  }
-  if (!Object.values(plan.positions).every((row) => row === 'front' || row === 'back')) return false;
-  return Object.values(plan.roles).every((id) => id === undefined || typeof id === 'string');
+  if (!Array.isArray(plan.activeIds) || !plan.activeIds.every((id) => typeof id === 'string') ||
+      typeof plan.positions !== 'object' || plan.positions === null || typeof plan.roles !== 'object' || plan.roles === null) return false;
+  return Object.values(plan.positions).every((row) => row === 'front' || row === 'back') &&
+    Object.values(plan.roles).every((id) => id === undefined || typeof id === 'string');
 }
 
 function isCurrentExpeditionSnapshot(value: unknown): value is ExpeditionState {
   if (typeof value !== 'object' || value === null) return false;
   const expedition = value as Record<string, unknown>;
-  return (
-    expedition.expeditionVersion === EXPEDITION_VERSION &&
-    Array.isArray(expedition.partyIds) &&
-    expedition.partyIds.every((id) => typeof id === 'string') &&
-    typeof expedition.positions === 'object' &&
-    expedition.positions !== null &&
-    typeof expedition.roles === 'object' &&
-    expedition.roles !== null
-  );
+  return expedition.expeditionVersion === EXPEDITION_VERSION && Array.isArray(expedition.partyIds) &&
+    expedition.partyIds.every((id) => typeof id === 'string') && typeof expedition.positions === 'object' && expedition.positions !== null &&
+    typeof expedition.roles === 'object' && expedition.roles !== null;
 }
 
-/** 解析任意輸入：逐版遷移到最新版本後驗證 shape；毀損或未來版本一律回 null */
 function parseAndMigrate(raw: unknown): SaveData | null {
   if (typeof raw !== 'object' || raw === null) return null;
   let parsed = raw as Record<string, unknown>;
-  if (typeof parsed.version !== 'number') return null;
-  if ((parsed.version as number) > CURRENT_VERSION) return null;
+  if (typeof parsed.version !== 'number' || parsed.version > CURRENT_VERSION) return null;
   while ((parsed.version as number) < CURRENT_VERSION) {
     const migrate = MIGRATIONS[parsed.version as number];
     if (!migrate) return null;
     parsed = migrate(parsed);
   }
   if (!isValidSaveShape(parsed)) return null;
-  // M17 為 v6 optional 欄位，不因舊玩家缺少它而 bump 存檔版本；毀損內容則退回預設編隊。
-  if (parsed.expeditionPlan !== undefined && !isValidExpeditionPlan(parsed.expeditionPlan)) {
-    delete parsed.expeditionPlan;
-  }
-  // 遠征快照版本防護（M4/M17）：舊版或缺少當前編隊欄位的遠征快照一律丟棄，
-  // 主檔（gold/inventory/roster...）完整保留——玩家不會因為引擎升級而整檔毀損，
-  // 只是進行中的那趟遠征記錄作廢。
-  if (parsed.expedition !== null && !isCurrentExpeditionSnapshot(parsed.expedition)) {
-    parsed.expedition = null;
-  }
+  if (parsed.expeditionPlan !== undefined && !isValidExpeditionPlan(parsed.expeditionPlan)) delete parsed.expeditionPlan;
+  if (parsed.expedition !== null && !isCurrentExpeditionSnapshot(parsed.expedition)) parsed.expedition = null;
   return parsed;
 }
 
 export function newGame(now: number = Date.now(), choice?: CharacterChoice): SaveData {
+  const protagonist = choice ? createProtagonist(choice) : defaultProtagonist();
+  const genesis = choice ? resolveCharacterGenesis(protagonist.stats, choice.trait) : null;
+  const inventory: Record<string, number> = {};
+  let gold = 200;
+  let reputation = 0;
+  if (genesis) {
+    protagonist.genesis = genesis.profile;
+    protagonist.maxHp = Math.max(8, protagonist.maxHp + genesis.effects.maxHpDelta);
+    protagonist.skills = { ...genesis.effects.skills };
+    protagonist.skillPoints = genesis.effects.skillPoints;
+    gold = Math.max(50, gold + genesis.effects.goldDelta);
+    reputation = Math.max(0, genesis.effects.reputationDelta);
+    for (const [itemId, count] of Object.entries(genesis.effects.inventory)) if (count > 0) inventory[itemId] = count;
+  }
   return {
-    version: 6,
-    createdAt: now,
-    gold: 200,
-    flags: {},
-    protagonist: choice ? createProtagonist(choice) : defaultProtagonist(),
-    companions: [],
-    inventory: {},
-    expedition: null,
-    wagonLevel: 0,
-    tavernSeed: now,
-    marketSeed: now + 1,
-    reputation: 0,
-    visitedBossDungeons: [],
+    version: 6, createdAt: now, gold, flags: {}, protagonist, companions: [], inventory,
+    expedition: null, wagonLevel: 0, tavernSeed: now, marketSeed: now + 1,
+    reputation, visitedBossDungeons: [],
   };
 }
 
-export function saveGame(data: SaveData, storage: Storage = localStorage): void {
-  storage.setItem(SAVE_KEY, JSON.stringify(data));
-}
-
+export function saveGame(data: SaveData, storage: Storage = localStorage): void { storage.setItem(SAVE_KEY, JSON.stringify(data)); }
 export function loadGame(storage: Storage = localStorage): SaveData | null {
   const raw = storage.getItem(SAVE_KEY);
   if (!raw) return null;
-  try {
-    return parseAndMigrate(JSON.parse(raw));
-  } catch {
-    return null;
-  }
+  try { return parseAndMigrate(JSON.parse(raw)); } catch { return null; }
 }
-
-export function exportSave(data: SaveData): string {
-  return btoa(encodeURIComponent(JSON.stringify(data)));
-}
-
+export function exportSave(data: SaveData): string { return btoa(encodeURIComponent(JSON.stringify(data))); }
 export function importSave(encoded: string): SaveData | null {
-  try {
-    return parseAndMigrate(JSON.parse(decodeURIComponent(atob(encoded))));
-  } catch {
-    return null;
-  }
+  try { return parseAndMigrate(JSON.parse(decodeURIComponent(atob(encoded)))); } catch { return null; }
 }


### PR DESCRIPTION
## Summary

- deepen character creation with a three-axis genesis matrix built from the selected origin trait plus the character's strongest and weakest final stats
- turn six existing origin traits into full lifepaths that affect gold, reputation, HP, skills, free skill points, and starting inventory
- derive five aptitude paths and five burden paths from post-roll, post-allocation stats, creating 150 reproducible character-genesis skeletons
- persist the resolved genesis profile on the protagonist without bumping the v6 save schema
- preserve exact legacy behavior when the player selects no origin trait
- add adversarial tests across all jobs, all origins, all aptitude/burden directions, invalid traits, minimum playability floors, valid item references, and dominance balance

## Game-design intent

The existing creator had four jobs, stat rolls, three allocation points, and six traits, but most of those choices converged into a narrow set of opening states. M22 makes the same choices interact across multiple systems. A player's final stat shape now determines an aptitude and a burden, while the chosen origin establishes a lifepath. Together they alter combat durability, expedition skills, economy, reputation progression, and starting supplies.

This expands character possibility without adding a disconnected menu: rolls and allocation can deliberately redirect the derived aptitude or burden.

## Player adversarial review

- no-origin characters remain byte-for-byte equivalent in gameplay values to the legacy opening
- all four jobs and all six lifepaths stay above safe minimum gold and HP floors
- every granted item ID resolves to a real item definition
- every granted skill rank remains inside the existing skill system's safe range
- invalid or corrupted trait IDs grant no genesis resources
- tied stats resolve deterministically so exported saves reproduce the same character
- rolls and allocation can materially change the resulting aptitude instead of the job template forcing one answer
- no single lifepath simultaneously owns the highest gold, reputation, HP, skill power, and item count

## Scope

- `src/scripts/games/caravan/data/genesis.ts`
- `src/scripts/games/caravan/save.ts`
- `src/scripts/games/caravan/data/genesis.test.ts`

No dependency, lockfile, generated output, asset, or save-version changes.