### PR TITLE
feat(caravan): add M29 operational payroll doctrines

### DIFF
--- a/src/pages/caravan/operations.astro
+++ b/src/pages/caravan/operations.astro
@@ -1,0 +1,188 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="營運帳目 — 商隊與劍"
+  description="檢視長程工程如何影響出征薪餉、後備費、維護成本、特許相性與羈絆折扣。"
+  lang="zh-TW"
+>
+  <main class="operations-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD</p>
+      <h1>營運帳目</h1>
+      <p>長程工程不是免費被動：每一種方案都會形成不同的維護與薪餉結構。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/initiatives">長程計畫</a>
+        <a href="/caravan/dossier">商隊檔案</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="empty" hidden>
+      <h2>尚未找到商隊存檔</h2>
+      <p>先建立角色並開始旅程，才會產生營運帳目。</p>
+      <a href="/caravan/play">開始旅程</a>
+    </section>
+
+    <div id="content" hidden>
+      <section class="summary">
+        <article><span>本趟預估薪餉</span><b id="total">0 G</b></article>
+        <article><span>出征薪餉</span><b id="active">0 G</b></article>
+        <article><span>後備留營費</span><b id="reserve">0 G</b></article>
+        <article><span>工程固定維護</span><b id="upkeep">0 G</b></article>
+        <article><span>忠誠與多樣性折扣</span><b id="discount">0 G</b></article>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="kicker">薪餉公式</p><h2>本趟帳目拆解</h2></div>
+          <p>與遊戲整裝畫面的出發薪餉使用同一個正式函式。</p>
+        </div>
+        <dl class="ledger">
+          <div><dt>出征成員原薪餉</dt><dd id="active-base">0 G</dd></div>
+          <div><dt>出征制度倍率</dt><dd id="active-factor">100%</dd></div>
+          <div><dt>調整後出征薪餉</dt><dd id="active-adjusted">0 G</dd></div>
+          <div><dt>健康後備原薪餉</dt><dd id="reserve-base">0 G</dd></div>
+          <div><dt>後備制度倍率</dt><dd id="reserve-factor">25%</dd></div>
+          <div><dt>軍需官倍率</dt><dd id="quartermaster">100%</dd></div>
+          <div><dt>調整後後備費</dt><dd id="reserve-adjusted">0 G</dd></div>
+          <div><dt>工程固定維護</dt><dd id="fixed-upkeep">0 G</dd></div>
+          <div><dt>折扣前總額</dt><dd id="gross">0 G</dd></div>
+          <div><dt>羈絆忠誠折扣</dt><dd id="loyalty">0 G</dd></div>
+          <div><dt>職涯多樣性折扣</dt><dd id="diversity">0 G</dd></div>
+          <div class="total-row"><dt>最終薪餉</dt><dd id="final">0 G</dd></div>
+        </dl>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="kicker">工程制度</p><h2>持續營運效果</h2></div>
+          <p>只有循序、單一路線且不超過 3／2／1 上限的收據會被採計。</p>
+        </div>
+        <div id="entries" class="entries"></div>
+      </section>
+
+      <section id="warnings-panel" class="panel warning-panel" hidden>
+        <div class="section-head">
+          <div><p class="kicker">資料稽核</p><h2>不採計的工程收據</h2></div>
+          <p>衝突、跳階或超額旗標不會轉化為營運利益。</p>
+        </div>
+        <ul id="warnings"></ul>
+      </section>
+    </div>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame } from '@scripts/games/caravan/save';
+  import { companyPayrollBreakdown } from '@scripts/games/caravan/data/operations';
+
+  const byId = (id: string) => document.getElementById(id)!;
+  const setText = (id: string, value: string | number) => { byId(id).textContent = String(value); };
+  const percent = (value: number) => `${Math.round(value * 100)}%`;
+  const signedPercent = (value: number) => `${value >= 0 ? '+' : ''}${Math.round(value * 100)}%`;
+
+  const save = loadGame();
+  if (!save) {
+    byId('empty').removeAttribute('hidden');
+  } else {
+    const payroll = companyPayrollBreakdown(save);
+    byId('content').removeAttribute('hidden');
+    setText('total', `${payroll.total} G`);
+    setText('active', `${payroll.activeAdjusted} G`);
+    setText('reserve', `${payroll.reserveAdjusted} G`);
+    setText('upkeep', `${payroll.fixedUpkeep} G`);
+    setText('discount', `${payroll.loyaltyDiscount + payroll.diversityDiscount} G`);
+    setText('active-base', `${payroll.activeBase} G`);
+    setText('active-factor', percent(payroll.activeWageFactor));
+    setText('active-adjusted', `${payroll.activeAdjusted} G`);
+    setText('reserve-base', `${payroll.reserveBase} G`);
+    setText('reserve-factor', percent(payroll.reserveWageFactor));
+    setText('quartermaster', percent(payroll.quartermasterFactor));
+    setText('reserve-adjusted', `${payroll.reserveAdjusted} G`);
+    setText('fixed-upkeep', `${payroll.fixedUpkeep} G`);
+    setText('gross', `${payroll.gross} G`);
+    setText('loyalty', `-${payroll.loyaltyDiscount} G`);
+    setText('diversity', `-${payroll.diversityDiscount} G`);
+    setText('final', `${payroll.total} G`);
+
+    const entries = byId('entries');
+    if (payroll.entries.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-copy';
+      empty.textContent = '尚未有有效長程工程；薪餉完全沿用原本出征、後備與軍需官規則。';
+      entries.appendChild(empty);
+    }
+    for (const entry of payroll.entries) {
+      const card = document.createElement('article');
+      card.className = 'entry';
+      card.innerHTML = `
+        <header><div><span>第 ${entry.stage} 階</span><h3>${entry.projectName}</h3></div><b>${entry.routeName}</b></header>
+        <dl>
+          <div><dt>基礎維護</dt><dd>${entry.baseMaintenance} G</dd></div>
+          <div><dt>方案效率</dt><dd>-${entry.efficiencyCredit} G</dd></div>
+          <div><dt>特許相性</dt><dd>-${entry.affinityCredit} G</dd></div>
+          <div><dt>實際維護</dt><dd>${entry.netMaintenance} G</dd></div>
+          <div><dt>出征倍率</dt><dd>${signedPercent(entry.activeFactorDelta)}</dd></div>
+          <div><dt>後備倍率</dt><dd>${signedPercent(entry.reserveFactorDelta)}</dd></div>
+        </dl>`;
+      entries.appendChild(card);
+    }
+
+    if (payroll.warnings.length > 0) {
+      byId('warnings-panel').removeAttribute('hidden');
+      const list = byId('warnings');
+      for (const warning of payroll.warnings) {
+        const item = document.createElement('li');
+        item.textContent = warning;
+        list.appendChild(item);
+      }
+    }
+  }
+</script>
+
+<style>
+  .operations-page { min-height: 100vh; padding: 2rem 1rem 5rem; background: #eee5d3; color: #2d281f; font-family: 'Noto Serif TC', serif; }
+  .operations-page > * { max-width: 72rem; margin-inline: auto; }
+  .hero { padding: 2.2rem; color: #f7edda; background: linear-gradient(135deg, #382f25, #725438); border-radius: 1rem; box-shadow: 0 1rem 2.5rem #3c2b1c33; }
+  .eyebrow, .kicker { margin: 0 0 .35rem; letter-spacing: .24em; font-size: .75rem; color: #d8b879; }
+  h1 { margin: 0; font-size: clamp(2.1rem, 7vw, 4rem); }
+  .hero > p:last-of-type { max-width: 44rem; color: #e5d8c3; }
+  nav { display: flex; flex-wrap: wrap; gap: .65rem; margin-top: 1.2rem; }
+  nav a, .empty a { padding: .65rem 1rem; border: 1px solid #d3b57a; border-radius: 999px; color: inherit; text-decoration: none; }
+  .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); gap: .75rem; margin-top: 1rem; }
+  .summary article, .panel, .empty { background: #fffaf0; border: 1px solid #d7c8ad; border-radius: .9rem; }
+  .summary article { padding: 1rem; }
+  .summary span { display: block; font-size: .8rem; color: #786b59; }
+  .summary b { display: block; margin-top: .3rem; font-size: 1.45rem; color: #8b452b; }
+  .panel, .empty { padding: 1.35rem; margin-top: 1rem; }
+  .section-head { display: flex; justify-content: space-between; gap: 1rem; align-items: end; border-bottom: 1px solid #ded0b8; padding-bottom: .8rem; }
+  .section-head h2 { margin: 0; }
+  .section-head > p { max-width: 30rem; margin: 0; color: #786b59; font-size: .86rem; text-align: right; }
+  .ledger { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 1.5rem; margin: 1rem 0 0; }
+  .ledger div { display: flex; justify-content: space-between; gap: 1rem; padding: .65rem 0; border-bottom: 1px dashed #dfd3bf; }
+  .ledger dt { color: #6f6250; }
+  .ledger dd { margin: 0; font-weight: 700; }
+  .ledger .total-row { grid-column: 1 / -1; margin-top: .4rem; padding: 1rem; border: 1px solid #b97b48; border-radius: .7rem; background: #f6e4c9; font-size: 1.15rem; }
+  .entries { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: .8rem; margin-top: 1rem; }
+  .entry { padding: 1rem; border: 1px solid #d8cab3; border-radius: .75rem; background: #f7efdf; }
+  .entry header { display: flex; justify-content: space-between; gap: .75rem; align-items: start; }
+  .entry header span { font-size: .72rem; color: #8d6b42; }
+  .entry h3 { margin: .15rem 0 0; }
+  .entry header > b { color: #8b452b; font-size: .85rem; }
+  .entry dl { margin: .8rem 0 0; }
+  .entry dl div { display: flex; justify-content: space-between; padding: .28rem 0; }
+  .entry dt { color: #746754; }
+  .entry dd { margin: 0; font-weight: 700; }
+  .warning-panel { border-color: #b96855; background: #fff1e7; }
+  .warning-panel li { margin: .45rem 0; }
+  .empty-copy { color: #786b59; }
+  [hidden] { display: none !important; }
+  @media (max-width: 42rem) {
+    .hero { padding: 1.4rem; }
+    .section-head { display: block; }
+    .section-head > p { margin-top: .45rem; text-align: left; }
+    .ledger { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/scripts/games/caravan/data/operations.m29.test.ts
+++ b/src/scripts/games/caravan/data/operations.m29.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord, SaveData } from '../save';
+import { newGame } from '../save';
+import { totalWage } from '../economy';
+import {
+  acceptedOperationalInitiatives,
+  companyOperatingProfile,
+  companyPayrollBreakdown,
+} from './operations';
+
+function companion(id: string, level: number, trait: string | null = null, bond = 0): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job: 'ranger',
+    level,
+    xp: 0,
+    stats: { str: 10, dex: 12, int: 10, cha: 10, con: 10 },
+    maxHp: 20,
+    injuredForTrips: 0,
+    trait,
+    equipment: { weapon: null, armor: null, trinket: null },
+    bond,
+  };
+}
+
+function matureSave(): SaveData {
+  const save = newGame(100, {
+    job: 'swordsman',
+    trait: 'seasoned',
+    allocation: { str: 3 },
+  });
+  save.protagonist.level = 5;
+  save.protagonist.skills = { martial: 5, scouting: 4, lore: 4, negotiation: 4, survival: 4 };
+  save.protagonist.skillPoints = 3;
+  save.protagonist.careerMilestones = [
+    { level: 2, pathId: 'martial', score: 20 },
+    { level: 3, pathId: 'scouting', score: 19 },
+    { level: 4, pathId: 'lore', score: 18 },
+    { level: 5, pathId: 'negotiation', score: 17 },
+  ];
+  save.companyCharter = { id: 'iron-vanguard', tier: 3 };
+  save.wagonLevel = 3;
+  save.companions = [
+    companion('a', 3, 'greedy', 9),
+    companion('b', 2, 'frugal', 5),
+    companion('c', 4, null, 2),
+    companion('reserve', 1, null, 0),
+  ];
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'a', 'b', 'c'],
+    positions: { protagonist: 'front', a: 'front', b: 'back', c: 'back' },
+    roles: { captain: 'protagonist', scout: 'a', quartermaster: 'b', medic: 'c' },
+  };
+  return save;
+}
+
+function receipt(save: SaveData, project: string, stage: number, route: string): void {
+  save.flags[`company-initiative:${project}:${stage}:${route}`] = true;
+}
+
+function legacyWage(save: SaveData): number {
+  const activeIds = new Set(save.expeditionPlan!.activeIds);
+  const wage = (record: CompanionRecord) => 8 + record.level * 4 + (record.trait === 'greedy' ? 3 : record.trait === 'frugal' ? -2 : 0);
+  const active = save.companions.filter((c) => !c.injuredForTrips && activeIds.has(c.id)).reduce((sum, c) => sum + wage(c), 0);
+  const reserve = save.companions.filter((c) => !c.injuredForTrips && !activeIds.has(c.id)).reduce((sum, c) => sum + wage(c), 0);
+  return active + Math.ceil(reserve * 0.25 * 0.5);
+}
+
+describe('M29 operational payroll', () => {
+  it('preserves exact legacy wage when no initiative receipt exists', () => {
+    const save = matureSave();
+    expect(companyOperatingProfile(save).entries).toHaveLength(0);
+    expect(companyPayrollBreakdown(save).total).toBe(legacyWage(save));
+    expect(totalWage(save)).toBe(legacyWage(save));
+  });
+
+  it('makes expertise, capital, and field routes produce distinct operating accounts', () => {
+    const expertise = matureSave();
+    const capital = matureSave();
+    const field = matureSave();
+    receipt(expertise, 'escort-network', 1, 'expertise');
+    receipt(capital, 'escort-network', 1, 'capital');
+    receipt(field, 'escort-network', 1, 'field');
+    const profiles = [expertise, capital, field].map(companyOperatingProfile);
+    expect(new Set(profiles.map((p) => `${p.fixedUpkeep}:${p.activeWageFactor}:${p.reserveWageFactor}`)).size).toBe(3);
+    expect(profiles.every((p) => p.entries.length === 1)).toBe(true);
+  });
+
+  it('uses skill and potential to reduce expertise upkeep', () => {
+    const skilled = matureSave();
+    const weak = matureSave();
+    receipt(skilled, 'escort-network', 1, 'expertise');
+    receipt(weak, 'escort-network', 1, 'expertise');
+    weak.protagonist.skills = { martial: 0 };
+    weak.protagonist.growth = undefined;
+    expect(companyOperatingProfile(skilled).fixedUpkeep).toBeLessThan(companyOperatingProfile(weak).fixedUpkeep);
+  });
+
+  it('uses wagon investment to reduce capital upkeep', () => {
+    const high = matureSave();
+    const low = matureSave();
+    receipt(high, 'trade-consortium', 1, 'capital');
+    receipt(low, 'trade-consortium', 1, 'capital');
+    low.wagonLevel = 0;
+    expect(companyOperatingProfile(high).fixedUpkeep).toBeLessThan(companyOperatingProfile(low).fixedUpkeep);
+  });
+
+  it('uses bonds and fellowship stages as a capped loyalty discount', () => {
+    const save = matureSave();
+    receipt(save, 'fellowship-hall', 1, 'field');
+    receipt(save, 'fellowship-hall', 2, 'field');
+    receipt(save, 'fellowship-hall', 3, 'field');
+    const profile = companyOperatingProfile(save);
+    expect(profile.loyaltyDiscount).toBeGreaterThan(0);
+    expect(profile.loyaltyDiscount).toBeLessThanOrEqual(12);
+  });
+
+  it('grants career diversity discount only after an accepted project exists', () => {
+    const save = matureSave();
+    expect(companyOperatingProfile(save).diversityDiscount).toBe(0);
+    receipt(save, 'frontier-office', 1, 'expertise');
+    expect(companyOperatingProfile(save).diversityDiscount).toBe(2);
+  });
+
+  it('rejects conflicting route receipts instead of stacking them', () => {
+    const save = matureSave();
+    receipt(save, 'escort-network', 1, 'expertise');
+    receipt(save, 'escort-network', 1, 'capital');
+    const result = acceptedOperationalInitiatives(save);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.warnings.some((warning) => warning.includes('衝突'))).toBe(true);
+  });
+
+  it('rejects stage skipping from operational benefits', () => {
+    const save = matureSave();
+    receipt(save, 'relic-workshop', 2, 'field');
+    const result = acceptedOperationalInitiatives(save);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.warnings.some((warning) => warning.includes('缺少前置'))).toBe(true);
+  });
+
+  it('caps over-limit receipts in deterministic project order', () => {
+    const save = matureSave();
+    for (const project of ['escort-network', 'frontier-office', 'trade-consortium', 'fellowship-hall']) {
+      receipt(save, project, 1, 'expertise');
+    }
+    const result = acceptedOperationalInitiatives(save);
+    expect(result.accepted).toHaveLength(3);
+    expect(result.accepted.map((entry) => entry.projectId)).toEqual([
+      'escort-network', 'frontier-office', 'trade-consortium',
+    ]);
+    expect(result.warnings.some((warning) => warning.includes('超過上限'))).toBe(true);
+  });
+
+  it('keeps factors and fixed upkeep within hard safety bounds', () => {
+    const save = matureSave();
+    receipt(save, 'escort-network', 1, 'capital');
+    receipt(save, 'frontier-office', 1, 'field');
+    receipt(save, 'trade-consortium', 1, 'capital');
+    receipt(save, 'escort-network', 2, 'capital');
+    receipt(save, 'frontier-office', 2, 'field');
+    receipt(save, 'escort-network', 3, 'capital');
+    const profile = companyOperatingProfile(save);
+    expect(profile.activeWageFactor).toBeGreaterThanOrEqual(0.8);
+    expect(profile.activeWageFactor).toBeLessThanOrEqual(1.15);
+    expect(profile.reserveWageFactor).toBeGreaterThanOrEqual(0.08);
+    expect(profile.reserveWageFactor).toBeLessThanOrEqual(0.3);
+    expect(profile.fixedUpkeep).toBeLessThanOrEqual(60);
+  });
+
+  it('never mutates the save while calculating payroll', () => {
+    const save = matureSave();
+    receipt(save, 'escort-network', 1, 'capital');
+    const before = JSON.stringify(save);
+    companyPayrollBreakdown(save);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('exposes the same total through economy.totalWage', () => {
+    const save = matureSave();
+    receipt(save, 'trade-consortium', 1, 'capital');
+    expect(totalWage(save)).toBe(companyPayrollBreakdown(save).total);
+  });
+});

--- a/src/scripts/games/caravan/data/operations.ts
+++ b/src/scripts/games/caravan/data/operations.ts
@@ -1,16 +1,4 @@
-import type { ExpeditionPlan, SaveData } from '../save';
-import {
-  EXPEDITION_ROLES,
-  RESERVE_WAGE_FACTOR,
-  bondTier,
-  normalizeExpeditionPlan,
-  wagePerTrip,
-} from '../roster';
-import {
-  COMPANY_INITIATIVE_ORDER,
-  COMPANY_INITIATIVES,
-  initiativeRoutesAtStage,
-} from './initiatives';
+import type { CompanionRecord, ExpeditionPlan, ExpeditionRole, SaveData } from '../save';
 import type {
   CompanyInitiativeId,
   CompanyInitiativeRouteId,
@@ -52,17 +40,44 @@ export interface CompanyPayrollBreakdown extends CompanyOperatingProfile {
   total: number;
 }
 
+interface ProjectMeta {
+  name: string;
+  primaryStat: 'str' | 'dex' | 'int' | 'cha' | 'con';
+  primarySkill: 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+  affinity: string[];
+}
+
+const PROJECT_ORDER: CompanyInitiativeId[] = [
+  'escort-network', 'frontier-office', 'trade-consortium', 'fellowship-hall', 'relic-workshop',
+];
+const PROJECTS: Record<CompanyInitiativeId, ProjectMeta> = {
+  'escort-network': { name: '跨鎮護運網', primaryStat: 'str', primarySkill: 'martial', affinity: ['iron-vanguard', 'bound-fellowship'] },
+  'frontier-office': { name: '遠境測繪局', primaryStat: 'dex', primarySkill: 'scouting', affinity: ['far-horizon', 'relic-covenant'] },
+  'trade-consortium': { name: '跨鎮交易聯盟', primaryStat: 'cha', primarySkill: 'negotiation', affinity: ['ledger-guild', 'far-horizon'] },
+  'fellowship-hall': { name: '同袍議事廳', primaryStat: 'cha', primarySkill: 'survival', affinity: ['bound-fellowship', 'ledger-guild'] },
+  'relic-workshop': { name: '遺珍研究工坊', primaryStat: 'int', primarySkill: 'lore', affinity: ['relic-covenant', 'far-horizon'] },
+};
+const ROUTES: CompanyInitiativeRouteId[] = ['expertise', 'capital', 'field'];
 const STAGES: CompanyInitiativeStage[] = [1, 2, 3];
 const STAGE_CAP: Record<CompanyInitiativeStage, number> = { 1: 3, 2: 2, 3: 1 };
 const BASE_MAINTENANCE: Record<CompanyInitiativeStage, number> = { 1: 4, 2: 8, 3: 13 };
 const ROUTE_NAMES: Record<CompanyInitiativeRouteId, string> = {
-  expertise: '專業方案',
-  capital: '資本方案',
-  field: '實地方案',
+  expertise: '專業方案', capital: '資本方案', field: '實地方案',
 };
+const RESERVE_WAGE_FACTOR = 0.25;
+const QUARTERMASTER_FACTOR = 0.5;
+const ROLE_ORDER: ExpeditionRole[] = ['captain', 'scout', 'quartermaster', 'medic'];
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function receiptKey(projectId: CompanyInitiativeId, stage: CompanyInitiativeStage, routeId: CompanyInitiativeRouteId): string {
+  return `company-initiative:${projectId}:${stage}:${routeId}`;
+}
+
+function routesAtStage(save: SaveData, projectId: CompanyInitiativeId, stage: CompanyInitiativeStage): CompanyInitiativeRouteId[] {
+  return ROUTES.filter((routeId) => save.flags[receiptKey(projectId, stage, routeId)] === true);
 }
 
 interface AcceptedInitiative {
@@ -71,10 +86,7 @@ interface AcceptedInitiative {
   routeId: CompanyInitiativeRouteId;
 }
 
-/**
- * 僅採用循序、單一路線且未超過 3／2／1 組合上限的工程收據。
- * 髒旗標只產生警告，不會轉化成額外營運收益。
- */
+/** 僅採用循序、單一路線且未超過 3／2／1 組合上限的工程收據。 */
 export function acceptedOperationalInitiatives(save: SaveData): {
   accepted: AcceptedInitiative[];
   warnings: string[];
@@ -82,23 +94,21 @@ export function acceptedOperationalInitiatives(save: SaveData): {
   const accepted: AcceptedInitiative[] = [];
   const warnings: string[] = [];
   let previous = new Set<CompanyInitiativeId>();
-
   for (const stage of STAGES) {
     const candidates: AcceptedInitiative[] = [];
-    for (const projectId of COMPANY_INITIATIVE_ORDER) {
-      const routes = initiativeRoutesAtStage(save, projectId, stage);
+    for (const projectId of PROJECT_ORDER) {
+      const routes = routesAtStage(save, projectId, stage);
       if (routes.length > 1) {
-        warnings.push(`${COMPANY_INITIATIVES[projectId].name}第 ${stage} 階存在衝突方案，營運效果不採計。`);
+        warnings.push(`${PROJECTS[projectId].name}第 ${stage} 階存在衝突方案，營運效果不採計。`);
         continue;
       }
       if (routes.length === 0) continue;
       if (stage > 1 && !previous.has(projectId)) {
-        warnings.push(`${COMPANY_INITIATIVES[projectId].name}第 ${stage} 階缺少前置工程，營運效果不採計。`);
+        warnings.push(`${PROJECTS[projectId].name}第 ${stage} 階缺少前置工程，營運效果不採計。`);
         continue;
       }
       candidates.push({ projectId, stage, routeId: routes[0] });
     }
-
     if (candidates.length > STAGE_CAP[stage]) {
       warnings.push(`第 ${stage} 階工程收據超過上限 ${STAGE_CAP[stage]}，僅採計固定順序中的前 ${STAGE_CAP[stage]} 項。`);
     }
@@ -106,8 +116,15 @@ export function acceptedOperationalInitiatives(save: SaveData): {
     accepted.push(...stageAccepted);
     previous = new Set(stageAccepted.map((entry) => entry.projectId));
   }
-
   return { accepted, warnings };
+}
+
+function bondTier(bond: number | undefined): number {
+  const value = bond ?? 0;
+  if (value >= 9) return 3;
+  if (value >= 5) return 2;
+  if (value >= 2) return 1;
+  return 0;
 }
 
 function bondTierTotal(save: SaveData): number {
@@ -122,57 +139,33 @@ function careerDiversity(save: SaveData): number {
   ).size;
 }
 
-function routeEfficiency(
-  save: SaveData,
-  projectId: CompanyInitiativeId,
-  stage: CompanyInitiativeStage,
-  routeId: CompanyInitiativeRouteId,
-  maintenance: number,
-): number {
-  const project = COMPANY_INITIATIVES[projectId];
-  if (routeId === 'expertise') {
+function routeEfficiency(save: SaveData, receipt: AcceptedInitiative, maintenance: number): number {
+  const project = PROJECTS[receipt.projectId];
+  if (receipt.routeId === 'expertise') {
     const skill = save.protagonist.skills?.[project.primarySkill] ?? 0;
     const potential = save.protagonist.growth?.potential?.[project.primaryStat] ?? 0;
     return Math.min(maintenance, Math.floor((Math.max(0, skill) + Math.max(0, potential)) / 2));
   }
-  if (routeId === 'capital') {
-    return Math.min(maintenance, Math.max(0, Math.floor(save.wagonLevel)));
-  }
+  if (receipt.routeId === 'capital') return Math.min(maintenance, Math.max(0, Math.floor(save.wagonLevel)));
   return Math.min(maintenance, Math.floor(bondTierTotal(save) / 2));
 }
 
-function projectAdjustments(
-  projectId: CompanyInitiativeId,
-  stage: CompanyInitiativeStage,
-): { maintenance: number; active: number; reserve: number } {
+function projectAdjustments(projectId: CompanyInitiativeId, stage: CompanyInitiativeStage) {
   switch (projectId) {
-    case 'escort-network':
-      return { maintenance: 0, active: -0.01 * stage, reserve: 0 };
-    case 'frontier-office':
-      return { maintenance: 0, active: 0.005 * stage, reserve: -0.005 * stage };
-    case 'trade-consortium':
-      return { maintenance: stage * 2, active: -0.005 * stage, reserve: 0 };
-    case 'fellowship-hall':
-      return { maintenance: 0, active: 0, reserve: -0.01 * stage };
-    case 'relic-workshop':
-      return { maintenance: stage, active: 0.01 * stage, reserve: 0 };
+    case 'escort-network': return { maintenance: 0, active: -0.01 * stage, reserve: 0 };
+    case 'frontier-office': return { maintenance: 0, active: 0.005 * stage, reserve: -0.005 * stage };
+    case 'trade-consortium': return { maintenance: stage * 2, active: -0.005 * stage, reserve: 0 };
+    case 'fellowship-hall': return { maintenance: 0, active: 0, reserve: -0.01 * stage };
+    case 'relic-workshop': return { maintenance: stage, active: 0.01 * stage, reserve: 0 };
   }
 }
 
-function routeAdjustments(
-  stage: CompanyInitiativeStage,
-  routeId: CompanyInitiativeRouteId,
-): { maintenance: number; active: number; reserve: number } {
-  if (routeId === 'expertise') {
-    return { maintenance: 2, active: -0.01 * stage, reserve: 0 };
-  }
-  if (routeId === 'capital') {
-    return { maintenance: 4, active: -0.015 * stage, reserve: -0.01 * stage };
-  }
+function routeAdjustments(stage: CompanyInitiativeStage, routeId: CompanyInitiativeRouteId) {
+  if (routeId === 'expertise') return { maintenance: 2, active: -0.01 * stage, reserve: 0 };
+  if (routeId === 'capital') return { maintenance: 4, active: -0.015 * stage, reserve: -0.01 * stage };
   return { maintenance: 0, active: 0.005 * stage, reserve: -0.015 * stage };
 }
 
-/** 建立工程投資在每趟遠征中產生的持續薪餉與維護結構。 */
 export function companyOperatingProfile(save: SaveData): CompanyOperatingProfile {
   const { accepted, warnings } = acceptedOperationalInitiatives(save);
   const charter = isValidCompanyCharterProgress(save.companyCharter) ? save.companyCharter : null;
@@ -180,26 +173,16 @@ export function companyOperatingProfile(save: SaveData): CompanyOperatingProfile
   let activeFactor = 1;
   let reserveFactor = RESERVE_WAGE_FACTOR;
   let fixedUpkeep = 0;
-
   for (const receipt of accepted) {
-    const project = COMPANY_INITIATIVES[receipt.projectId];
+    const project = PROJECTS[receipt.projectId];
     const projectDelta = projectAdjustments(receipt.projectId, receipt.stage);
     const routeDelta = routeAdjustments(receipt.stage, receipt.routeId);
     const baseMaintenance = BASE_MAINTENANCE[receipt.stage] + projectDelta.maintenance + routeDelta.maintenance;
-    const efficiencyCredit = routeEfficiency(
-      save,
-      receipt.projectId,
-      receipt.stage,
-      receipt.routeId,
-      baseMaintenance,
-    );
-    const affinityCredit = charter && project.affinity.includes(charter.id)
-      ? receipt.stage
-      : 0;
+    const efficiencyCredit = routeEfficiency(save, receipt, baseMaintenance);
+    const affinityCredit = charter && project.affinity.includes(charter.id) ? receipt.stage : 0;
     const netMaintenance = Math.max(0, baseMaintenance - efficiencyCredit - affinityCredit);
     const activeFactorDelta = projectDelta.active + routeDelta.active;
     const reserveFactorDelta = projectDelta.reserve + routeDelta.reserve;
-
     fixedUpkeep += netMaintenance;
     activeFactor += activeFactorDelta;
     reserveFactor += reserveFactorDelta;
@@ -217,31 +200,66 @@ export function companyOperatingProfile(save: SaveData): CompanyOperatingProfile
       reserveFactorDelta,
     });
   }
-
   const fellowshipStages = accepted.filter((entry) => entry.projectId === 'fellowship-hall').length;
-  const loyaltyDiscount = Math.min(12, bondTierTotal(save) * fellowshipStages);
-  const diversityDiscount = accepted.length > 0 && careerDiversity(save) >= 3 ? 2 : 0;
-
   return {
     activeWageFactor: clamp(activeFactor, 0.8, 1.15),
     reserveWageFactor: clamp(reserveFactor, 0.08, 0.3),
     fixedUpkeep: Math.min(60, fixedUpkeep),
-    loyaltyDiscount,
-    diversityDiscount,
+    loyaltyDiscount: Math.min(12, bondTierTotal(save) * fellowshipStages),
+    diversityDiscount: accepted.length > 0 && careerDiversity(save) >= 3 ? 2 : 0,
     entries,
     warnings,
   };
 }
 
+function wagePerTrip(record: CompanionRecord): number {
+  const traitDelta = record.trait === 'greedy' ? 3 : record.trait === 'frugal' ? -2 : 0;
+  return 8 + record.level * 4 + traitDelta;
+}
+
 /**
- * M29 營運薪餉：延續原本出征／後備／軍需官規則，再加入工程維護與制度效率。
- * 無工程收據時結果與 M17 totalWage 完全相同。
+ * 薪餉只需要知道健康出征者與軍需官是否存在；此處以純存檔資料重建同等規則，
+ * 避免 economy → operations → roster → save → expedition → economy 的模組循環。
  */
-export function companyPayrollBreakdown(
-  save: SaveData,
-  candidate?: ExpeditionPlan,
-): CompanyPayrollBreakdown {
-  const plan = normalizeExpeditionPlan(save, candidate);
+function payrollPlan(save: SaveData, candidate?: ExpeditionPlan): ExpeditionPlan {
+  const healthy = [save.protagonist, ...save.companions.filter((member) => member.injuredForTrips === 0)];
+  const validIds = new Set(healthy.map((member) => member.id));
+  const requested = candidate?.activeIds ?? save.expeditionPlan?.activeIds ?? healthy.map((member) => member.id);
+  const desiredSize = candidate || save.expeditionPlan
+    ? Math.min(4, Math.max(1, requested.length))
+    : Math.min(4, healthy.length);
+  const activeIds = [save.protagonist.id];
+  for (const id of requested) {
+    if (activeIds.length >= 4) break;
+    if (id !== save.protagonist.id && validIds.has(id) && !activeIds.includes(id)) activeIds.push(id);
+  }
+  for (const member of healthy) {
+    if (activeIds.length >= desiredSize) break;
+    if (!activeIds.includes(member.id)) activeIds.push(member.id);
+  }
+
+  const requestedRoles = candidate?.roles ?? save.expeditionPlan?.roles ?? {};
+  const roles: Partial<Record<ExpeditionRole, string>> = {};
+  const assigned = new Set<string>();
+  for (const role of ROLE_ORDER) {
+    const holder = requestedRoles[role];
+    if (holder && activeIds.includes(holder) && !assigned.has(holder)) {
+      roles[role] = holder;
+      assigned.add(holder);
+    }
+  }
+  for (const role of ROLE_ORDER) {
+    if (roles[role]) continue;
+    const holder = activeIds.find((id) => !assigned.has(id));
+    if (!holder) continue;
+    roles[role] = holder;
+    assigned.add(holder);
+  }
+  return { activeIds, positions: {}, roles };
+}
+
+export function companyPayrollBreakdown(save: SaveData, candidate?: ExpeditionPlan): CompanyPayrollBreakdown {
+  const plan = payrollPlan(save, candidate);
   const activeIds = new Set(plan.activeIds);
   const activeBase = save.companions
     .filter((companion) => companion.injuredForTrips === 0 && activeIds.has(companion.id))
@@ -250,14 +268,11 @@ export function companyPayrollBreakdown(
     .filter((companion) => companion.injuredForTrips === 0 && !activeIds.has(companion.id))
     .reduce((sum, companion) => sum + wagePerTrip(companion), 0);
   const profile = companyOperatingProfile(save);
-  const quartermasterFactor = plan.roles.quartermaster
-    ? (EXPEDITION_ROLES.quartermaster.reserveWageFactor ?? 1)
-    : 1;
+  const quartermasterFactor = plan.roles.quartermaster ? QUARTERMASTER_FACTOR : 1;
   const activeAdjusted = Math.ceil(activeBase * profile.activeWageFactor);
   const reserveAdjusted = Math.ceil(reserveBase * profile.reserveWageFactor * quartermasterFactor);
   const gross = activeAdjusted + reserveAdjusted + profile.fixedUpkeep;
   const total = Math.max(0, gross - profile.loyaltyDiscount - profile.diversityDiscount);
-
   return {
     ...profile,
     activeBase,

--- a/src/scripts/games/caravan/data/operations.ts
+++ b/src/scripts/games/caravan/data/operations.ts
@@ -1,0 +1,271 @@
+import type { ExpeditionPlan, SaveData } from '../save';
+import {
+  EXPEDITION_ROLES,
+  RESERVE_WAGE_FACTOR,
+  bondTier,
+  normalizeExpeditionPlan,
+  wagePerTrip,
+} from '../roster';
+import {
+  COMPANY_INITIATIVE_ORDER,
+  COMPANY_INITIATIVES,
+  initiativeRoutesAtStage,
+} from './initiatives';
+import type {
+  CompanyInitiativeId,
+  CompanyInitiativeRouteId,
+  CompanyInitiativeStage,
+} from './initiatives';
+import { isValidCompanyCharterProgress } from './charters';
+
+export interface CompanyOperatingEntry {
+  projectId: CompanyInitiativeId;
+  projectName: string;
+  stage: CompanyInitiativeStage;
+  routeId: CompanyInitiativeRouteId;
+  routeName: string;
+  baseMaintenance: number;
+  efficiencyCredit: number;
+  affinityCredit: number;
+  netMaintenance: number;
+  activeFactorDelta: number;
+  reserveFactorDelta: number;
+}
+
+export interface CompanyOperatingProfile {
+  activeWageFactor: number;
+  reserveWageFactor: number;
+  fixedUpkeep: number;
+  loyaltyDiscount: number;
+  diversityDiscount: number;
+  entries: CompanyOperatingEntry[];
+  warnings: string[];
+}
+
+export interface CompanyPayrollBreakdown extends CompanyOperatingProfile {
+  activeBase: number;
+  activeAdjusted: number;
+  reserveBase: number;
+  reserveAdjusted: number;
+  quartermasterFactor: number;
+  gross: number;
+  total: number;
+}
+
+const STAGES: CompanyInitiativeStage[] = [1, 2, 3];
+const STAGE_CAP: Record<CompanyInitiativeStage, number> = { 1: 3, 2: 2, 3: 1 };
+const BASE_MAINTENANCE: Record<CompanyInitiativeStage, number> = { 1: 4, 2: 8, 3: 13 };
+const ROUTE_NAMES: Record<CompanyInitiativeRouteId, string> = {
+  expertise: '專業方案',
+  capital: '資本方案',
+  field: '實地方案',
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+interface AcceptedInitiative {
+  projectId: CompanyInitiativeId;
+  stage: CompanyInitiativeStage;
+  routeId: CompanyInitiativeRouteId;
+}
+
+/**
+ * 僅採用循序、單一路線且未超過 3／2／1 組合上限的工程收據。
+ * 髒旗標只產生警告，不會轉化成額外營運收益。
+ */
+export function acceptedOperationalInitiatives(save: SaveData): {
+  accepted: AcceptedInitiative[];
+  warnings: string[];
+} {
+  const accepted: AcceptedInitiative[] = [];
+  const warnings: string[] = [];
+  let previous = new Set<CompanyInitiativeId>();
+
+  for (const stage of STAGES) {
+    const candidates: AcceptedInitiative[] = [];
+    for (const projectId of COMPANY_INITIATIVE_ORDER) {
+      const routes = initiativeRoutesAtStage(save, projectId, stage);
+      if (routes.length > 1) {
+        warnings.push(`${COMPANY_INITIATIVES[projectId].name}第 ${stage} 階存在衝突方案，營運效果不採計。`);
+        continue;
+      }
+      if (routes.length === 0) continue;
+      if (stage > 1 && !previous.has(projectId)) {
+        warnings.push(`${COMPANY_INITIATIVES[projectId].name}第 ${stage} 階缺少前置工程，營運效果不採計。`);
+        continue;
+      }
+      candidates.push({ projectId, stage, routeId: routes[0] });
+    }
+
+    if (candidates.length > STAGE_CAP[stage]) {
+      warnings.push(`第 ${stage} 階工程收據超過上限 ${STAGE_CAP[stage]}，僅採計固定順序中的前 ${STAGE_CAP[stage]} 項。`);
+    }
+    const stageAccepted = candidates.slice(0, STAGE_CAP[stage]);
+    accepted.push(...stageAccepted);
+    previous = new Set(stageAccepted.map((entry) => entry.projectId));
+  }
+
+  return { accepted, warnings };
+}
+
+function bondTierTotal(save: SaveData): number {
+  return save.companions.reduce((sum, companion) => sum + bondTier(companion.bond), 0);
+}
+
+function careerDiversity(save: SaveData): number {
+  return new Set(
+    (save.protagonist.careerMilestones ?? [])
+      .map((milestone) => milestone?.pathId)
+      .filter((pathId): pathId is string => typeof pathId === 'string')
+  ).size;
+}
+
+function routeEfficiency(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+  maintenance: number,
+): number {
+  const project = COMPANY_INITIATIVES[projectId];
+  if (routeId === 'expertise') {
+    const skill = save.protagonist.skills?.[project.primarySkill] ?? 0;
+    const potential = save.protagonist.growth?.potential?.[project.primaryStat] ?? 0;
+    return Math.min(maintenance, Math.floor((Math.max(0, skill) + Math.max(0, potential)) / 2));
+  }
+  if (routeId === 'capital') {
+    return Math.min(maintenance, Math.max(0, Math.floor(save.wagonLevel)));
+  }
+  return Math.min(maintenance, Math.floor(bondTierTotal(save) / 2));
+}
+
+function projectAdjustments(
+  projectId: CompanyInitiativeId,
+  stage: CompanyInitiativeStage,
+): { maintenance: number; active: number; reserve: number } {
+  switch (projectId) {
+    case 'escort-network':
+      return { maintenance: 0, active: -0.01 * stage, reserve: 0 };
+    case 'frontier-office':
+      return { maintenance: 0, active: 0.005 * stage, reserve: -0.005 * stage };
+    case 'trade-consortium':
+      return { maintenance: stage * 2, active: -0.005 * stage, reserve: 0 };
+    case 'fellowship-hall':
+      return { maintenance: 0, active: 0, reserve: -0.01 * stage };
+    case 'relic-workshop':
+      return { maintenance: stage, active: 0.01 * stage, reserve: 0 };
+  }
+}
+
+function routeAdjustments(
+  stage: CompanyInitiativeStage,
+  routeId: CompanyInitiativeRouteId,
+): { maintenance: number; active: number; reserve: number } {
+  if (routeId === 'expertise') {
+    return { maintenance: 2, active: -0.01 * stage, reserve: 0 };
+  }
+  if (routeId === 'capital') {
+    return { maintenance: 4, active: -0.015 * stage, reserve: -0.01 * stage };
+  }
+  return { maintenance: 0, active: 0.005 * stage, reserve: -0.015 * stage };
+}
+
+/** 建立工程投資在每趟遠征中產生的持續薪餉與維護結構。 */
+export function companyOperatingProfile(save: SaveData): CompanyOperatingProfile {
+  const { accepted, warnings } = acceptedOperationalInitiatives(save);
+  const charter = isValidCompanyCharterProgress(save.companyCharter) ? save.companyCharter : null;
+  const entries: CompanyOperatingEntry[] = [];
+  let activeFactor = 1;
+  let reserveFactor = RESERVE_WAGE_FACTOR;
+  let fixedUpkeep = 0;
+
+  for (const receipt of accepted) {
+    const project = COMPANY_INITIATIVES[receipt.projectId];
+    const projectDelta = projectAdjustments(receipt.projectId, receipt.stage);
+    const routeDelta = routeAdjustments(receipt.stage, receipt.routeId);
+    const baseMaintenance = BASE_MAINTENANCE[receipt.stage] + projectDelta.maintenance + routeDelta.maintenance;
+    const efficiencyCredit = routeEfficiency(
+      save,
+      receipt.projectId,
+      receipt.stage,
+      receipt.routeId,
+      baseMaintenance,
+    );
+    const affinityCredit = charter && project.affinity.includes(charter.id)
+      ? receipt.stage
+      : 0;
+    const netMaintenance = Math.max(0, baseMaintenance - efficiencyCredit - affinityCredit);
+    const activeFactorDelta = projectDelta.active + routeDelta.active;
+    const reserveFactorDelta = projectDelta.reserve + routeDelta.reserve;
+
+    fixedUpkeep += netMaintenance;
+    activeFactor += activeFactorDelta;
+    reserveFactor += reserveFactorDelta;
+    entries.push({
+      projectId: receipt.projectId,
+      projectName: project.name,
+      stage: receipt.stage,
+      routeId: receipt.routeId,
+      routeName: ROUTE_NAMES[receipt.routeId],
+      baseMaintenance,
+      efficiencyCredit,
+      affinityCredit,
+      netMaintenance,
+      activeFactorDelta,
+      reserveFactorDelta,
+    });
+  }
+
+  const fellowshipStages = accepted.filter((entry) => entry.projectId === 'fellowship-hall').length;
+  const loyaltyDiscount = Math.min(12, bondTierTotal(save) * fellowshipStages);
+  const diversityDiscount = accepted.length > 0 && careerDiversity(save) >= 3 ? 2 : 0;
+
+  return {
+    activeWageFactor: clamp(activeFactor, 0.8, 1.15),
+    reserveWageFactor: clamp(reserveFactor, 0.08, 0.3),
+    fixedUpkeep: Math.min(60, fixedUpkeep),
+    loyaltyDiscount,
+    diversityDiscount,
+    entries,
+    warnings,
+  };
+}
+
+/**
+ * M29 營運薪餉：延續原本出征／後備／軍需官規則，再加入工程維護與制度效率。
+ * 無工程收據時結果與 M17 totalWage 完全相同。
+ */
+export function companyPayrollBreakdown(
+  save: SaveData,
+  candidate?: ExpeditionPlan,
+): CompanyPayrollBreakdown {
+  const plan = normalizeExpeditionPlan(save, candidate);
+  const activeIds = new Set(plan.activeIds);
+  const activeBase = save.companions
+    .filter((companion) => companion.injuredForTrips === 0 && activeIds.has(companion.id))
+    .reduce((sum, companion) => sum + wagePerTrip(companion), 0);
+  const reserveBase = save.companions
+    .filter((companion) => companion.injuredForTrips === 0 && !activeIds.has(companion.id))
+    .reduce((sum, companion) => sum + wagePerTrip(companion), 0);
+  const profile = companyOperatingProfile(save);
+  const quartermasterFactor = plan.roles.quartermaster
+    ? (EXPEDITION_ROLES.quartermaster.reserveWageFactor ?? 1)
+    : 1;
+  const activeAdjusted = Math.ceil(activeBase * profile.activeWageFactor);
+  const reserveAdjusted = Math.ceil(reserveBase * profile.reserveWageFactor * quartermasterFactor);
+  const gross = activeAdjusted + reserveAdjusted + profile.fixedUpkeep;
+  const total = Math.max(0, gross - profile.loyaltyDiscount - profile.diversityDiscount);
+
+  return {
+    ...profile,
+    activeBase,
+    activeAdjusted,
+    reserveBase,
+    reserveAdjusted,
+    quartermasterFactor,
+    gross,
+    total,
+  };
+}

--- a/src/scripts/games/caravan/economy.ts
+++ b/src/scripts/games/caravan/economy.ts
@@ -1,11 +1,6 @@
 import { ITEMS } from './data/items';
 import type { ExpeditionPlan, SaveData } from './save';
-import {
-  EXPEDITION_ROLES,
-  RESERVE_WAGE_FACTOR,
-  normalizeExpeditionPlan,
-  wagePerTrip,
-} from './roster';
+import { companyPayrollBreakdown } from './data/operations';
 
 export interface TownDef {
   id: string;
@@ -25,20 +20,19 @@ export interface TownDef {
  * 浮動對象＝priceModifiers 既有品項 ∪ stock 品項。
  */
 export function applyMarket(town: TownDef, marketSeed: number): TownDef {
-  // 每鎮每品項各自可重現的偽隨機：字串雜湊 + seed（mulberry32 一步）
   const swing = (key: string): number => {
     let h = marketSeed >>> 0;
     for (let i = 0; i < key.length; i++) h = Math.imul(h ^ key.charCodeAt(i), 2654435761);
     h = Math.imul(h ^ (h >>> 13), 1597334677);
-    const unit = ((h ^ (h >>> 16)) >>> 0) / 4294967296; // 0-1
-    return 0.75 + unit * 0.6; // 0.75-1.35
+    const unit = ((h ^ (h >>> 16)) >>> 0) / 4294967296;
+    return 0.75 + unit * 0.6;
   };
   const itemIds = new Set([...Object.keys(town.priceModifiers), ...town.stock]);
   const priceModifiers: Record<string, number> = {};
   for (const itemId of itemIds) {
     const base = town.priceModifiers[itemId] ?? 1;
     priceModifiers[itemId] = ITEMS[itemId]?.equip
-      ? base // 裝備維持基準
+      ? base
       : Math.round(base * swing(`${town.id}:${itemId}`) * 100) / 100;
   }
   return { ...town, priceModifiers };
@@ -50,9 +44,7 @@ function priceModifier(town: TownDef, itemId: string): number {
 
 function requireItem(itemId: string, callerName: string) {
   const item = ITEMS[itemId];
-  if (!item) {
-    throw new Error(`${callerName}: 找不到物品「${itemId}」`);
-  }
+  if (!item) throw new Error(`${callerName}: 找不到物品「${itemId}」`);
   return item;
 }
 
@@ -69,14 +61,11 @@ export function sellPrice(town: TownDef, itemId: string): number {
 
 /**
  * 異鎮轉賣價格（押貨貿易的差價空間）：round(ITEMS.value × 城鎮係數 × 0.9)。
- * M5 套利裁決（終審移交）：equip 類物品不吃異鎮 0.9 係數與城鎮係數，一律
- * round(value × 0.5)（＝與原鎮 sellPrice 同量級）——裝備要嘛用、要嘛半價賣，無套利。
+ * 裝備不吃異鎮套利，一律半價出售。
  */
 export function tradeSellPrice(town: TownDef, itemId: string): number {
   const item = requireItem(itemId, 'tradeSellPrice');
-  if (item.equip) {
-    return Math.round(item.value * 0.5);
-  }
+  if (item.equip) return Math.round(item.value * 0.5);
   return Math.round(item.value * priceModifier(town, itemId) * 0.9);
 }
 
@@ -91,21 +80,10 @@ export function wagonUpgradeCost(wagonLevel: number): number {
 }
 
 /**
- * M17 薪餉：出征傭兵領全額；健康後備收 25% 留營費。
- * 軍需官讓後備費再減半。主角永不領薪。
+ * M29 營運薪餉：保留 M17 出征／後備／軍需官規則，再套用 M28 工程形成的
+ * 維護費、方案效率、特許相性、羈絆忠誠與職涯多樣性。
+ * 無有效工程收據時，結果精確等同舊版薪餉。
  */
 export function totalWage(save: SaveData, candidate?: ExpeditionPlan): number {
-  const plan = normalizeExpeditionPlan(save, candidate);
-  const activeIds = new Set(plan.activeIds);
-  const active = save.companions
-    .filter((companion) => companion.injuredForTrips === 0 && activeIds.has(companion.id))
-    .reduce((sum, companion) => sum + wagePerTrip(companion), 0);
-  const reserveBase = save.companions
-    .filter((companion) => companion.injuredForTrips === 0 && !activeIds.has(companion.id))
-    .reduce((sum, companion) => sum + wagePerTrip(companion), 0);
-  const hasQuartermaster = !!plan.roles.quartermaster;
-  const quartermasterFactor = hasQuartermaster
-    ? (EXPEDITION_ROLES.quartermaster.reserveWageFactor ?? 1)
-    : 1;
-  return active + Math.ceil(reserveBase * RESERVE_WAGE_FACTOR * quartermasterFactor);
+  return companyPayrollBreakdown(save, candidate).total;
 }


### PR DESCRIPTION
## Summary

- turn completed M28 company initiatives into persistent operational payroll doctrines used by the real expedition wage calculation
- derive active wages, reserve fees, fixed maintenance, route efficiency, charter affinity, loyalty discounts, and career-diversity discounts from the existing save
- keep no-initiative saves exactly compatible with the previous M17 wage rules
- accept only sequential, single-route, portfolio-cap-compliant initiative receipts; conflicting, skipped, or over-cap flags produce warnings and no extra benefit
- make expertise routes scale from the protagonist's relevant skill and growth potential, capital routes from wagon investment, and field routes from companion bond tiers
- hard-cap active and reserve factors, fixed upkeep, and discounts to prevent runaway negative wages or infinite economic exploits
- expose a player-facing `/caravan/operations` ledger with the same formal payroll function used by expedition departure previews
- avoid runtime module cycles by keeping the payroll calculation dependent only on save data and pure constants
- add adversarial tests for legacy parity, route differentiation, cross-system efficiency, loyalty and diversity rules, dirty receipts, safety bounds, purity, and economy integration

## Game-design intent

M28 created irreversible company projects, but their impact was still mostly a one-time reward. M29 makes organizational choices part of every expedition's operating cost. Expertise, capital, and field routes now create different ongoing maintenance and payroll structures, so character creation, growth potential, careers, charter affinity, wagon investment, companion bonds, roster deployment, and quartermaster assignment all meet in one transparent recurring decision.

The system deliberately includes both benefits and obligations. A larger organization may lower active wages or reserve fees, but it also has fixed upkeep. Strong relevant skills and potential, matching charters, wagon infrastructure, bonds, and career diversity can offset that upkeep. This keeps projects meaningful without turning them into free compounding bonuses.

## Player adversarial review

- saves without initiative receipts return exactly the legacy wage result
- expertise, capital, and field receipts produce mechanically distinct wage accounts
- expertise efficiency is driven by the matching skill and potential
- capital efficiency is driven by wagon investment
- field efficiency and fellowship loyalty are driven by actual companion bond tiers
- active wage factor is clamped to 80%–115%, reserve factor to 8%–30%, and fixed upkeep to 60 G
- conflicting routes, stage skipping, and receipts beyond the 3/2/1 portfolio caps do not stack benefits
- deterministic project ordering handles corrupted over-cap saves consistently
- payroll calculation never mutates the save
- `economy.totalWage()` and the player-facing operations ledger use the same source of truth
- the runtime dependency graph avoids economy/save/expedition circular initialization

## Scope

- `src/scripts/games/caravan/data/operations.ts`
- `src/scripts/games/caravan/data/operations.m29.test.ts`
- `src/scripts/games/caravan/economy.ts`
- `src/pages/caravan/operations.astro`

No dependency, lockfile, generated-output, asset, or save-version changes.