### PR TITLE
feat(caravan): add M28 interwoven company initiatives

### DIFF
--- a/src/pages/caravan/initiatives.astro
+++ b/src/pages/caravan/initiatives.astro
@@ -1,0 +1,278 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="商隊長程計畫 — 商隊與劍"
+  description="規劃跨鎮護運、遠境測繪、交易聯盟、同袍議事與遺珍研究工程。"
+  lang="zh-TW"
+>
+  <main class="initiative-page">
+    <header class="initiative-hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD</p>
+      <h1>商隊長程計畫</h1>
+      <p>把角色能力、職涯、特許、編隊、資產、探索與羈絆投入永久工程。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/dossier">商隊檔案</a>
+        <a href="/caravan">返回入口</a>
+      </nav>
+    </header>
+
+    <section id="initiative-empty" class="empty-state" hidden>
+      <h2>尚未找到商隊存檔</h2>
+      <p>完成角色創建並開始旅程後，才能規劃長程工程。</p>
+      <a href="/caravan/play">開始旅程</a>
+    </section>
+
+    <div id="initiative-content" hidden>
+      <section class="portfolio panel">
+        <div>
+          <p class="section-kicker">工程組合限制</p>
+          <h2>3 個基礎工程、2 個擴建工程、1 個終局工程</h2>
+          <p>完成的方案不可撤銷；每階名額由所有工程共同競爭。</p>
+        </div>
+        <div id="capacity-grid" class="capacity-grid"></div>
+      </section>
+
+      <section id="initiative-warnings" class="warning-panel" hidden></section>
+      <section id="project-list" class="project-list"></section>
+    </div>
+
+    <div id="initiative-toast" class="toast" hidden role="status"></div>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    buildCompanyInitiativeBoard,
+    completeCompanyInitiative,
+  } from '@scripts/games/caravan/data/initiatives';
+  import type {
+    CompanyInitiativeId,
+    CompanyInitiativeOption,
+    CompanyInitiativeRouteId,
+    CompanyInitiativeStage,
+    InitiativeCost,
+    InitiativeReward,
+  } from '@scripts/games/caravan/data/initiatives';
+  import { ITEMS } from '@scripts/games/caravan/data/items';
+
+  const byId = (id: string) => document.getElementById(id)!;
+  let save = loadGame();
+
+  const formatItems = (items: Record<string, number> | undefined): string[] =>
+    Object.entries(items ?? {}).map(([id, count]) => `${ITEMS[id]?.name ?? id} ×${count}`);
+
+  function formatCost(cost: InitiativeCost): string[] {
+    const parts: string[] = [];
+    if (cost.gold) parts.push(`${cost.gold} G`);
+    if (cost.skillPoints) parts.push(`自由技能點 ${cost.skillPoints}`);
+    parts.push(...formatItems(cost.inventory));
+    return parts.length ? parts : ['無額外成本'];
+  }
+
+  function formatReward(reward: InitiativeReward): string[] {
+    const parts: string[] = [];
+    for (const [stat, value] of Object.entries(reward.stats ?? {})) parts.push(`${stat.toUpperCase()} +${value}`);
+    if (reward.maxHp) parts.push(`生命 +${reward.maxHp}`);
+    if (reward.skill) parts.push(`${reward.skill.id} rank +${reward.skill.amount}`);
+    if (reward.skillPoints) parts.push(`自由技能點 +${reward.skillPoints}`);
+    if (reward.gold) parts.push(`金幣 +${reward.gold}`);
+    if (reward.reputation) parts.push(`聲望 +${reward.reputation}`);
+    if (reward.wagonLevels) parts.push(`馬車等級 +${reward.wagonLevels}`);
+    if (reward.bondAll) parts.push(`全旅伴羈絆 +${reward.bondAll}`);
+    parts.push(...formatItems(reward.inventory));
+    return parts.length ? parts : ['完成紀錄'];
+  }
+
+  function showToast(message: string, kind: 'ok' | 'error' = 'ok'): void {
+    const toast = byId('initiative-toast');
+    toast.textContent = message;
+    toast.className = `toast ${kind}`;
+    toast.removeAttribute('hidden');
+  }
+
+  function optionCard(option: CompanyInitiativeOption): HTMLElement {
+    const article = document.createElement('article');
+    article.className = `route-card ${option.available ? 'available' : 'blocked'}`;
+
+    const head = document.createElement('div');
+    head.className = 'route-head';
+    const title = document.createElement('h4');
+    title.textContent = option.routeName;
+    const state = document.createElement('span');
+    state.textContent = option.available ? '可執行' : option.affordable ? '條件未達' : '資源不足';
+    head.append(title, state);
+
+    const desc = document.createElement('p');
+    desc.textContent = option.routeDesc;
+
+    const columns = document.createElement('div');
+    columns.className = 'route-columns';
+    const cost = document.createElement('div');
+    cost.innerHTML = `<b>成本</b><ul>${formatCost(option.cost).map((item) => `<li>${item}</li>`).join('')}</ul>`;
+    const reward = document.createElement('div');
+    reward.innerHTML = `<b>成果</b><ul>${formatReward(option.reward).map((item) => `<li>${item}</li>`).join('')}</ul>`;
+    columns.append(cost, reward);
+
+    const requirements = document.createElement('div');
+    requirements.className = 'requirements';
+    for (const entry of option.requirements) {
+      const row = document.createElement('div');
+      row.className = entry.met ? 'met' : 'unmet';
+      row.innerHTML = `<span>${entry.met ? '✓' : '○'} ${entry.label}</span><b>${entry.current} / ${entry.target}</b>`;
+      requirements.appendChild(row);
+    }
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'execute-btn';
+    button.disabled = !option.available;
+    button.textContent = option.available ? `完成第 ${option.stage} 階・${option.routeName}` : option.blockingReasons.join('；');
+    button.addEventListener('click', () => {
+      if (!save) return;
+      try {
+        completeCompanyInitiative(
+          save,
+          option.projectId as CompanyInitiativeId,
+          option.stage as CompanyInitiativeStage,
+          option.routeId as CompanyInitiativeRouteId,
+        );
+        saveGame(save);
+        showToast(`已完成${option.routeName}，成本與成果已寫入存檔。`);
+        render();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : '工程執行失敗', 'error');
+        save = loadGame();
+        render();
+      }
+    });
+
+    article.append(head, desc, columns, requirements, button);
+    return article;
+  }
+
+  function render(): void {
+    if (!save) {
+      byId('initiative-empty').removeAttribute('hidden');
+      byId('initiative-content').setAttribute('hidden', '');
+      return;
+    }
+    byId('initiative-empty').setAttribute('hidden', '');
+    byId('initiative-content').removeAttribute('hidden');
+
+    const board = buildCompanyInitiativeBoard(save);
+    const capacity = byId('capacity-grid');
+    capacity.innerHTML = '';
+    for (const stage of [1, 2, 3] as const) {
+      const card = document.createElement('div');
+      const data = board.stageCapacity[stage];
+      card.className = data.used >= data.cap ? 'full' : '';
+      card.innerHTML = `<b>第 ${stage} 階</b><strong>${data.used} / ${data.cap}</strong><span>${data.used >= data.cap ? '名額已滿' : '仍可投資'}</span>`;
+      capacity.appendChild(card);
+    }
+
+    const warningPanel = byId('initiative-warnings');
+    warningPanel.innerHTML = '';
+    if (board.warnings.length) {
+      warningPanel.removeAttribute('hidden');
+      warningPanel.innerHTML = `<h2>工程資料警告</h2>${board.warnings.map((warning) => `<p>${warning}</p>`).join('')}`;
+    } else {
+      warningPanel.setAttribute('hidden', '');
+    }
+
+    const list = byId('project-list');
+    list.innerHTML = '';
+    for (const project of board.projects) {
+      const section = document.createElement('section');
+      section.className = 'project panel';
+      const header = document.createElement('header');
+      header.innerHTML = `
+        <div><p class="section-kicker">長程工程</p><h2>${project.name}</h2><p>${project.desc}</p></div>
+        <strong>${project.completedStage === 3 ? '全部完成' : `完成 ${project.completedStage}/3`}</strong>
+      `;
+
+      const history = document.createElement('div');
+      history.className = 'history';
+      for (const entry of project.history) {
+        const item = document.createElement('div');
+        item.className = entry.routeId ? 'done' : '';
+        if (entry.conflict) item.classList.add('conflict');
+        item.innerHTML = `<b>第 ${entry.stage} 階</b><span>${entry.routeName}</span>`;
+        history.appendChild(item);
+      }
+      section.append(header, history);
+
+      if (project.nextStage) {
+        const next = document.createElement('h3');
+        next.textContent = `第 ${project.nextStage} 階可選方案`;
+        const routes = document.createElement('div');
+        routes.className = 'route-grid';
+        for (const option of project.options) routes.appendChild(optionCard(option));
+        section.append(next, routes);
+      } else {
+        const complete = document.createElement('p');
+        complete.className = 'complete-note';
+        complete.textContent = '此工程已完成全部三階段。';
+        section.appendChild(complete);
+      }
+      list.appendChild(section);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { margin: 0; background: #17130f; color: #efe4cc; }
+  .initiative-page { min-height: 100vh; padding: 0 1rem 4rem; font-family: 'Noto Serif TC', serif; background: radial-gradient(circle at top, #403221 0, #17130f 34rem); }
+  .initiative-hero { max-width: 72rem; margin: 0 auto; padding: 3.5rem 0 2rem; text-align: center; }
+  .eyebrow, .section-kicker { color: #d3a75d; letter-spacing: .25em; font-size: .76rem; }
+  h1 { margin: .2rem 0; font-size: clamp(2.2rem, 7vw, 4.4rem); }
+  .initiative-hero nav { display: flex; justify-content: center; flex-wrap: wrap; gap: .7rem; margin-top: 1.4rem; }
+  a, button { font: inherit; }
+  .initiative-hero a, .empty-state a { color: #fff1cd; border: 1px solid #a9844e; padding: .55rem 1rem; text-decoration: none; }
+  .panel, .warning-panel, .empty-state { max-width: 72rem; margin: 1rem auto; padding: 1.25rem; border: 1px solid #5c4930; background: rgba(29, 23, 17, .93); box-shadow: 0 14px 40px rgba(0,0,0,.22); }
+  .portfolio { display: flex; justify-content: space-between; gap: 1.5rem; align-items: center; }
+  .capacity-grid { display: grid; grid-template-columns: repeat(3, minmax(7rem, 1fr)); gap: .6rem; min-width: min(100%, 28rem); }
+  .capacity-grid > div { padding: .7rem; background: #262017; border: 1px solid #5c4930; display: grid; gap: .25rem; text-align: center; }
+  .capacity-grid strong { font-size: 1.35rem; color: #ebc26e; }
+  .capacity-grid .full { border-color: #9a4c3b; }
+  .project header { display: flex; justify-content: space-between; gap: 1rem; align-items: start; }
+  .project h2 { margin: .2rem 0; }
+  .project header > strong { color: #ebc26e; white-space: nowrap; }
+  .history { display: grid; grid-template-columns: repeat(3, 1fr); gap: .6rem; margin: 1rem 0; }
+  .history > div { display: flex; justify-content: space-between; padding: .65rem; background: #211b15; color: #837969; }
+  .history .done { color: #dfd1b5; border-left: 3px solid #72a779; }
+  .history .conflict { border-color: #c65c4a; }
+  .route-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; }
+  .route-card { padding: 1rem; border: 1px solid #55442e; background: #201a14; display: flex; flex-direction: column; gap: .7rem; }
+  .route-card.available { border-color: #b28b4d; }
+  .route-card.blocked { opacity: .76; }
+  .route-head { display: flex; justify-content: space-between; gap: .5rem; align-items: center; }
+  .route-head h4 { margin: 0; font-size: 1.15rem; }
+  .route-head span { font-size: .75rem; color: #d0a861; }
+  .route-columns { display: grid; grid-template-columns: 1fr 1fr; gap: .7rem; font-size: .84rem; }
+  ul { margin: .35rem 0 0; padding-left: 1.15rem; }
+  .requirements { display: grid; gap: .3rem; }
+  .requirements > div { display: flex; justify-content: space-between; gap: .6rem; font-size: .78rem; padding: .3rem .4rem; background: #18130f; }
+  .requirements .met { color: #9fcf9d; }
+  .requirements .unmet { color: #d59b8a; }
+  .execute-btn { margin-top: auto; padding: .65rem; border: 1px solid #a9844e; background: #8c552f; color: #fff2d7; cursor: pointer; }
+  .execute-btn:disabled { cursor: not-allowed; background: #302820; color: #817668; border-color: #4c4032; }
+  .warning-panel { border-color: #9a4c3b; color: #f2b5a8; }
+  .toast { position: fixed; right: 1rem; bottom: 1rem; max-width: 24rem; padding: .9rem 1rem; background: #28442d; border: 1px solid #72a779; box-shadow: 0 8px 30px rgba(0,0,0,.4); }
+  .toast.error { background: #552b24; border-color: #c65c4a; }
+  .complete-note { color: #9fcf9d; }
+  @media (max-width: 850px) {
+    .portfolio, .project header { display: block; }
+    .capacity-grid { margin-top: 1rem; }
+    .route-grid { grid-template-columns: 1fr; }
+  }
+  @media (max-width: 520px) {
+    .capacity-grid, .history { grid-template-columns: 1fr; }
+    .route-columns { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/scripts/games/caravan/data/initiatives.m28.test.ts
+++ b/src/scripts/games/caravan/data/initiatives.m28.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import { ITEMS } from './items';
+import {
+  COMPANY_INITIATIVE_ORDER,
+  buildCompanyInitiativeBoard,
+  buildCompanyInitiativeOption,
+  completeCompanyInitiative,
+  initiativeCompletedStage,
+  initiativeReceiptKey,
+  initiativeStageUsage,
+  nextInitiativeStage,
+} from './initiatives';
+import type {
+  CompanyInitiativeId,
+  CompanyInitiativeRouteId,
+  CompanyInitiativeStage,
+} from './initiatives';
+import { newGame } from '../save';
+import type { CompanionRecord, SaveData } from '../save';
+
+function companion(id: string, bond = 3): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job: id.endsWith('1') ? 'swordsman' : id.endsWith('2') ? 'ranger' : 'cleric',
+    level: 5,
+    xp: 0,
+    stats: { str: 14, dex: 14, int: 14, cha: 14, con: 14 },
+    maxHp: 24,
+    injuredForTrips: 0,
+    equipment: {
+      weapon: 'salt-crystal-blade',
+      armor: 'saltforged-mail',
+      trinket: 'den-idol',
+    },
+    equipmentPlus: { weapon: 2, armor: 2, trinket: 1 },
+    bond,
+  };
+}
+
+function matureSave(): SaveData {
+  const save = newGame(100, {
+    job: 'swordsman',
+    trait: 'seasoned',
+    statRoll: { str: 15, dex: 14, int: 13, cha: 14, con: 14 },
+    allocation: { int: 1, cha: 1, con: 1 },
+  });
+  save.protagonist.level = 5;
+  save.protagonist.stats = { str: 18, dex: 18, int: 18, cha: 18, con: 18 };
+  save.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+  save.protagonist.skillPoints = 12;
+  save.protagonist.careerMilestones = [
+    { level: 2, pathId: 'martial', score: 20 },
+    { level: 3, pathId: 'scouting', score: 20 },
+    { level: 4, pathId: 'lore', score: 20 },
+    { level: 5, pathId: 'negotiation', score: 20 },
+  ];
+  save.companyCharter = { id: 'bound-fellowship', tier: 3 };
+  save.flags['company-charter:bound-fellowship'] = true;
+  for (let tier = 1; tier <= 3; tier++) save.flags[`company-charter-reward:bound-fellowship:${tier}`] = true;
+  save.reputation = 100;
+  save.gold = 5000;
+  save.wagonLevel = 5;
+  save.inventory = {
+    ore: 30,
+    'tattered-map': 30,
+    torch: 30,
+    'dried-rations': 30,
+    salt: 30,
+    'spice-pouch': 30,
+    bandage: 30,
+    'war-tonic': 30,
+  };
+  save.flags['discovered:a'] = true;
+  save.flags['discovered:b'] = true;
+  save.flags['discovered:c'] = true;
+  save.visitedBossDungeons = ['boss-a', 'boss-b', 'boss-c'];
+  save.companions = [companion('c1'), companion('c2'), companion('c3')];
+  save.protagonist.equipment = {
+    weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol',
+  };
+  save.protagonist.equipmentPlus = { weapon: 2, armor: 2, trinket: 2 };
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'c1', 'c2', 'c3'],
+    positions: { protagonist: 'front', c1: 'front', c2: 'back', c3: 'back' },
+    roles: { captain: 'protagonist', scout: 'c2', quartermaster: 'c3', medic: 'c1' },
+  };
+  return save;
+}
+
+function completePriorStages(save: SaveData, projectId: CompanyInitiativeId, upTo: number): void {
+  for (let stage = 1; stage <= upTo; stage++) {
+    save.flags[initiativeReceiptKey(projectId, stage as CompanyInitiativeStage, 'expertise')] = true;
+  }
+}
+
+describe('M28 company initiatives', () => {
+  it('defines three genuinely different available routes for every project and stage on a mature save', () => {
+    for (const projectId of COMPANY_INITIATIVE_ORDER) {
+      for (const stage of [1, 2, 3] as CompanyInitiativeStage[]) {
+        const save = matureSave();
+        completePriorStages(save, projectId, stage - 1);
+        const options = (['expertise', 'capital', 'field'] as CompanyInitiativeRouteId[])
+          .map((route) => buildCompanyInitiativeOption(save, projectId, stage, route));
+        expect(options.every((option) => option.available)).toBe(true);
+        expect(new Set(options.map((option) => JSON.stringify(option.cost))).size).toBe(3);
+        expect(new Set(options.map((option) => JSON.stringify(option.reward))).size).toBe(3);
+      }
+    }
+  });
+
+  it('references only real items in all costs and rewards', () => {
+    for (const projectId of COMPANY_INITIATIVE_ORDER) {
+      for (const stage of [1, 2, 3] as CompanyInitiativeStage[]) {
+        const save = matureSave();
+        completePriorStages(save, projectId, stage - 1);
+        for (const route of ['expertise', 'capital', 'field'] as CompanyInitiativeRouteId[]) {
+          const option = buildCompanyInitiativeOption(save, projectId, stage, route);
+          for (const itemId of Object.keys(option.cost.inventory ?? {})) expect(ITEMS[itemId]).toBeDefined();
+          for (const itemId of Object.keys(option.reward.inventory ?? {})) expect(ITEMS[itemId]).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('is atomic when requirements or resources fail', () => {
+    const save = matureSave();
+    save.protagonist.skillPoints = 0;
+    const before = JSON.stringify(save);
+    expect(() => completeCompanyInitiative(save, 'escort-network', 1, 'expertise')).toThrow();
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('cannot repeat the same stage or farm a second route', () => {
+    const save = matureSave();
+    const first = completeCompanyInitiative(save, 'escort-network', 1, 'expertise');
+    const after = JSON.stringify(save);
+    expect(first.available).toBe(true);
+    expect(() => completeCompanyInitiative(save, 'escort-network', 1, 'capital')).toThrow();
+    expect(JSON.stringify(save)).toBe(after);
+  });
+
+  it('cannot skip project stages', () => {
+    const save = matureSave();
+    expect(nextInitiativeStage(save, 'frontier-office')).toBe(1);
+    expect(() => completeCompanyInitiative(save, 'frontier-office', 2, 'field')).toThrow(/先完成第 1 階/);
+    expect(initiativeCompletedStage(save, 'frontier-office')).toBe(0);
+  });
+
+  it('enforces global 3/2/1 portfolio caps', () => {
+    const save = matureSave();
+    for (const projectId of COMPANY_INITIATIVE_ORDER.slice(0, 3)) {
+      completeCompanyInitiative(save, projectId, 1, 'expertise');
+    }
+    expect(initiativeStageUsage(save, 1)).toBe(3);
+    const fourth = buildCompanyInitiativeOption(save, 'fellowship-hall', 1, 'expertise');
+    expect(fourth.available).toBe(false);
+    expect(fourth.requirements.find((requirement) => requirement.id === 'stage-capacity')?.met).toBe(false);
+  });
+
+  it('capital routes cannot immediately print more gold than they cost', () => {
+    for (const projectId of COMPANY_INITIATIVE_ORDER) {
+      for (const stage of [1, 2, 3] as CompanyInitiativeStage[]) {
+        const save = matureSave();
+        completePriorStages(save, projectId, stage - 1);
+        const option = buildCompanyInitiativeOption(save, projectId, stage, 'capital');
+        expect(option.reward.gold ?? 0).toBeLessThan(option.cost.gold ?? 0);
+      }
+    }
+  });
+
+  it('caps skill rewards at rank 5 and wagon rewards at level 6', () => {
+    const save = matureSave();
+    save.protagonist.skills!.martial = 5;
+    completeCompanyInitiative(save, 'escort-network', 1, 'expertise');
+    completeCompanyInitiative(save, 'escort-network', 2, 'expertise');
+    expect(save.protagonist.skills!.martial).toBe(5);
+
+    const trade = matureSave();
+    trade.wagonLevel = 6;
+    completeCompanyInitiative(trade, 'trade-consortium', 1, 'capital');
+    expect(trade.wagonLevel).toBe(6);
+  });
+
+  it('records irreversible route identity and exact resource deltas', () => {
+    const save = matureSave();
+    const beforePoints = save.protagonist.skillPoints ?? 0;
+    const beforeStr = save.protagonist.stats.str;
+    const option = completeCompanyInitiative(save, 'escort-network', 1, 'expertise');
+    expect(save.flags[initiativeReceiptKey('escort-network', 1, 'expertise')]).toBe(true);
+    expect(save.protagonist.skillPoints).toBe(beforePoints - (option.cost.skillPoints ?? 0));
+    expect(save.protagonist.stats.str).toBe(beforeStr + (option.reward.stats?.str ?? 0));
+  });
+
+  it('detects conflicting receipt corruption without granting anything', () => {
+    const save = matureSave();
+    save.flags[initiativeReceiptKey('relic-workshop', 1, 'expertise')] = true;
+    save.flags[initiativeReceiptKey('relic-workshop', 1, 'capital')] = true;
+    const before = JSON.stringify(save);
+    const board = buildCompanyInitiativeBoard(save);
+    const project = board.projects.find((entry) => entry.id === 'relic-workshop')!;
+    expect(project.history[0].conflict).toBe(true);
+    expect(board.warnings.some((warning) => warning.includes('多個完成收據'))).toBe(true);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('keeps low-system legacy saves outside all available initiative routes', () => {
+    const save = newGame(1);
+    const board = buildCompanyInitiativeBoard(save);
+    expect(board.projects.every((project) => project.options.every((option) => !option.available))).toBe(true);
+    expect(board.stageCapacity[1]).toEqual({ used: 0, cap: 3 });
+  });
+});

--- a/src/scripts/games/caravan/data/initiatives.ts
+++ b/src/scripts/games/caravan/data/initiatives.ts
@@ -1,0 +1,687 @@
+import type { SaveData } from '../save';
+import type { StatBlock } from '../types';
+import { effectiveStats } from '../roster';
+import type { CareerPathId } from './careers';
+import {
+  companyCharterMetrics,
+  isValidCompanyCharterProgress,
+} from './charters';
+import type { CompanyCharterId } from './charters';
+import { ITEMS } from './items';
+
+export type CompanyInitiativeId =
+  | 'escort-network'
+  | 'frontier-office'
+  | 'trade-consortium'
+  | 'fellowship-hall'
+  | 'relic-workshop';
+export type CompanyInitiativeStage = 1 | 2 | 3;
+export type CompanyInitiativeRouteId = 'expertise' | 'capital' | 'field';
+
+export interface CompanyInitiativeDef {
+  id: CompanyInitiativeId;
+  name: string;
+  desc: string;
+  primaryStat: keyof StatBlock;
+  primarySkill: CareerPathId;
+  secondaryStat: keyof StatBlock;
+  capitalItem: string;
+  fieldItems: [string, string];
+  affinity: CompanyCharterId[];
+}
+
+export interface InitiativeRequirement {
+  id: string;
+  label: string;
+  current: string;
+  target: string;
+  met: boolean;
+}
+
+export interface InitiativeCost {
+  gold?: number;
+  skillPoints?: number;
+  inventory?: Record<string, number>;
+}
+
+export interface InitiativeReward {
+  stats?: Partial<StatBlock>;
+  maxHp?: number;
+  skill?: { id: CareerPathId; amount: number };
+  skillPoints?: number;
+  gold?: number;
+  reputation?: number;
+  inventory?: Record<string, number>;
+  wagonLevels?: number;
+  bondAll?: number;
+}
+
+export interface CompanyInitiativeOption {
+  projectId: CompanyInitiativeId;
+  stage: CompanyInitiativeStage;
+  routeId: CompanyInitiativeRouteId;
+  routeName: string;
+  routeDesc: string;
+  requirements: InitiativeRequirement[];
+  cost: InitiativeCost;
+  reward: InitiativeReward;
+  affordable: boolean;
+  available: boolean;
+  blockingReasons: string[];
+}
+
+export interface CompanyInitiativeHistoryEntry {
+  stage: CompanyInitiativeStage;
+  routeId: CompanyInitiativeRouteId | null;
+  routeName: string;
+  conflict: boolean;
+}
+
+export interface CompanyInitiativeCard {
+  id: CompanyInitiativeId;
+  name: string;
+  desc: string;
+  completedStage: number;
+  nextStage: CompanyInitiativeStage | null;
+  history: CompanyInitiativeHistoryEntry[];
+  options: CompanyInitiativeOption[];
+}
+
+export interface CompanyInitiativeBoard {
+  stageCapacity: Record<CompanyInitiativeStage, { used: number; cap: number }>;
+  projects: CompanyInitiativeCard[];
+  warnings: string[];
+}
+
+const INITIATIVE_STAGE_CAP: Record<CompanyInitiativeStage, number> = { 1: 3, 2: 2, 3: 1 };
+const INITIATIVE_ROUTE_ORDER: CompanyInitiativeRouteId[] = ['expertise', 'capital', 'field'];
+const STAGES: CompanyInitiativeStage[] = [1, 2, 3];
+const ROUTE_NAMES: Record<CompanyInitiativeRouteId, string> = {
+  expertise: '專業方案',
+  capital: '資本方案',
+  field: '實地方案',
+};
+const ROUTE_DESCS: Record<CompanyInitiativeRouteId, string> = {
+  expertise: '消耗自由技能點，以角色能力與潛力建立專業體系。',
+  capital: '投入金幣與產業物資，換取商隊基礎設施與組織聲望。',
+  field: '消耗遠征補給，依探索、編隊與羈絆成果完成工程。',
+};
+
+export const COMPANY_INITIATIVE_ORDER: CompanyInitiativeId[] = [
+  'escort-network',
+  'frontier-office',
+  'trade-consortium',
+  'fellowship-hall',
+  'relic-workshop',
+];
+
+export const COMPANY_INITIATIVES: Record<CompanyInitiativeId, CompanyInitiativeDef> = {
+  'escort-network': {
+    id: 'escort-network',
+    name: '跨鎮護運網',
+    desc: '把前排武力、裝備與同袍經驗整理成可複製的護運制度。',
+    primaryStat: 'str', primarySkill: 'martial', secondaryStat: 'con',
+    capitalItem: 'ore', fieldItems: ['bandage', 'war-tonic'],
+    affinity: ['iron-vanguard', 'bound-fellowship'],
+  },
+  'frontier-office': {
+    id: 'frontier-office',
+    name: '遠境測繪局',
+    desc: '整合斥候、補給、地圖與新地點情報，建立穩定拓荒能力。',
+    primaryStat: 'dex', primarySkill: 'scouting', secondaryStat: 'int',
+    capitalItem: 'tattered-map', fieldItems: ['torch', 'dried-rations'],
+    affinity: ['far-horizon', 'relic-covenant'],
+  },
+  'trade-consortium': {
+    id: 'trade-consortium',
+    name: '跨鎮交易聯盟',
+    desc: '結合交涉、帳務、馬車與交易貨，建立長期商業網絡。',
+    primaryStat: 'cha', primarySkill: 'negotiation', secondaryStat: 'int',
+    capitalItem: 'salt', fieldItems: ['spice-pouch', 'salt'],
+    affinity: ['ledger-guild', 'far-horizon'],
+  },
+  'fellowship-hall': {
+    id: 'fellowship-hall',
+    name: '同袍議事廳',
+    desc: '把職涯差異、遠征職務與羈絆轉化為可持續的團隊制度。',
+    primaryStat: 'cha', primarySkill: 'survival', secondaryStat: 'con',
+    capitalItem: 'bandage', fieldItems: ['dried-rations', 'bandage'],
+    affinity: ['bound-fellowship', 'ledger-guild'],
+  },
+  'relic-workshop': {
+    id: 'relic-workshop',
+    name: '遺珍研究工坊',
+    desc: '以首領戰績、學識、強化與遺珍素材建立危險研究體系。',
+    primaryStat: 'int', primarySkill: 'lore', secondaryStat: 'con',
+    capitalItem: 'ore', fieldItems: ['ore', 'tattered-map'],
+    affinity: ['relic-covenant', 'far-horizon'],
+  },
+};
+
+function requirement(
+  id: string,
+  label: string,
+  current: number | boolean,
+  target: number | boolean,
+  met: boolean,
+): InitiativeRequirement {
+  const show = (value: number | boolean) => typeof value === 'boolean'
+    ? (value ? '已完成' : '未完成')
+    : String(value);
+  return { id, label, current: show(current), target: show(target), met };
+}
+
+export function initiativeReceiptKey(
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): string {
+  return `company-initiative:${projectId}:${stage}:${routeId}`;
+}
+
+export function initiativeRoutesAtStage(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): CompanyInitiativeRouteId[] {
+  return INITIATIVE_ROUTE_ORDER.filter((routeId) =>
+    save.flags[initiativeReceiptKey(projectId, stage, routeId)] === true
+  );
+}
+
+export function completedInitiativeRoute(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): CompanyInitiativeRouteId | null {
+  return initiativeRoutesAtStage(save, projectId, stage)[0] ?? null;
+}
+
+export function initiativeStageUsage(
+  save: SaveData,
+  stage: CompanyInitiativeStage,
+): number {
+  return COMPANY_INITIATIVE_ORDER.filter((projectId) =>
+    completedInitiativeRoute(save, projectId, stage) !== null
+  ).length;
+}
+
+export function initiativeCompletedStage(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+): number {
+  let completed = 0;
+  for (const stage of STAGES) {
+    if (!completedInitiativeRoute(save, projectId, stage)) break;
+    completed = stage;
+  }
+  return completed;
+}
+
+export function nextInitiativeStage(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+): CompanyInitiativeStage | null {
+  const next = initiativeCompletedStage(save, projectId) + 1;
+  return next >= 1 && next <= 3 ? next as CompanyInitiativeStage : null;
+}
+
+function initiativeBaseRequirements(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): InitiativeRequirement[] {
+  const project = COMPANY_INITIATIVES[projectId];
+  const metrics = companyCharterMetrics(save);
+  const charter = isValidCompanyCharterProgress(save.companyCharter) ? save.companyCharter : null;
+  const reputationTarget = ({ 1: 10, 2: 25, 3: 45 } as const)[stage];
+  const requirements: InitiativeRequirement[] = [
+    requirement('charter-tier', '商隊特許章節', charter?.tier ?? 0, stage, !!charter && charter.tier >= stage),
+    requirement('career-count', '已形成職涯里程碑', metrics.careerCount, stage, metrics.careerCount >= stage),
+    requirement('reputation', '商隊聲望', save.reputation, reputationTarget, save.reputation >= reputationTarget),
+  ];
+
+  if (stage === 3) {
+    const affinity = !!charter && project.affinity.includes(charter.id);
+    requirements.push(requirement(
+      'charter-affinity',
+      '特許與工程相性，或至少三種職涯形成混合能力',
+      affinity || metrics.distinctCareers >= 3,
+      true,
+      affinity || metrics.distinctCareers >= 3,
+    ));
+  }
+
+  switch (projectId) {
+    case 'escort-network':
+      if (stage === 1) requirements.push(
+        requirement('active', '健康出征人數', metrics.activeCount, 2, metrics.activeCount >= 2),
+        requirement('front', '前排出征人數', metrics.frontCount, 1, metrics.frontCount >= 1),
+        requirement('armed', '持武器出征者', metrics.armedCount, 1, metrics.armedCount >= 1),
+      );
+      if (stage === 2) requirements.push(
+        requirement('active', '健康出征人數', metrics.activeCount, 3, metrics.activeCount >= 3),
+        requirement('front', '前排出征人數', metrics.frontCount, 2, metrics.frontCount >= 2),
+        requirement('escort-careers', '武鬥與生存里程碑合計', metrics.careerCounts.martial + metrics.careerCounts.survival, 2, metrics.careerCounts.martial + metrics.careerCounts.survival >= 2),
+        requirement('plus', '出征裝備強化總和', metrics.equipmentPlusTotal, 1, metrics.equipmentPlusTotal >= 1),
+      );
+      if (stage === 3) requirements.push(
+        requirement('active', '滿編健康出征隊', metrics.activeCount, 4, metrics.activeCount >= 4),
+        requirement('front', '前排出征人數', metrics.frontCount, 2, metrics.frontCount >= 2),
+        requirement('equipment', '出征裝備欄總數', metrics.equippedCount, 6, metrics.equippedCount >= 6),
+        requirement('bond', '旅伴羈絆總和', metrics.bondTotal, 4, metrics.bondTotal >= 4),
+      );
+      break;
+    case 'frontier-office':
+      if (stage === 1) requirements.push(
+        requirement('scout', '斥候里程碑或有效斥候職務', Math.max(metrics.careerCounts.scouting, metrics.hasScout ? 1 : 0), 1, metrics.careerCounts.scouting >= 1 || metrics.hasScout),
+        requirement('supplies', '路線補給總數', metrics.routeSupplies, 2, metrics.routeSupplies >= 2),
+        requirement('back', '後排出征人數', metrics.backCount, 1, metrics.backCount >= 1),
+      );
+      if (stage === 2) requirements.push(
+        requirement('discovery', '已發現地點', metrics.discoveredCount, 1, metrics.discoveredCount >= 1),
+        requirement('back', '後排出征人數', metrics.backCount, 2, metrics.backCount >= 2),
+        requirement('frontier-careers', '斥候與學識里程碑合計', metrics.careerCounts.scouting + metrics.careerCounts.lore, 2, metrics.careerCounts.scouting + metrics.careerCounts.lore >= 2),
+        requirement('supplies', '路線補給總數', metrics.routeSupplies, 3, metrics.routeSupplies >= 3),
+      );
+      if (stage === 3) requirements.push(
+        requirement('discovery', '已發現地點', metrics.discoveredCount, 2, metrics.discoveredCount >= 2),
+        requirement('scout-role', '有效斥候職務', metrics.hasScout, true, metrics.hasScout),
+        requirement('back', '後排出征人數', metrics.backCount, 2, metrics.backCount >= 2),
+        requirement('bond', '旅伴羈絆總和', metrics.bondTotal, 3, metrics.bondTotal >= 3),
+      );
+      break;
+    case 'trade-consortium': {
+      const ledgerCareers = metrics.careerCounts.negotiation + metrics.careerCounts.lore;
+      if (stage === 1) requirements.push(
+        requirement('ledger-careers', '交涉與學識里程碑合計', ledgerCareers, 1, ledgerCareers >= 1),
+        requirement('leadership-role', '有效隊長或軍需官', metrics.hasCaptain || metrics.hasQuartermaster, true, metrics.hasCaptain || metrics.hasQuartermaster),
+        requirement('gold', '持有金幣', save.gold, 150, save.gold >= 150),
+      );
+      if (stage === 2) requirements.push(
+        requirement('wagon', '馬車等級', save.wagonLevel, 1, save.wagonLevel >= 1),
+        requirement('trade-goods', '交易貨物總數', metrics.tradeGoods, 2, metrics.tradeGoods >= 2),
+        requirement('ledger-careers', '交涉與學識里程碑合計', ledgerCareers, 2, ledgerCareers >= 2),
+        requirement('gold', '持有金幣', save.gold, 300, save.gold >= 300),
+      );
+      if (stage === 3) requirements.push(
+        requirement('wagon', '馬車等級', save.wagonLevel, 2, save.wagonLevel >= 2),
+        requirement('gold', '持有金幣', save.gold, 550, save.gold >= 550),
+        requirement('ledger-careers', '交涉與學識里程碑合計', ledgerCareers, 3, ledgerCareers >= 3),
+        requirement('roles', '有效遠征職務', metrics.assignedRoles, 2, metrics.assignedRoles >= 2),
+      );
+      break;
+    }
+    case 'fellowship-hall':
+      if (stage === 1) requirements.push(
+        requirement('companions', '旅伴人數', metrics.companionCount, 2, metrics.companionCount >= 2),
+        requirement('variety', '不同職涯種類', metrics.distinctCareers, 2, metrics.distinctCareers >= 2),
+        requirement('roles', '有效遠征職務', metrics.assignedRoles, 2, metrics.assignedRoles >= 2),
+      );
+      if (stage === 2) requirements.push(
+        requirement('active', '健康出征人數', metrics.activeCount, 3, metrics.activeCount >= 3),
+        requirement('bond', '旅伴羈絆總和', metrics.bondTotal, 3, metrics.bondTotal >= 3),
+        requirement('careers', '已形成職涯里程碑', metrics.careerCount, 3, metrics.careerCount >= 3),
+        requirement('care-role', '有效隊長或醫護', metrics.hasCaptain || metrics.hasMedic, true, metrics.hasCaptain || metrics.hasMedic),
+      );
+      if (stage === 3) requirements.push(
+        requirement('companions', '旅伴人數', metrics.companionCount, 3, metrics.companionCount >= 3),
+        requirement('bond', '旅伴羈絆總和', metrics.bondTotal, 7, metrics.bondTotal >= 7),
+        requirement('roles', '有效遠征職務', metrics.assignedRoles, 3, metrics.assignedRoles >= 3),
+        requirement('variety', '不同職涯種類', metrics.distinctCareers, 3, metrics.distinctCareers >= 3),
+      );
+      break;
+    case 'relic-workshop': {
+      const relicCareers = metrics.careerCounts.lore + metrics.careerCounts.survival;
+      if (stage === 1) requirements.push(
+        requirement('boss', '已擊破首領地城', metrics.bossCount, 1, metrics.bossCount >= 1),
+        requirement('relic-careers', '學識與生存里程碑合計', relicCareers, 1, relicCareers >= 1),
+        requirement('relic-assets', '遺珍物資至少 2，或強化總和至少 1', Math.max(metrics.relicSupplies, metrics.equipmentPlusTotal), 2, metrics.relicSupplies >= 2 || metrics.equipmentPlusTotal >= 1),
+      );
+      if (stage === 2) requirements.push(
+        requirement('boss', '已擊破首領地城', metrics.bossCount, 1, metrics.bossCount >= 1),
+        requirement('relic-careers', '學識與生存里程碑合計', relicCareers, 2, relicCareers >= 2),
+        requirement('plus', '出征裝備強化總和', metrics.equipmentPlusTotal, 2, metrics.equipmentPlusTotal >= 2),
+      );
+      if (stage === 3) requirements.push(
+        requirement('boss', '已擊破首領地城', metrics.bossCount, 2, metrics.bossCount >= 2),
+        requirement('relic-careers', '學識與生存里程碑合計', relicCareers, 3, relicCareers >= 3),
+        requirement('plus', '出征裝備強化總和', metrics.equipmentPlusTotal, 3, metrics.equipmentPlusTotal >= 3),
+        requirement('relic-supplies', '遺珍物資總數', metrics.relicSupplies, 4, metrics.relicSupplies >= 4),
+      );
+      break;
+    }
+  }
+
+  requirements.push(requirement(
+    'stage-capacity',
+    `第 ${stage} 階工程名額`,
+    initiativeStageUsage(save, stage),
+    INITIATIVE_STAGE_CAP[stage],
+    initiativeStageUsage(save, stage) < INITIATIVE_STAGE_CAP[stage],
+  ));
+  return requirements;
+}
+
+function expertiseRequirements(
+  save: SaveData,
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+): InitiativeRequirement[] {
+  const effective = effectiveStats(save.protagonist);
+  const statTarget = 11 + stage * 2;
+  const skill = save.protagonist.skills?.[project.primarySkill] ?? 0;
+  const potential = save.protagonist.growth?.potential?.[project.primaryStat] ?? 0;
+  const mastery = Math.max(skill, potential);
+  const masteryTarget = stage + 1;
+  return [
+    requirement('expert-stat', `${project.primaryStat.toUpperCase()} 有效屬性`, effective[project.primaryStat], statTarget, effective[project.primaryStat] >= statTarget),
+    requirement('expert-mastery', `${project.primarySkill} 技能 rank 或對應潛力`, mastery, masteryTarget, mastery >= masteryTarget),
+  ];
+}
+
+function capitalRequirements(
+  save: SaveData,
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+  cost: InitiativeCost,
+): InitiativeRequirement[] {
+  const goldCost = cost.gold ?? 0;
+  const itemCost = cost.inventory?.[project.capitalItem] ?? 0;
+  const liquidityTarget = goldCost + stage * 40;
+  return [
+    requirement('capital-liquidity', '支付後仍保留的營運資金門檻', save.gold, liquidityTarget, save.gold >= liquidityTarget),
+    requirement('capital-material', `${ITEMS[project.capitalItem]?.name ?? project.capitalItem} 投資`, save.inventory[project.capitalItem] ?? 0, itemCost, (save.inventory[project.capitalItem] ?? 0) >= itemCost),
+  ];
+}
+
+function fieldRequirements(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): InitiativeRequirement[] {
+  const m = companyCharterMetrics(save);
+  switch (projectId) {
+    case 'escort-network':
+      return [requirement('field-bond', '旅伴羈絆總和', m.bondTotal, stage * 2, m.bondTotal >= stage * 2)];
+    case 'frontier-office':
+      return [requirement('field-discovery', '已發現地點', m.discoveredCount, stage, m.discoveredCount >= stage)];
+    case 'trade-consortium':
+      return [
+        requirement('field-trade', '交易貨物總數', m.tradeGoods, stage + 1, m.tradeGoods >= stage + 1),
+        requirement('field-leader', '有效隊長或軍需官', m.hasCaptain || m.hasQuartermaster, true, m.hasCaptain || m.hasQuartermaster),
+      ];
+    case 'fellowship-hall':
+      return [requirement('field-bond', '旅伴羈絆總和', m.bondTotal, stage * 3, m.bondTotal >= stage * 3)];
+    case 'relic-workshop':
+      return [
+        requirement('field-boss', '已擊破首領地城', m.bossCount, stage === 3 ? 2 : 1, m.bossCount >= (stage === 3 ? 2 : 1)),
+        requirement('field-relic', '遺珍物資總數', m.relicSupplies, stage + 1, m.relicSupplies >= stage + 1),
+      ];
+  }
+}
+
+function routeCost(
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): InitiativeCost {
+  if (routeId === 'expertise') {
+    return { skillPoints: stage === 3 ? 2 : 1 };
+  }
+  if (routeId === 'capital') {
+    const gold = ({ 1: 120, 2: 260, 3: 480 } as const)[stage];
+    return { gold, inventory: { [project.capitalItem]: stage === 3 ? 2 : 1 } };
+  }
+  const [first, second] = project.fieldItems;
+  return {
+    inventory: {
+      [first]: stage,
+      [second]: stage === 3 ? 2 : 1,
+    },
+  };
+}
+
+function expertiseReward(
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+): InitiativeReward {
+  if (stage === 1) return { stats: { [project.primaryStat]: 1 } };
+  if (stage === 2) return { skill: { id: project.primarySkill, amount: 1 }, maxHp: project.primarySkill === 'survival' ? 1 : 0 };
+  return {
+    stats: { [project.primaryStat]: 1 },
+    skill: { id: project.primarySkill, amount: 1 },
+    skillPoints: 1,
+  };
+}
+
+function capitalReward(
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): InitiativeReward {
+  switch (projectId) {
+    case 'escort-network':
+      return stage === 1
+        ? { reputation: 2, inventory: { 'war-tonic': 1 } }
+        : stage === 2
+          ? { reputation: 4, inventory: { 'war-tonic': 2, bandage: 1 } }
+          : { reputation: 6, maxHp: 2, inventory: { 'war-tonic': 2, ore: 1 } };
+    case 'frontier-office':
+      return stage === 1
+        ? { reputation: 2, inventory: { torch: 2 } }
+        : stage === 2
+          ? { reputation: 3, wagonLevels: 1, inventory: { 'tattered-map': 1 } }
+          : { reputation: 5, wagonLevels: 1, skillPoints: 1, inventory: { torch: 2 } };
+    case 'trade-consortium':
+      return stage === 1
+        ? { reputation: 2, wagonLevels: 1 }
+        : stage === 2
+          ? { reputation: 4, wagonLevels: 1, inventory: { 'spice-pouch': 1 } }
+          : { reputation: 7, wagonLevels: 1, skillPoints: 1, inventory: { 'spice-pouch': 2 } };
+    case 'fellowship-hall':
+      return stage === 1
+        ? { reputation: 2, bondAll: 1 }
+        : stage === 2
+          ? { reputation: 3, bondAll: 1, inventory: { bandage: 2 } }
+          : { reputation: 5, bondAll: 2, skillPoints: 1, inventory: { bandage: 2 } };
+    case 'relic-workshop':
+      return stage === 1
+        ? { reputation: 2, inventory: { ore: 2 } }
+        : stage === 2
+          ? { reputation: 4, inventory: { ore: 3, 'tattered-map': 1 } }
+          : { reputation: 6, skillPoints: 1, inventory: { ore: 4, 'tattered-map': 1 } };
+  }
+}
+
+function fieldReward(
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+): InitiativeReward {
+  switch (project.id) {
+    case 'escort-network':
+      return stage === 1
+        ? { maxHp: 1, bondAll: 1 }
+        : stage === 2
+          ? { maxHp: 2, bondAll: 1, inventory: { bandage: 1 } }
+          : { stats: { con: 1 }, maxHp: 3, bondAll: 1 };
+    case 'frontier-office':
+      return stage === 1
+        ? { reputation: 1, inventory: { 'tattered-map': 1 } }
+        : stage === 2
+          ? { stats: { dex: 1 }, bondAll: 1, inventory: { torch: 1 } }
+          : { skill: { id: 'scouting', amount: 1 }, skillPoints: 1, reputation: 3 };
+    case 'trade-consortium':
+      return stage === 1
+        ? { gold: 30, reputation: 1 }
+        : stage === 2
+          ? { gold: 60, reputation: 2, bondAll: 1 }
+          : { gold: 100, reputation: 4, stats: { int: 1 } };
+    case 'fellowship-hall':
+      return stage === 1
+        ? { maxHp: 1, bondAll: 1 }
+        : stage === 2
+          ? { maxHp: 2, bondAll: 2 }
+          : { stats: { cha: 1 }, maxHp: 2, bondAll: 2, reputation: 3 };
+    case 'relic-workshop':
+      return stage === 1
+        ? { skill: { id: 'lore', amount: 1 }, inventory: { ore: 1 } }
+        : stage === 2
+          ? { stats: { int: 1 }, reputation: 2, inventory: { ore: 2 } }
+          : { stats: { int: 1 }, skillPoints: 1, reputation: 4, inventory: { ore: 2 } };
+  }
+}
+
+function routeReward(
+  project: CompanyInitiativeDef,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): InitiativeReward {
+  if (routeId === 'expertise') return expertiseReward(project, stage);
+  if (routeId === 'capital') return capitalReward(project.id, stage);
+  return fieldReward(project, stage);
+}
+
+function canAfford(save: SaveData, cost: InitiativeCost): boolean {
+  if (save.gold < (cost.gold ?? 0)) return false;
+  if ((save.protagonist.skillPoints ?? 0) < (cost.skillPoints ?? 0)) return false;
+  for (const [itemId, count] of Object.entries(cost.inventory ?? {})) {
+    if ((save.inventory[itemId] ?? 0) < count) return false;
+  }
+  return true;
+}
+
+export function buildCompanyInitiativeOption(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): CompanyInitiativeOption {
+  const project = COMPANY_INITIATIVES[projectId];
+  const cost = routeCost(project, stage, routeId);
+  const routeRequirements = routeId === 'expertise'
+    ? expertiseRequirements(save, project, stage)
+    : routeId === 'capital'
+      ? capitalRequirements(save, project, stage, cost)
+      : fieldRequirements(save, projectId, stage);
+  const requirements = [...initiativeBaseRequirements(save, projectId, stage), ...routeRequirements];
+  const affordable = canAfford(save, cost);
+  const expectedStage = nextInitiativeStage(save, projectId);
+  const blockingReasons: string[] = [];
+  if (expectedStage !== stage) blockingReasons.push(expectedStage === null ? '此工程已完成' : `必須先完成第 ${expectedStage} 階`);
+  if (!requirements.every((entry) => entry.met)) blockingReasons.push('尚有工程條件未達成');
+  if (!affordable) blockingReasons.push('資源不足');
+  return {
+    projectId,
+    stage,
+    routeId,
+    routeName: ROUTE_NAMES[routeId],
+    routeDesc: ROUTE_DESCS[routeId],
+    requirements,
+    cost,
+    reward: routeReward(project, stage, routeId),
+    affordable,
+    available: blockingReasons.length === 0,
+    blockingReasons,
+  };
+}
+
+function applyCost(save: SaveData, cost: InitiativeCost): void {
+  save.gold -= cost.gold ?? 0;
+  save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) - (cost.skillPoints ?? 0);
+  for (const [itemId, count] of Object.entries(cost.inventory ?? {})) {
+    const next = (save.inventory[itemId] ?? 0) - count;
+    if (next > 0) save.inventory[itemId] = next;
+    else delete save.inventory[itemId];
+  }
+}
+
+function applyReward(save: SaveData, reward: InitiativeReward): void {
+  for (const [stat, amount] of Object.entries(reward.stats ?? {}) as Array<[keyof StatBlock, number]>) {
+    save.protagonist.stats[stat] += amount;
+  }
+  if (reward.maxHp) save.protagonist.maxHp += reward.maxHp;
+  if (reward.skill) {
+    const current = save.protagonist.skills?.[reward.skill.id] ?? 0;
+    save.protagonist.skills = {
+      ...(save.protagonist.skills ?? {}),
+      [reward.skill.id]: Math.min(5, current + reward.skill.amount),
+    };
+  }
+  if (reward.skillPoints) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+  if (reward.gold) save.gold += reward.gold;
+  if (reward.reputation) save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory ?? {})) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.wagonLevels && save.wagonLevel < 6) {
+    save.wagonLevel += Math.min(reward.wagonLevels, 6 - save.wagonLevel);
+  }
+  if (reward.bondAll) {
+    for (const companion of save.companions) {
+      companion.bond = (companion.bond ?? 0) + reward.bondAll;
+    }
+  }
+}
+
+/**
+ * 原子完成一個工程路線：所有條件與成本先驗證，成功後才扣資源、發獎勵並寫收據。
+ * 每工程必須循序完成，每階全商隊共用 3／2／1 個名額。
+ */
+export function completeCompanyInitiative(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): CompanyInitiativeOption {
+  if (!(projectId in COMPANY_INITIATIVES)) throw new Error(`未知商隊工程「${projectId}」`);
+  if (!STAGES.includes(stage)) throw new Error(`非法工程階段「${stage}」`);
+  if (!INITIATIVE_ROUTE_ORDER.includes(routeId)) throw new Error(`未知工程方案「${routeId}」`);
+  const existing = initiativeRoutesAtStage(save, projectId, stage);
+  if (existing.length > 0) throw new Error(`「${COMPANY_INITIATIVES[projectId].name}」第 ${stage} 階已完成`);
+  const option = buildCompanyInitiativeOption(save, projectId, stage, routeId);
+  if (!option.available) throw new Error(option.blockingReasons.join('；'));
+
+  applyCost(save, option.cost);
+  applyReward(save, option.reward);
+  save.flags[initiativeReceiptKey(projectId, stage, routeId)] = true;
+  return option;
+}
+
+export function buildCompanyInitiativeBoard(save: SaveData): CompanyInitiativeBoard {
+  const warnings: string[] = [];
+  const projects = COMPANY_INITIATIVE_ORDER.map((projectId) => {
+    const history = STAGES.map((stage): CompanyInitiativeHistoryEntry => {
+      const routes = initiativeRoutesAtStage(save, projectId, stage);
+      if (routes.length > 1) warnings.push(`${COMPANY_INITIATIVES[projectId].name}第 ${stage} 階存在多個完成收據。`);
+      const routeId = routes[0] ?? null;
+      return {
+        stage,
+        routeId,
+        routeName: routeId ? ROUTE_NAMES[routeId] : '尚未完成',
+        conflict: routes.length > 1,
+      };
+    });
+    const nextStage = nextInitiativeStage(save, projectId);
+    return {
+      id: projectId,
+      name: COMPANY_INITIATIVES[projectId].name,
+      desc: COMPANY_INITIATIVES[projectId].desc,
+      completedStage: initiativeCompletedStage(save, projectId),
+      nextStage,
+      history,
+      options: nextStage
+        ? INITIATIVE_ROUTE_ORDER.map((routeId) => buildCompanyInitiativeOption(save, projectId, nextStage, routeId))
+        : [],
+    };
+  });
+  const stageCapacity = Object.fromEntries(STAGES.map((stage) => [
+    stage,
+    { used: initiativeStageUsage(save, stage), cap: INITIATIVE_STAGE_CAP[stage] },
+  ])) as Record<CompanyInitiativeStage, { used: number; cap: number }>;
+  for (const stage of STAGES) {
+    if (stageCapacity[stage].used > stageCapacity[stage].cap) {
+      warnings.push(`第 ${stage} 階工程完成數超過上限 ${stageCapacity[stage].cap}。`);
+    }
+  }
+  return { stageCapacity, projects, warnings };
+}


### PR DESCRIPTION
## Summary

- add five long-term company initiatives that interweave character stats, growth potential, career history, charter tier, active formation, expedition roles, equipment, wagon investment, wealth, supplies, discoveries, boss history, and companion bonds
- give every initiative three irreversible stages and three distinct completion routes: expertise, capital, or field achievement
- enforce global portfolio limits of 3 foundation projects, 2 expansion projects, and 1 capstone project so one save cannot maximize every route
- complete initiatives atomically: validate stage order, cross-system requirements, portfolio capacity, and costs before any resource mutation
- persist route identity through receipt flags, cap skill ranks at 5 and wagon level at 6, and detect conflicting or over-cap corrupted receipts
- add a player-facing `/caravan/initiatives` page that reads the real local save, shows exact costs/rewards/requirements, revalidates on click, applies the transaction, and saves immediately
- add adversarial tests for route diversity, item validity, atomic failure, duplicate-reward prevention, stage skipping, portfolio caps, capital arbitrage, caps, corruption warnings, and legacy compatibility

## Game-design intent

M22–M27 created deep character and company identities, but players still needed irreversible strategic decisions that consume the resources produced by all those systems. M28 introduces a portfolio of long-term organizational projects. The same problem can be solved through character expertise, capital investment, or field experience, allowing different creation and career builds to remain viable while producing permanently different companies.

Global stage capacity prevents completionist homogenization: players may establish only three foundations, expand two of them, and finish one capstone. This turns creation, careers, charter identity, roster choices, discoveries, equipment, economy, and bonds into competing long-term priorities rather than parallel checklists.

## Player adversarial review

- all five projects and all three stages expose three mechanically distinct routes with different costs and rewards
- all referenced item IDs exist in the real item catalog
- failed transactions do not mutate any gold, items, skill points, stats, flags, or rewards
- completed stages cannot be repeated or completed through a second route
- stages cannot be skipped
- the whole company shares strict 3/2/1 portfolio limits
- capital routes never return more immediate gold than they cost
- skill and wagon rewards respect existing caps
- route identity and exact resource deltas are persisted in the save
- conflicting receipt corruption is surfaced without granting rewards
- low-system legacy saves cannot access initiative rewards
- the player page revalidates at execution time, preventing stale multi-tab resource exploits

## Scope

- `src/scripts/games/caravan/data/initiatives.ts`
- `src/scripts/games/caravan/data/initiatives.m28.test.ts`
- `src/pages/caravan/initiatives.astro`

No dependency, lockfile, generated-output, asset, or save-version changes.