### PR TITLE
feat(caravan): add M27 truthful company dossier

### DIFF
--- a/src/pages/caravan/dossier.astro
+++ b/src/pages/caravan/dossier.astro
@@ -1,0 +1,291 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="商隊檔案 — 商隊與劍"
+  description="檢視角色命運、五維潛力、職涯、編隊、商隊特許分數與下一章發展條件。"
+  lang="zh-TW"
+>
+  <main class="dossier-page">
+    <header class="dossier-hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD</p>
+      <h1>商隊檔案</h1>
+      <p>把命運、潛力、職涯、編隊與特許放在同一張帳頁上。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan">返回入口</a>
+      </nav>
+    </header>
+
+    <section id="dossier-empty" class="empty-state" hidden>
+      <h2>尚未找到商隊存檔</h2>
+      <p>先建立角色並開始旅程，商隊檔案才會形成。</p>
+      <a href="/caravan/play">開始旅程</a>
+    </section>
+
+    <div id="dossier-content" hidden>
+      <section class="summary-grid">
+        <article class="panel identity-panel">
+          <p class="section-kicker">角色命運</p>
+          <h2 id="identity-name">—</h2>
+          <p id="identity-job" class="muted">—</p>
+          <dl class="identity-list">
+            <div><dt>完整命運</dt><dd id="identity-genesis">—</dd></div>
+            <div><dt>出身道路</dt><dd id="identity-lifepath">—</dd></div>
+            <div><dt>天賦方向</dt><dd id="identity-aptitude">—</dd></div>
+            <div><dt>開局缺陷</dt><dd id="identity-burden">—</dd></div>
+            <div><dt>潛力簽名</dt><dd id="identity-growth">—</dd></div>
+          </dl>
+        </article>
+
+        <article class="panel company-panel">
+          <p class="section-kicker">商隊現況</p>
+          <h2 id="company-charter">尚未取得特許</h2>
+          <p id="company-candidate" class="muted">—</p>
+          <div class="metric-grid">
+            <div><b id="metric-gold">0</b><span>金幣</span></div>
+            <div><b id="metric-reputation">0</b><span>聲望</span></div>
+            <div><b id="metric-wagon">0</b><span>馬車</span></div>
+            <div><b id="metric-party">0</b><span>出征者</span></div>
+            <div><b id="metric-companions">0</b><span>旅伴</span></div>
+            <div><b id="metric-inventory">0</b><span>物資種類</span></div>
+          </div>
+        </article>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="section-kicker">角色數值</p><h2>基礎、有效與潛力</h2></div>
+          <p>有效值包含裝備、特質與專精；潛力為 1～5。</p>
+        </div>
+        <div id="stat-grid" class="stat-grid"></div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="section-kicker">職涯軌跡</p><h2>Lv2～Lv5 的發展選擇</h2></div>
+          <p>里程碑一旦形成便不會因短期換裝而改寫。</p>
+        </div>
+        <div id="career-timeline" class="career-timeline"></div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="section-kicker">商隊編成</p><h2>出征、職務與後備</h2></div>
+          <p>只有健康且實際出征者會計入特許的編隊指標。</p>
+        </div>
+        <div id="member-grid" class="member-grid"></div>
+      </section>
+
+      <section class="panel charter-panel">
+        <div class="section-head">
+          <div><p class="section-kicker">特許形成</p><h2>五種商隊身份分數</h2></div>
+          <p>目前身份成立後永久鎖定；未成立時最高分為候選。</p>
+        </div>
+        <div id="charter-scores" class="charter-scores"></div>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="section-kicker">下一步</p><h2 id="next-tier-title">特許第一章</h2></div>
+          <p id="next-tier-status">—</p>
+        </div>
+        <div id="requirement-list" class="requirement-list"></div>
+      </section>
+
+      <section class="panel audit-panel">
+        <div class="section-head">
+          <div><p class="section-kicker">資料稽核</p><h2>存檔一致性</h2></div>
+          <p>此頁只讀，不會偷偷補發獎勵或修改存檔。</p>
+        </div>
+        <div id="audit-list" class="audit-list"></div>
+      </section>
+    </div>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame } from '@scripts/games/caravan/save';
+  import { buildCompanyDossier } from '@scripts/games/caravan/data/dossier';
+
+  const byId = (id: string) => document.getElementById(id)!;
+  const text = (id: string, value: string | number) => { byId(id).textContent = String(value); };
+
+  const save = loadGame();
+  if (!save) {
+    byId('dossier-empty').removeAttribute('hidden');
+  } else {
+    const dossier = buildCompanyDossier(save);
+    byId('dossier-content').removeAttribute('hidden');
+
+    text('identity-name', dossier.protagonist.name);
+    text('identity-job', `${dossier.protagonist.job} · Lv${dossier.protagonist.level} · XP ${dossier.protagonist.xp} · HP ${dossier.protagonist.maxHp}`);
+    text('identity-genesis', dossier.protagonist.genesis);
+    text('identity-lifepath', dossier.protagonist.lifepath);
+    text('identity-aptitude', dossier.protagonist.aptitude);
+    text('identity-burden', dossier.protagonist.burden);
+    text('identity-growth', dossier.protagonist.growthSignature);
+
+    text('company-charter', `${dossier.charter.currentName}${dossier.charter.currentTier ? `・第 ${dossier.charter.currentTier} 章` : ''}`);
+    text('company-candidate', dossier.charter.currentId
+      ? `身份已鎖定；目前最高分候選仍為 ${dossier.charter.scores[0]?.name ?? '—'}`
+      : `目前候選：${dossier.charter.candidateName}`);
+    text('metric-gold', dossier.company.gold);
+    text('metric-reputation', dossier.company.reputation);
+    text('metric-wagon', `Lv${dossier.company.wagonLevel}`);
+    text('metric-party', dossier.company.activeCount);
+    text('metric-companions', dossier.company.companionCount);
+    text('metric-inventory', dossier.company.inventoryKinds);
+
+    const statGrid = byId('stat-grid');
+    for (const stat of dossier.protagonist.stats) {
+      const article = document.createElement('article');
+      article.className = 'stat-card';
+      article.innerHTML = `
+        <h3>${stat.name}</h3>
+        <div><b>${stat.base}</b><span>基礎</span></div>
+        <div><b>${stat.effective}</b><span>有效</span></div>
+        <div><b>${stat.potential ?? '—'}</b><span>潛力</span></div>`;
+      statGrid.appendChild(article);
+    }
+
+    const careerTimeline = byId('career-timeline');
+    for (const career of dossier.protagonist.careers) {
+      const article = document.createElement('article');
+      article.className = `career-step${career.pathId ? ' formed' : ''}`;
+      article.innerHTML = `<span>Lv${career.level}</span><b>${career.name}</b><small>${career.score === null ? '等待升級與培養方向' : `形成分數 ${career.score}`}</small>`;
+      careerTimeline.appendChild(article);
+    }
+
+    const memberGrid = byId('member-grid');
+    for (const member of dossier.company.members) {
+      const article = document.createElement('article');
+      article.className = `member-card ${member.row === 'reserve' ? 'reserve' : 'active'}`;
+      const row = member.row === 'reserve' ? '後備' : member.row === 'front' ? '前排' : '後排';
+      const injury = member.injuredForTrips > 0 ? ` · 重傷 ${member.injuredForTrips} 趟` : '';
+      article.innerHTML = `
+        <div><b>${member.name}</b><span>${member.job} · Lv${member.level}</span></div>
+        <p>${row}${member.roleName ? ` · ${member.roleName}` : ''}${injury}</p>
+        <small>裝備 ${member.equippedSlots}/3 · 羈絆 ${member.bond}</small>`;
+      memberGrid.appendChild(article);
+    }
+
+    const maxScore = Math.max(1, ...dossier.charter.scores.map((score) => score.score));
+    const charterScores = byId('charter-scores');
+    for (const score of dossier.charter.scores) {
+      const article = document.createElement('article');
+      article.className = `charter-score${score.locked ? ' locked' : ''}`;
+      const width = Math.max(3, Math.round((score.score / maxScore) * 100));
+      article.innerHTML = `
+        <div><b>${score.name}${score.locked ? '〔已鎖定〕' : ''}</b><span>${score.score} 分</span></div>
+        <p>${score.desc}</p>
+        <div class="score-track"><i style="width:${width}%"></i></div>`;
+      charterScores.appendChild(article);
+    }
+
+    if (dossier.charter.nextTier === null) {
+      text('next-tier-title', '特許已完成');
+      text('next-tier-status', '三章均已完成。');
+    } else {
+      text('next-tier-title', `${dossier.charter.currentId ? dossier.charter.currentName : dossier.charter.candidateName}・第 ${dossier.charter.nextTier} 章`);
+      text('next-tier-status', dossier.charter.nextTierEligible ? '所有條件已達成；下一次保存將完成章節。' : '仍有條件尚未達成。');
+    }
+    const requirementList = byId('requirement-list');
+    if (dossier.charter.requirements.length === 0) {
+      requirementList.innerHTML = '<p class="empty-copy">目前沒有待完成的章節條件。</p>';
+    } else {
+      for (const requirement of dossier.charter.requirements) {
+        const row = document.createElement('div');
+        row.className = `requirement ${requirement.met ? 'met' : 'missing'}`;
+        row.innerHTML = `<span>${requirement.met ? '✓' : '○'}</span><b>${requirement.label}</b><small>${requirement.current} / ${requirement.target}</small>`;
+        requirementList.appendChild(row);
+      }
+    }
+
+    const auditList = byId('audit-list');
+    if (dossier.audit.length === 0) {
+      auditList.innerHTML = '<p class="audit-ok">✓ 未發現存檔結構異常。</p>';
+    } else {
+      for (const item of dossier.audit) {
+        const row = document.createElement('p');
+        row.className = `audit-item ${item.severity}`;
+        row.textContent = `${item.severity === 'error' ? '錯誤' : '警告'}：${item.message}`;
+        auditList.appendChild(row);
+      }
+    }
+  }
+</script>
+
+<style>
+  :global(body) { background: #17130f; }
+  .dossier-page {
+    min-height: 100vh;
+    padding: 2rem clamp(1rem, 4vw, 3rem) 5rem;
+    color: #eee2ca;
+    background:
+      radial-gradient(circle at top left, rgba(179,85,46,.18), transparent 32rem),
+      linear-gradient(180deg, #211a13, #12100d);
+    font-family: 'Noto Serif TC', serif;
+  }
+  .dossier-hero { max-width: 78rem; margin: 0 auto 2rem; border-bottom: 1px solid #6c5840; padding-bottom: 1.5rem; }
+  .dossier-hero h1 { margin: .2rem 0; font-size: clamp(2.3rem, 6vw, 4.6rem); letter-spacing: .18em; }
+  .dossier-hero > p:not(.eyebrow) { color: #cbb99a; }
+  .eyebrow, .section-kicker { color: #e99a5e; letter-spacing: .24em; font-size: .78rem; text-transform: uppercase; }
+  nav { display: flex; gap: .8rem; margin-top: 1rem; }
+  nav a, .empty-state a { color: #fff0d5; border: 1px solid #91623e; padding: .55rem .9rem; text-decoration: none; }
+  #dossier-content, .empty-state { max-width: 78rem; margin: 0 auto; }
+  .summary-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
+  .panel { background: rgba(44,34,24,.88); border: 1px solid #5d4934; padding: clamp(1rem, 3vw, 1.6rem); margin-bottom: 1rem; box-shadow: 0 18px 50px rgba(0,0,0,.18); }
+  .panel h2 { margin: .15rem 0 .45rem; }
+  .muted, .section-head p { color: #b9a78b; }
+  .identity-list { margin: 1.2rem 0 0; }
+  .identity-list div { display: grid; grid-template-columns: 7rem 1fr; gap: .6rem; padding: .45rem 0; border-top: 1px solid rgba(193,163,119,.18); }
+  dt { color: #b99b70; } dd { margin: 0; }
+  .metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: .7rem; margin-top: 1.2rem; }
+  .metric-grid div { background: #18130f; padding: .8rem; text-align: center; }
+  .metric-grid b { display: block; color: #f0b16f; font-size: 1.4rem; }
+  .metric-grid span { color: #ab9a7f; font-size: .78rem; }
+  .section-head { display: flex; align-items: end; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+  .section-head h2 { margin: .1rem 0 0; }
+  .section-head > p { max-width: 32rem; margin: 0; text-align: right; }
+  .stat-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: .7rem; }
+  .stat-card { background: #18130f; padding: .9rem; }
+  .stat-card h3 { margin: 0 0 .7rem; color: #eeb173; }
+  .stat-card div { display: flex; justify-content: space-between; padding: .25rem 0; }
+  .stat-card span { color: #9e8b70; }
+  .career-timeline { display: grid; grid-template-columns: repeat(4, 1fr); gap: .8rem; }
+  .career-step { border-left: 3px solid #5b4a37; background: #18130f; padding: 1rem; }
+  .career-step.formed { border-color: #c66c3f; }
+  .career-step span, .career-step small { display: block; color: #a99576; }
+  .career-step b { display: block; margin: .35rem 0; }
+  .member-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .7rem; }
+  .member-card { background: #18130f; padding: .9rem; border-top: 3px solid #9f6845; }
+  .member-card.reserve { opacity: .66; border-color: #51483d; }
+  .member-card div { display: flex; justify-content: space-between; gap: .5rem; }
+  .member-card span, .member-card small { color: #a99576; }
+  .charter-scores { display: grid; gap: .75rem; }
+  .charter-score { background: #18130f; padding: .9rem; }
+  .charter-score.locked { outline: 1px solid #e69b5f; }
+  .charter-score > div:first-child { display: flex; justify-content: space-between; }
+  .charter-score p { margin: .35rem 0 .7rem; color: #aa987c; }
+  .score-track { height: .45rem; background: #3a2d22; overflow: hidden; }
+  .score-track i { display: block; height: 100%; background: linear-gradient(90deg, #a64f2d, #e0a25e); }
+  .requirement-list { display: grid; gap: .5rem; }
+  .requirement { display: grid; grid-template-columns: 2rem 1fr auto; align-items: center; background: #18130f; padding: .75rem; }
+  .requirement.met span { color: #91c98e; } .requirement.missing span { color: #e19a65; }
+  .requirement small { color: #a99576; }
+  .audit-item, .audit-ok { margin: .45rem 0; padding: .7rem; background: #18130f; }
+  .audit-item.error { border-left: 3px solid #d45c4d; }
+  .audit-item.warning { border-left: 3px solid #d3a34f; }
+  .audit-ok { border-left: 3px solid #70a36c; }
+  .empty-state { text-align: center; padding: 5rem 1rem; }
+  [hidden] { display: none !important; }
+  @media (max-width: 760px) {
+    .summary-grid { grid-template-columns: 1fr; }
+    .stat-grid { grid-template-columns: repeat(2, 1fr); }
+    .career-timeline { grid-template-columns: 1fr 1fr; }
+    .section-head { display: block; }
+    .section-head > p { text-align: left; }
+  }
+</style>

--- a/src/scripts/games/caravan/data/dossier.m27.test.ts
+++ b/src/scripts/games/caravan/data/dossier.m27.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import {
+  COMPANY_CHARTER_ORDER,
+  companyCharterTierEligible,
+  type CompanyCharterId,
+} from './charters';
+import { buildCompanyDossier, dossierCharterRequirements } from './dossier';
+
+function companion(id: string, job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job,
+    level: 3,
+    xp: 120,
+    stats: { str: 12, dex: 12, int: 12, cha: 12, con: 12 },
+    maxHp: 24,
+    injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+    bond: 2,
+  };
+}
+
+function matureSave(): SaveData {
+  const save = newGame(1, {
+    job: 'ranger',
+    trait: 'nimble',
+    allocation: { dex: 3 },
+  });
+  save.protagonist.level = 5;
+  save.protagonist.careerMilestones = [
+    { level: 2, pathId: 'scouting', score: 20 },
+    { level: 3, pathId: 'lore', score: 19 },
+    { level: 4, pathId: 'negotiation', score: 18 },
+    { level: 5, pathId: 'survival', score: 17 },
+  ];
+  save.companions = [companion('a'), companion('b', 'mage'), companion('c', 'cleric')];
+  save.companions[0].equipment.weapon = 'salt-crystal-blade';
+  save.companions[0].equipment.armor = 'saltforged-mail';
+  save.companions[1].equipment.weapon = 'ghostflame-staff';
+  save.companions[1].equipment.armor = 'saltwoven-robe';
+  save.companions[2].equipment.weapon = 'brine-blessed-mace';
+  save.companions[2].equipment.armor = 'saltpriest-vestment';
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'a', 'b', 'c'],
+    positions: { protagonist: 'back', a: 'front', b: 'back', c: 'front' },
+    roles: { captain: 'protagonist', scout: 'a', quartermaster: 'b', medic: 'c' },
+  };
+  save.gold = 700;
+  save.reputation = 60;
+  save.wagonLevel = 3;
+  save.inventory = {
+    torch: 3,
+    'tattered-map': 3,
+    'dried-rations': 3,
+    salt: 3,
+    'spice-pouch': 2,
+    ore: 4,
+    'overseer-ledger': 1,
+  };
+  save.flags['discovered:mist-pass'] = true;
+  save.flags['discovered:salt-cave'] = true;
+  save.visitedBossDungeons = ['goblin-den', 'salt-cave'];
+  return save;
+}
+
+describe('M27 商隊檔案與路線圖', () => {
+  it('逐項門檻與正式特許 eligibility 在五種身份與三章保持完全一致', () => {
+    const base = matureSave();
+    for (const id of COMPANY_CHARTER_ORDER) {
+      for (const tier of [1, 2, 3] as const) {
+        const cases: SaveData[] = [structuredClone(base)];
+        const low = structuredClone(base);
+        low.reputation = 0;
+        cases.push(low);
+        const sparse = structuredClone(base);
+        sparse.inventory = {};
+        sparse.gold = 0;
+        sparse.wagonLevel = 0;
+        sparse.visitedBossDungeons = [];
+        sparse.flags = {};
+        cases.push(sparse);
+        for (const save of cases) {
+          const requirements = dossierCharterRequirements(save, id, tier);
+          expect(requirements.every((requirement) => requirement.met)).toBe(
+            companyCharterTierEligible(save, id, tier),
+          );
+        }
+      }
+    }
+  });
+
+  it('檔案使用與正式 M26 相同的特許分數、候選與指標', () => {
+    const save = matureSave();
+    const dossier = buildCompanyDossier(save);
+    expect(dossier.charter.scores).toHaveLength(5);
+    expect(dossier.charter.scores[0].score).toBeGreaterThanOrEqual(dossier.charter.scores[4].score);
+    expect(dossier.charter.candidateId).toBeTruthy();
+    expect(dossier.charter.metrics.activeCount).toBe(4);
+    expect(dossier.charter.metrics.assignedRoles).toBe(4);
+    expect(dossier.company.activeCount).toBe(4);
+  });
+
+  it('完整呈現命運、五維潛力、四次職涯與基礎／有效屬性差異', () => {
+    const save = matureSave();
+    save.protagonist.equipment.trinket = 'overseer-ledger';
+    const dossier = buildCompanyDossier(save);
+    expect(dossier.protagonist.genesis).not.toContain('舊版');
+    expect(dossier.protagonist.growthSignature).not.toBe('—');
+    expect(dossier.protagonist.stats).toHaveLength(5);
+    expect(dossier.protagonist.careers).toHaveLength(4);
+    expect(dossier.protagonist.careers.every((career) => career.pathId !== null)).toBe(true);
+    const int = dossier.protagonist.stats.find((stat) => stat.id === 'int')!;
+    expect(int.effective).toBeGreaterThanOrEqual(int.base);
+  });
+
+  it('不寫入或正規化原始存檔，保持純只讀診斷', () => {
+    const save = matureSave();
+    save.expeditionPlan!.activeIds.push('missing-member');
+    const before = JSON.stringify(save);
+    buildCompanyDossier(save);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('偵測非法命運、潛力、技能、物品、裝備與編隊髒資料', () => {
+    const save = matureSave();
+    save.protagonist.genesis = {
+      lifepathId: 'bad' as never,
+      aptitudeId: 'str',
+      burdenId: 'con',
+    };
+    save.protagonist.growth = { potential: { str: 99 } } as never;
+    save.protagonist.growthRealizedLevel = 99;
+    save.protagonist.skills = { martial: 6, unknown: 1 };
+    save.protagonist.equipment.weapon = 'missing-sword';
+    save.inventory['missing-item'] = 2;
+    save.inventory.ore = -1;
+    save.expeditionPlan = {
+      activeIds: ['protagonist', 'protagonist', 'ghost'],
+      positions: { protagonist: 'front' },
+      roles: { captain: 'protagonist', scout: 'protagonist', medic: 'ghost' },
+    };
+    const codes = new Set(buildCompanyDossier(save).audit.map((item) => item.code));
+    expect(codes.has('invalid-genesis')).toBe(true);
+    expect(codes.has('invalid-growth')).toBe(true);
+    expect(codes.has('growth-level')).toBe(true);
+    expect(codes.has('duplicate-active')).toBe(true);
+    expect(codes.has('missing-active')).toBe(true);
+    expect(codes.has('duplicate-role')).toBe(true);
+    expect(codes.has('reserve-role')).toBe(true);
+    expect([...codes].some((code) => code.startsWith('unknown-equipment'))).toBe(true);
+    expect([...codes].some((code) => code.startsWith('invalid-skill'))).toBe(true);
+    expect(codes.has('unknown-item-missing-item')).toBe(true);
+    expect(codes.has('invalid-count-ore')).toBe(true);
+  });
+
+  it('舊版無命運角色仍可產生可讀檔案且不出現虛假特許', () => {
+    const save = newGame(1, { job: 'swordsman', trait: null });
+    const dossier = buildCompanyDossier(save);
+    expect(dossier.protagonist.genesis).toContain('舊版');
+    expect(dossier.protagonist.growthSignature).toBe('—');
+    expect(dossier.charter.currentId).toBeNull();
+    expect(dossier.charter.candidateId).toBeNull();
+    expect(dossier.charter.nextTierEligible).toBe(false);
+  });
+
+  it('已鎖定特許時顯示該身份下一章，而不是改追最高候選分數', () => {
+    const save = matureSave();
+    save.companyCharter = { id: 'iron-vanguard', tier: 1 };
+    save.flags['company-charter:iron-vanguard'] = true;
+    save.flags['company-charter-reward:iron-vanguard:1'] = true;
+    const dossier = buildCompanyDossier(save);
+    expect(dossier.charter.currentId).toBe('iron-vanguard');
+    expect(dossier.charter.nextTier).toBe(2);
+    expect(dossier.charter.requirements.length).toBeGreaterThan(0);
+    expect(dossier.charter.scores.find((score) => score.id === 'iron-vanguard')?.locked).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/dossier.ts
+++ b/src/scripts/games/caravan/data/dossier.ts
@@ -1,0 +1,448 @@
+import type {
+  CompanionRecord,
+  ExpeditionRole,
+  FormationRow,
+  SaveData,
+} from '../save';
+import type { StatBlock } from '../types';
+import {
+  EXPEDITION_ROLES,
+  effectiveStats,
+  memberRole,
+  normalizeExpeditionPlan,
+} from '../roster';
+import { JOBS } from './jobs';
+import { ITEMS } from './items';
+import {
+  GENESIS_APTITUDES,
+  GENESIS_BURDENS,
+  GENESIS_LIFEPATHS,
+  genesisName,
+  isGenesisTraitId,
+} from './genesis';
+import {
+  CAREER_LEVELS,
+  CAREER_PATHS,
+  isValidCareerMilestone,
+} from './careers';
+import type { CareerLevel, CareerPathId } from './careers';
+import {
+  growthSignature,
+  isValidGrowthProfile,
+} from './growth';
+import {
+  COMPANY_CHARTERS,
+  COMPANY_CHARTER_ORDER,
+  chooseCompanyCharter,
+  companyCharterMetrics,
+  companyCharterScorecard,
+  companyCharterTierEligible,
+  isValidCompanyCharterProgress,
+} from './charters';
+import type {
+  CompanyCharterId,
+  CompanyCharterMetrics,
+} from './charters';
+
+const STAT_ORDER: Array<keyof StatBlock> = ['str', 'dex', 'int', 'cha', 'con'];
+const STAT_LABELS: Record<keyof StatBlock, string> = {
+  str: '力量', dex: '敏捷', int: '智力', cha: '魅力', con: '體質',
+};
+
+export type DossierAuditSeverity = 'warning' | 'error';
+
+export interface DossierAuditItem {
+  code: string;
+  severity: DossierAuditSeverity;
+  message: string;
+}
+
+export interface DossierStat {
+  id: keyof StatBlock;
+  name: string;
+  base: number;
+  effective: number;
+  potential: number | null;
+}
+
+export interface DossierCareerEntry {
+  level: CareerLevel;
+  pathId: CareerPathId | null;
+  name: string;
+  score: number | null;
+}
+
+export interface DossierMember {
+  id: string;
+  name: string;
+  job: string;
+  level: number;
+  row: FormationRow | 'reserve';
+  role: ExpeditionRole | null;
+  roleName: string | null;
+  injuredForTrips: number;
+  bond: number;
+  equippedSlots: number;
+}
+
+export interface DossierCharterScore {
+  id: CompanyCharterId;
+  name: string;
+  desc: string;
+  score: number;
+  locked: boolean;
+}
+
+export interface DossierRequirement {
+  id: string;
+  label: string;
+  current: string;
+  target: string;
+  met: boolean;
+}
+
+export interface DossierCharter {
+  currentId: CompanyCharterId | null;
+  currentName: string;
+  currentTier: number;
+  candidateId: CompanyCharterId | null;
+  candidateName: string;
+  scores: DossierCharterScore[];
+  nextTier: 1 | 2 | 3 | null;
+  nextTierEligible: boolean;
+  requirements: DossierRequirement[];
+  metrics: CompanyCharterMetrics;
+}
+
+export interface CompanyDossier {
+  generatedFromVersion: number;
+  protagonist: {
+    name: string;
+    job: string;
+    level: number;
+    xp: number;
+    maxHp: number;
+    genesis: string;
+    lifepath: string;
+    aptitude: string;
+    burden: string;
+    growthSignature: string;
+    stats: DossierStat[];
+    careers: DossierCareerEntry[];
+  };
+  company: {
+    gold: number;
+    reputation: number;
+    wagonLevel: number;
+    inventoryKinds: number;
+    companionCount: number;
+    activeCount: number;
+    members: DossierMember[];
+  };
+  charter: DossierCharter;
+  audit: DossierAuditItem[];
+}
+
+function req(
+  id: string,
+  label: string,
+  current: number | boolean,
+  target: number | boolean,
+  met: boolean,
+): DossierRequirement {
+  const show = (value: number | boolean) => typeof value === 'boolean' ? (value ? '已完成' : '未完成') : String(value);
+  return { id, label, current: show(current), target: show(target), met };
+}
+
+/**
+ * 與 M26 companyCharterTierEligible 使用相同門檻，拆成玩家可讀的逐項清單。
+ * dossier 測試會對大量邊界快照比對 every(met) 與正式 eligibility，防止規則漂移。
+ */
+export function dossierCharterRequirements(
+  save: SaveData,
+  id: CompanyCharterId,
+  tier: 1 | 2 | 3,
+): DossierRequirement[] {
+  const m = companyCharterMetrics(save);
+  if (tier === 1) {
+    return [
+      req('reputation', '商隊聲望', save.reputation, 10, save.reputation >= 10),
+      req('career', '至少形成一個職涯里程碑', m.careerCount, 1, m.careerCount >= 1),
+    ];
+  }
+
+  if (tier === 2) {
+    switch (id) {
+      case 'iron-vanguard':
+        return [
+          req('reputation', '商隊聲望', save.reputation, 25, save.reputation >= 25),
+          req('martial-front', '武鬥里程碑至少 2，或前排至少 2 人', Math.max(m.careerCounts.martial, m.frontCount), 2, m.careerCounts.martial >= 2 || m.frontCount >= 2),
+          req('armed-plus', '出征武器至少 2，或裝備強化總和至少 1', Math.max(m.armedCount, m.equipmentPlusTotal), 2, m.armedCount >= 2 || m.equipmentPlusTotal >= 1),
+        ];
+      case 'far-horizon':
+        return [
+          req('reputation', '商隊聲望', save.reputation, 25, save.reputation >= 25),
+          req('scouting-role', '斥候里程碑至少 2，或已指派斥候', Math.max(m.careerCounts.scouting, m.hasScout ? 2 : 0), 2, m.careerCounts.scouting >= 2 || m.hasScout),
+          req('route-supplies', '路線補給總數', m.routeSupplies, 2, m.routeSupplies >= 2),
+          req('discovery', '已發現地點', m.discoveredCount, 1, m.discoveredCount >= 1),
+        ];
+      case 'ledger-guild':
+        return [
+          req('reputation', '商隊聲望', save.reputation, 25, save.reputation >= 25),
+          req('ledger-careers', '交涉與學識里程碑合計', m.careerCounts.negotiation + m.careerCounts.lore, 2, m.careerCounts.negotiation + m.careerCounts.lore >= 2),
+          req('quartermaster-wagon', '已指派軍需官，或馬車至少 Lv1', Math.max(m.hasQuartermaster ? 1 : 0, save.wagonLevel), 1, m.hasQuartermaster || save.wagonLevel >= 1),
+          req('gold', '持有金幣', save.gold, 250, save.gold >= 250),
+        ];
+      case 'bound-fellowship':
+        return [
+          req('reputation', '商隊聲望', save.reputation, 20, save.reputation >= 20),
+          req('companions', '旅伴人數', m.companionCount, 2, m.companionCount >= 2),
+          req('career-variety', '不同職涯種類', m.distinctCareers, 2, m.distinctCareers >= 2),
+          req('bond', '旅伴羈絆總和', m.bondTotal, 2, m.bondTotal >= 2),
+          req('roles', '有效遠征職務', m.assignedRoles, 2, m.assignedRoles >= 2),
+        ];
+      case 'relic-covenant':
+        return [
+          req('reputation', '商隊聲望', save.reputation, 25, save.reputation >= 25),
+          req('boss', '已擊破首領地城', m.bossCount, 1, m.bossCount >= 1),
+          req('relic-careers', '學識與生存里程碑合計', m.careerCounts.lore + m.careerCounts.survival, 2, m.careerCounts.lore + m.careerCounts.survival >= 2),
+          req('relic-assets', '遺珍物資至少 2，或強化總和至少 1', Math.max(m.relicSupplies, m.equipmentPlusTotal), 2, m.relicSupplies >= 2 || m.equipmentPlusTotal >= 1),
+        ];
+    }
+  }
+
+  switch (id) {
+    case 'iron-vanguard':
+      return [
+        req('reputation', '商隊聲望', save.reputation, 50, save.reputation >= 50),
+        req('martial', '武鬥里程碑', m.careerCounts.martial, 3, m.careerCounts.martial >= 3),
+        req('front', '前排出征者', m.frontCount, 2, m.frontCount >= 2),
+        req('equipment', '出征裝備欄總數', m.equippedCount, 6, m.equippedCount >= 6),
+      ];
+    case 'far-horizon':
+      return [
+        req('reputation', '商隊聲望', save.reputation, 50, save.reputation >= 50),
+        req('scouting', '斥候里程碑', m.careerCounts.scouting, 3, m.careerCounts.scouting >= 3),
+        req('scout-role', '指派有效斥候', m.hasScout, true, m.hasScout),
+        req('discovery', '已發現地點', m.discoveredCount, 2, m.discoveredCount >= 2),
+      ];
+    case 'ledger-guild':
+      return [
+        req('reputation', '商隊聲望', save.reputation, 50, save.reputation >= 50),
+        req('ledger-careers', '交涉與學識里程碑合計', m.careerCounts.negotiation + m.careerCounts.lore, 3, m.careerCounts.negotiation + m.careerCounts.lore >= 3),
+        req('wagon', '馬車等級', save.wagonLevel, 2, save.wagonLevel >= 2),
+        req('gold', '持有金幣', save.gold, 500, save.gold >= 500),
+      ];
+    case 'bound-fellowship':
+      return [
+        req('reputation', '商隊聲望', save.reputation, 45, save.reputation >= 45),
+        req('companions', '旅伴人數', m.companionCount, 3, m.companionCount >= 3),
+        req('career-variety', '不同職涯種類', m.distinctCareers, 3, m.distinctCareers >= 3),
+        req('bond', '旅伴羈絆總和', m.bondTotal, 6, m.bondTotal >= 6),
+        req('roles', '有效遠征職務', m.assignedRoles, 3, m.assignedRoles >= 3),
+      ];
+    case 'relic-covenant':
+      return [
+        req('reputation', '商隊聲望', save.reputation, 50, save.reputation >= 50),
+        req('boss', '已擊破首領地城', m.bossCount, 2, m.bossCount >= 2),
+        req('relic-careers', '學識與生存里程碑合計', m.careerCounts.lore + m.careerCounts.survival, 3, m.careerCounts.lore + m.careerCounts.survival >= 3),
+        req('plus', '出征裝備強化總和', m.equipmentPlusTotal, 2, m.equipmentPlusTotal >= 2),
+      ];
+  }
+}
+
+function equippedSlots(record: CompanionRecord): number {
+  return Object.values(record.equipment).filter((id) => typeof id === 'string' && id.length > 0).length;
+}
+
+function buildAudit(save: SaveData): DossierAuditItem[] {
+  const audit: DossierAuditItem[] = [];
+  const protagonist = save.protagonist as CompanionRecord;
+  const genesis = protagonist.genesis;
+  if (genesis) {
+    if (!isGenesisTraitId(genesis.lifepathId) || !(genesis.aptitudeId in GENESIS_APTITUDES) || !(genesis.burdenId in GENESIS_BURDENS)) {
+      audit.push({ code: 'invalid-genesis', severity: 'error', message: '角色命運資料包含不存在的出身、天賦或缺陷。' });
+    }
+    if (!protagonist.growth) {
+      audit.push({ code: 'missing-growth', severity: 'error', message: '角色已有命運，但缺少五維潛力資料。' });
+    }
+  }
+  if (protagonist.growth && !isValidGrowthProfile(protagonist.growth)) {
+    audit.push({ code: 'invalid-growth', severity: 'error', message: '五維潛力超出 1～5 或缺少欄位，遊戲不應給予成長加成。' });
+  }
+  if (protagonist.growth && (!Number.isInteger(protagonist.growthRealizedLevel) || (protagonist.growthRealizedLevel ?? 0) < 1 || (protagonist.growthRealizedLevel ?? 0) > 5)) {
+    audit.push({ code: 'growth-level', severity: 'warning', message: '潛力實現等級標記無效，下一次保存會依目前等級重新整理。' });
+  }
+
+  const milestones = Array.isArray(protagonist.careerMilestones) ? protagonist.careerMilestones : [];
+  const validLevels = milestones.filter(isValidCareerMilestone).map((m) => m.level);
+  if (milestones.some((m) => !isValidCareerMilestone(m))) {
+    audit.push({ code: 'invalid-career', severity: 'warning', message: '職涯歷史包含非法紀錄，下一次進度交易會忽略該筆資料。' });
+  }
+  if (new Set(validLevels).size !== validLevels.length) {
+    audit.push({ code: 'duplicate-career', severity: 'warning', message: '同一等級存在重複職涯紀錄，可能阻礙正確的里程碑顯示。' });
+  }
+
+  if (save.companyCharter !== undefined && !isValidCompanyCharterProgress(save.companyCharter)) {
+    audit.push({ code: 'invalid-charter', severity: 'error', message: '商隊特許資料無效，不能據此發放章節獎勵。' });
+  }
+  if (isValidCompanyCharterProgress(save.companyCharter)) {
+    for (let tier = 1; tier <= save.companyCharter.tier; tier++) {
+      const receipt = `company-charter-reward:${save.companyCharter.id}:${tier}`;
+      if (!save.flags[receipt]) {
+        audit.push({ code: `missing-receipt-${tier}`, severity: 'warning', message: `特許第 ${tier} 章缺少獎勵收據旗標，進度與資源可能不同步。` });
+      }
+    }
+  }
+
+  const members = [save.protagonist, ...save.companions];
+  const ids = new Set(members.map((member) => member.id));
+  const plan = save.expeditionPlan;
+  if (plan) {
+    if (new Set(plan.activeIds).size !== plan.activeIds.length) {
+      audit.push({ code: 'duplicate-active', severity: 'warning', message: '出征名單包含重複角色。' });
+    }
+    if (plan.activeIds.some((id) => !ids.has(id))) {
+      audit.push({ code: 'missing-active', severity: 'warning', message: '出征名單包含已不存在的角色。' });
+    }
+    const roleIds = Object.values(plan.roles).filter((id): id is string => typeof id === 'string');
+    if (new Set(roleIds).size !== roleIds.length) {
+      audit.push({ code: 'duplicate-role', severity: 'warning', message: '同一角色被指派到多個互斥遠征職務。' });
+    }
+    if (roleIds.some((id) => !plan.activeIds.includes(id))) {
+      audit.push({ code: 'reserve-role', severity: 'warning', message: '遠征職務指派給未出征的角色。' });
+    }
+  }
+
+  for (const member of members) {
+    for (const [slot, itemId] of Object.entries(member.equipment)) {
+      if (itemId && !ITEMS[itemId]) {
+        audit.push({ code: `unknown-equipment-${member.id}-${slot}`, severity: 'error', message: `${member.name} 的${slot}欄引用不存在的裝備「${itemId}」。` });
+      }
+    }
+    for (const [skillId, rank] of Object.entries(member.skills ?? {})) {
+      if (!Number.isInteger(rank) || rank < 0 || rank > 5 || !(skillId in CAREER_PATHS)) {
+        audit.push({ code: `invalid-skill-${member.id}-${skillId}`, severity: 'error', message: `${member.name} 的技能「${skillId}」rank ${rank} 不合法。` });
+      }
+    }
+    for (const stat of STAT_ORDER) {
+      if (!Number.isFinite(member.stats[stat])) {
+        audit.push({ code: `invalid-stat-${member.id}-${stat}`, severity: 'error', message: `${member.name} 的${STAT_LABELS[stat]}不是有效數字。` });
+      }
+    }
+  }
+  for (const [itemId, count] of Object.entries(save.inventory)) {
+    if (!ITEMS[itemId]) audit.push({ code: `unknown-item-${itemId}`, severity: 'warning', message: `背包包含不存在的物品「${itemId}」。` });
+    if (!Number.isInteger(count) || count < 0) audit.push({ code: `invalid-count-${itemId}`, severity: 'error', message: `物品「${itemId}」數量 ${count} 不合法。` });
+  }
+  return audit;
+}
+
+/** 建立只讀商隊檔案；不會寫入、補發獎勵或正規化原始存檔。 */
+export function buildCompanyDossier(save: SaveData): CompanyDossier {
+  const protagonist = save.protagonist;
+  const effective = effectiveStats(protagonist);
+  const genesis = protagonist.genesis;
+  const stats: DossierStat[] = STAT_ORDER.map((id) => ({
+    id,
+    name: STAT_LABELS[id],
+    base: protagonist.stats[id],
+    effective: effective[id],
+    potential: isValidGrowthProfile(protagonist.growth) ? protagonist.growth.potential[id] : null,
+  }));
+
+  const careerByLevel = new Map(
+    (protagonist.careerMilestones ?? [])
+      .filter(isValidCareerMilestone)
+      .map((milestone) => [milestone.level, milestone]),
+  );
+  const careers: DossierCareerEntry[] = CAREER_LEVELS.map((level) => {
+    const milestone = careerByLevel.get(level);
+    return milestone
+      ? { level, pathId: milestone.pathId, name: CAREER_PATHS[milestone.pathId].name, score: milestone.score }
+      : { level, pathId: null, name: '尚未形成', score: null };
+  });
+
+  const plan = normalizeExpeditionPlan(save);
+  const memberMap = new Map([save.protagonist, ...save.companions].map((member) => [member.id, member]));
+  const activeSet = new Set(plan.activeIds);
+  const members: DossierMember[] = [save.protagonist, ...save.companions].map((member) => {
+    const active = activeSet.has(member.id);
+    const role = active ? memberRole(plan, member.id) : null;
+    return {
+      id: member.id,
+      name: member.name,
+      job: JOBS[member.job].name,
+      level: member.level,
+      row: active ? (plan.positions[member.id] ?? 'front') : 'reserve',
+      role,
+      roleName: role ? EXPEDITION_ROLES[role].name : null,
+      injuredForTrips: member.injuredForTrips,
+      bond: member.bond ?? 0,
+      equippedSlots: equippedSlots(member),
+    };
+  });
+  void memberMap;
+
+  const metrics = companyCharterMetrics(save);
+  const scorecard = companyCharterScorecard(save);
+  const current = isValidCompanyCharterProgress(save.companyCharter) ? save.companyCharter : null;
+  const candidateId = current?.id ?? chooseCompanyCharter(save);
+  const scores = COMPANY_CHARTER_ORDER
+    .map((id) => ({
+      id,
+      name: COMPANY_CHARTERS[id].name,
+      desc: COMPANY_CHARTERS[id].desc,
+      score: scorecard[id],
+      locked: current?.id === id,
+    }))
+    .sort((a, b) => b.score - a.score || COMPANY_CHARTER_ORDER.indexOf(a.id) - COMPANY_CHARTER_ORDER.indexOf(b.id));
+  const nextTier = current
+    ? (current.tier < 3 ? (current.tier + 1) as 1 | 2 | 3 : null)
+    : 1;
+  const targetId = current?.id ?? candidateId;
+  const requirements = targetId && nextTier ? dossierCharterRequirements(save, targetId, nextTier) : [];
+  const nextTierEligible = targetId && nextTier
+    ? companyCharterTierEligible(save, targetId, nextTier)
+    : false;
+
+  return {
+    generatedFromVersion: save.version,
+    protagonist: {
+      name: protagonist.name,
+      job: JOBS[protagonist.job].name,
+      level: protagonist.level,
+      xp: protagonist.xp,
+      maxHp: protagonist.maxHp,
+      genesis: genesis ? genesisName(genesis) : '舊版角色／未啟用命運矩陣',
+      lifepath: genesis && isGenesisTraitId(genesis.lifepathId) ? GENESIS_LIFEPATHS[genesis.lifepathId].name : '—',
+      aptitude: genesis && genesis.aptitudeId in GENESIS_APTITUDES ? GENESIS_APTITUDES[genesis.aptitudeId].name : '—',
+      burden: genesis && genesis.burdenId in GENESIS_BURDENS ? GENESIS_BURDENS[genesis.burdenId].name : '—',
+      growthSignature: growthSignature(protagonist.growth),
+      stats,
+      careers,
+    },
+    company: {
+      gold: save.gold,
+      reputation: save.reputation,
+      wagonLevel: save.wagonLevel,
+      inventoryKinds: Object.values(save.inventory).filter((count) => count > 0).length,
+      companionCount: save.companions.length,
+      activeCount: plan.activeIds.length,
+      members,
+    },
+    charter: {
+      currentId: current?.id ?? null,
+      currentName: current ? COMPANY_CHARTERS[current.id].name : '尚未取得特許',
+      currentTier: current?.tier ?? 0,
+      candidateId,
+      candidateName: candidateId ? COMPANY_CHARTERS[candidateId].name : '尚未形成候選',
+      scores,
+      nextTier,
+      nextTierEligible,
+      requirements,
+      metrics,
+    },
+    audit: buildAudit(save),
+  };
+}


### PR DESCRIPTION
## Summary

- add a player-facing `/caravan/dossier` page that reads the real local save and explains character genesis, five-dimensional potential, career history, active formation, charter scores, and next-chapter requirements
- introduce a pure read-only `buildCompanyDossier(save)` model that reuses the same M22–M26 source-of-truth functions instead of duplicating gameplay formulas in the UI
- expose base versus effective stats, potential ratings, four career milestones, active/reserve roster truth, five charter score rankings, locked charter state, and per-requirement progress
- add save auditing for invalid genesis, corrupt growth, duplicate careers, invalid charter progress, missing reward receipts, dirty formation/role data, unknown equipment/items, illegal skill ranks, and invalid counts/stats
- add adversarial tests that prove dossier requirement rows remain logically equivalent to the formal M26 eligibility function across all five charters and all three tiers
- preserve save v6 and keep dossier generation strictly read-only

## Game-design intent

M22–M26 interwove creation, growth, careers, formation, economy, exploration, bonds, and company charters, but the player could not see why a charter formed or what exact systems blocked the next chapter. Hidden complexity is not meaningful choice. M27 turns the interwoven rules into a transparent planning surface without creating a second calculation path.

The dossier uses the same effective-stat, normalized-expedition-plan, career, growth, and charter functions as live gameplay. It shows causal links and performs structural audits, so the page can reveal discrepancies rather than cosmetically hiding them.

## Player adversarial review

- every displayed charter requirement is checked against the formal `companyCharterTierEligible()` result for all five identities and all three chapters
- the page uses the official charter scorecard and metrics, including healthy active-member filtering
- dossier generation never mutates or normalizes the source save
- base, effective, and potential stats remain distinct
- locked charters continue tracking their own next chapter instead of following the current highest score
- invalid genesis, growth, skills, equipment, inventory, formation, roles, receipts, and counts produce explicit audit findings
- legacy no-genesis characters receive a readable dossier without a fake charter candidate

## Scope

- `src/scripts/games/caravan/data/dossier.ts`
- `src/scripts/games/caravan/data/dossier.m27.test.ts`
- `src/pages/caravan/dossier.astro`

No dependency, lockfile, generated-output, asset, save-version, or gameplay reward changes.