### PR TITLE
feat(caravan): add M23 growth potential curves

### DIFF
--- a/src/scripts/games/caravan/data/growth.test.ts
+++ b/src/scripts/games/caravan/data/growth.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, STARTING_PROFILE } from '../save';
+import type { JobId } from './jobs';
+import {
+  deriveGrowthProfile,
+  growthCombatBonuses,
+  growthSignature,
+  isValidGrowthProfile,
+  latentStatBonuses,
+} from './growth';
+import type { CharacterGenesis } from './genesis';
+
+const JOBS: JobId[] = ['swordsman', 'ranger', 'mage', 'cleric'];
+const GENESIS: CharacterGenesis[] = [
+  { lifepathId: 'seasoned', aptitudeId: 'int', burdenId: 'str' },
+  { lifepathId: 'brawny', aptitudeId: 'str', burdenId: 'cha' },
+  { lifepathId: 'nimble', aptitudeId: 'dex', burdenId: 'int' },
+  { lifepathId: 'learned', aptitudeId: 'int', burdenId: 'con' },
+  { lifepathId: 'charming', aptitudeId: 'cha', burdenId: 'str' },
+  { lifepathId: 'tough', aptitudeId: 'con', burdenId: 'dex' },
+];
+
+describe('M23 成長潛力', () => {
+  it('所有職業與命運組合都產生 1～5 的完整五維潛力', () => {
+    for (const job of JOBS) {
+      for (const genesis of GENESIS) {
+        const base = STARTING_PROFILE[job].stats;
+        const profile = deriveGrowthProfile(base, base, genesis);
+        expect(isValidGrowthProfile(profile)).toBe(true);
+        expect(Object.values(profile.potential)).toHaveLength(5);
+        for (const value of Object.values(profile.potential)) {
+          expect(value).toBeGreaterThanOrEqual(1);
+          expect(value).toBeLessThanOrEqual(5);
+        }
+      }
+    }
+  });
+
+  it('天賦與出身能改變同職業的潛力，不會只由職業模板決定', () => {
+    const base = STARTING_PROFILE.mage.stats;
+    const scholar = deriveGrowthProfile(base, base, {
+      lifepathId: 'learned', aptitudeId: 'int', burdenId: 'str',
+    });
+    const fighter = deriveGrowthProfile(base, base, {
+      lifepathId: 'brawny', aptitudeId: 'str', burdenId: 'cha',
+    });
+    expect(growthSignature(scholar)).not.toBe(growthSignature(fighter));
+    expect(scholar.potential.int).toBeGreaterThan(fighter.potential.int);
+    expect(fighter.potential.str).toBeGreaterThan(scholar.potential.str);
+  });
+
+  it('擲骰與配點偏移會改變潛力，而不是只改表面屬性', () => {
+    const base = STARTING_PROFILE.ranger.stats;
+    const normal = deriveGrowthProfile(base, base, {
+      lifepathId: 'nimble', aptitudeId: 'dex', burdenId: 'int',
+    });
+    const altered = deriveGrowthProfile(
+      { ...base, int: base.int + 3, dex: base.dex - 2 },
+      base,
+      { lifepathId: 'nimble', aptitudeId: 'int', burdenId: 'dex' },
+    );
+    expect(altered.potential.int).toBeGreaterThan(normal.potential.int);
+    expect(altered.potential.dex).toBeLessThan(normal.potential.dex);
+  });
+
+  it('Lv1 不額外灌入戰鬥成長，Lv5 的總量仍受嚴格上限控制', () => {
+    const profile = {
+      potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } as const,
+    };
+    expect(growthCombatBonuses(profile, 1)).toEqual({
+      stats: {}, maxHp: 0, defense: 0, damageBonus: 0,
+    });
+    const cap = growthCombatBonuses(profile, 5);
+    expect(Object.values(cap.stats).reduce((sum, value) => sum + (value ?? 0), 0)).toBe(4);
+    expect(cap.maxHp).toBeLessThanOrEqual(5);
+    expect(cap.defense).toBeLessThanOrEqual(2);
+    expect(cap.damageBonus).toBeLessThanOrEqual(3);
+  });
+
+  it('潛在屬性採公平分配，不會四級全部灌入單一最高屬性', () => {
+    const profile = {
+      potential: { str: 5, dex: 3, int: 2, cha: 1, con: 4 } as const,
+    };
+    const bonuses = latentStatBonuses(profile, 5);
+    expect(Object.keys(bonuses).length).toBeGreaterThanOrEqual(2);
+    expect(Math.max(...Object.values(bonuses).map((value) => value ?? 0))).toBeLessThanOrEqual(2);
+  });
+
+  it('無出身角色維持舊版開局，不產生潛力或額外屬性', () => {
+    const save = newGame(123, { job: 'swordsman', trait: null });
+    expect(save.protagonist.growth).toBeUndefined();
+    expect(save.protagonist.stats).toEqual(STARTING_PROFILE.swordsman.stats);
+    expect(save.protagonist.maxHp).toBe(STARTING_PROFILE.swordsman.maxHp);
+  });
+
+  it('命運角色保存可重現潛力，並只表現一點潛力萌芽', () => {
+    const choice = {
+      job: 'cleric' as const,
+      trait: 'charming',
+      allocation: { cha: 3 },
+    };
+    const first = newGame(1, choice);
+    const second = newGame(999, choice);
+    expect(first.protagonist.growth).toEqual(second.protagonist.growth);
+    const baseTotal = Object.values(STARTING_PROFILE.cleric.stats).reduce((a, b) => a + b, 0) + 3;
+    const actualTotal = Object.values(first.protagonist.stats).reduce((a, b) => a + b, 0);
+    expect(actualTotal - baseTotal).toBe(1);
+  });
+
+  it('毀損潛力不產生任何戰鬥加成', () => {
+    const corrupt = { potential: { str: 99 } };
+    expect(isValidGrowthProfile(corrupt)).toBe(false);
+    expect(growthCombatBonuses(corrupt as never, 5)).toEqual({
+      stats: {}, maxHp: 0, defense: 0, damageBonus: 0,
+    });
+  });
+});

--- a/src/scripts/games/caravan/data/growth.ts
+++ b/src/scripts/games/caravan/data/growth.ts
@@ -1,0 +1,139 @@
+import type { CharacterGenesis, GenesisTraitId } from './genesis';
+import type { StatBlock } from '../types';
+
+export type PotentialScore = 1 | 2 | 3 | 4 | 5;
+
+export interface GrowthProfile {
+  potential: Record<keyof StatBlock, PotentialScore>;
+}
+
+export interface GrowthCombatBonuses {
+  stats: Partial<StatBlock>;
+  maxHp: number;
+  defense: number;
+  damageBonus: number;
+}
+
+const STAT_ORDER: Array<keyof StatBlock> = ['str', 'dex', 'int', 'cha', 'con'];
+
+/** 每條出身有兩個長期成長傾向，讓同一職業因人生經歷產生不同曲線。 */
+const LIFEPATH_AFFINITIES: Record<GenesisTraitId, Array<keyof StatBlock>> = {
+  seasoned: ['int', 'cha'],
+  brawny: ['str', 'con'],
+  nimble: ['dex', 'con'],
+  learned: ['int', 'dex'],
+  charming: ['cha', 'dex'],
+  tough: ['con', 'str'],
+};
+
+function clampPotential(value: number): PotentialScore {
+  return Math.max(1, Math.min(5, Math.round(value))) as PotentialScore;
+}
+
+/**
+ * 潛力由最終創角屬性、出身傾向、天賦與缺陷共同構成：
+ * - 擲骰與配點高於職業基準，會提高對應潛力。
+ * - 天賦方向 +2、缺陷方向 -1。
+ * - 出身的兩個長期傾向各 +1。
+ */
+export function deriveGrowthProfile(
+  stats: StatBlock,
+  jobBaseline: StatBlock,
+  genesis: CharacterGenesis,
+): GrowthProfile {
+  const potential = {} as Record<keyof StatBlock, PotentialScore>;
+  const affinities = new Set(LIFEPATH_AFFINITIES[genesis.lifepathId]);
+
+  for (const stat of STAT_ORDER) {
+    const offset = stats[stat] - jobBaseline[stat];
+    let score = 2;
+    if (offset >= 3) score += 2;
+    else if (offset >= 1) score += 1;
+    else if (offset <= -2) score -= 1;
+    if (affinities.has(stat)) score += 1;
+    if (genesis.aptitudeId === stat) score += 2;
+    if (genesis.burdenId === stat) score -= 1;
+    potential[stat] = clampPotential(score);
+  }
+
+  return { potential };
+}
+
+export function isValidGrowthProfile(value: unknown): value is GrowthProfile {
+  if (typeof value !== 'object' || value === null) return false;
+  const profile = value as Record<string, unknown>;
+  if (typeof profile.potential !== 'object' || profile.potential === null) return false;
+  const potential = profile.potential as Record<string, unknown>;
+  return STAT_ORDER.every((stat) =>
+    Number.isInteger(potential[stat]) &&
+    (potential[stat] as number) >= 1 &&
+    (potential[stat] as number) <= 5
+  );
+}
+
+/**
+ * 每個等級（Lv2～Lv5）展開一點潛在屬性。
+ * 使用加權公平分配：高潛力會更常成長，但不會四點全部灌進同一屬性。
+ */
+export function latentStatBonuses(
+  profile: GrowthProfile | undefined,
+  level: number,
+): Partial<StatBlock> {
+  if (!isValidGrowthProfile(profile)) return {};
+  const steps = Math.max(0, Math.min(4, Math.floor(level) - 1));
+  const result: StatBlock = { str: 0, dex: 0, int: 0, cha: 0, con: 0 };
+
+  for (let step = 0; step < steps; step++) {
+    let selected = STAT_ORDER[0];
+    let bestScore = -Infinity;
+    for (const stat of STAT_ORDER) {
+      const fairness = profile.potential[stat] / (result[stat] + 1);
+      if (fairness > bestScore) {
+        bestScore = fairness;
+        selected = stat;
+      }
+    }
+    result[selected] += 1;
+  }
+
+  return Object.fromEntries(
+    STAT_ORDER.filter((stat) => result[stat] > 0).map((stat) => [stat, result[stat]])
+  ) as Partial<StatBlock>;
+}
+
+/**
+ * 潛力在戰鬥中的衍生成長。所有增益 Lv1 都是 0；Lv5 仍被嚴格限制：
+ * - 潛在屬性總和 4
+ * - 額外生命最多 5
+ * - 額外防禦最多 2
+ * - 額外固定傷害最多 3
+ */
+export function growthCombatBonuses(
+  profile: GrowthProfile | undefined,
+  level: number,
+): GrowthCombatBonuses {
+  if (!isValidGrowthProfile(profile) || level <= 1) {
+    return { stats: {}, maxHp: 0, defense: 0, damageBonus: 0 };
+  }
+  const levels = Math.max(0, Math.min(4, Math.floor(level) - 1));
+  const offensePotential = Math.max(
+    profile.potential.str,
+    profile.potential.dex,
+    profile.potential.int,
+    profile.potential.cha,
+  );
+  return {
+    stats: latentStatBonuses(profile, level),
+    maxHp: Math.min(5, Math.floor((levels * profile.potential.con) / 4)),
+    defense: Math.min(
+      2,
+      Math.floor((levels * Math.max(0, profile.potential.dex + profile.potential.con - 2)) / 16),
+    ),
+    damageBonus: Math.min(3, Math.floor((levels * Math.max(0, offensePotential - 2)) / 4)),
+  };
+}
+
+export function growthSignature(profile: GrowthProfile | undefined): string {
+  if (!isValidGrowthProfile(profile)) return '—';
+  return STAT_ORDER.map((stat) => `${stat.toUpperCase()}${profile.potential[stat]}`).join('·');
+}

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -4,6 +4,8 @@ import type { ExpeditionState } from './expedition';
 import { EXPEDITION_VERSION } from './expedition';
 import { resolveCharacterGenesis } from './data/genesis';
 import type { CharacterGenesis } from './data/genesis';
+import { deriveGrowthProfile, latentStatBonuses } from './data/growth';
+import type { GrowthProfile } from './data/growth';
 
 export const SAVE_KEY = 'caravan-save-v1';
 export type FormationRow = 'front' | 'back';
@@ -26,6 +28,8 @@ export interface CompanionRecord {
   injuredForTrips: number;
   trait?: string | null;
   genesis?: CharacterGenesis;
+  /** M23 五維成長潛力；舊角色缺少時沿用原本成長規則。 */
+  growth?: GrowthProfile;
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
   specialization?: string | null;
   bond?: number;
@@ -89,9 +93,7 @@ export function createProtagonist(choice: CharacterChoice): CompanionRecord {
   const allocation = choice.allocation ?? {};
   let total = 0;
   for (const value of Object.values(allocation)) {
-    if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
-      throw new Error('創角配點每項必須為非負整數');
-    }
+    if (value !== undefined && (!Number.isInteger(value) || value < 0)) throw new Error('創角配點每項必須為非負整數');
     total += value ?? 0;
   }
   if (total > CREATION_BONUS_POINTS) throw new Error(`創角配點總和不可超過 ${CREATION_BONUS_POINTS}`);
@@ -99,9 +101,7 @@ export function createProtagonist(choice: CharacterChoice): CompanionRecord {
   if (choice.statRoll) {
     for (const stat of Object.keys(profile.stats) as Array<keyof StatBlock>) {
       const offset = choice.statRoll[stat] - profile.stats[stat];
-      if (offset < STAT_ROLL_MIN || offset > STAT_ROLL_MAX) {
-        throw new Error(`擲骰屬性超出允許範圍（${String(stat)} 偏離 ${offset}）`);
-      }
+      if (offset < STAT_ROLL_MIN || offset > STAT_ROLL_MAX) throw new Error(`擲骰屬性超出允許範圍（${String(stat)} 偏離 ${offset}）`);
     }
   }
   const stats = { ...base };
@@ -190,7 +190,11 @@ export function newGame(now: number = Date.now(), choice?: CharacterChoice): Sav
   let reputation = 0;
   if (genesis) {
     protagonist.genesis = genesis.profile;
-    protagonist.maxHp = Math.max(8, protagonist.maxHp + genesis.effects.maxHpDelta);
+    const growth = deriveGrowthProfile(protagonist.stats, STARTING_PROFILE[protagonist.job].stats, genesis.profile);
+    protagonist.growth = growth;
+    const seed = latentStatBonuses(growth, 2);
+    for (const stat of Object.keys(seed) as Array<keyof StatBlock>) protagonist.stats[stat] += seed[stat] ?? 0;
+    protagonist.maxHp = Math.max(8, protagonist.maxHp + genesis.effects.maxHpDelta + Math.max(0, growth.potential.con - 3));
     protagonist.skills = { ...genesis.effects.skills };
     protagonist.skillPoints = genesis.effects.skillPoints;
     gold = Math.max(50, gold + genesis.effects.goldDelta);


### PR DESCRIPTION
## Summary

- add five-dimensional growth potential profiles derived from final creation stats and the M22 genesis profile
- let lifepath affinities, aptitude, burden, stat rolls, and allocation all influence long-term potential ratings
- persist potential on new genesis characters without changing save version or affecting legacy characters
- express one controlled potential seed at creation so different profiles have an immediate numerical identity
- provide capped latent stat, HP, defense, and damage growth curves for continued system integration
- add adversarial tests across all jobs, lifepaths, stat offsets, level caps, corruption guards, and legacy compatibility

## Game-design intent

M22 created 150 opening genesis skeletons, but the existing fixed level-up formula would eventually make many of them converge. M23 introduces a reproducible five-stat potential signature so the same job can grow differently depending on origin, aptitude, burden, rolls, and allocation.

The curve is deliberately restrained: creation expresses only one latent stat point plus at most a small constitution HP difference, while the reusable level curve caps at four latent stat points, five HP, two defense, and three damage by level 5. Player-assigned level-up points, equipment, skills, and specializations remain the main build decisions.

## Player adversarial review

- every job and representative genesis profile produces five valid potential scores from 1 to 5
- the same job can produce materially different potential signatures
- rolls and allocation affect potential rather than only visible starting stats
- level 1 receives no hidden combat-growth package
- level 5 bonuses remain inside strict caps
- latent stat growth is distributed fairly instead of stacking all four points into one stat
- no-origin characters remain exactly on the legacy opening values
- identical choices produce identical profiles regardless of timestamp
- corrupted potential data grants no bonuses

## Scope

- `src/scripts/games/caravan/data/growth.ts`
- `src/scripts/games/caravan/save.ts`
- `src/scripts/games/caravan/data/growth.test.ts`

No dependency, lockfile, generated output, asset, UI, or save-version changes.