### PR TITLE
feat(caravan): add M34 dynamic company mandates

### DIFF
--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -1,0 +1,190 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="公司委託議程 — 商隊與劍"
+  description="依命運、職涯、特許、工程、治理與市場週期形成的動態公司委託。"
+  lang="zh-TW"
+>
+  <main class="mandate-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M34</p>
+      <h1>公司委託議程</h1>
+      <p>每個市場週期會形成三項不同領域的公司級委託。每項都有專業、資本與實地三種解法，但本週期只能完成其中一項。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/governance">營運治理</a>
+        <a href="/caravan/initiatives">長程工程</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立旅程，再回來查看本週期議程。</p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">MARKET CYCLE</p>
+        <h2 id="cycle-title"></h2>
+      </div>
+      <p id="cycle-state"></p>
+    </section>
+
+    <section id="cards" class="cards"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    companyMandateAgenda,
+    completeCompanyMandate,
+    type CompanyMandate,
+    type MandateRoute,
+  } from '@scripts/games/caravan/data/mandates';
+
+  const emptyEl = document.getElementById('empty')!;
+  const summaryEl = document.getElementById('summary')!;
+  const cycleTitleEl = document.getElementById('cycle-title')!;
+  const cycleStateEl = document.getElementById('cycle-state')!;
+  const cardsEl = document.getElementById('cards')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function itemList(items: Record<string, number>): string {
+    const entries = Object.entries(items).filter(([, count]) => count > 0);
+    return entries.length > 0 ? entries.map(([id, count]) => `${id} ×${count}`).join('、') : '無';
+  }
+
+  function rewardText(mandate: CompanyMandate): string {
+    const reward = mandate.reward;
+    const parts = [`${reward.gold} G`, `聲望 +${reward.reputation}`];
+    if (Object.keys(reward.inventory).length > 0) parts.push(itemList(reward.inventory));
+    if (reward.bondAll > 0) parts.push(`全旅伴羈絆 +${reward.bondAll}`);
+    if (reward.skillPoints > 0) parts.push(`技能點 +${reward.skillPoints}`);
+    return parts.join('｜');
+  }
+
+  function routeCost(route: MandateRoute): string {
+    const parts: string[] = [];
+    if (route.goldCost > 0) parts.push(`${route.goldCost} G`);
+    if (Object.keys(route.inventoryCost).length > 0) parts.push(itemList(route.inventoryCost));
+    return parts.length > 0 ? parts.join('＋') : '無直接成本';
+  }
+
+  function render(): void {
+    const save = loadGame();
+    cardsEl.replaceChildren();
+    if (!save) {
+      emptyEl.hidden = false;
+      summaryEl.hidden = true;
+      return;
+    }
+    emptyEl.hidden = true;
+    summaryEl.hidden = false;
+    const agenda = companyMandateAgenda(save);
+    cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
+    cycleStateEl.textContent = agenda.completed
+      ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
+      : `目前資金 ${save.gold} G；請從三項委託中選擇一項完成。`;
+
+    for (const mandate of agenda.mandates) {
+      const card = document.createElement('article');
+      card.className = 'mandate-card';
+      if (agenda.completedMandateId === mandate.id) card.classList.add('completed');
+
+      const head = document.createElement('header');
+      const titleWrap = document.createElement('div');
+      titleWrap.append(
+        text('p', `${mandate.domain.toUpperCase()} · 難度 ${mandate.difficulty}`, 'eyebrow'),
+        text('h2', mandate.title),
+      );
+      head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
+      card.append(head, text('p', mandate.description, 'description'));
+
+      const reward = text('p', `獎勵：${rewardText(mandate)}`, 'reward');
+      card.append(reward);
+
+      const routes = document.createElement('div');
+      routes.className = 'routes';
+      for (const route of mandate.routes) {
+        const routeEl = document.createElement('section');
+        routeEl.className = `route ${route.eligible ? 'eligible' : 'blocked'}`;
+        routeEl.append(
+          text('h3', route.name),
+          text('p', route.description),
+          text('p', `能力 ${route.score} / ${route.threshold}`, 'score'),
+          text('p', `成本：${routeCost(route)}`, 'cost'),
+        );
+        if (!route.eligible) {
+          routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
+        }
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.disabled = agenda.completed || !route.eligible;
+        button.textContent = agenda.completed ? '本週期已結算' : route.eligible ? `採用${route.name}` : '條件不足';
+        button.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) {
+            statusEl.textContent = '存檔已不存在。';
+            return;
+          }
+          try {
+            const result = completeCompanyMandate(latest, mandate.id, route.id);
+            saveGame(latest);
+            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G 與聲望 +${result.reward.reputation}。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '委託結算失敗。';
+          }
+          render();
+        });
+        routeEl.append(button);
+        routes.append(routeEl);
+      }
+      card.append(routes);
+      cardsEl.append(card);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #11100d; color: #eee6d5; }
+  .mandate-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .mandate-card { border: 1px solid #4a4032; background: #1a1713; }
+  .hero { padding: 32px; background: linear-gradient(135deg, #241c13, #15120e); }
+  .eyebrow { margin: 0 0 7px; color: #c9a45e; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
+  .hero > p:not(.eyebrow), .description, .route p, .panel p, .status { color: #b9b0a1; line-height: 1.7; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
+  a { color: #e0bd78; }
+  .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .cards { display: grid; gap: 18px; margin-top: 18px; }
+  .mandate-card { padding: 24px; }
+  .mandate-card.completed { border-color: #9e7d42; }
+  .mandate-card > header { display: flex; justify-content: space-between; gap: 18px; align-items: flex-start; }
+  .domain-tag { padding: 6px 10px; border: 1px solid #5b4a31; color: #d9b972; white-space: nowrap; }
+  .reward { padding: 12px; background: #211d16; border-left: 3px solid #b88a3f; }
+  .routes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+  .route { padding: 16px; border: 1px solid #443a2d; background: #201c17; }
+  .route.eligible { border-color: #7c7044; }
+  .route.blocked { opacity: .68; }
+  .score { color: #d7bd84 !important; }
+  .cost { color: #d7a17e !important; }
+  .blockers { color: #df8f7b !important; }
+  button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 820px) { .routes { grid-template-columns: 1fr; } .panel, .mandate-card > header { align-items: flex-start; flex-direction: column; } }
+</style>

--- a/src/scripts/games/caravan/data/mandates.m34.test.ts
+++ b/src/scripts/games/caravan/data/mandates.m34.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { newGame } from '../save';
+import {
+  companyMandateAgenda,
+  completeCompanyMandate,
+  type MandateRouteId,
+} from './mandates';
+
+function richSave() {
+  const save = newGame(100, {
+    job: 'cleric',
+    trait: 'charming',
+    allocation: { cha: 3 },
+    statRoll: { str: 10, dex: 9, int: 11, cha: 16, con: 12 },
+  });
+  save.marketSeed = 4242;
+  save.gold = 1000;
+  save.wagonLevel = 6;
+  save.inventory['dried-rations'] = 20;
+  save.visitedBossDungeons = ['a', 'b', 'c'];
+  save.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+  save.protagonist.growth = { potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } };
+  save.protagonist.careerMilestones = [
+    { level: 2, pathId: 'martial', score: 20 },
+    { level: 3, pathId: 'scouting', score: 20 },
+    { level: 4, pathId: 'lore', score: 20 },
+    { level: 5, pathId: 'negotiation', score: 20 },
+  ];
+  save.companions = [
+    {
+      id: 'c1', name: '甲', job: 'swordsman', level: 5, xp: 0,
+      stats: { str: 15, dex: 10, int: 9, cha: 9, con: 14 }, maxHp: 30,
+      injuredForTrips: 0, trait: 'brawny', equipment: { weapon: null, armor: null, trinket: null },
+      bond: 9,
+      genesis: { lifepathId: 'brawny', aptitudeId: 'str', burdenId: 'int' },
+      growth: { potential: { str: 5, dex: 2, int: 1, cha: 2, con: 5 } },
+      careerMilestones: [{ level: 5, pathId: 'martial', score: 20 }],
+    },
+    {
+      id: 'c2', name: '乙', job: 'ranger', level: 5, xp: 0,
+      stats: { str: 9, dex: 16, int: 11, cha: 10, con: 12 }, maxHp: 26,
+      injuredForTrips: 0, trait: 'nimble', equipment: { weapon: null, armor: null, trinket: null },
+      bond: 9,
+      genesis: { lifepathId: 'nimble', aptitudeId: 'dex', burdenId: 'str' },
+      growth: { potential: { str: 1, dex: 5, int: 3, cha: 2, con: 4 } },
+      careerMilestones: [{ level: 5, pathId: 'scouting', score: 20 }],
+    },
+    {
+      id: 'c3', name: '丙', job: 'mage', level: 5, xp: 0,
+      stats: { str: 8, dex: 11, int: 17, cha: 10, con: 10 }, maxHp: 22,
+      injuredForTrips: 0, trait: 'learned', equipment: { weapon: null, armor: null, trinket: null },
+      bond: 9,
+      genesis: { lifepathId: 'learned', aptitudeId: 'int', burdenId: 'str' },
+      growth: { potential: { str: 1, dex: 3, int: 5, cha: 2, con: 3 } },
+      careerMilestones: [{ level: 5, pathId: 'lore', score: 20 }],
+    },
+  ];
+  save.flags['company-initiative:escort-network:1:expertise'] = true;
+  save.flags['company-initiative:frontier-office:1:capital'] = true;
+  save.flags['company-initiative:trade-consortium:1:field'] = true;
+  return save;
+}
+
+function eligibleChoice(save: ReturnType<typeof richSave>) {
+  const agenda = companyMandateAgenda(save);
+  for (const mandate of agenda.mandates) {
+    const route = mandate.routes.find((entry) => entry.eligible);
+    if (route) return { agenda, mandate, route };
+  }
+  throw new Error('測試存檔應至少有一條可行路線');
+}
+
+describe('M34 dynamic company mandates', () => {
+  it('is deterministic, presents three distinct domains, and preview is read-only', () => {
+    const save = richSave();
+    const before = JSON.stringify(save);
+    const first = companyMandateAgenda(save);
+    const second = companyMandateAgenda(save);
+    expect(first).toEqual(second);
+    expect(new Set(first.mandates.map((entry) => entry.domain)).size).toBe(3);
+    expect(first.mandates.every((entry) => entry.routes.length === 3)).toBe(true);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('allows exactly one mandate per market cycle even when another route remains eligible', () => {
+    const save = richSave();
+    const { agenda, mandate, route } = eligibleChoice(save);
+    completeCompanyMandate(save, mandate.id, route.id);
+    expect(companyMandateAgenda(save).completed).toBe(true);
+    const other = agenda.mandates.find((entry) => entry.id !== mandate.id)!;
+    const otherRoute = other.routes.find((entry) => entry.eligible) ?? other.routes[0];
+    const snapshot = JSON.stringify(save);
+    expect(() => completeCompanyMandate(save, other.id, otherRoute.id)).toThrow(/已經完成/);
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('revalidates current resources and fails atomically after a stale preview', () => {
+    const save = richSave();
+    const agenda = companyMandateAgenda(save);
+    const field = agenda.mandates
+      .flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.id === 'field' && route.eligible);
+    expect(field).toBeTruthy();
+    save.inventory['dried-rations'] = 0;
+    const before = JSON.stringify(save);
+    expect(() => completeCompanyMandate(save, field!.mandate.id, 'field')).toThrow(/不足/);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('does not allow duplicate capital rewards or negative-cost inventory', () => {
+    const save = richSave();
+    const agenda = companyMandateAgenda(save);
+    const choice = agenda.mandates
+      .flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.id === 'capital' && route.eligible);
+    expect(choice).toBeTruthy();
+    const goldBefore = save.gold;
+    const result = completeCompanyMandate(save, choice!.mandate.id, 'capital');
+    expect(save.gold).toBe(goldBefore - choice!.route.goldCost + result.reward.gold);
+    expect(Object.values(save.inventory).every((count) => count >= 0)).toBe(true);
+    const after = JSON.stringify(save);
+    expect(() => completeCompanyMandate(save, choice!.mandate.id, 'capital')).toThrow();
+    expect(JSON.stringify(save)).toBe(after);
+  });
+
+  it('invalid mandate and route ids never mutate resources', () => {
+    const save = richSave();
+    const before = JSON.stringify(save);
+    expect(() => completeCompanyMandate(save, 'missing', 'expertise')).toThrow(/找不到/);
+    expect(JSON.stringify(save)).toBe(before);
+    const mandate = companyMandateAgenda(save).mandates[0];
+    expect(() => completeCompanyMandate(save, mandate.id, 'bad' as MandateRouteId)).toThrow(/找不到/);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('a new market seed creates a new agenda without erasing the prior receipt', () => {
+    const save = richSave();
+    const { mandate, route, agenda } = eligibleChoice(save);
+    completeCompanyMandate(save, mandate.id, route.id);
+    expect(save.flags[agenda.receipt]).toBe(true);
+    save.marketSeed += 1;
+    const next = companyMandateAgenda(save);
+    expect(next.cycle).not.toBe(agenda.cycle);
+    expect(next.completed).toBe(false);
+    expect(save.flags[agenda.receipt]).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/mandates.ts
+++ b/src/scripts/games/caravan/data/mandates.ts
@@ -1,0 +1,308 @@
+import type { SaveData } from '../save';
+import { isValidCompanyCharterProgress } from './charters';
+import { acceptedOperationalInitiatives } from './operations';
+
+export type MandateDomain = 'escort' | 'frontier' | 'trade' | 'fellowship' | 'relic';
+export type MandateRouteId = 'expertise' | 'capital' | 'field';
+
+export interface MandateReward {
+  gold: number;
+  reputation: number;
+  inventory: Record<string, number>;
+  bondAll: number;
+  skillPoints: number;
+}
+
+export interface MandateRoute {
+  id: MandateRouteId;
+  name: string;
+  description: string;
+  score: number;
+  threshold: number;
+  goldCost: number;
+  inventoryCost: Record<string, number>;
+  eligible: boolean;
+  blockers: string[];
+}
+
+export interface CompanyMandate {
+  id: string;
+  domain: MandateDomain;
+  title: string;
+  description: string;
+  difficulty: 1 | 2 | 3;
+  primaryStat: 'str' | 'dex' | 'int' | 'cha' | 'con';
+  primarySkill: 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+  reward: MandateReward;
+  routes: MandateRoute[];
+}
+
+export interface MandateAgenda {
+  cycle: number;
+  receipt: string;
+  completed: boolean;
+  completedMandateId: string | null;
+  completedRouteId: MandateRouteId | null;
+  mandates: CompanyMandate[];
+}
+
+export interface MandateCompletion {
+  cycle: number;
+  mandateId: string;
+  routeId: MandateRouteId;
+  reward: MandateReward;
+  receipt: string;
+}
+
+interface MandateTemplate {
+  domain: MandateDomain;
+  title: string;
+  description: string;
+  stat: CompanyMandate['primaryStat'];
+  skill: CompanyMandate['primarySkill'];
+  affinity: string[];
+  rewardItems: string[];
+}
+
+const TEMPLATES: MandateTemplate[] = [
+  {
+    domain: 'escort', title: '危路護運合約',
+    description: '一支高價商隊必須穿越盜匪與斷橋並存的路段。',
+    stat: 'str', skill: 'martial', affinity: ['iron-vanguard', 'bound-fellowship'],
+    rewardItems: ['war-tonic', 'ore'],
+  },
+  {
+    domain: 'frontier', title: '失落支線測繪',
+    description: '舊地圖出現互相矛盾的岔路，需要重新建立可靠路線。',
+    stat: 'dex', skill: 'scouting', affinity: ['far-horizon', 'relic-covenant'],
+    rewardItems: ['tattered-map', 'torch'],
+  },
+  {
+    domain: 'trade', title: '價格崩落調停',
+    description: '兩地商人互相壓價，商隊必須建立新的交換秩序。',
+    stat: 'cha', skill: 'negotiation', affinity: ['ledger-guild', 'far-horizon'],
+    rewardItems: ['spice-pouch', 'dried-rations'],
+  },
+  {
+    domain: 'fellowship', title: '營地信任危機',
+    description: '長途壓力造成隊員與雇工對立，需要重新協調責任。',
+    stat: 'con', skill: 'survival', affinity: ['bound-fellowship', 'ledger-guild'],
+    rewardItems: ['bandage', 'dried-rations'],
+  },
+  {
+    domain: 'relic', title: '遺珍真偽鑑定',
+    description: '一件可能改寫商路歷史的遺物，需要在消息外洩前完成鑑定。',
+    stat: 'int', skill: 'lore', affinity: ['relic-covenant', 'far-horizon'],
+    rewardItems: ['herb', 'tattered-map'],
+  },
+];
+
+const ROUTE_NAMES: Record<MandateRouteId, string> = {
+  expertise: '專業解法', capital: '資本解法', field: '實地解法',
+};
+
+function hash(value: string): number {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    result ^= value.charCodeAt(index);
+    result = Math.imul(result, 16777619);
+  }
+  return result >>> 0;
+}
+
+function bondTier(value: number | undefined): number {
+  const bond = value ?? 0;
+  if (bond >= 9) return 3;
+  if (bond >= 5) return 2;
+  if (bond >= 2) return 1;
+  return 0;
+}
+
+function activeStance(save: SaveData): 'balanced' | 'lean' | 'ambitious' {
+  const active = (['balanced', 'lean', 'ambitious'] as const)
+    .filter((id) => save.flags[`operating-stance:${id}`] === true);
+  return active.length === 1 ? active[0] : 'balanced';
+}
+
+function careerCount(save: SaveData, pathId: string): number {
+  return [save.protagonist, ...save.companions].reduce((sum, member) =>
+    sum + ((member.careerMilestones ?? []).some((milestone) => milestone.pathId === pathId) ? 1 : 0), 0);
+}
+
+function expertiseScore(save: SaveData, template: MandateTemplate): number {
+  const protagonist = save.protagonist;
+  const stat = protagonist.stats[template.stat] ?? 0;
+  const skill = protagonist.skills?.[template.skill] ?? 0;
+  const potential = protagonist.growth?.potential?.[template.stat] ?? 0;
+  const careers = careerCount(save, template.skill);
+  const charter = isValidCompanyCharterProgress(save.companyCharter) ? save.companyCharter : null;
+  const charterBonus = charter && template.affinity.includes(charter.id) ? charter.tier : 0;
+  return Math.floor(stat / 4) + skill + potential + Math.min(2, careers) + charterBonus;
+}
+
+function capitalScore(save: SaveData): number {
+  const initiatives = acceptedOperationalInitiatives(save).accepted.length;
+  const stance = activeStance(save);
+  return Math.floor(save.gold / 60) + Math.max(0, Math.floor(save.wagonLevel)) +
+    Math.min(4, initiatives) + (stance === 'ambitious' ? 2 : 0);
+}
+
+function fieldScore(save: SaveData): number {
+  const healthy = save.companions.filter((member) => member.injuredForTrips === 0);
+  const bond = healthy.reduce((sum, member) => sum + bondTier(member.bond), 0);
+  const registered = healthy.filter((member) => member.genesis && member.growth).length;
+  const stance = activeStance(save);
+  return Math.min(4, healthy.length) + Math.min(5, bond) + Math.min(3, registered) +
+    Math.min(3, save.visitedBossDungeons.length) + (stance === 'lean' ? 1 : 0);
+}
+
+function inventoryBlockers(save: SaveData, costs: Record<string, number>): string[] {
+  return Object.entries(costs)
+    .filter(([itemId, count]) => (save.inventory[itemId] ?? 0) < count)
+    .map(([itemId, count]) => `${itemId} 不足，需要 ${count}`);
+}
+
+function routeFor(
+  save: SaveData,
+  template: MandateTemplate,
+  routeId: MandateRouteId,
+  difficulty: 1 | 2 | 3,
+): MandateRoute {
+  const threshold = 6 + difficulty * 2;
+  const goldCost = routeId === 'expertise' ? 5 * difficulty : routeId === 'capital' ? 30 * difficulty : 0;
+  const inventoryCost = routeId === 'field' ? { 'dried-rations': difficulty } : {};
+  const score = routeId === 'expertise'
+    ? expertiseScore(save, template)
+    : routeId === 'capital'
+      ? capitalScore(save)
+      : fieldScore(save);
+  const blockers = inventoryBlockers(save, inventoryCost);
+  if (score < threshold) blockers.push(`能力分數 ${score}，需要 ${threshold}`);
+  if (save.gold < goldCost) blockers.push(`金幣不足，需要 ${goldCost} G`);
+  return {
+    id: routeId,
+    name: ROUTE_NAMES[routeId],
+    description: routeId === 'expertise'
+      ? `以${template.skill}技能、${template.stat}潛力、職涯與特許解決。`
+      : routeId === 'capital'
+        ? '以金幣、馬車、工程規模與擴張治理調度資源。'
+        : '以健康旅伴、身世登記、羈絆、探索與精簡治理完成。',
+    score,
+    threshold,
+    goldCost,
+    inventoryCost,
+    eligible: blockers.length === 0,
+    blockers,
+  };
+}
+
+function rewardFor(template: MandateTemplate, difficulty: 1 | 2 | 3): MandateReward {
+  const baseGold: Record<MandateDomain, number> = {
+    escort: 22, frontier: 14, trade: 30, fellowship: 10, relic: 16,
+  };
+  const itemId = template.rewardItems[(difficulty - 1) % template.rewardItems.length];
+  return {
+    gold: baseGold[template.domain] + difficulty * 12,
+    reputation: template.domain === 'trade' || template.domain === 'fellowship' ? difficulty + 1 : difficulty,
+    inventory: { [itemId]: difficulty },
+    bondAll: template.domain === 'fellowship' ? difficulty : 0,
+    skillPoints: template.domain === 'relic' && difficulty === 3 ? 1 : 0,
+  };
+}
+
+function cycleReceipt(cycle: number): string {
+  return `company-mandate-cycle:${cycle}`;
+}
+
+function completedChoice(save: SaveData, cycle: number): { mandateId: string; routeId: MandateRouteId } | null {
+  const prefix = `company-mandate:${cycle}:`;
+  const key = Object.keys(save.flags).find((flag) => flag.startsWith(prefix) && save.flags[flag] === true);
+  if (!key) return null;
+  const parts = key.slice(prefix.length).split(':');
+  const routeId = parts.pop() as MandateRouteId | undefined;
+  if (!routeId || !['expertise', 'capital', 'field'].includes(routeId)) return null;
+  return { mandateId: parts.join(':'), routeId };
+}
+
+/** 每個 marketSeed 形成一個決定性週期；同一存檔與週期永遠得到相同三項議程。 */
+export function companyMandateAgenda(save: SaveData): MandateAgenda {
+  const cycle = Math.max(0, Math.floor(save.marketSeed));
+  const ordered = [...TEMPLATES]
+    .map((template) => ({ template, rank: hash(`${cycle}:${template.domain}:${save.protagonist.genesis?.lifepathId ?? 'legacy'}`) }))
+    .sort((a, b) => a.rank - b.rank)
+    .slice(0, 3);
+  const mandates = ordered.map(({ template }, index) => {
+    const difficulty = (1 + (hash(`${cycle}:${template.domain}:difficulty`) % 3)) as 1 | 2 | 3;
+    const id = `${template.domain}-${cycle}-${index + 1}`;
+    return {
+      id,
+      domain: template.domain,
+      title: template.title,
+      description: template.description,
+      difficulty,
+      primaryStat: template.stat,
+      primarySkill: template.skill,
+      reward: rewardFor(template, difficulty),
+      routes: (['expertise', 'capital', 'field'] as MandateRouteId[])
+        .map((routeId) => routeFor(save, template, routeId, difficulty)),
+    };
+  });
+  const choice = completedChoice(save, cycle);
+  return {
+    cycle,
+    receipt: cycleReceipt(cycle),
+    completed: save.flags[cycleReceipt(cycle)] === true || choice !== null,
+    completedMandateId: choice?.mandateId ?? null,
+    completedRouteId: choice?.routeId ?? null,
+    mandates,
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+/** 原子完成一項公司委託；每週期只能完成一項，三種路線共享同一週期收據。 */
+export function completeCompanyMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): MandateCompletion {
+  const agenda = companyMandateAgenda(save);
+  if (agenda.completed) throw new Error('本市場週期的公司委託已經完成。');
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到公司委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項公司委託已經結算。');
+  }
+
+  // 所有驗證完成後才修改資源。
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: { ...mandate.reward, inventory: { ...mandate.reward.inventory } },
+    receipt: preciseReceipt,
+  };
+}


### PR DESCRIPTION
## Summary

- add deterministic company mandate agendas keyed by the current market seed
- generate three distinct mandate domains per cycle from escort, frontier, trade, fellowship, and relic work
- give every mandate three mechanically distinct routes: expertise, capital, and field execution
- interweave protagonist stats, skills, growth potential, career coverage, charter affinity, companion registration, bond tiers, boss exploration, wagon investment, completed initiatives, operating stance, gold, and supplies
- allow exactly one mandate completion per market cycle across all three agenda options and all routes
- revalidate the current save at execution time and settle costs/rewards atomically
- persist both a shared cycle receipt and a precise mandate/route receipt to prevent refresh, stale-tab, or corrupted-flag duplicate rewards
- add a player-facing `/caravan/mandates` page showing route scores, thresholds, costs, blockers, rewards, and the one-choice-per-cycle rule
- add adversarial tests for determinism, read-only previews, stale-resource revalidation, one-of-three enforcement, duplicate capital rewards, invalid ids, and next-cycle independence

## Game-design intent

M22-M33 made character creation, companion histories, growth, careers, charters, initiatives, payroll, team chemistry, and operating governance increasingly interdependent. The remaining weakness was repeatable content: most player-facing work still came from a comparatively fixed quest layer.

M34 turns the current organization into the content generator. A cleric-led trade charter with ambitious governance, strong wagon assets, and capital initiatives will see different feasible solutions than a lean frontier company built around registered high-bond companions. The agenda is deterministic rather than random-rerollable, and the player must commit to one company priority per market cycle.

## Player adversarial review

- identical saves and market seeds always produce the same three mandates, order, difficulty, route scores, and rewards
- the three agenda entries always use distinct mandate domains
- previews never mutate gold, items, reputation, companions, flags, or progression
- every mandate exposes expertise, capital, and field routes with independent scores and costs
- completing one mandate blocks every other mandate and route in the same market cycle
- execution recalculates the latest save, so spending gold or supplies after preview can invalidate a stale route without partial mutation
- capital completion cannot be repeated to farm gold
- field costs cannot make inventory negative
- invalid mandate or route ids fail without mutation
- increasing marketSeed creates a new independent agenda while preserving the prior cycle receipt
- no save-version, dependency, lockfile, asset, or generated-output changes

## Scope

- `src/scripts/games/caravan/data/mandates.ts`
- `src/scripts/games/caravan/data/mandates.m34.test.ts`
- `src/pages/caravan/mandates.astro`