### PR TITLE
feat(caravan): add M31 companion origin parity

### DIFF
--- a/src/pages/caravan/companions.astro
+++ b/src/pages/caravan/companions.astro
@@ -1,0 +1,139 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="旅伴身世登記 — 商隊與劍"
+  description="為旅伴建立可重現的出身、潛力與職涯，使整支商隊都參與長期角色系統。"
+  lang="zh-TW"
+>
+  <main class="origin-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M31</p>
+      <h1>旅伴身世登記</h1>
+      <p>旅伴不再只是職業與隨機屬性。登記會補上命運、五維潛力、技能與既有等級對應的職涯脈絡。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/dossier">商隊檔案</a>
+        <a href="/caravan/forge">命運鍛造所</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>目前沒有可登記的旅伴</h2>
+      <p>先在酒館招募旅伴，再回來查看每個人的命運與長期成長。</p>
+    </section>
+
+    <section class="notice panel">
+      <h2>登記規則</h2>
+      <p>只補上角色能力層：命運、潛力、合理成長、生命、技能與職涯。不会補發金幣、物資、聲望、馬車或特許獎勵，也不能重複登記。</p>
+    </section>
+
+    <section id="cards" class="cards"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    previewAllCompanionOrigins,
+    registerCompanionOrigin,
+  } from '@scripts/games/caravan/data/companionOrigins';
+
+  const cards = document.getElementById('cards')!;
+  const empty = document.getElementById('empty')!;
+  const status = document.getElementById('status')!;
+  const statNames: Record<string, string> = {
+    str: '力量', dex: '敏捷', int: '智力', cha: '魅力', con: '體質',
+  };
+  const skillNames: Record<string, string> = {
+    martial: '武藝', scouting: '偵查', lore: '博識', negotiation: '交涉', survival: '生存',
+  };
+
+  let save = loadGame();
+
+  function formatMap(values: Record<string, number | undefined>, names: Record<string, string>): string {
+    const entries = Object.entries(values).filter(([, value]) => (value ?? 0) !== 0);
+    return entries.length
+      ? entries.map(([key, value]) => `${names[key] ?? key} ${Number(value) > 0 ? '+' : ''}${value}`).join('、')
+      : '無';
+  }
+
+  function render(): void {
+    cards.innerHTML = '';
+    if (!save || save.companions.length === 0) {
+      empty.removeAttribute('hidden');
+      return;
+    }
+    empty.setAttribute('hidden', '');
+    const previews = previewAllCompanionOrigins(save);
+    for (const preview of previews) {
+      const record = save.companions.find((companion) => companion.id === preview.companionId)!;
+      const article = document.createElement('article');
+      article.className = 'panel companion-card';
+      article.innerHTML = `
+        <div class="card-head">
+          <div>
+            <p class="eyebrow">${record.job.toUpperCase()} · Lv${record.level}</p>
+            <h2>${record.name}</h2>
+          </div>
+          <span class="badge ${preview.alreadyRegistered ? 'done' : ''}">${preview.alreadyRegistered ? '已登記' : '待確認'}</span>
+        </div>
+        <dl>
+          <div><dt>出身道路</dt><dd>${preview.lifepathName}</dd></div>
+          <div><dt>完整命運</dt><dd>${preview.genesisName}</dd></div>
+          <div><dt>五維潛力</dt><dd>${preview.growthSignature}</dd></div>
+          <div><dt>職涯脈絡</dt><dd>${preview.careerSequence}</dd></div>
+          <div><dt>屬性增量</dt><dd>${formatMap(preview.statBonuses, statNames)}</dd></div>
+          <div><dt>生命增量</dt><dd>${preview.maxHpBonus >= 0 ? '+' : ''}${preview.maxHpBonus}</dd></div>
+          <div><dt>技能增量</dt><dd>${formatMap(preview.skillBonuses, skillNames)}</dd></div>
+        </dl>
+      `;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = preview.alreadyRegistered ? '已完成登記' : '確認身世登記';
+      button.disabled = preview.alreadyRegistered;
+      button.addEventListener('click', () => {
+        if (!save) return;
+        try {
+          registerCompanionOrigin(save, preview.companionId);
+          saveGame(save);
+          status.textContent = `${record.name} 的身世已登記並保存。`;
+          render();
+        } catch (error) {
+          status.textContent = error instanceof Error ? error.message : '身世登記失敗。';
+        }
+      });
+      article.appendChild(button);
+      cards.appendChild(article);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  .origin-page { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 80px; }
+  .hero { margin-bottom: 24px; }
+  .hero h1 { margin: 4px 0 8px; font-size: clamp(2rem, 6vw, 4rem); }
+  .hero nav { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 18px; }
+  .hero a, button { border: 1px solid currentColor; border-radius: 999px; padding: 10px 16px; text-decoration: none; background: transparent; color: inherit; cursor: pointer; }
+  .panel { border: 1px solid rgba(150,130,95,.42); border-radius: 18px; padding: 20px; background: rgba(28,24,19,.72); }
+  .notice { margin-bottom: 20px; }
+  .notice h2 { margin-top: 0; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(310px, 1fr)); gap: 18px; }
+  .companion-card { display: flex; flex-direction: column; gap: 16px; }
+  .card-head { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; }
+  .card-head h2 { margin: 2px 0 0; }
+  .eyebrow { margin: 0; letter-spacing: .12em; opacity: .72; font-size: .78rem; }
+  .badge { border: 1px solid #c9a45f; border-radius: 999px; padding: 5px 9px; font-size: .78rem; }
+  .badge.done { opacity: .65; }
+  dl { display: grid; gap: 9px; margin: 0; }
+  dl div { display: grid; grid-template-columns: 92px 1fr; gap: 12px; }
+  dt { opacity: .68; }
+  dd { margin: 0; }
+  button { align-self: flex-start; }
+  button:disabled { cursor: default; opacity: .48; }
+  .status { min-height: 1.5em; margin-top: 18px; }
+</style>

--- a/src/scripts/games/caravan/data/companionOrigins.m31.test.ts
+++ b/src/scripts/games/caravan/data/companionOrigins.m31.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord, SaveData } from '../save';
+import {
+  companionOriginFingerprint,
+  previewAllCompanionOrigins,
+  previewCompanionOrigin,
+  registerCompanionOrigin,
+} from './companionOrigins';
+
+function companion(overrides: Partial<CompanionRecord> = {}): CompanionRecord {
+  return {
+    id: 'companion-a',
+    name: '沈昭',
+    job: 'ranger',
+    level: 3,
+    xp: 120,
+    stats: { str: 10, dex: 15, int: 11, cha: 9, con: 12 },
+    maxHp: 22,
+    injuredForTrips: 0,
+    trait: 'nimble',
+    equipment: { weapon: null, armor: null, trinket: null },
+    bond: 4,
+    skills: { scouting: 1 },
+    skillPoints: 1,
+    ...overrides,
+  };
+}
+
+function saveWith(companions: CompanionRecord[] = [companion()]): SaveData {
+  return {
+    version: 6,
+    createdAt: 100,
+    gold: 321,
+    flags: {},
+    protagonist: {
+      id: 'protagonist', name: '你', job: 'swordsman', level: 1, xp: 0,
+      stats: { str: 12, dex: 12, int: 10, cha: 12, con: 12 },
+      maxHp: 22, injuredForTrips: 0, trait: null,
+      equipment: { weapon: null, armor: null, trinket: null },
+    },
+    companions,
+    inventory: { herb: 3, ore: 2 },
+    expedition: null,
+    wagonLevel: 1,
+    tavernSeed: 100,
+    marketSeed: 101,
+    reputation: 17,
+    visitedBossDungeons: [],
+  };
+}
+
+describe('M31 companion origins', () => {
+  it('is deterministic and preview-only', () => {
+    const save = saveWith();
+    const before = JSON.stringify(save);
+    const first = previewCompanionOrigin(save, 'companion-a');
+    const second = previewCompanionOrigin(save, 'companion-a');
+    expect(companionOriginFingerprint(first)).toBe(companionOriginFingerprint(second));
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('uses an existing genesis-compatible trait as the lifepath', () => {
+    const preview = previewCompanionOrigin(saveWith(), 'companion-a');
+    expect(preview.lifepathId).toBe('nimble');
+    expect(preview.careerMilestones.map((milestone) => milestone.level)).toEqual([2, 3]);
+  });
+
+  it('assigns non-genesis traits through a stable identity hash', () => {
+    const record = companion({ trait: 'greedy' });
+    const a = previewCompanionOrigin(saveWith([record]), record.id);
+    const b = previewCompanionOrigin(saveWith([{ ...record }]), record.id);
+    expect(a.lifepathId).toBe(b.lifepathId);
+  });
+
+  it('registers only character power and never grants economic rewards', () => {
+    const save = saveWith();
+    const economyBefore = {
+      gold: save.gold,
+      reputation: save.reputation,
+      inventory: { ...save.inventory },
+      wagonLevel: save.wagonLevel,
+      flags: { ...save.flags },
+    };
+    const preview = previewCompanionOrigin(save, 'companion-a');
+    registerCompanionOrigin(save, 'companion-a');
+    const record = save.companions[0];
+
+    expect(record.genesis).toBeDefined();
+    expect(record.growth).toEqual(preview.growth);
+    expect(record.growthRealizedLevel).toBe(record.level);
+    expect(record.careerMilestones).toEqual(preview.careerMilestones);
+    expect(save.gold).toBe(economyBefore.gold);
+    expect(save.reputation).toBe(economyBefore.reputation);
+    expect(save.inventory).toEqual(economyBefore.inventory);
+    expect(save.wagonLevel).toBe(economyBefore.wagonLevel);
+    expect(save.flags).toEqual(economyBefore.flags);
+  });
+
+  it('cannot be repeated to stack stats, hp, skills, or careers', () => {
+    const save = saveWith();
+    registerCompanionOrigin(save, 'companion-a');
+    const after = JSON.stringify(save.companions[0]);
+    expect(() => registerCompanionOrigin(save, 'companion-a')).toThrow('已完成身世登記');
+    expect(JSON.stringify(save.companions[0])).toBe(after);
+  });
+
+  it('respects the skill cap when an origin adds an existing skill', () => {
+    const save = saveWith([companion({ skills: { scouting: 5 } })]);
+    registerCompanionOrigin(save, 'companion-a');
+    expect(save.companions[0].skills?.scouting).toBe(5);
+  });
+
+  it('lists mixed registered and unregistered companions without mutating either', () => {
+    const registered = companion({
+      id: 'registered',
+      genesis: { lifepathId: 'nimble', aptitudeId: 'dex', burdenId: 'cha' },
+      growth: { potential: { str: 2, dex: 5, int: 3, cha: 1, con: 4 } },
+    });
+    const save = saveWith([registered, companion({ id: 'fresh', name: '顧言' })]);
+    const before = JSON.stringify(save);
+    const previews = previewAllCompanionOrigins(save);
+    expect(previews.map((entry) => entry.alreadyRegistered)).toEqual([true, false]);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('fails cleanly for an unknown companion', () => {
+    const save = saveWith();
+    const before = JSON.stringify(save);
+    expect(() => registerCompanionOrigin(save, 'missing')).toThrow('找不到旅伴');
+    expect(JSON.stringify(save)).toBe(before);
+  });
+});

--- a/src/scripts/games/caravan/data/companionOrigins.ts
+++ b/src/scripts/games/caravan/data/companionOrigins.ts
@@ -1,0 +1,174 @@
+import type { CompanionRecord, SaveData } from '../save';
+import { STARTING_PROFILE } from '../save';
+import type { StatBlock } from '../types';
+import {
+  GENESIS_LIFEPATHS,
+  genesisName,
+  resolveCharacterGenesis,
+} from './genesis';
+import type { GenesisTraitId } from './genesis';
+import {
+  creationGrowthSeed,
+  deriveGrowthProfile,
+  growthSignature,
+  realizedGrowthBonuses,
+} from './growth';
+import type { GrowthProfile } from './growth';
+import {
+  CAREER_LEVELS,
+  CAREER_PATHS,
+  chooseCareerMilestone,
+} from './careers';
+import type { CareerMilestone, CareerPathId } from './careers';
+
+export interface CompanionOriginPreview {
+  companionId: string;
+  name: string;
+  lifepathId: GenesisTraitId;
+  lifepathName: string;
+  genesisName: string;
+  growth: GrowthProfile;
+  growthSignature: string;
+  careerMilestones: CareerMilestone[];
+  careerSequence: string;
+  statBonuses: Partial<StatBlock>;
+  maxHpBonus: number;
+  skillBonuses: Partial<Record<CareerPathId, number>>;
+  alreadyRegistered: boolean;
+}
+
+const LIFEPATH_ORDER = Object.keys(GENESIS_LIFEPATHS) as GenesisTraitId[];
+const GENESIS_TRAITS = new Set<GenesisTraitId>(LIFEPATH_ORDER);
+const STAT_ORDER: Array<keyof StatBlock> = ['str', 'dex', 'int', 'cha', 'con'];
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function selectedLifepath(record: CompanionRecord): GenesisTraitId {
+  if (record.trait && GENESIS_TRAITS.has(record.trait as GenesisTraitId)) {
+    return record.trait as GenesisTraitId;
+  }
+  const seed = `${record.id}|${record.name}|${record.job}|${record.level}`;
+  return LIFEPATH_ORDER[stableHash(seed) % LIFEPATH_ORDER.length];
+}
+
+function addStats(
+  target: Partial<StatBlock>,
+  source: Partial<StatBlock>,
+): void {
+  for (const stat of STAT_ORDER) {
+    const value = source[stat] ?? 0;
+    if (value !== 0) target[stat] = (target[stat] ?? 0) + value;
+  }
+}
+
+function originPackage(record: CompanionRecord): CompanionOriginPreview {
+  const lifepathId = selectedLifepath(record);
+  const resolved = resolveCharacterGenesis(record.stats, lifepathId);
+  if (!resolved) throw new Error(`無法為旅伴「${record.name}」解析命運`);
+  const baseline = STARTING_PROFILE[record.job].stats;
+  const growth = deriveGrowthProfile(record.stats, baseline, resolved.profile);
+  const seed = creationGrowthSeed(growth);
+  const realized = realizedGrowthBonuses(growth, record.level);
+  const statBonuses: Partial<StatBlock> = {};
+  addStats(statBonuses, seed.stats);
+  addStats(statBonuses, realized.stats);
+
+  const skillBonuses: Partial<Record<CareerPathId, number>> = {};
+  for (const [skillId, rank] of Object.entries(resolved.effects.skills) as Array<[CareerPathId, number]>) {
+    if (rank > 0) skillBonuses[skillId] = rank;
+  }
+
+  const projectedStats = { ...record.stats };
+  for (const stat of STAT_ORDER) projectedStats[stat] += statBonuses[stat] ?? 0;
+  const projectedSkills = { ...(record.skills ?? {}) };
+  for (const [skillId, rank] of Object.entries(skillBonuses) as Array<[CareerPathId, number]>) {
+    projectedSkills[skillId] = Math.min(5, (projectedSkills[skillId] ?? 0) + rank);
+  }
+  const careerMilestones = CAREER_LEVELS
+    .filter((level) => level <= Math.max(1, Math.min(5, Math.floor(record.level))))
+    .map((level) => chooseCareerMilestone({
+      stats: projectedStats,
+      skills: projectedSkills,
+      growth,
+    }, level));
+
+  return {
+    companionId: record.id,
+    name: record.name,
+    lifepathId,
+    lifepathName: GENESIS_LIFEPATHS[lifepathId].name,
+    genesisName: genesisName(resolved.profile),
+    growth,
+    growthSignature: growthSignature(growth),
+    careerMilestones,
+    careerSequence: careerMilestones.length > 0
+      ? careerMilestones.map((milestone) => CAREER_PATHS[milestone.pathId].name).join(' → ')
+      : '尚未形成',
+    statBonuses,
+    maxHpBonus: seed.maxHp + realized.maxHp + resolved.effects.maxHpDelta,
+    skillBonuses,
+    alreadyRegistered: !!record.genesis && !!record.growth,
+  };
+}
+
+export function previewCompanionOrigin(
+  save: SaveData,
+  companionId: string,
+): CompanionOriginPreview {
+  const record = save.companions.find((companion) => companion.id === companionId);
+  if (!record) throw new Error(`找不到旅伴「${companionId}」`);
+  return originPackage(record);
+}
+
+export function previewAllCompanionOrigins(save: SaveData): CompanionOriginPreview[] {
+  return save.companions.map((companion) => originPackage(companion));
+}
+
+/**
+ * 原子登記旅伴身世。只補角色能力層，不補發出身的金幣、物資、聲望或自由技能點。
+ */
+export function registerCompanionOrigin(
+  save: SaveData,
+  companionId: string,
+): CompanionOriginPreview {
+  const record = save.companions.find((companion) => companion.id === companionId);
+  if (!record) throw new Error(`找不到旅伴「${companionId}」`);
+  if (record.genesis || record.growth) throw new Error(`${record.name} 已完成身世登記`);
+
+  const preview = originPackage(record);
+  const resolved = resolveCharacterGenesis(record.stats, preview.lifepathId);
+  if (!resolved) throw new Error(`無法為旅伴「${record.name}」建立命運`);
+
+  // 全部資料先在複本計算完成，再一次性寫入，避免半套狀態。
+  const nextStats = { ...record.stats };
+  for (const stat of STAT_ORDER) nextStats[stat] += preview.statBonuses[stat] ?? 0;
+  const nextSkills = { ...(record.skills ?? {}) };
+  for (const [skillId, rank] of Object.entries(preview.skillBonuses) as Array<[CareerPathId, number]>) {
+    nextSkills[skillId] = Math.min(5, (nextSkills[skillId] ?? 0) + rank);
+  }
+
+  record.stats = nextStats;
+  record.maxHp = Math.max(8, record.maxHp + preview.maxHpBonus);
+  record.skills = nextSkills;
+  record.genesis = resolved.profile;
+  record.growth = preview.growth;
+  record.growthRealizedLevel = Math.max(1, Math.min(5, Math.floor(record.level)));
+  record.careerMilestones = preview.careerMilestones.map((milestone) => ({ ...milestone }));
+  return { ...preview, alreadyRegistered: true };
+}
+
+export function companionOriginFingerprint(preview: CompanionOriginPreview): string {
+  return [
+    preview.companionId,
+    preview.genesisName,
+    preview.growthSignature,
+    preview.careerMilestones.map((milestone) => `${milestone.level}:${milestone.pathId}`).join(','),
+  ].join('|');
+}


### PR DESCRIPTION
## Summary

- add deterministic, player-confirmed origin registration for companions so the full roster can participate in genesis, growth potential, and career identity systems
- preserve existing genesis-compatible traits as lifepaths; map non-genesis traits such as greedy/frugal through a stable identity hash so reloads never reroll a companion's history
- derive companion genesis and five-dimensional potential from the same formal genesis/growth functions used by the protagonist
- grant only character-layer parity: growth stats, HP, capped adventure skills, and level-appropriate career milestones
- explicitly withhold all economic genesis rewards: no gold, inventory, reputation, wagon, charter, flag, or free-skill-point grants
- make registration atomic and irreversible; previews are read-only and repeated registration cannot stack stats, HP, skills, or careers
- add a player-facing `/caravan/companions` registry showing each companion's lifepath, full genesis, potential signature, career sequence, and exact ability deltas before confirmation
- add adversarial tests for determinism, stable hashing, economic non-arbitrage, idempotence, skill caps, mixed legacy rosters, and unknown-companion failure

## Game-design intent

M22-M30 gave the protagonist a deep chain from origin to potential, careers, charter, initiatives, operations, and long-term planning. Tavern companions still remained mostly job/trait/stat bundles, creating a structural imbalance: the party systems were deep, but only one member had a meaningful personal history.

M31 closes that gap without turning recruitment into an economy exploit. Companion histories are deterministic and explicitly registered by the player. Registration makes companions mechanically legible and gives their stats, skills, growth, and existing level a coherent career identity, but strips all economic origin rewards. The result is a richer roster that can support future relationship, formation, and organization systems without allowing hire-register-dismiss farming.

## Player adversarial review

- previewing origins never mutates the save
- identical companion identity data always resolves to the same lifepath, genesis, growth, and careers
- existing compatible traits remain the companion's lifepath instead of being overwritten
- greedy/frugal and other non-genesis traits resolve through a stable hash, not runtime randomness
- registration grants no gold, items, reputation, wagon levels, flags, charter progress, or free skill points
- registration is single-use and a repeated attempt leaves the companion byte-for-byte unchanged
- generated skill bonuses respect rank 5
- growth realization level is set to the companion's current level, preventing save-time double realization
- career milestones are backfilled only through the companion's current level and do not grant career rewards
- mixed registered/unregistered legacy rosters remain readable
- unknown companion ids fail without mutating any data

## Scope

- `src/scripts/games/caravan/data/companionOrigins.ts`
- `src/scripts/games/caravan/data/companionOrigins.m31.test.ts`
- `src/pages/caravan/companions.astro`

No dependency, lockfile, asset, generated-output, or save-version changes.