### PR TITLE
feat(caravan): add M33 operational governance

### DIFF
--- a/src/pages/caravan/governance.astro
+++ b/src/pages/caravan/governance.astro
@@ -1,0 +1,194 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="營運治理 — 商隊與劍"
+  description="切換商隊營運姿態、暫停長程工程並避免固定維護費造成軟鎖。"
+  lang="zh-TW"
+>
+  <main class="governance-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M33</p>
+      <h1>營運治理</h1>
+      <p>長期工程不再只能永久全開。選擇營運姿態，或暫停暫時負擔不起的工程；被暫停的工程會同時失去維護費、薪資效果與折扣。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/operations">營運帳本</a>
+        <a href="/caravan/initiatives">長程工程</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立旅程，再回來設定營運治理。</p>
+    </section>
+
+    <div id="app" hidden>
+      <section class="panel">
+        <div class="section-head">
+          <div><p class="eyebrow">STANCE</p><h2>營運姿態</h2></div>
+          <p id="gold" class="gold"></p>
+        </div>
+        <div id="stances" class="stance-grid"></div>
+        <p class="hint">舊存檔預設為標準營運。首次明確選擇免費，之後每次切換需 10 G。</p>
+      </section>
+
+      <section class="panel summary">
+        <div><span>本趟總成本</span><strong id="total">0 G</strong></div>
+        <div><span>出征薪餉</span><strong id="active">0 G</strong></div>
+        <div><span>後備費</span><strong id="reserve">0 G</strong></div>
+        <div><span>固定維護</span><strong id="upkeep">0 G</strong></div>
+        <div><span>折扣</span><strong id="discount">0 G</strong></div>
+      </section>
+
+      <section class="panel">
+        <p class="eyebrow">PROJECTS</p>
+        <h2>工程啟停</h2>
+        <p class="hint">暫停免費；重新啟動依最高完成階段支付 15／30／45 G。</p>
+        <div id="projects" class="project-list"></div>
+      </section>
+
+      <p id="message" class="message" aria-live="polite"></p>
+    </div>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    OPERATING_STANCE_ORDER,
+    OPERATING_STANCES,
+    currentOperatingStance,
+    governanceProjects,
+    governedPayrollBreakdown,
+    setOperatingStance,
+    setProjectSuspended,
+  } from '@scripts/games/caravan/data/governance';
+  import type { OperatingStanceId } from '@scripts/games/caravan/data/governance';
+  import type { CompanyInitiativeId } from '@scripts/games/caravan/data/initiatives';
+
+  const emptyEl = document.getElementById('empty')!;
+  const appEl = document.getElementById('app')!;
+  const goldEl = document.getElementById('gold')!;
+  const stancesEl = document.getElementById('stances')!;
+  const projectsEl = document.getElementById('projects')!;
+  const totalEl = document.getElementById('total')!;
+  const activeEl = document.getElementById('active')!;
+  const reserveEl = document.getElementById('reserve')!;
+  const upkeepEl = document.getElementById('upkeep')!;
+  const discountEl = document.getElementById('discount')!;
+  const messageEl = document.getElementById('message')!;
+
+  let save = loadGame();
+
+  function button(label: string, onClick: () => void): HTMLButtonElement {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.textContent = label;
+    element.addEventListener('click', onClick);
+    return element;
+  }
+
+  function execute(action: (latest: NonNullable<typeof save>) => void): void {
+    const latest = loadGame();
+    if (!latest) { messageEl.textContent = '存檔已不存在。'; return; }
+    try {
+      action(latest);
+      saveGame(latest);
+      save = latest;
+      messageEl.textContent = '營運設定已保存。';
+    } catch (error) {
+      save = latest;
+      messageEl.textContent = error instanceof Error ? error.message : '操作失敗。';
+    }
+    render();
+  }
+
+  function render(): void {
+    if (!save) {
+      emptyEl.hidden = false;
+      appEl.hidden = true;
+      return;
+    }
+    emptyEl.hidden = true;
+    appEl.hidden = false;
+    const result = governedPayrollBreakdown(save);
+    const current = currentOperatingStance(save);
+    goldEl.textContent = `商隊資金 ${save.gold} G`;
+    totalEl.textContent = `${result.total} G`;
+    activeEl.textContent = `${result.activeAdjusted} G`;
+    reserveEl.textContent = `${result.reserveAdjusted} G`;
+    upkeepEl.textContent = `${result.fixedUpkeep} G`;
+    discountEl.textContent = `-${result.loyaltyDiscount + result.diversityDiscount} G`;
+
+    stancesEl.replaceChildren();
+    for (const id of OPERATING_STANCE_ORDER) {
+      const def = OPERATING_STANCES[id];
+      const card = document.createElement('article');
+      card.className = `stance-card${id === current ? ' selected' : ''}`;
+      const title = document.createElement('h3'); title.textContent = def.name;
+      const desc = document.createElement('p'); desc.textContent = def.desc;
+      const previewSave = JSON.parse(JSON.stringify(save));
+      for (const stanceId of OPERATING_STANCE_ORDER) delete previewSave.flags[`operating-stance:${stanceId}`];
+      previewSave.flags[`operating-stance:${id}`] = true;
+      const preview = governedPayrollBreakdown(previewSave);
+      const cost = document.createElement('strong'); cost.textContent = `預估 ${preview.total} G`;
+      const apply = button(id === current ? '目前使用中' : '切換姿態', () => execute((latest) => setOperatingStance(latest, id as OperatingStanceId)));
+      apply.disabled = id === current;
+      card.append(title, desc, cost, apply);
+      stancesEl.append(card);
+    }
+
+    projectsEl.replaceChildren();
+    const projects = governanceProjects(save);
+    if (projects.length === 0) {
+      const empty = document.createElement('p'); empty.textContent = '目前沒有形成持續營運效果的工程。';
+      projectsEl.append(empty);
+    }
+    for (const project of projects) {
+      const row = document.createElement('article'); row.className = `project${project.suspended ? ' suspended' : ''}`;
+      const copy = document.createElement('div');
+      const title = document.createElement('h3'); title.textContent = project.projectName;
+      const detail = document.createElement('p');
+      const upkeep = project.entries.reduce((sum, entry) => sum + entry.netMaintenance, 0);
+      detail.textContent = `最高第 ${project.highestStage} 階｜原始淨維護 ${upkeep} G｜${project.suspended ? `重新啟動 ${project.restartCost} G` : '目前啟用'}`;
+      copy.append(title, detail);
+      const toggle = button(project.suspended ? `支付 ${project.restartCost} G 重新啟動` : '暫停工程', () =>
+        execute((latest) => setProjectSuspended(latest, project.projectId as CompanyInitiativeId, !project.suspended)),
+      );
+      row.append(copy, toggle);
+      projectsEl.append(row);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #11100d; color: #eee5d2; }
+  .governance-page { width: min(1080px, calc(100% - 28px)); margin: auto; padding: 42px 0 80px; }
+  .hero, .panel { border: 1px solid #4d4335; background: #1a1713; padding: 26px; margin-bottom: 18px; }
+  .hero { background: linear-gradient(135deg, #251d14, #14120f); }
+  .eyebrow { color: #c9a25e; letter-spacing: .16em; font-size: .72rem; margin: 0 0 8px; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1 { font-size: clamp(2.2rem, 5vw, 4rem); }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; }
+  a { color: #dfc17e; }
+  .section-head, .project, .summary { display: flex; justify-content: space-between; gap: 18px; align-items: center; }
+  .gold, .hint, .project p, .message { color: #aaa092; }
+  .stance-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  .stance-card, .project { border: 1px solid #4b4032; background: #211d17; padding: 16px; }
+  .stance-card.selected { border-color: #d0aa61; }
+  .stance-card strong { display: block; margin: 12px 0; color: #d5b66f; }
+  .summary { align-items: stretch; flex-wrap: wrap; }
+  .summary div { min-width: 150px; display: grid; gap: 6px; }
+  .summary span { color: #a99f90; }
+  .summary strong { font-size: 1.4rem; }
+  .project-list { display: grid; gap: 10px; }
+  .project.suspended { opacity: .68; border-style: dashed; }
+  button { padding: 10px 14px; border: 1px solid #d0aa61; background: #b88738; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .message { min-height: 1.5em; }
+  @media (max-width: 760px) { .stance-grid { grid-template-columns: 1fr; } .project { align-items: flex-start; flex-direction: column; } }
+</style>

--- a/src/scripts/games/caravan/data/governance.m33.test.ts
+++ b/src/scripts/games/caravan/data/governance.m33.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { newGame } from '../save';
+import { totalWage } from '../economy';
+import { companyPayrollBreakdown } from './operations';
+import {
+  currentOperatingStance,
+  governedPayrollBreakdown,
+  governanceProjects,
+  setOperatingStance,
+  setProjectSuspended,
+} from './governance';
+
+function matureSave() {
+  const save = newGame(1, {
+    job: 'swordsman', trait: 'brawny', allocation: { str: 3 },
+  });
+  save.gold = 1000;
+  save.wagonLevel = 3;
+  save.companions = [
+    { id: 'a', name: '甲', job: 'ranger', level: 4, xp: 210, stats: { str: 10, dex: 15, int: 10, cha: 10, con: 12 }, maxHp: 22, injuredForTrips: 0, trait: 'frugal', equipment: { weapon: null, armor: null, trinket: null }, bond: 6 },
+    { id: 'b', name: '乙', job: 'cleric', level: 4, xp: 210, stats: { str: 10, dex: 9, int: 12, cha: 15, con: 13 }, maxHp: 23, injuredForTrips: 0, trait: 'seasoned', equipment: { weapon: null, armor: null, trinket: null }, bond: 6 },
+  ];
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'a', 'b'],
+    positions: { protagonist: 'front', a: 'back', b: 'back' },
+    roles: { captain: 'protagonist', scout: 'a', quartermaster: 'b' },
+  };
+  save.flags['company-initiative:escort-network:1:expertise'] = true;
+  save.flags['company-initiative:escort-network:2:capital'] = true;
+  save.flags['company-initiative:fellowship-hall:1:field'] = true;
+  save.flags['company-initiative:fellowship-hall:2:field'] = true;
+  return save;
+}
+
+describe('M33 operational governance', () => {
+  it('keeps legacy balanced saves exactly equal to M29', () => {
+    const save = matureSave();
+    expect(currentOperatingStance(save)).toBe('balanced');
+    expect(governedPayrollBreakdown(save)).toEqual({
+      ...companyPayrollBreakdown(save),
+      stanceId: 'balanced',
+      stanceName: '標準營運',
+      suspendedProjectIds: [],
+      governanceWarnings: [],
+    });
+    expect(totalWage(save)).toBe(companyPayrollBreakdown(save).total);
+  });
+
+  it('lean stance reduces fixed upkeep but raises labor factors', () => {
+    const save = matureSave();
+    const balanced = governedPayrollBreakdown(save);
+    setOperatingStance(save, 'lean');
+    const lean = governedPayrollBreakdown(save);
+    expect(lean.fixedUpkeep).toBeLessThan(balanced.fixedUpkeep);
+    expect(lean.activeWageFactor).toBeGreaterThanOrEqual(balanced.activeWageFactor);
+    expect(totalWage(save)).toBe(lean.total);
+  });
+
+  it('suspending a project removes both its costs and its benefits', () => {
+    const save = matureSave();
+    const before = governedPayrollBreakdown(save);
+    setProjectSuspended(save, 'fellowship-hall', true);
+    const after = governedPayrollBreakdown(save);
+    expect(after.entries.some((entry) => entry.projectId === 'fellowship-hall')).toBe(false);
+    expect(after.loyaltyDiscount).toBe(0);
+    expect(after.fixedUpkeep).toBeLessThan(before.fixedUpkeep);
+  });
+
+  it('restart costs scale with highest stage and are atomic on failure', () => {
+    const save = matureSave();
+    setProjectSuspended(save, 'escort-network', true);
+    const project = governanceProjects(save).find((entry) => entry.projectId === 'escort-network')!;
+    expect(project.restartCost).toBe(30);
+    save.gold = 29;
+    const snapshot = JSON.stringify(save);
+    expect(() => setProjectSuspended(save, 'escort-network', false)).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+    save.gold = 30;
+    setProjectSuspended(save, 'escort-network', false);
+    expect(save.gold).toBe(0);
+  });
+
+  it('corrupt multiple stance flags safely fall back to balanced', () => {
+    const save = matureSave();
+    save.flags['operating-stance:lean'] = true;
+    save.flags['operating-stance:ambitious'] = true;
+    const result = governedPayrollBreakdown(save);
+    expect(result.stanceId).toBe('balanced');
+    expect(result.governanceWarnings.length).toBe(1);
+  });
+
+  it('stance changes charge only after the first explicit choice', () => {
+    const save = matureSave();
+    setOperatingStance(save, 'lean');
+    expect(save.gold).toBe(1000);
+    setOperatingStance(save, 'ambitious');
+    expect(save.gold).toBe(990);
+  });
+});

--- a/src/scripts/games/caravan/data/governance.ts
+++ b/src/scripts/games/caravan/data/governance.ts
@@ -1,0 +1,206 @@
+import type { ExpeditionPlan, SaveData } from '../save';
+import type { CompanyInitiativeId } from './initiatives';
+import {
+  companyPayrollBreakdown,
+  type CompanyOperatingEntry,
+  type CompanyPayrollBreakdown,
+} from './operations';
+
+export type OperatingStanceId = 'lean' | 'balanced' | 'ambitious';
+
+export interface OperatingStanceDef {
+  id: OperatingStanceId;
+  name: string;
+  desc: string;
+  maintenanceFactor: number;
+  activeFactorDelta: number;
+  reserveFactorDelta: number;
+  discountFactor: number;
+}
+
+export const OPERATING_STANCE_ORDER: OperatingStanceId[] = ['lean', 'balanced', 'ambitious'];
+export const OPERATING_STANCES: Record<OperatingStanceId, OperatingStanceDef> = {
+  lean: {
+    id: 'lean',
+    name: '精簡營運',
+    desc: '固定維護費減半，但臨時調度使出征薪餉與後備費率提高。適合現金吃緊時避免軟鎖。',
+    maintenanceFactor: 0.5,
+    activeFactorDelta: 0.05,
+    reserveFactorDelta: 0.03,
+    discountFactor: 0.75,
+  },
+  balanced: {
+    id: 'balanced',
+    name: '標準營運',
+    desc: '完整沿用工程原本的維護、效率、忠誠與職涯折扣。',
+    maintenanceFactor: 1,
+    activeFactorDelta: 0,
+    reserveFactorDelta: 0,
+    discountFactor: 1,
+  },
+  ambitious: {
+    id: 'ambitious',
+    name: '擴張營運',
+    desc: '固定維護費提高 25%，換取更低的出征與後備人力成本。適合成熟大型商隊。',
+    maintenanceFactor: 1.25,
+    activeFactorDelta: -0.04,
+    reserveFactorDelta: -0.02,
+    discountFactor: 1,
+  },
+};
+
+export interface GovernanceProjectState {
+  projectId: CompanyInitiativeId;
+  projectName: string;
+  highestStage: number;
+  suspended: boolean;
+  restartCost: number;
+  entries: CompanyOperatingEntry[];
+}
+
+export interface GovernedPayrollBreakdown extends CompanyPayrollBreakdown {
+  stanceId: OperatingStanceId;
+  stanceName: string;
+  suspendedProjectIds: CompanyInitiativeId[];
+  governanceWarnings: string[];
+}
+
+const PROJECT_ORDER: CompanyInitiativeId[] = [
+  'escort-network', 'frontier-office', 'trade-consortium', 'fellowship-hall', 'relic-workshop',
+];
+const STANCE_FLAG_PREFIX = 'operating-stance:';
+const SUSPEND_FLAG_PREFIX = 'operating-suspended:';
+const STANCE_CHANGE_COST = 10;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function isOperatingStanceId(value: unknown): value is OperatingStanceId {
+  return value === 'lean' || value === 'balanced' || value === 'ambitious';
+}
+
+export function currentOperatingStance(save: SaveData): OperatingStanceId {
+  const selected = OPERATING_STANCE_ORDER.filter((id) => save.flags[`${STANCE_FLAG_PREFIX}${id}`] === true);
+  return selected.length === 1 ? selected[0] : 'balanced';
+}
+
+export function isProjectSuspended(save: SaveData, projectId: CompanyInitiativeId): boolean {
+  return save.flags[`${SUSPEND_FLAG_PREFIX}${projectId}`] === true;
+}
+
+export function governanceProjects(save: SaveData, candidate?: ExpeditionPlan): GovernanceProjectState[] {
+  const base = companyPayrollBreakdown(save, candidate);
+  return PROJECT_ORDER
+    .map((projectId) => {
+      const entries = base.entries.filter((entry) => entry.projectId === projectId);
+      const highestStage = entries.reduce((max, entry) => Math.max(max, entry.stage), 0);
+      return {
+        projectId,
+        projectName: entries[0]?.projectName ?? projectId,
+        highestStage,
+        suspended: isProjectSuspended(save, projectId),
+        restartCost: highestStage * 15,
+        entries,
+      };
+    })
+    .filter((project) => project.highestStage > 0);
+}
+
+/**
+ * 在 M29 正式薪餉明細上重算治理結果。標準姿態且無暫停時必須精確等於 M29。
+ */
+export function governedPayrollBreakdown(
+  save: SaveData,
+  candidate?: ExpeditionPlan,
+): GovernedPayrollBreakdown {
+  const base = companyPayrollBreakdown(save, candidate);
+  const stanceId = currentOperatingStance(save);
+  const stance = OPERATING_STANCES[stanceId];
+  const governanceWarnings: string[] = [];
+  const stanceFlags = OPERATING_STANCE_ORDER.filter((id) => save.flags[`${STANCE_FLAG_PREFIX}${id}`] === true);
+  if (stanceFlags.length > 1) governanceWarnings.push('偵測到多個營運姿態旗標，已安全回退為標準營運。');
+
+  const activeEntries = base.entries.filter((entry) => !isProjectSuspended(save, entry.projectId));
+  const suspendedProjectIds = PROJECT_ORDER.filter((projectId) =>
+    base.entries.some((entry) => entry.projectId === projectId) && isProjectSuspended(save, projectId),
+  );
+
+  let activeWageFactor = 1 + stance.activeFactorDelta;
+  let reserveWageFactor = 0.25 + stance.reserveFactorDelta;
+  let fixedUpkeep = 0;
+  for (const entry of activeEntries) {
+    activeWageFactor += entry.activeFactorDelta;
+    reserveWageFactor += entry.reserveFactorDelta;
+    fixedUpkeep += entry.netMaintenance;
+  }
+  activeWageFactor = clamp(activeWageFactor, 0.8, 1.15);
+  reserveWageFactor = clamp(reserveWageFactor, 0.08, 0.3);
+  fixedUpkeep = Math.min(60, Math.ceil(fixedUpkeep * stance.maintenanceFactor));
+
+  const fellowshipActive = activeEntries.some((entry) => entry.projectId === 'fellowship-hall');
+  const loyaltyDiscount = fellowshipActive
+    ? Math.floor(base.loyaltyDiscount * stance.discountFactor)
+    : 0;
+  const diversityDiscount = activeEntries.length > 0
+    ? Math.floor(base.diversityDiscount * stance.discountFactor)
+    : 0;
+  const activeAdjusted = Math.ceil(base.activeBase * activeWageFactor);
+  const reserveAdjusted = Math.ceil(base.reserveBase * reserveWageFactor * base.quartermasterFactor);
+  const gross = activeAdjusted + reserveAdjusted + fixedUpkeep;
+  const total = Math.max(0, gross - loyaltyDiscount - diversityDiscount);
+
+  return {
+    ...base,
+    activeWageFactor,
+    reserveWageFactor,
+    fixedUpkeep,
+    loyaltyDiscount,
+    diversityDiscount,
+    entries: activeEntries,
+    activeAdjusted,
+    reserveAdjusted,
+    gross,
+    total,
+    stanceId,
+    stanceName: stance.name,
+    suspendedProjectIds,
+    governanceWarnings,
+    warnings: [...base.warnings, ...governanceWarnings],
+  };
+}
+
+/** 原子切換姿態；第一次從舊檔預設標準切換免費，後續每次需 10 G。 */
+export function setOperatingStance(save: SaveData, next: OperatingStanceId): void {
+  if (!isOperatingStanceId(next)) throw new Error(`未知營運姿態「${String(next)}」`);
+  const current = currentOperatingStance(save);
+  if (current === next) return;
+  const hasExplicitStance = OPERATING_STANCE_ORDER.some((id) => save.flags[`${STANCE_FLAG_PREFIX}${id}`] === true);
+  const cost = hasExplicitStance ? STANCE_CHANGE_COST : 0;
+  if (save.gold < cost) throw new Error(`切換營運姿態需要 ${cost} G`);
+
+  save.gold -= cost;
+  for (const id of OPERATING_STANCE_ORDER) delete save.flags[`${STANCE_FLAG_PREFIX}${id}`];
+  save.flags[`${STANCE_FLAG_PREFIX}${next}`] = true;
+}
+
+/** 暫停免費；重新啟動依最高完成階段支付 15/30/45 G，防止出發前免費切換套利。 */
+export function setProjectSuspended(
+  save: SaveData,
+  projectId: CompanyInitiativeId,
+  suspended: boolean,
+): void {
+  if (!PROJECT_ORDER.includes(projectId)) throw new Error(`未知工程「${String(projectId)}」`);
+  const project = governanceProjects(save).find((entry) => entry.projectId === projectId);
+  if (!project) throw new Error('此工程尚未形成有效營運效果。');
+  if (project.suspended === suspended) return;
+
+  const flag = `${SUSPEND_FLAG_PREFIX}${projectId}`;
+  if (suspended) {
+    save.flags[flag] = true;
+    return;
+  }
+  if (save.gold < project.restartCost) throw new Error(`重新啟動需要 ${project.restartCost} G`);
+  save.gold -= project.restartCost;
+  delete save.flags[flag];
+}

--- a/src/scripts/games/caravan/economy.ts
+++ b/src/scripts/games/caravan/economy.ts
@@ -1,6 +1,6 @@
 import { ITEMS } from './data/items';
 import type { ExpeditionPlan, SaveData } from './save';
-import { companyPayrollBreakdown } from './data/operations';
+import { governedPayrollBreakdown } from './data/governance';
 
 export interface TownDef {
   id: string;
@@ -48,42 +48,30 @@ function requireItem(itemId: string, callerName: string) {
   return item;
 }
 
-/** 該鎮買入某物品的價格：round(ITEMS[itemId].value × 城鎮係數) */
 export function buyPrice(town: TownDef, itemId: string): number {
   const item = requireItem(itemId, 'buyPrice');
   return Math.round(item.value * priceModifier(town, itemId));
 }
 
-/** 原鎮賣回價格（商店收購折扣，全物品通用，含 boss 遺寶）：round(buyPrice × 0.5) */
 export function sellPrice(town: TownDef, itemId: string): number {
   return Math.round(buyPrice(town, itemId) * 0.5);
 }
 
-/**
- * 異鎮轉賣價格（押貨貿易的差價空間）：round(ITEMS.value × 城鎮係數 × 0.9)。
- * 裝備不吃異鎮套利，一律半價出售。
- */
 export function tradeSellPrice(town: TownDef, itemId: string): number {
   const item = requireItem(itemId, 'tradeSellPrice');
   if (item.equip) return Math.round(item.value * 0.5);
   return Math.round(item.value * priceModifier(town, itemId) * 0.9);
 }
 
-/** 馬車載貨上限（單位=件）：6 + wagonLevel×4 */
 export function cargoCapacity(wagonLevel: number): number {
   return 6 + wagonLevel * 4;
 }
 
-/** 馬車升級花費（升到下一級）：120 + wagonLevel×180 */
 export function wagonUpgradeCost(wagonLevel: number): number {
   return 120 + wagonLevel * 180;
 }
 
-/**
- * M29 營運薪餉：保留 M17 出征／後備／軍需官規則，再套用 M28 工程形成的
- * 維護費、方案效率、特許相性、羈絆忠誠與職涯多樣性。
- * 無有效工程收據時，結果精確等同舊版薪餉。
- */
+/** M33：正式遠征與治理頁共用同一份受姿態／暫停影響的薪餉明細。 */
 export function totalWage(save: SaveData, candidate?: ExpeditionPlan): number {
-  return companyPayrollBreakdown(save, candidate).total;
+  return governedPayrollBreakdown(save, candidate).total;
 }


### PR DESCRIPTION
## Summary

- add balanced, lean, and ambitious operating stances on top of the existing M29 payroll model
- keep balanced/no-suspension saves exactly compatible with the previous payroll result
- let players suspend individual initiative projects, removing both their maintenance costs and their wage/discount benefits
- charge stage-scaled restart costs of 15/30/45 G so suspension cannot be toggled freely before every expedition
- make the first explicit stance choice free, then charge 10 G for later stance changes
- route the real `economy.totalWage()` through the governed payroll breakdown so expedition departure and the player-facing ledger share one source of truth
- add a `/caravan/governance` page showing stance previews, current payroll components, project state, restart costs, and latest-save revalidation
- add adversarial tests for M29 parity, lean anti-softlock behavior, suspension symmetry, atomic restart failures, corrupt stance flags, and stance-switch costs

## Game-design intent

M28 and M29 made long-term initiatives create recurring operational obligations, but those commitments could become an irreversible soft lock when a player had low cash or a temporarily unsuitable roster. M33 turns those obligations into governable policy without erasing the weight of prior choices.

Lean operations halve fixed upkeep but increase labor factors and weaken discounts. Ambitious operations increase upkeep while lowering active and reserve labor factors. Individual projects may be suspended, but all of their costs and benefits stop together. Restarting costs gold according to the project's highest stage, preventing free per-expedition optimization.

## Player adversarial review

- balanced mode with no suspensions exactly matches the M29 breakdown and total wage
- lean mode can reduce fixed upkeep and provide a real escape from maintenance pressure, but does not produce universally lower costs
- ambitious mode trades higher fixed obligations for lower labor factors
- suspended projects provide neither maintenance nor payroll effects nor fellowship loyalty discounts
- suspension is free, but restarting costs 15/30/45 G based on highest accepted stage
- insufficient restart funds fail without changing gold or flags
- corrupt multiple-stance flags fall back to balanced and surface a warning
- first explicit stance selection is free; later changes cost 10 G
- the live expedition `totalWage()` and governance page use the same governed breakdown
- no save-version, dependency, asset, or lockfile changes

## Scope

- `src/scripts/games/caravan/data/governance.ts`
- `src/scripts/games/caravan/data/governance.m33.test.ts`
- `src/scripts/games/caravan/economy.ts`
- `src/pages/caravan/governance.astro`