### PR TITLE
feat(caravan): add M24 transactional growth realization

### DIFF
--- a/src/scripts/games/caravan/data/growth.m24.test.ts
+++ b/src/scripts/games/caravan/data/growth.m24.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import {
+  loadGame,
+  newGame,
+  realizeSaveGrowth,
+  saveGame,
+  STARTING_PROFILE,
+} from '../save';
+import type { SaveData } from '../save';
+import { realizedGrowthBonuses } from './growth';
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+  get length(): number { return this.values.size; }
+  clear(): void { this.values.clear(); }
+  getItem(key: string): string | null { return this.values.get(key) ?? null; }
+  key(index: number): string | null { return [...this.values.keys()][index] ?? null; }
+  removeItem(key: string): void { this.values.delete(key); }
+  setItem(key: string, value: string): void { this.values.set(key, value); }
+}
+
+function growthSave(): SaveData {
+  return newGame(123, {
+    job: 'swordsman',
+    trait: 'brawny',
+    allocation: { str: 2, con: 1 },
+  });
+}
+
+function statTotal(save: SaveData): number {
+  return Object.values(save.protagonist.stats).reduce((sum, value) => sum + value, 0);
+}
+
+describe('M24 潛力實現交易', () => {
+  it('升級後保存會一次性實現尚未取得的潛力屬性與生命', () => {
+    const save = growthSave();
+    const growth = save.protagonist.growth!;
+    const beforeStats = { ...save.protagonist.stats };
+    const beforeHp = save.protagonist.maxHp;
+    save.protagonist.level = 4;
+
+    realizeSaveGrowth(save);
+    const expected = realizedGrowthBonuses(growth, 4);
+    for (const stat of Object.keys(beforeStats) as Array<keyof typeof beforeStats>) {
+      expect(save.protagonist.stats[stat] - beforeStats[stat]).toBe(expected.stats[stat] ?? 0);
+    }
+    expect(save.protagonist.maxHp - beforeHp).toBe(expected.maxHp);
+    expect(save.protagonist.growthRealizedLevel).toBe(4);
+  });
+
+  it('重複保存、載入與匯出不會重複灌入同一批成長', () => {
+    const storage = new MemoryStorage();
+    const save = growthSave();
+    save.protagonist.level = 5;
+    saveGame(save, storage);
+    const firstStats = { ...save.protagonist.stats };
+    const firstHp = save.protagonist.maxHp;
+
+    saveGame(save, storage);
+    realizeSaveGrowth(save);
+    expect(save.protagonist.stats).toEqual(firstStats);
+    expect(save.protagonist.maxHp).toBe(firstHp);
+
+    const loaded = loadGame(storage)!;
+    expect(loaded.protagonist.stats).toEqual(firstStats);
+    expect(loaded.protagonist.maxHp).toBe(firstHp);
+    expect(loaded.protagonist.growthRealizedLevel).toBe(5);
+  });
+
+  it('跨多級補領與逐級保存會得到相同最終數值', () => {
+    const direct = growthSave();
+    direct.protagonist.level = 5;
+    realizeSaveGrowth(direct);
+
+    const stepped = growthSave();
+    for (let level = 2; level <= 5; level++) {
+      stepped.protagonist.level = level;
+      realizeSaveGrowth(stepped);
+    }
+
+    expect(stepped.protagonist.stats).toEqual(direct.protagonist.stats);
+    expect(stepped.protagonist.maxHp).toBe(direct.protagonist.maxHp);
+    expect(stepped.protagonist.growthRealizedLevel).toBe(5);
+  });
+
+  it('玩家手動配點保留，潛力只追加自身差分', () => {
+    const save = growthSave();
+    const before = statTotal(save);
+    save.protagonist.stats.cha += 2;
+    save.protagonist.level = 3;
+    const expectedGrowth = Object.values(realizedGrowthBonuses(save.protagonist.growth, 3).stats)
+      .reduce((sum, value) => sum + (value ?? 0), 0);
+
+    realizeSaveGrowth(save);
+    expect(statTotal(save) - before).toBe(2 + expectedGrowth);
+  });
+
+  it('舊 M23 存檔缺少實現標記時，依目前等級安全補算一次', () => {
+    const storage = new MemoryStorage();
+    const save = growthSave();
+    save.protagonist.level = 4;
+    delete save.protagonist.growthRealizedLevel;
+    storage.setItem('caravan-save-v1', JSON.stringify(save));
+
+    const loaded = loadGame(storage)!;
+    const expected = realizedGrowthBonuses(loaded.protagonist.growth, 4);
+    const original = growthSave();
+    for (const stat of Object.keys(original.protagonist.stats) as Array<keyof typeof original.protagonist.stats>) {
+      expect(loaded.protagonist.stats[stat] - original.protagonist.stats[stat]).toBe(expected.stats[stat] ?? 0);
+    }
+    expect(loaded.protagonist.growthRealizedLevel).toBe(4);
+  });
+
+  it('無潛力的舊角色維持原本數值與升級規則', () => {
+    const save = newGame(123, { job: 'swordsman', trait: null });
+    save.protagonist.level = 5;
+    const stats = { ...save.protagonist.stats };
+    const hp = save.protagonist.maxHp;
+    realizeSaveGrowth(save);
+    expect(save.protagonist.stats).toEqual(stats);
+    expect(save.protagonist.maxHp).toBe(hp);
+    expect(save.protagonist.growthRealizedLevel).toBeUndefined();
+    expect(stats).toEqual(STARTING_PROFILE.swordsman.stats);
+  });
+
+  it('毀損潛力不能產生屬性或生命增益', () => {
+    const save = growthSave();
+    save.protagonist.growth = { potential: { str: 99 } } as never;
+    save.protagonist.level = 5;
+    const stats = { ...save.protagonist.stats };
+    const hp = save.protagonist.maxHp;
+    realizeSaveGrowth(save);
+    expect(save.protagonist.stats).toEqual(stats);
+    expect(save.protagonist.maxHp).toBe(hp);
+  });
+});

--- a/src/scripts/games/caravan/data/growth.ts
+++ b/src/scripts/games/caravan/data/growth.ts
@@ -101,8 +101,21 @@ export function latentStatBonuses(
   ) as Partial<StatBlock>;
 }
 
+/** M23 創角時已永久寫入存檔的潛力萌芽。 */
+export function creationGrowthSeed(profile: GrowthProfile | undefined): GrowthCombatBonuses {
+  if (!isValidGrowthProfile(profile)) {
+    return { stats: {}, maxHp: 0, defense: 0, damageBonus: 0 };
+  }
+  return {
+    stats: latentStatBonuses(profile, 2),
+    maxHp: Math.max(0, profile.potential.con - 3),
+    defense: 0,
+    damageBonus: 0,
+  };
+}
+
 /**
- * 潛力在戰鬥中的衍生成長。所有增益 Lv1 都是 0；Lv5 仍被嚴格限制：
+ * 潛力完整成長曲線。Lv5 仍被嚴格限制：
  * - 潛在屬性總和 4
  * - 額外生命最多 5
  * - 額外防禦最多 2
@@ -130,6 +143,32 @@ export function growthCombatBonuses(
       Math.floor((levels * Math.max(0, profile.potential.dex + profile.potential.con - 2)) / 16),
     ),
     damageBonus: Math.min(3, Math.floor((levels * Math.max(0, offensePotential - 2)) / 4)),
+  };
+}
+
+/**
+ * M24 實際套用的成長包：完整曲線扣掉 M23 已永久寫入的創角萌芽。
+ * 只回傳非負差分，因此角色不會因升級暫時失去已取得的生命或屬性。
+ */
+export function realizedGrowthBonuses(
+  profile: GrowthProfile | undefined,
+  level: number,
+): GrowthCombatBonuses {
+  if (!isValidGrowthProfile(profile)) {
+    return { stats: {}, maxHp: 0, defense: 0, damageBonus: 0 };
+  }
+  const full = growthCombatBonuses(profile, level);
+  const seed = creationGrowthSeed(profile);
+  const stats: Partial<StatBlock> = {};
+  for (const stat of STAT_ORDER) {
+    const delta = (full.stats[stat] ?? 0) - (seed.stats[stat] ?? 0);
+    if (delta > 0) stats[stat] = delta;
+  }
+  return {
+    stats,
+    maxHp: Math.max(0, full.maxHp - seed.maxHp),
+    defense: full.defense,
+    damageBonus: full.damageBonus,
   };
 }
 

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -4,7 +4,7 @@ import type { ExpeditionState } from './expedition';
 import { EXPEDITION_VERSION } from './expedition';
 import { resolveCharacterGenesis } from './data/genesis';
 import type { CharacterGenesis } from './data/genesis';
-import { deriveGrowthProfile, latentStatBonuses } from './data/growth';
+import { deriveGrowthProfile, latentStatBonuses, realizedGrowthBonuses } from './data/growth';
 import type { GrowthProfile } from './data/growth';
 
 export const SAVE_KEY = 'caravan-save-v1';
@@ -30,6 +30,8 @@ export interface CompanionRecord {
   genesis?: CharacterGenesis;
   /** M23 五維成長潛力；舊角色缺少時沿用原本成長規則。 */
   growth?: GrowthProfile;
+  /** M24 已永久實現到角色基礎值的潛力等級；optional 保持 v6 舊檔相容。 */
+  growthRealizedLevel?: number;
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
   specialization?: string | null;
   bond?: number;
@@ -167,6 +169,36 @@ function isCurrentExpeditionSnapshot(value: unknown): value is ExpeditionState {
     typeof expedition.roles === 'object' && expedition.roles !== null;
 }
 
+function realizeMemberGrowth(record: CompanionRecord): void {
+  if (!record.growth) return;
+  const targetLevel = Math.max(1, Math.min(5, Math.floor(record.level)));
+  const rawCurrent = record.growthRealizedLevel;
+  const currentLevel = Number.isInteger(rawCurrent) && rawCurrent! >= 1 && rawCurrent! <= 5
+    ? rawCurrent!
+    : 1;
+  if (targetLevel <= currentLevel) {
+    record.growthRealizedLevel = currentLevel;
+    return;
+  }
+
+  const previous = realizedGrowthBonuses(record.growth, currentLevel);
+  const next = realizedGrowthBonuses(record.growth, targetLevel);
+  for (const stat of Object.keys(next.stats) as Array<keyof StatBlock>) {
+    const delta = (next.stats[stat] ?? 0) - (previous.stats[stat] ?? 0);
+    if (delta > 0) record.stats[stat] += delta;
+  }
+  const hpDelta = next.maxHp - previous.maxHp;
+  if (hpDelta > 0) record.maxHp += hpDelta;
+  record.growthRealizedLevel = targetLevel;
+}
+
+/** M24 成長交易：冪等地補齊所有角色尚未實現的潛力，不碰裝備、專精或手動配點。 */
+export function realizeSaveGrowth(data: SaveData): SaveData {
+  realizeMemberGrowth(data.protagonist);
+  for (const companion of data.companions) realizeMemberGrowth(companion);
+  return data;
+}
+
 function parseAndMigrate(raw: unknown): SaveData | null {
   if (typeof raw !== 'object' || raw === null) return null;
   let parsed = raw as Record<string, unknown>;
@@ -179,7 +211,7 @@ function parseAndMigrate(raw: unknown): SaveData | null {
   if (!isValidSaveShape(parsed)) return null;
   if (parsed.expeditionPlan !== undefined && !isValidExpeditionPlan(parsed.expeditionPlan)) delete parsed.expeditionPlan;
   if (parsed.expedition !== null && !isCurrentExpeditionSnapshot(parsed.expedition)) parsed.expedition = null;
-  return parsed;
+  return realizeSaveGrowth(parsed);
 }
 
 export function newGame(now: number = Date.now(), choice?: CharacterChoice): SaveData {
@@ -192,6 +224,7 @@ export function newGame(now: number = Date.now(), choice?: CharacterChoice): Sav
     protagonist.genesis = genesis.profile;
     const growth = deriveGrowthProfile(protagonist.stats, STARTING_PROFILE[protagonist.job].stats, genesis.profile);
     protagonist.growth = growth;
+    protagonist.growthRealizedLevel = 1;
     const seed = latentStatBonuses(growth, 2);
     for (const stat of Object.keys(seed) as Array<keyof StatBlock>) protagonist.stats[stat] += seed[stat] ?? 0;
     protagonist.maxHp = Math.max(8, protagonist.maxHp + genesis.effects.maxHpDelta + Math.max(0, growth.potential.con - 3));
@@ -208,13 +241,17 @@ export function newGame(now: number = Date.now(), choice?: CharacterChoice): Sav
   };
 }
 
-export function saveGame(data: SaveData, storage: Storage = localStorage): void { storage.setItem(SAVE_KEY, JSON.stringify(data)); }
+export function saveGame(data: SaveData, storage: Storage = localStorage): void {
+  storage.setItem(SAVE_KEY, JSON.stringify(realizeSaveGrowth(data)));
+}
 export function loadGame(storage: Storage = localStorage): SaveData | null {
   const raw = storage.getItem(SAVE_KEY);
   if (!raw) return null;
   try { return parseAndMigrate(JSON.parse(raw)); } catch { return null; }
 }
-export function exportSave(data: SaveData): string { return btoa(encodeURIComponent(JSON.stringify(data))); }
+export function exportSave(data: SaveData): string {
+  return btoa(encodeURIComponent(JSON.stringify(realizeSaveGrowth(data))));
+}
 export function importSave(encoded: string): SaveData | null {
   try { return parseAndMigrate(JSON.parse(decodeURIComponent(atob(encoded)))); } catch { return null; }
 }


### PR DESCRIPTION
## Summary

- turn M23 latent growth into a transactional, persistent progression system for attributes and HP
- subtract the creation-time growth seed before realizing later levels, preventing double application
- record the last realized growth level so save, load, export, import, and repeated persistence stay idempotent
- apply growth through the save pipeline so event checks, role selection, roster displays, combat stats, and expedition HP all read the same base character values
- safely backfill M23 characters that already have growth profiles but lack realization markers
- add adversarial regression tests for repeated saves, multi-level jumps, manual allocations, legacy characters, old M23 saves, and corrupt growth data

## Game-design intent

M22 and M23 created deep opening identities and five-dimensional potential curves, but the level 2–5 curve was not yet realized by the live character record. M24 closes that progression loop without introducing a second competing stat source. Potential attributes and HP are permanently applied exactly once when the character reaches the relevant level, while the player's manual level-up allocations, equipment, traits, skills, and specializations remain independent layers.

Using the persistence boundary as the transaction point also keeps all existing systems consistent: anything reading `record.stats` or `record.maxHp` sees the same values instead of combat and expedition using separate calculations.

## Player adversarial review

- creation seed attributes and HP are subtracted before later growth is applied
- saving, loading, exporting, or realizing repeatedly cannot duplicate bonuses
- jumping directly from level 1 to level 5 matches realizing one level at a time
- manual attribute allocation remains intact and growth only adds its own delta
- old M23 saves without `growthRealizedLevel` backfill from their current level
- characters without growth remain byte-for-byte on legacy progression values
- corrupted growth profiles grant no attributes or HP
- growth never rewrites equipment, specialization, skills, prepared moves, or player allocations

## Scope

- `src/scripts/games/caravan/data/growth.ts`
- `src/scripts/games/caravan/save.ts`
- `src/scripts/games/caravan/data/growth.m24.test.ts`

Defense and fixed-damage potential curves remain defined but are not claimed as live in this milestone. No dependency, lockfile, asset, UI, generated-output, or save-version changes.