### PR TITLE
feat(caravan): add M26 interwoven company charters

### DIFF
--- a/src/scripts/games/caravan/data/charters.m26.test.ts
+++ b/src/scripts/games/caravan/data/charters.m26.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from './items';
+import type { CareerMilestone, CareerPathId } from './careers';
+import {
+  COMPANY_CHARTER_ORDER,
+  chooseCompanyCharter,
+  companyCharterMetrics,
+  companyCharterReward,
+  companyCharterTierEligible,
+  isValidCompanyCharterProgress,
+  type CompanyCharterId,
+  type CompanyCharterSnapshot,
+} from './charters';
+import {
+  newGame,
+  realizeSaveCompanyCharter,
+  type CompanionRecord,
+  type SaveData,
+} from '../save';
+
+const milestone = (level: 2 | 3 | 4 | 5, pathId: CareerPathId): CareerMilestone => ({
+  level,
+  pathId,
+  score: 20,
+});
+
+function member(id: string, job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job,
+    level: 5,
+    xp: 320,
+    stats: { str: 12, dex: 12, int: 12, cha: 12, con: 12 },
+    maxHp: 24,
+    injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+function snapshot(paths: CareerPathId[]): CompanyCharterSnapshot {
+  const protagonist = member('protagonist');
+  protagonist.genesis = { lifepathId: 'seasoned', aptitudeId: 'int', burdenId: 'str' };
+  protagonist.growth = { potential: { str: 2, dex: 2, int: 2, cha: 2, con: 2 } };
+  protagonist.careerMilestones = paths.map((pathId, index) => milestone((index + 2) as 2 | 3 | 4 | 5, pathId));
+  return {
+    protagonist,
+    companions: [],
+    gold: 200,
+    reputation: 30,
+    wagonLevel: 0,
+    inventory: {},
+    flags: {},
+    visitedBossDungeons: [],
+  };
+}
+
+function prepareSave(paths: CareerPathId[]): SaveData {
+  const save = newGame(100, { job: 'swordsman', trait: 'seasoned' });
+  save.protagonist.level = 5;
+  save.protagonist.growthRealizedLevel = 5;
+  save.protagonist.careerMilestones = paths.map((pathId, index) =>
+    milestone((index + 2) as 2 | 3 | 4 | 5, pathId));
+  save.reputation = 60;
+  return save;
+}
+
+function totalInventory(save: SaveData): number {
+  return Object.values(save.inventory).reduce((sum, count) => sum + count, 0);
+}
+
+describe('M26 商隊特許', () => {
+  it('五種特許都有三章合法且只引用現有物品的獎勵', () => {
+    for (const id of COMPANY_CHARTER_ORDER) {
+      for (const tier of [1, 2, 3] as const) {
+        const reward = companyCharterReward(id, tier);
+        for (const [itemId, count] of Object.entries(reward.inventory ?? {})) {
+          expect(ITEMS[itemId]).toBeDefined();
+          expect(count).toBeGreaterThan(0);
+        }
+        expect(reward.gold ?? 0).toBeGreaterThanOrEqual(0);
+        expect(reward.reputation ?? 0).toBeGreaterThanOrEqual(0);
+        expect(reward.maxHp ?? 0).toBeGreaterThanOrEqual(0);
+        expect(reward.wagonLevels ?? 0).toBeGreaterThanOrEqual(0);
+        expect(reward.bondAll ?? 0).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
+  it('不同跨系統構築能鎖定五種不同特許，而非只由職業決定', () => {
+    const iron = snapshot(['martial', 'martial', 'martial', 'martial']);
+    iron.protagonist.genesis!.lifepathId = 'brawny';
+    iron.protagonist.growth!.potential.str = 5;
+    iron.protagonist.equipment = { weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol' };
+    iron.protagonist.equipmentPlus = { weapon: 2, armor: 1, trinket: 0 };
+    iron.expeditionPlan = {
+      activeIds: ['protagonist'], positions: { protagonist: 'front' }, roles: { captain: 'protagonist' },
+    };
+
+    const horizon = snapshot(['scouting', 'scouting', 'scouting', 'scouting']);
+    horizon.protagonist.genesis!.lifepathId = 'nimble';
+    horizon.protagonist.growth!.potential.dex = 5;
+    horizon.inventory = { torch: 3, 'tattered-map': 2, 'dried-rations': 3 };
+    horizon.flags = { 'discovered:mist-pass': true, 'discovered:old-road': true };
+    horizon.expeditionPlan = {
+      activeIds: ['protagonist'], positions: { protagonist: 'back' }, roles: { scout: 'protagonist' },
+    };
+
+    const ledger = snapshot(['negotiation', 'negotiation', 'lore', 'negotiation']);
+    ledger.protagonist.genesis!.lifepathId = 'charming';
+    ledger.protagonist.growth!.potential.cha = 5;
+    ledger.gold = 800;
+    ledger.wagonLevel = 3;
+    ledger.inventory = { salt: 4, 'spice-pouch': 4, 'silver-locket': 2 };
+    ledger.expeditionPlan = {
+      activeIds: ['protagonist'], positions: { protagonist: 'back' }, roles: { quartermaster: 'protagonist' },
+    };
+
+    const fellowship = snapshot(['martial', 'scouting', 'lore', 'negotiation']);
+    fellowship.companions = [member('a'), member('b', 'ranger'), member('c', 'cleric')];
+    fellowship.companions.forEach((companion) => { companion.bond = 4; });
+    fellowship.expeditionPlan = {
+      activeIds: ['protagonist', 'a', 'b', 'c'],
+      positions: { protagonist: 'front', a: 'front', b: 'back', c: 'back' },
+      roles: { captain: 'protagonist', scout: 'b', quartermaster: 'a', medic: 'c' },
+    };
+
+    const relic = snapshot(['lore', 'survival', 'lore', 'survival']);
+    relic.protagonist.genesis!.lifepathId = 'learned';
+    relic.protagonist.growth!.potential.int = 5;
+    relic.protagonist.growth!.potential.con = 5;
+    relic.protagonist.equipmentPlus = { weapon: 2, armor: 2, trinket: 1 };
+    relic.inventory = { ore: 5, 'tattered-map': 2, 'overseer-ledger': 1 };
+    relic.visitedBossDungeons = ['goblin-den', 'salt-mine'];
+
+    expect(chooseCompanyCharter(iron)).toBe('iron-vanguard');
+    expect(chooseCompanyCharter(horizon)).toBe('far-horizon');
+    expect(chooseCompanyCharter(ledger)).toBe('ledger-guild');
+    expect(chooseCompanyCharter(fellowship)).toBe('bound-fellowship');
+    expect(chooseCompanyCharter(relic)).toBe('relic-covenant');
+  });
+
+  it('高階章節要求角色、編隊與經營條件共同成立', () => {
+    const save = snapshot(['negotiation', 'negotiation', 'lore', 'negotiation']);
+    save.gold = 600;
+    save.reputation = 60;
+    save.wagonLevel = 2;
+    expect(companyCharterTierEligible(save, 'ledger-guild', 3)).toBe(true);
+
+    save.wagonLevel = 0;
+    expect(companyCharterTierEligible(save, 'ledger-guild', 3)).toBe(false);
+    save.wagonLevel = 2;
+    save.gold = 100;
+    expect(companyCharterTierEligible(save, 'ledger-guild', 3)).toBe(false);
+  });
+
+  it('重複保存或重複實現不能刷取特許獎勵', () => {
+    const save = prepareSave(['martial', 'martial', 'martial', 'martial']);
+    save.protagonist.equipment = {
+      weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol',
+    };
+    save.protagonist.equipmentPlus = { weapon: 2, armor: 2, trinket: 2 };
+    save.expeditionPlan = {
+      activeIds: ['protagonist'], positions: { protagonist: 'front' }, roles: { captain: 'protagonist' },
+    };
+
+    realizeSaveCompanyCharter(save);
+    const after = {
+      stats: { ...save.protagonist.stats },
+      hp: save.protagonist.maxHp,
+      skills: { ...save.protagonist.skills },
+      gold: save.gold,
+      reputation: save.reputation,
+      inventory: { ...save.inventory },
+      charter: { ...save.companyCharter! },
+    };
+    realizeSaveCompanyCharter(save);
+    realizeSaveCompanyCharter(save);
+    expect({
+      stats: save.protagonist.stats,
+      hp: save.protagonist.maxHp,
+      skills: save.protagonist.skills,
+      gold: save.gold,
+      reputation: save.reputation,
+      inventory: save.inventory,
+      charter: save.companyCharter,
+    }).toEqual(after);
+  });
+
+  it('身份鎖定後換裝、換編隊或改資產都不能跳槽領另一套獎勵', () => {
+    const save = prepareSave(['martial', 'martial', 'martial', 'martial']);
+    save.protagonist.equipment = {
+      weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol',
+    };
+    realizeSaveCompanyCharter(save);
+    expect(save.companyCharter?.id).toBe('iron-vanguard');
+
+    save.protagonist.careerMilestones = [
+      milestone(2, 'negotiation'), milestone(3, 'negotiation'),
+      milestone(4, 'lore'), milestone(5, 'negotiation'),
+    ];
+    save.gold = 1000;
+    save.wagonLevel = 4;
+    save.inventory = { salt: 10, 'spice-pouch': 10 };
+    realizeSaveCompanyCharter(save);
+    expect(save.companyCharter?.id).toBe('iron-vanguard');
+    expect(save.flags['company-charter:ledger-guild']).not.toBe(true);
+  });
+
+  it('獎勵收據可抵抗進度遺失，不能刪欄位後重新領取', () => {
+    const save = prepareSave(['scouting', 'scouting', 'scouting', 'scouting']);
+    save.inventory = { torch: 4, 'tattered-map': 3, 'dried-rations': 4 };
+    save.flags['discovered:a'] = true;
+    save.flags['discovered:b'] = true;
+    save.expeditionPlan = {
+      activeIds: ['protagonist'], positions: { protagonist: 'back' }, roles: { scout: 'protagonist' },
+    };
+    realizeSaveCompanyCharter(save);
+    const total = totalInventory(save);
+    const gold = save.gold;
+    delete save.companyCharter;
+    realizeSaveCompanyCharter(save);
+    expect(totalInventory(save)).toBe(total);
+    expect(save.gold).toBe(gold);
+    expect(save.companyCharter?.id).toBe('far-horizon');
+  });
+
+  it('無命運角色不取得特許，非法進度會被清除而不發獎', () => {
+    const legacy = newGame(1, { job: 'swordsman', trait: null });
+    legacy.reputation = 99;
+    legacy.companyCharter = { id: 'iron-vanguard', tier: 3 };
+    realizeSaveCompanyCharter(legacy);
+    expect(legacy.companyCharter).toEqual({ id: 'iron-vanguard', tier: 3 });
+    expect(Object.keys(legacy.flags).some((key) => key.startsWith('company-charter-reward:'))).toBe(false);
+
+    expect(isValidCompanyCharterProgress({ id: 'fake', tier: 99 })).toBe(false);
+  });
+
+  it('編隊指標只計算健康且真正出征的成員，後備不能灌高特許分數', () => {
+    const state = snapshot(['martial']);
+    const active = member('active');
+    const reserve = member('reserve');
+    const injured = member('injured');
+    active.equipment.weapon = 'salt-crystal-blade';
+    reserve.equipment = { weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol' };
+    injured.injuredForTrips = 2;
+    injured.equipment = { weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol' };
+    state.companions = [active, reserve, injured];
+    state.expeditionPlan = {
+      activeIds: ['protagonist', 'active'],
+      positions: { protagonist: 'front', active: 'front', reserve: 'front', injured: 'front' },
+      roles: { captain: 'protagonist', scout: 'reserve', medic: 'injured' },
+    };
+    const metrics = companyCharterMetrics(state);
+    expect(metrics.activeCount).toBe(2);
+    expect(metrics.armedCount).toBe(1);
+    expect(metrics.assignedRoles).toBe(1);
+  });
+});

--- a/src/scripts/games/caravan/data/charters.ts
+++ b/src/scripts/games/caravan/data/charters.ts
@@ -1,0 +1,362 @@
+import type { CareerMilestone, CareerPathId } from './careers';
+import { isValidCareerMilestone } from './careers';
+import type { CharacterGenesis } from './genesis';
+import type { GrowthProfile } from './growth';
+import type { StatBlock } from '../types';
+
+export type CompanyCharterId =
+  | 'iron-vanguard'
+  | 'far-horizon'
+  | 'ledger-guild'
+  | 'bound-fellowship'
+  | 'relic-covenant';
+export type CompanyCharterTier = 0 | 1 | 2 | 3;
+
+export interface CompanyCharterProgress {
+  id: CompanyCharterId;
+  tier: CompanyCharterTier;
+}
+
+export interface CompanyCharterReward {
+  stats?: Partial<StatBlock>;
+  maxHp?: number;
+  skill?: { id: CareerPathId; amount: number };
+  skillPoints?: number;
+  gold?: number;
+  reputation?: number;
+  inventory?: Record<string, number>;
+  wagonLevels?: number;
+  bondAll?: number;
+}
+
+export interface CompanyCharterMember {
+  id: string;
+  job: 'swordsman' | 'ranger' | 'mage' | 'cleric';
+  injuredForTrips: number;
+  bond?: number;
+  equipment: { weapon: string | null; armor: string | null; trinket: string | null };
+  equipmentPlus?: { weapon: number; armor: number; trinket: number };
+}
+
+export interface CompanyCharterSnapshot {
+  protagonist: CompanyCharterMember & {
+    genesis?: CharacterGenesis;
+    growth?: GrowthProfile;
+    careerMilestones?: CareerMilestone[];
+    specialization?: string | null;
+  };
+  companions: CompanyCharterMember[];
+  expeditionPlan?: {
+    activeIds: string[];
+    positions: Record<string, 'front' | 'back'>;
+    roles: Partial<Record<'captain' | 'scout' | 'quartermaster' | 'medic', string>>;
+  };
+  gold: number;
+  reputation: number;
+  wagonLevel: number;
+  inventory: Record<string, number>;
+  flags: Record<string, boolean>;
+  visitedBossDungeons: string[];
+}
+
+export interface CompanyCharterMetrics {
+  careerCount: number;
+  distinctCareers: number;
+  careerCounts: Record<CareerPathId, number>;
+  activeCount: number;
+  frontCount: number;
+  backCount: number;
+  armedCount: number;
+  equippedCount: number;
+  equipmentPlusTotal: number;
+  assignedRoles: number;
+  hasCaptain: boolean;
+  hasScout: boolean;
+  hasQuartermaster: boolean;
+  hasMedic: boolean;
+  companionCount: number;
+  bondTotal: number;
+  discoveredCount: number;
+  bossCount: number;
+  routeSupplies: number;
+  tradeGoods: number;
+  relicSupplies: number;
+}
+
+export interface CompanyCharterDef {
+  id: CompanyCharterId;
+  name: string;
+  desc: string;
+}
+
+export const COMPANY_CHARTER_ORDER: CompanyCharterId[] = [
+  'iron-vanguard',
+  'far-horizon',
+  'ledger-guild',
+  'bound-fellowship',
+  'relic-covenant',
+];
+
+export const COMPANY_CHARTERS: Record<CompanyCharterId, CompanyCharterDef> = {
+  'iron-vanguard': {
+    id: 'iron-vanguard',
+    name: '鐵衛戰團特許',
+    desc: '以前排、武藝、武裝與聲望建立護運威信。',
+  },
+  'far-horizon': {
+    id: 'far-horizon',
+    name: '遠境拓荒特許',
+    desc: '以斥候、路線補給與新地點發現拓展商路。',
+  },
+  'ledger-guild': {
+    id: 'ledger-guild',
+    name: '金帳商會特許',
+    desc: '把交涉、學識、軍需與馬車資產整合成商業優勢。',
+  },
+  'bound-fellowship': {
+    id: 'bound-fellowship',
+    name: '同袍盟約特許',
+    desc: '以多元職涯、完整職務與旅伴羈絆建立穩定團隊。',
+  },
+  'relic-covenant': {
+    id: 'relic-covenant',
+    name: '遺珍尋跡特許',
+    desc: '以知識、生存、首領探索與裝備強化追逐危險遺物。',
+  },
+};
+
+const emptyCareerCounts = (): Record<CareerPathId, number> => ({
+  martial: 0,
+  scouting: 0,
+  lore: 0,
+  negotiation: 0,
+  survival: 0,
+});
+
+function inventoryCount(inventory: Record<string, number>, ids: string[]): number {
+  return ids.reduce((sum, id) => sum + Math.max(0, inventory[id] ?? 0), 0);
+}
+
+function equipmentCount(member: CompanyCharterMember): number {
+  return Object.values(member.equipment).filter(Boolean).length;
+}
+
+function equipmentPlus(member: CompanyCharterMember): number {
+  return Object.values(member.equipmentPlus ?? {}).reduce((sum, value) => sum + Math.max(0, value), 0);
+}
+
+/** 將角色、編隊、經濟、探索與關係狀態壓成同一份特許判定指標。 */
+export function companyCharterMetrics(snapshot: CompanyCharterSnapshot): CompanyCharterMetrics {
+  const careers = (snapshot.protagonist.careerMilestones ?? []).filter(isValidCareerMilestone);
+  const careerCounts = emptyCareerCounts();
+  for (const milestone of careers) careerCounts[milestone.pathId] += 1;
+
+  const healthy = [
+    snapshot.protagonist,
+    ...snapshot.companions.filter((member) => member.injuredForTrips === 0),
+  ];
+  const healthyIds = new Set(healthy.map((member) => member.id));
+  const requested = snapshot.expeditionPlan?.activeIds ?? healthy.map((member) => member.id);
+  const activeIds: string[] = [snapshot.protagonist.id];
+  for (const id of requested) {
+    if (activeIds.length >= 4) break;
+    if (id !== snapshot.protagonist.id && healthyIds.has(id) && !activeIds.includes(id)) activeIds.push(id);
+  }
+  const active = activeIds
+    .map((id) => healthy.find((member) => member.id === id))
+    .filter((member): member is CompanyCharterMember => member !== undefined);
+  const positions = snapshot.expeditionPlan?.positions ?? {};
+  const roles = snapshot.expeditionPlan?.roles ?? {};
+  const roleHolders = new Set(Object.values(roles).filter((id): id is string => !!id && activeIds.includes(id)));
+
+  const frontCount = active.filter((member) =>
+    (positions[member.id] ?? (member.job === 'swordsman' ? 'front' : 'back')) === 'front'
+  ).length;
+  const armedCount = active.filter((member) => !!member.equipment.weapon).length;
+  const equippedCount = active.reduce((sum, member) => sum + equipmentCount(member), 0);
+  const equipmentPlusTotal = active.reduce((sum, member) => sum + equipmentPlus(member), 0);
+
+  return {
+    careerCount: careers.length,
+    distinctCareers: Object.values(careerCounts).filter((count) => count > 0).length,
+    careerCounts,
+    activeCount: active.length,
+    frontCount,
+    backCount: Math.max(0, active.length - frontCount),
+    armedCount,
+    equippedCount,
+    equipmentPlusTotal,
+    assignedRoles: roleHolders.size,
+    hasCaptain: !!roles.captain && activeIds.includes(roles.captain),
+    hasScout: !!roles.scout && activeIds.includes(roles.scout),
+    hasQuartermaster: !!roles.quartermaster && activeIds.includes(roles.quartermaster),
+    hasMedic: !!roles.medic && activeIds.includes(roles.medic),
+    companionCount: snapshot.companions.length,
+    bondTotal: snapshot.companions.reduce((sum, member) => sum + Math.max(0, member.bond ?? 0), 0),
+    discoveredCount: Object.entries(snapshot.flags)
+      .filter(([key, value]) => value && key.startsWith('discovered:')).length,
+    bossCount: new Set(snapshot.visitedBossDungeons).size,
+    routeSupplies: inventoryCount(snapshot.inventory, ['torch', 'tattered-map', 'dried-rations']),
+    tradeGoods: inventoryCount(snapshot.inventory, ['salt', 'spice-pouch', 'silver-locket', 'goblin-earring']),
+    relicSupplies: inventoryCount(snapshot.inventory, ['ore', 'tattered-map', 'overseer-ledger', 'den-idol']),
+  };
+}
+
+function potential(snapshot: CompanyCharterSnapshot, stat: keyof StatBlock): number {
+  return snapshot.protagonist.growth?.potential?.[stat] ?? 0;
+}
+
+function genesisBonus(snapshot: CompanyCharterSnapshot, ids: string[]): number {
+  const genesis = snapshot.protagonist.genesis;
+  return genesis && ids.includes(genesis.lifepathId) ? 3 : 0;
+}
+
+export function companyCharterScorecard(
+  snapshot: CompanyCharterSnapshot,
+): Record<CompanyCharterId, number> {
+  const m = companyCharterMetrics(snapshot);
+  return {
+    'iron-vanguard':
+      m.careerCounts.martial * 4 + m.frontCount * 2 + m.armedCount + m.equipmentPlusTotal +
+      potential(snapshot, 'str') + genesisBonus(snapshot, ['brawny', 'tough']),
+    'far-horizon':
+      m.careerCounts.scouting * 4 + (m.hasScout ? 3 : 0) + m.backCount + m.routeSupplies +
+      m.discoveredCount * 2 + potential(snapshot, 'dex') + genesisBonus(snapshot, ['nimble', 'seasoned']),
+    'ledger-guild':
+      m.careerCounts.negotiation * 3 + m.careerCounts.lore * 2 + (m.hasQuartermaster ? 3 : 0) +
+      (m.hasCaptain ? 1 : 0) + snapshot.wagonLevel * 3 + m.tradeGoods + Math.floor(snapshot.gold / 150) +
+      potential(snapshot, 'cha') + potential(snapshot, 'int') + genesisBonus(snapshot, ['charming', 'learned']),
+    'bound-fellowship':
+      m.distinctCareers * 3 + m.companionCount * 2 + Math.min(8, m.bondTotal) + m.assignedRoles * 2 +
+      potential(snapshot, 'cha') + potential(snapshot, 'con') + genesisBonus(snapshot, ['seasoned']),
+    'relic-covenant':
+      m.careerCounts.lore * 3 + m.careerCounts.survival * 2 + m.bossCount * 4 +
+      m.equipmentPlusTotal * 2 + m.relicSupplies + potential(snapshot, 'int') + potential(snapshot, 'con') +
+      genesisBonus(snapshot, ['learned', 'tough']),
+  };
+}
+
+/** 特許在首次符合門檻時依整體商隊狀態鎖定；平手採固定順序。 */
+export function chooseCompanyCharter(snapshot: CompanyCharterSnapshot): CompanyCharterId | null {
+  const metrics = companyCharterMetrics(snapshot);
+  if (snapshot.reputation < 10 || metrics.careerCount < 1) return null;
+  const scores = companyCharterScorecard(snapshot);
+  let selected = COMPANY_CHARTER_ORDER[0];
+  for (const id of COMPANY_CHARTER_ORDER.slice(1)) {
+    if (scores[id] > scores[selected]) selected = id;
+  }
+  return selected;
+}
+
+export function companyCharterTierEligible(
+  snapshot: CompanyCharterSnapshot,
+  id: CompanyCharterId,
+  tier: 1 | 2 | 3,
+): boolean {
+  const m = companyCharterMetrics(snapshot);
+  if (tier === 1) return snapshot.reputation >= 10 && m.careerCount >= 1;
+
+  if (tier === 2) {
+    switch (id) {
+      case 'iron-vanguard':
+        return snapshot.reputation >= 25 &&
+          (m.careerCounts.martial >= 2 || m.frontCount >= 2) &&
+          (m.armedCount >= 2 || m.equipmentPlusTotal >= 1);
+      case 'far-horizon':
+        return snapshot.reputation >= 25 &&
+          (m.careerCounts.scouting >= 2 || m.hasScout) &&
+          m.routeSupplies >= 2 && m.discoveredCount >= 1;
+      case 'ledger-guild':
+        return snapshot.reputation >= 25 &&
+          m.careerCounts.negotiation + m.careerCounts.lore >= 2 &&
+          (m.hasQuartermaster || snapshot.wagonLevel >= 1) && snapshot.gold >= 250;
+      case 'bound-fellowship':
+        return snapshot.reputation >= 20 && m.companionCount >= 2 &&
+          m.distinctCareers >= 2 && m.bondTotal >= 2 && m.assignedRoles >= 2;
+      case 'relic-covenant':
+        return snapshot.reputation >= 25 && m.bossCount >= 1 &&
+          m.careerCounts.lore + m.careerCounts.survival >= 2 &&
+          (m.relicSupplies >= 2 || m.equipmentPlusTotal >= 1);
+    }
+  }
+
+  switch (id) {
+    case 'iron-vanguard':
+      return snapshot.reputation >= 50 && m.careerCounts.martial >= 3 &&
+        m.frontCount >= 2 && m.equippedCount >= 6;
+    case 'far-horizon':
+      return snapshot.reputation >= 50 && m.careerCounts.scouting >= 3 &&
+        m.hasScout && m.discoveredCount >= 2;
+    case 'ledger-guild':
+      return snapshot.reputation >= 50 &&
+        m.careerCounts.negotiation + m.careerCounts.lore >= 3 &&
+        snapshot.wagonLevel >= 2 && snapshot.gold >= 500;
+    case 'bound-fellowship':
+      return snapshot.reputation >= 45 && m.companionCount >= 3 &&
+        m.distinctCareers >= 3 && m.bondTotal >= 6 && m.assignedRoles >= 3;
+    case 'relic-covenant':
+      return snapshot.reputation >= 50 && m.bossCount >= 2 &&
+        m.careerCounts.lore + m.careerCounts.survival >= 3 && m.equipmentPlusTotal >= 2;
+  }
+}
+
+const CHARTER_REWARDS: Record<CompanyCharterId, Record<1 | 2 | 3, CompanyCharterReward>> = {
+  'iron-vanguard': {
+    1: { stats: { str: 1 }, inventory: { 'war-tonic': 1 } },
+    2: { maxHp: 2, skill: { id: 'martial', amount: 1 }, reputation: 2 },
+    3: { stats: { str: 1 }, maxHp: 2, reputation: 4, inventory: { 'war-tonic': 2, ore: 1 } },
+  },
+  'far-horizon': {
+    1: { stats: { dex: 1 }, inventory: { torch: 2, 'dried-rations': 1 } },
+    2: { skill: { id: 'scouting', amount: 1 }, gold: 20, inventory: { 'tattered-map': 1 } },
+    3: { stats: { dex: 1 }, skillPoints: 1, reputation: 4, inventory: { torch: 2, 'tattered-map': 1 } },
+  },
+  'ledger-guild': {
+    1: { stats: { cha: 1 }, gold: 40, inventory: { 'spice-pouch': 1 } },
+    2: { skill: { id: 'negotiation', amount: 1 }, gold: 30, wagonLevels: 1 },
+    3: { stats: { cha: 1 }, gold: 80, reputation: 5, wagonLevels: 1 },
+  },
+  'bound-fellowship': {
+    1: { skillPoints: 1, inventory: { bandage: 1 }, bondAll: 1 },
+    2: { stats: { cha: 1, con: 1 }, reputation: 3, bondAll: 1 },
+    3: { maxHp: 2, reputation: 5, inventory: { bandage: 2 }, bondAll: 2 },
+  },
+  'relic-covenant': {
+    1: { stats: { int: 1 }, inventory: { 'tattered-map': 1, ore: 1 } },
+    2: { skill: { id: 'lore', amount: 1 }, gold: 30, inventory: { ore: 2 } },
+    3: { stats: { int: 1 }, skillPoints: 1, gold: 60, reputation: 5, inventory: { ore: 3 } },
+  },
+};
+
+export function companyCharterReward(
+  id: CompanyCharterId,
+  tier: 1 | 2 | 3,
+): CompanyCharterReward {
+  const reward = CHARTER_REWARDS[id][tier];
+  return {
+    ...reward,
+    stats: reward.stats ? { ...reward.stats } : undefined,
+    skill: reward.skill ? { ...reward.skill } : undefined,
+    inventory: reward.inventory ? { ...reward.inventory } : undefined,
+  };
+}
+
+export function isCompanyCharterId(value: unknown): value is CompanyCharterId {
+  return typeof value === 'string' && value in COMPANY_CHARTERS;
+}
+
+export function isCompanyCharterTier(value: unknown): value is CompanyCharterTier {
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 3;
+}
+
+export function isValidCompanyCharterProgress(value: unknown): value is CompanyCharterProgress {
+  if (typeof value !== 'object' || value === null) return false;
+  const progress = value as Record<string, unknown>;
+  return isCompanyCharterId(progress.id) && isCompanyCharterTier(progress.tier);
+}
+
+export function companyCharterName(progress: CompanyCharterProgress | undefined): string {
+  return progress && isValidCompanyCharterProgress(progress)
+    ? `${COMPANY_CHARTERS[progress.id].name}・第 ${progress.tier} 章`
+    : '尚未取得特許';
+}

--- a/src/scripts/games/caravan/save.ts
+++ b/src/scripts/games/caravan/save.ts
@@ -13,6 +13,18 @@ import {
   isValidCareerMilestone,
 } from './data/careers';
 import type { CareerMilestone, CareerReward } from './data/careers';
+import {
+  COMPANY_CHARTER_ORDER,
+  chooseCompanyCharter,
+  companyCharterReward,
+  companyCharterTierEligible,
+  isValidCompanyCharterProgress,
+} from './data/charters';
+import type {
+  CompanyCharterId,
+  CompanyCharterProgress,
+  CompanyCharterReward,
+} from './data/charters';
 
 export const SAVE_KEY = 'caravan-save-v1';
 export type FormationRow = 'front' | 'back';
@@ -76,6 +88,8 @@ export interface SaveDataV6 extends Omit<SaveDataV5, 'version'> {
   marketSeed: number;
   endlessTier?: number;
   expeditionPlan?: ExpeditionPlan;
+  /** M26 商隊特許與已完成章節；optional 保持 v6 舊檔相容。 */
+  companyCharter?: CompanyCharterProgress;
 }
 export type SaveData = SaveDataV6;
 
@@ -262,10 +276,100 @@ export function realizeSaveCareer(data: SaveData): SaveData {
   return data;
 }
 
-/** 所有持久化前置交易的單一入口，順序固定為潛力成長後再判定職涯。 */
+const charterIdentityFlag = (id: CompanyCharterId): string => `company-charter:${id}`;
+const charterRewardFlag = (id: CompanyCharterId, tier: 1 | 2 | 3): string =>
+  `company-charter-reward:${id}:${tier}`;
+
+function lockedCompanyCharter(data: SaveData): CompanyCharterId | null {
+  const flagged = COMPANY_CHARTER_ORDER.find((id) => data.flags[charterIdentityFlag(id)] === true);
+  if (flagged) return flagged;
+  return isValidCompanyCharterProgress(data.companyCharter) ? data.companyCharter.id : null;
+}
+
+function appliedCompanyCharterTier(data: SaveData, id: CompanyCharterId): 0 | 1 | 2 | 3 {
+  let tier: 0 | 1 | 2 | 3 = 0;
+  for (const candidate of [1, 2, 3] as const) {
+    if (data.flags[charterRewardFlag(id, candidate)] === true) tier = candidate;
+  }
+  if (isValidCompanyCharterProgress(data.companyCharter) && data.companyCharter.id === id) {
+    tier = Math.max(tier, data.companyCharter.tier) as 0 | 1 | 2 | 3;
+  }
+  return tier;
+}
+
+function applyCompanyCharterReward(
+  data: SaveData,
+  id: CompanyCharterId,
+  tier: 1 | 2 | 3,
+  reward: CompanyCharterReward,
+): void {
+  const receipt = charterRewardFlag(id, tier);
+  if (data.flags[receipt] === true) return;
+
+  const protagonist = data.protagonist;
+  if (reward.stats) {
+    for (const stat of Object.keys(reward.stats) as Array<keyof StatBlock>) {
+      protagonist.stats[stat] += reward.stats[stat] ?? 0;
+    }
+  }
+  if (reward.maxHp) protagonist.maxHp = Math.max(8, protagonist.maxHp + reward.maxHp);
+  if (reward.skill) {
+    const current = protagonist.skills?.[reward.skill.id] ?? 0;
+    protagonist.skills = {
+      ...(protagonist.skills ?? {}),
+      [reward.skill.id]: Math.min(CAREER_SKILL_RANK_CAP, current + reward.skill.amount),
+    };
+  }
+  if (reward.skillPoints) protagonist.skillPoints = (protagonist.skillPoints ?? 0) + reward.skillPoints;
+  if (reward.gold) data.gold += reward.gold;
+  if (reward.reputation) data.reputation += reward.reputation;
+  if (reward.wagonLevels) data.wagonLevel += reward.wagonLevels;
+  if (reward.inventory) {
+    for (const [itemId, count] of Object.entries(reward.inventory)) {
+      if (count > 0) data.inventory[itemId] = (data.inventory[itemId] ?? 0) + count;
+    }
+  }
+  if (reward.bondAll) {
+    for (const companion of data.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  data.flags[receipt] = true;
+}
+
+/**
+ * M26 商隊特許：以命運、職涯、編隊、經濟、探索、裝備與羈絆共同判定。
+ * 身份首次成立後永久鎖定；三章依跨系統條件逐步完成，且每章獎勵有獨立收據。
+ */
+export function realizeSaveCompanyCharter(data: SaveData): SaveData {
+  if (!data.protagonist.genesis || !data.protagonist.growth) return data;
+
+  let id = lockedCompanyCharter(data);
+  if (!id) {
+    id = chooseCompanyCharter(data);
+    if (!id) {
+      if (data.companyCharter !== undefined && !isValidCompanyCharterProgress(data.companyCharter)) {
+        delete data.companyCharter;
+      }
+      return data;
+    }
+    data.flags[charterIdentityFlag(id)] = true;
+  }
+
+  let tier = appliedCompanyCharterTier(data, id);
+  for (const candidate of [1, 2, 3] as const) {
+    if (candidate <= tier || !companyCharterTierEligible(data, id, candidate)) continue;
+    applyCompanyCharterReward(data, id, candidate, companyCharterReward(id, candidate));
+    tier = candidate;
+  }
+  data.companyCharter = { id, tier };
+  data.flags[charterIdentityFlag(id)] = true;
+  return data;
+}
+
+/** 所有持久化前置交易的單一入口：潛力 → 職涯 → 商隊特許。 */
 export function realizeSaveProgression(data: SaveData): SaveData {
   realizeSaveGrowth(data);
   realizeSaveCareer(data);
+  realizeSaveCompanyCharter(data);
   return data;
 }
 


### PR DESCRIPTION
## Summary

- add five company charter identities derived from genesis, growth potential, career history, active formation, expedition roles, equipment, economy, exploration, and companion bonds
- lock the first qualified charter identity so short-term gear or roster changes cannot switch reward tracks
- add three escalating charter chapters with cross-system requirements and rewards across stats, HP, skills, skill points, gold, reputation, wagon levels, supplies, and bonds
- integrate charter realization after M24 growth and M25 career transactions so every existing system reads the same permanent save values
- store independent identity and reward receipt flags to prevent duplicate rewards, deleted-progress exploits, and cross-charter farming
- preserve v6 save compatibility with an optional charter progress field
- add player-adversarial tests for all identities, tier gates, idempotence, locking, receipt recovery, invalid progress, and active-roster truthfulness

## Game-design intent

M22–M25 made character creation and growth highly variable, but those choices still needed to shape the caravan as an organization. M26 converts the combined character and company state into a persistent charter: Iron Vanguard, Far Horizon, Ledger Guild, Bound Fellowship, or Relic Covenant.

A charter is not selected from a menu or dictated by class. It emerges from the player's interwoven build and operating decisions, then advances through three chapters that require multiple systems to align. This makes formation, roles, gear, wagon investment, supplies, discoveries, boss history, reputation, wealth, career diversity, and companion bonds meaningful to the same progression loop.

## Player adversarial review

- five deliberately different builds resolve to five different charter identities
- chapter 2 and 3 requirements combine multiple systems instead of accepting one inflated number
- only healthy active members contribute formation, equipment, and role metrics
- reserve or injured characters cannot inflate active-company charter scores
- charter identity remains locked after qualification and cannot be changed to farm another reward tree
- every chapter reward has an independent receipt, so repeated saves and deleted progress fields cannot duplicate rewards
- skill rewards respect the existing rank-5 cap
- all item references resolve to the actual item catalog
- no-genesis legacy characters receive no charter rewards
- invalid progress cannot create an unknown charter or reward

## Scope

- `src/scripts/games/caravan/data/charters.ts`
- `src/scripts/games/caravan/save.ts`
- `src/scripts/games/caravan/data/charters.m26.test.ts`

No dependency, lockfile, asset, generated-output, UI, or save-version changes.