### PR TITLE
feat(caravan): add M25 adaptive career milestones

### DIFF
--- a/src/scripts/games/caravan/data/careers.m25.test.ts
+++ b/src/scripts/games/caravan/data/careers.m25.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  newGame,
+  realizeSaveCareer,
+  realizeSaveProgression,
+  STARTING_PROFILE,
+} from '../save';
+import {
+  CAREER_LEVELS,
+  CAREER_PATHS,
+  careerReward,
+  chooseCareerMilestone,
+  careerSignature,
+} from './careers';
+
+function makeCareerSave() {
+  return newGame(1, {
+    job: 'ranger',
+    trait: 'nimble',
+    allocation: { dex: 2, con: 1 },
+  });
+}
+
+const totalStats = (stats: Record<string, number>) =>
+  Object.values(stats).reduce((sum, value) => sum + value, 0);
+
+describe('M25 自適應職涯里程碑', () => {
+  it('五條職涯都有 Lv2～Lv5 獎勵且不會引用負資源', () => {
+    for (const pathId of Object.keys(CAREER_PATHS) as Array<keyof typeof CAREER_PATHS>) {
+      for (const level of CAREER_LEVELS) {
+        const reward = careerReward(level, pathId);
+        expect((reward.maxHp ?? 0)).toBeGreaterThanOrEqual(0);
+        expect((reward.skillPoints ?? 0)).toBeGreaterThanOrEqual(0);
+        expect((reward.gold ?? 0)).toBeGreaterThanOrEqual(0);
+        expect((reward.reputation ?? 0)).toBeGreaterThanOrEqual(0);
+        for (const count of Object.values(reward.inventory ?? {})) expect(count).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('同職業可因屬性、技能與潛力不同而走不同路線', () => {
+    const growth = {
+      potential: { str: 2, dex: 4, int: 2, cha: 2, con: 3 } as const,
+    };
+    const scout = chooseCareerMilestone({
+      stats: { str: 10, dex: 16, int: 10, cha: 10, con: 11 },
+      skills: { scouting: 2 },
+      growth,
+    }, 2);
+    const scholar = chooseCareerMilestone({
+      stats: { str: 10, dex: 12, int: 17, cha: 10, con: 11 },
+      skills: { lore: 3 },
+      growth: { potential: { str: 2, dex: 2, int: 5, cha: 2, con: 3 } },
+    }, 2);
+    expect(scout.pathId).toBe('scouting');
+    expect(scholar.pathId).toBe('lore');
+  });
+
+  it('保存或實現多次不會重複發放里程碑獎勵', () => {
+    const save = makeCareerSave();
+    save.protagonist.level = 3;
+    realizeSaveProgression(save);
+    const snapshot = JSON.stringify({
+      stats: save.protagonist.stats,
+      maxHp: save.protagonist.maxHp,
+      skills: save.protagonist.skills,
+      skillPoints: save.protagonist.skillPoints,
+      gold: save.gold,
+      reputation: save.reputation,
+      inventory: save.inventory,
+      milestones: save.protagonist.careerMilestones,
+    });
+    realizeSaveProgression(save);
+    realizeSaveProgression(save);
+    expect(JSON.stringify({
+      stats: save.protagonist.stats,
+      maxHp: save.protagonist.maxHp,
+      skills: save.protagonist.skills,
+      skillPoints: save.protagonist.skillPoints,
+      gold: save.gold,
+      reputation: save.reputation,
+      inventory: save.inventory,
+      milestones: save.protagonist.careerMilestones,
+    })).toBe(snapshot);
+  });
+
+  it('一次跳至 Lv5 與逐級實現得到相同職涯歷史和總資源', () => {
+    const jump = makeCareerSave();
+    jump.protagonist.level = 5;
+    realizeSaveProgression(jump);
+
+    const step = makeCareerSave();
+    for (const level of CAREER_LEVELS) {
+      step.protagonist.level = level;
+      realizeSaveProgression(step);
+    }
+
+    expect(step.protagonist.careerMilestones).toEqual(jump.protagonist.careerMilestones);
+    expect(step.protagonist.stats).toEqual(jump.protagonist.stats);
+    expect(step.protagonist.maxHp).toBe(jump.protagonist.maxHp);
+    expect(step.protagonist.skills).toEqual(jump.protagonist.skills);
+    expect(step.protagonist.skillPoints).toBe(jump.protagonist.skillPoints);
+    expect(step.gold).toBe(jump.gold);
+    expect(step.reputation).toBe(jump.reputation);
+    expect(step.inventory).toEqual(jump.inventory);
+  });
+
+  it('玩家能中途轉向，既有里程碑不會被後續屬性改寫', () => {
+    const save = makeCareerSave();
+    save.protagonist.level = 2;
+    realizeSaveProgression(save);
+    const first = save.protagonist.careerMilestones![0];
+
+    save.protagonist.stats.int += 10;
+    save.protagonist.skills = { ...(save.protagonist.skills ?? {}), lore: 4 };
+    save.protagonist.level = 3;
+    realizeSaveProgression(save);
+
+    expect(save.protagonist.careerMilestones![0]).toEqual(first);
+    expect(save.protagonist.careerMilestones![1].pathId).toBe('lore');
+    expect(careerSignature(save.protagonist.careerMilestones)).toContain('學識者');
+  });
+
+  it('技能達上限時不會溢出，其他獎勵仍正常發放', () => {
+    const save = makeCareerSave();
+    save.protagonist.skills = { scouting: 5 };
+    save.protagonist.level = 2;
+    const goldBefore = save.gold;
+    realizeSaveProgression(save);
+    expect(save.protagonist.skills.scouting).toBe(5);
+    expect(save.gold).toBeGreaterThanOrEqual(goldBefore);
+    expect(save.protagonist.careerMilestones).toHaveLength(1);
+  });
+
+  it('無出身角色完全不啟動職涯系統', () => {
+    const save = newGame(1, { job: 'swordsman', trait: null });
+    save.protagonist.level = 5;
+    const statsBefore = { ...save.protagonist.stats };
+    const hpBefore = save.protagonist.maxHp;
+    const goldBefore = save.gold;
+    realizeSaveCareer(save);
+    expect(save.protagonist.careerMilestones).toBeUndefined();
+    expect(save.protagonist.stats).toEqual(statsBefore);
+    expect(save.protagonist.maxHp).toBe(hpBefore);
+    expect(save.gold).toBe(goldBefore);
+  });
+
+  it('舊 M24 角色缺少里程碑時依目前等級安全補算且只補一次', () => {
+    const save = makeCareerSave();
+    save.protagonist.level = 4;
+    delete save.protagonist.careerMilestones;
+    realizeSaveProgression(save);
+    expect(save.protagonist.careerMilestones?.map((m) => m.level)).toEqual([2, 3, 4]);
+    const total = totalStats(save.protagonist.stats);
+    realizeSaveProgression(save);
+    expect(totalStats(save.protagonist.stats)).toBe(total);
+    expect(save.protagonist.careerMilestones?.map((m) => m.level)).toEqual([2, 3, 4]);
+  });
+
+  it('毀損或重複里程碑會被整理，不得阻止缺少等級正常補發', () => {
+    const save = makeCareerSave();
+    save.protagonist.level = 4;
+    save.protagonist.careerMilestones = [
+      { level: 2, pathId: 'scouting' },
+      { level: 2, pathId: 'martial' },
+      { level: 9, pathId: 'lore' } as never,
+    ];
+    realizeSaveProgression(save);
+    expect(save.protagonist.careerMilestones?.map((m) => m.level)).toEqual([2, 3, 4]);
+    expect(new Set(save.protagonist.careerMilestones?.map((m) => m.level)).size).toBe(3);
+  });
+
+  it('四次同路線獎勵仍保持受控，不壓過手動升級與裝備系統', () => {
+    const base = STARTING_PROFILE.swordsman.stats;
+    let statGain = 0;
+    let hpGain = 0;
+    let skillGain = 0;
+    for (const level of CAREER_LEVELS) {
+      const reward = careerReward(level, 'martial');
+      statGain += totalStats(reward.stats ?? {});
+      hpGain += reward.maxHp ?? 0;
+      skillGain += reward.skill?.amount ?? 0;
+    }
+    expect(statGain).toBeLessThanOrEqual(2);
+    expect(hpGain).toBeLessThanOrEqual(2);
+    expect(skillGain).toBeLessThanOrEqual(2);
+    expect(totalStats(base)).toBeGreaterThan(statGain * 10);
+  });
+});

--- a/src/scripts/games/caravan/data/careers.ts
+++ b/src/scripts/games/caravan/data/careers.ts
@@ -1,0 +1,163 @@
+import type { GrowthProfile } from './growth';
+import type { StatBlock } from '../types';
+
+export type CareerPathId = 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+export type CareerLevel = 2 | 3 | 4 | 5;
+export type CareerSkillId = CareerPathId;
+
+export interface CareerPathDef {
+  id: CareerPathId;
+  name: string;
+  stat: keyof StatBlock;
+  skillId: CareerSkillId;
+  desc: string;
+}
+
+export interface CareerReward {
+  stats?: Partial<StatBlock>;
+  maxHp?: number;
+  skill?: { id: CareerSkillId; amount: number };
+  skillPoints?: number;
+  gold?: number;
+  reputation?: number;
+  inventory?: Record<string, number>;
+}
+
+export interface CareerMilestone {
+  level: CareerLevel;
+  pathId: CareerPathId;
+  /** 選路當下的總分，供未來 UI 與存檔稽核；不參與獎勵重算。 */
+  score: number;
+}
+
+export interface CareerSnapshot {
+  stats: StatBlock;
+  skills?: Record<string, number>;
+  growth?: GrowthProfile;
+}
+
+export const CAREER_LEVELS: CareerLevel[] = [2, 3, 4, 5];
+
+/** 平手時採固定順序，讓相同存檔在所有瀏覽器得到相同職涯。 */
+export const CAREER_PATH_ORDER: CareerPathId[] = [
+  'martial', 'scouting', 'lore', 'negotiation', 'survival',
+];
+
+export const CAREER_PATHS: Record<CareerPathId, CareerPathDef> = {
+  martial: {
+    id: 'martial', name: '武鬥之路', stat: 'str', skillId: 'martial',
+    desc: '以力量、武藝與正面戰鬥作為商隊的開路手段。',
+  },
+  scouting: {
+    id: 'scouting', name: '斥候之路', stat: 'dex', skillId: 'scouting',
+    desc: '依靠敏捷、偵查與路線判讀避開不必要的損失。',
+  },
+  lore: {
+    id: 'lore', name: '學識之路', stat: 'int', skillId: 'lore',
+    desc: '把知識、古籍與軍需推演轉化為遠征優勢。',
+  },
+  negotiation: {
+    id: 'negotiation', name: '交涉之路', stat: 'cha', skillId: 'negotiation',
+    desc: '以魅力、名聲與交易手腕擴張商隊影響力。',
+  },
+  survival: {
+    id: 'survival', name: '生存之路', stat: 'con', skillId: 'survival',
+    desc: '靠體質、補給與野外經驗撐過漫長而惡劣的旅途。',
+  },
+};
+
+/**
+ * 每級獎勵都跨越不同系統；同一路線走到底也不會壟斷全部資源。
+ * Lv2 是開路物資、Lv3 是技能形成、Lv4 是核心屬性、Lv5 是路線冠冕。
+ */
+const CAREER_REWARDS: Record<CareerLevel, Record<CareerPathId, CareerReward>> = {
+  2: {
+    martial: { maxHp: 1, inventory: { 'war-tonic': 1 } },
+    scouting: { inventory: { torch: 1, 'dried-rations': 2 } },
+    lore: { inventory: { 'tattered-map': 1, herb: 1 } },
+    negotiation: { gold: 20, inventory: { 'spice-pouch': 1 } },
+    survival: { maxHp: 2, inventory: { bandage: 1 } },
+  },
+  3: {
+    martial: { skill: { id: 'martial', amount: 1 }, inventory: { ore: 1 } },
+    scouting: { skill: { id: 'scouting', amount: 1 }, inventory: { 'tattered-map': 1 } },
+    lore: { skill: { id: 'lore', amount: 1 }, inventory: { herb: 1 } },
+    negotiation: { skill: { id: 'negotiation', amount: 1 }, gold: 15 },
+    survival: { skill: { id: 'survival', amount: 1 }, inventory: { herb: 1 } },
+  },
+  4: {
+    martial: { stats: { str: 1 }, inventory: { 'war-tonic': 1 } },
+    scouting: { stats: { dex: 1 }, inventory: { torch: 1 } },
+    lore: { stats: { int: 1 }, skillPoints: 1 },
+    negotiation: { stats: { cha: 1 }, reputation: 1 },
+    survival: { stats: { con: 1 }, maxHp: 1 },
+  },
+  5: {
+    martial: { stats: { str: 1 }, maxHp: 2, inventory: { ore: 2 } },
+    scouting: { stats: { dex: 1 }, skillPoints: 1, inventory: { 'tattered-map': 1 } },
+    lore: { stats: { int: 1 }, skillPoints: 1, inventory: { 'tattered-map': 1 } },
+    negotiation: { stats: { cha: 1 }, gold: 40, reputation: 2, inventory: { 'spice-pouch': 1 } },
+    survival: { stats: { con: 1 }, maxHp: 3, inventory: { bandage: 2 } },
+  },
+};
+
+export function careerScorecard(snapshot: CareerSnapshot): Record<CareerPathId, number> {
+  const scores = {} as Record<CareerPathId, number>;
+  for (const pathId of CAREER_PATH_ORDER) {
+    const path = CAREER_PATHS[pathId];
+    const statScore = snapshot.stats[path.stat];
+    const skillScore = snapshot.skills?.[path.skillId] ?? 0;
+    const potentialScore = snapshot.growth?.potential?.[path.stat] ?? 0;
+    scores[pathId] = statScore + skillScore + potentialScore;
+  }
+  return scores;
+}
+
+/** 玩家可藉由升級配點與技能投資改變下一個里程碑；平手依固定路線順序。 */
+export function chooseCareerMilestone(
+  snapshot: CareerSnapshot,
+  level: CareerLevel,
+): CareerMilestone {
+  const scores = careerScorecard(snapshot);
+  let selected = CAREER_PATH_ORDER[0];
+  for (const pathId of CAREER_PATH_ORDER.slice(1)) {
+    if (scores[pathId] > scores[selected]) selected = pathId;
+  }
+  return { level, pathId: selected, score: scores[selected] };
+}
+
+export function careerReward(level: CareerLevel, pathId: CareerPathId): CareerReward {
+  const reward = CAREER_REWARDS[level][pathId];
+  return {
+    ...reward,
+    stats: reward.stats ? { ...reward.stats } : undefined,
+    skill: reward.skill ? { ...reward.skill } : undefined,
+    inventory: reward.inventory ? { ...reward.inventory } : undefined,
+  };
+}
+
+export function isCareerPathId(value: unknown): value is CareerPathId {
+  return typeof value === 'string' && value in CAREER_PATHS;
+}
+
+export function isCareerLevel(value: unknown): value is CareerLevel {
+  return Number.isInteger(value) && CAREER_LEVELS.includes(value as CareerLevel);
+}
+
+export function isValidCareerMilestone(value: unknown): value is CareerMilestone {
+  if (typeof value !== 'object' || value === null) return false;
+  const milestone = value as Record<string, unknown>;
+  return isCareerLevel(milestone.level) &&
+    isCareerPathId(milestone.pathId) &&
+    typeof milestone.score === 'number' &&
+    Number.isFinite(milestone.score);
+}
+
+export function careerSequenceName(milestones: CareerMilestone[] | undefined): string {
+  if (!Array.isArray(milestones) || milestones.length === 0) return '尚未形成';
+  return [...milestones]
+    .filter(isValidCareerMilestone)
+    .sort((a, b) => a.level - b.level)
+    .map((milestone) => CAREER_PATHS[milestone.pathId].name)
+    .join(' → ');
+}

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -6,6 +6,13 @@ import { resolveCharacterGenesis } from './data/genesis';
 import type { CharacterGenesis } from './data/genesis';
 import { deriveGrowthProfile, latentStatBonuses, realizedGrowthBonuses } from './data/growth';
 import type { GrowthProfile } from './data/growth';
+import {
+  CAREER_LEVELS,
+  careerReward,
+  chooseCareerMilestone,
+  isValidCareerMilestone,
+} from './data/careers';
+import type { CareerMilestone, CareerReward } from './data/careers';
 
 export const SAVE_KEY = 'caravan-save-v1';
 export type FormationRow = 'front' | 'back';
@@ -32,6 +39,8 @@ export interface CompanionRecord {
   growth?: GrowthProfile;
   /** M24 已永久實現到角色基礎值的潛力等級；optional 保持 v6 舊檔相容。 */
   growthRealizedLevel?: number;
+  /** M25 Lv2～Lv5 已鎖定並領取的職涯路線；主角使用，舊角色可自動補算。 */
+  careerMilestones?: CareerMilestone[];
   equipment: { weapon: string | null; armor: string | null; trinket: string | null };
   specialization?: string | null;
   bond?: number;
@@ -71,6 +80,7 @@ export interface SaveDataV6 extends Omit<SaveDataV5, 'version'> {
 export type SaveData = SaveDataV6;
 
 const CURRENT_VERSION = 6;
+const CAREER_SKILL_RANK_CAP = 5;
 const defaultEquipment = (): CompanionRecord['equipment'] => ({ weapon: null, armor: null, trinket: null });
 export const CREATION_BONUS_POINTS = 3;
 export const STARTING_PROFILE: Record<JobId, { stats: StatBlock; maxHp: number }> = {
@@ -199,6 +209,66 @@ export function realizeSaveGrowth(data: SaveData): SaveData {
   return data;
 }
 
+function applyCareerReward(data: SaveData, record: CompanionRecord, reward: CareerReward): void {
+  if (reward.stats) {
+    for (const stat of Object.keys(reward.stats) as Array<keyof StatBlock>) {
+      record.stats[stat] += reward.stats[stat] ?? 0;
+    }
+  }
+  if (reward.maxHp) record.maxHp = Math.max(8, record.maxHp + reward.maxHp);
+  if (reward.skill) {
+    const current = record.skills?.[reward.skill.id] ?? 0;
+    record.skills = {
+      ...(record.skills ?? {}),
+      [reward.skill.id]: Math.min(CAREER_SKILL_RANK_CAP, current + reward.skill.amount),
+    };
+  }
+  if (reward.skillPoints) record.skillPoints = (record.skillPoints ?? 0) + reward.skillPoints;
+  if (reward.gold) data.gold += reward.gold;
+  if (reward.reputation) data.reputation += reward.reputation;
+  if (reward.inventory) {
+    for (const [itemId, count] of Object.entries(reward.inventory)) {
+      if (count > 0) data.inventory[itemId] = (data.inventory[itemId] ?? 0) + count;
+    }
+  }
+}
+
+/**
+ * M25 職涯里程碑：先看已實現潛力與玩家投入，再鎖定該級路線並一次性發放獎勵。
+ * 僅主角的 M22/M23 命運角色啟用；舊版與無出身角色保持原流程。
+ */
+export function realizeSaveCareer(data: SaveData): SaveData {
+  const record = data.protagonist;
+  if (!record.genesis || !record.growth) return data;
+
+  const valid = Array.isArray(record.careerMilestones)
+    ? record.careerMilestones.filter(isValidCareerMilestone)
+    : [];
+  const byLevel = new Map(valid.map((milestone) => [milestone.level, milestone]));
+  const targetLevel = Math.max(1, Math.min(5, Math.floor(record.level)));
+
+  for (const level of CAREER_LEVELS) {
+    if (level > targetLevel || byLevel.has(level)) continue;
+    const milestone = chooseCareerMilestone({
+      stats: record.stats,
+      skills: record.skills,
+      growth: record.growth,
+    }, level);
+    applyCareerReward(data, record, careerReward(level, milestone.pathId));
+    byLevel.set(level, milestone);
+  }
+
+  record.careerMilestones = [...byLevel.values()].sort((a, b) => a.level - b.level);
+  return data;
+}
+
+/** 所有持久化前置交易的單一入口，順序固定為潛力成長後再判定職涯。 */
+export function realizeSaveProgression(data: SaveData): SaveData {
+  realizeSaveGrowth(data);
+  realizeSaveCareer(data);
+  return data;
+}
+
 function parseAndMigrate(raw: unknown): SaveData | null {
   if (typeof raw !== 'object' || raw === null) return null;
   let parsed = raw as Record<string, unknown>;
@@ -211,7 +281,7 @@ function parseAndMigrate(raw: unknown): SaveData | null {
   if (!isValidSaveShape(parsed)) return null;
   if (parsed.expeditionPlan !== undefined && !isValidExpeditionPlan(parsed.expeditionPlan)) delete parsed.expeditionPlan;
   if (parsed.expedition !== null && !isCurrentExpeditionSnapshot(parsed.expedition)) parsed.expedition = null;
-  return realizeSaveGrowth(parsed);
+  return realizeSaveProgression(parsed);
 }
 
 export function newGame(now: number = Date.now(), choice?: CharacterChoice): SaveData {
@@ -225,6 +295,7 @@ export function newGame(now: number = Date.now(), choice?: CharacterChoice): Sav
     const growth = deriveGrowthProfile(protagonist.stats, STARTING_PROFILE[protagonist.job].stats, genesis.profile);
     protagonist.growth = growth;
     protagonist.growthRealizedLevel = 1;
+    protagonist.careerMilestones = [];
     const seed = latentStatBonuses(growth, 2);
     for (const stat of Object.keys(seed) as Array<keyof StatBlock>) protagonist.stats[stat] += seed[stat] ?? 0;
     protagonist.maxHp = Math.max(8, protagonist.maxHp + genesis.effects.maxHpDelta + Math.max(0, growth.potential.con - 3));
@@ -242,7 +313,7 @@ export function newGame(now: number = Date.now(), choice?: CharacterChoice): Sav
 }
 
 export function saveGame(data: SaveData, storage: Storage = localStorage): void {
-  storage.setItem(SAVE_KEY, JSON.stringify(realizeSaveGrowth(data)));
+  storage.setItem(SAVE_KEY, JSON.stringify(realizeSaveProgression(data)));
 }
 export function loadGame(storage: Storage = localStorage): SaveData | null {
   const raw = storage.getItem(SAVE_KEY);
@@ -250,7 +321,7 @@ export function loadGame(storage: Storage = localStorage): SaveData | null {
   try { return parseAndMigrate(JSON.parse(raw)); } catch { return null; }
 }
 export function exportSave(data: SaveData): string {
-  return btoa(encodeURIComponent(JSON.stringify(realizeSaveGrowth(data))));
+  return btoa(encodeURIComponent(JSON.stringify(realizeSaveProgression(data))));
 }
 export function importSave(encoded: string): SaveData | null {
   try { return parseAndMigrate(JSON.parse(decodeURIComponent(atob(encoded)))); } catch { return null; }


### PR DESCRIPTION
## Summary

- add five adaptive career paths driven by current stats, invested adventure skills, and M23 growth potential
- lock one milestone at each level from 2 to 5, creating persistent mixed career histories instead of a single fixed class route
- distribute rewards across attributes, HP, skills, free skill points, gold, reputation, and supplies
- realize milestones transactionally after M24 growth so all systems read the same permanent character record
- backfill existing M22–M24 genesis characters without changing save version
- add adversarial tests for idempotence, level jumps, player redirection, caps, legacy compatibility, corruption cleanup, and reward dominance

## Game-design intent

Character creation and latent growth now produce many opening and long-term profiles, but level-up decisions still lacked a persistent record of what the player actually developed. M25 converts each level from 2 through 5 into an adaptive career milestone. The route is chosen from the character's live stats, skill investment, and potential at that moment, then locked permanently.

The five paths are Martial, Scouting, Lore, Negotiation, and Survival. A player may specialize in one path or redirect between levels, producing 5^4 possible path sequences before accounting for jobs, genesis, rolls, allocation, skills, gear, and specialization.

## Player adversarial review

- all five paths define rewards for every milestone level
- the same job can select different paths from different builds
- repeated saves or realizations cannot duplicate rewards
- jumping directly to level 5 matches level-by-level realization when choices remain unchanged
- previous milestones do not change when the player redirects later
- skill rewards respect the rank-5 cap while other rewards remain valid
- no-origin characters remain completely outside the career system
- old M24 saves safely backfill missing milestones exactly once
- corrupt and duplicate milestone histories are normalized without blocking missing rewards
- four repeated milestones stay below strict attribute, HP, and skill-growth caps

## Scope

- `src/scripts/games/caravan/data/careers.ts`
- `src/scripts/games/caravan/save.ts`
- `src/scripts/games/caravan/data/careers.m25.test.ts`

No dependency, lockfile, asset, generated-output, UI, or save-version changes.