### PR TITLE
feat(caravan): add M35 company constitution clauses

### DIFF
--- a/src/pages/caravan/constitution.astro
+++ b/src/pages/caravan/constitution.astro
@@ -1,0 +1,147 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="公司憲章 — 商隊與劍"
+  description="制定帶有優勢與代價的公司條款，改變動態委託的門檻、成本與報酬。"
+  lang="zh-TW"
+>
+  <main class="constitution-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M35</p>
+      <h1>公司憲章</h1>
+      <p>將商隊的命運、職涯與組織選擇寫成長期規則。每項條款都有一個主要優勢與一個必須承擔的代價。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/mandates">公司委託</a>
+        <a href="/caravan/governance">營運治理</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立旅程，再制定公司憲章。</p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">CURRENT CLAUSE</p>
+        <h2 id="current-title">尚未制定</h2>
+      </div>
+      <p id="cost-copy"></p>
+    </section>
+
+    <section id="warnings" class="warnings" hidden></section>
+    <section id="clauses" class="clauses"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    CONSTITUTION_CLAUSES,
+    CONSTITUTION_CLAUSE_ORDER,
+    companyConstitutionState,
+    enactCompanyConstitution,
+  } from '@scripts/games/caravan/data/constitution';
+
+  const emptyEl = document.getElementById('empty')!;
+  const summaryEl = document.getElementById('summary')!;
+  const currentTitleEl = document.getElementById('current-title')!;
+  const costCopyEl = document.getElementById('cost-copy')!;
+  const warningsEl = document.getElementById('warnings')!;
+  const clausesEl = document.getElementById('clauses')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function render(): void {
+    const save = loadGame();
+    clausesEl.replaceChildren();
+    warningsEl.replaceChildren();
+    if (!save) {
+      emptyEl.hidden = false;
+      summaryEl.hidden = true;
+      return;
+    }
+    emptyEl.hidden = true;
+    summaryEl.hidden = false;
+    const state = companyConstitutionState(save);
+    currentTitleEl.textContent = state.active ? CONSTITUTION_CLAUSES[state.active].name : '尚未制定';
+    costCopyEl.textContent = state.amendmentGoldCost === 0
+      ? '首次制定免費。'
+      : `修憲成本：${state.amendmentGoldCost} G＋聲望 ${state.amendmentReputationCost}。目前 ${save.gold} G／聲望 ${save.reputation}。`;
+
+    warningsEl.hidden = state.warnings.length === 0;
+    for (const warning of state.warnings) warningsEl.append(text('p', warning));
+
+    for (const id of CONSTITUTION_CLAUSE_ORDER) {
+      const clause = CONSTITUTION_CLAUSES[id];
+      const card = document.createElement('article');
+      card.className = 'clause-card';
+      if (state.active === id) card.classList.add('active');
+      card.append(
+        text('p', id.toUpperCase(), 'eyebrow'),
+        text('h2', clause.name),
+        text('p', clause.summary, 'summary'),
+        text('p', `優勢：${clause.advantage}`, 'advantage'),
+        text('p', `代價：${clause.cost}`, 'cost'),
+      );
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.disabled = state.active === id && state.warnings.length === 0;
+      button.textContent = state.active === id ? '目前生效' : state.amendmentGoldCost === 0 ? '制定此條款' : '支付成本修憲';
+      button.addEventListener('click', () => {
+        const latest = loadGame();
+        if (!latest) {
+          statusEl.textContent = '存檔已不存在。';
+          return;
+        }
+        try {
+          enactCompanyConstitution(latest, id);
+          saveGame(latest);
+          statusEl.textContent = `「${clause.name}」已生效。公司委託將立即採用新條款。`;
+        } catch (error) {
+          statusEl.textContent = error instanceof Error ? error.message : '條款制定失敗。';
+        }
+        render();
+      });
+      card.append(button);
+      clausesEl.append(card);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #11100d; color: #eee6d5; }
+  .constitution-page { width: min(1120px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .clause-card { border: 1px solid #4a4032; background: #1a1713; }
+  .hero { padding: 32px; background: linear-gradient(135deg, #241c13, #15120e); }
+  .eyebrow { margin: 0 0 7px; color: #c9a45e; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  h1, h2, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
+  .hero > p:not(.eyebrow), .summary, .panel p, .status { color: #b9b0a1; line-height: 1.7; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
+  a { color: #e0bd78; }
+  .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #c75e4b; background: #2a1916; }
+  .warnings p { margin: 4px 0; }
+  .clauses { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; margin-top: 18px; }
+  .clause-card { padding: 22px; }
+  .clause-card.active { border-color: #b9924d; box-shadow: inset 0 0 0 1px #6c532d; }
+  .advantage { color: #a9c982; }
+  .cost { color: #dc9a82; }
+  button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 760px) { .panel { align-items: flex-start; flex-direction: column; } }
+</style>

--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -4,17 +4,18 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="公司委託議程 — 商隊與劍"
-  description="依命運、職涯、特許、工程、治理與市場週期形成的動態公司委託。"
+  description="依命運、職涯、特許、工程、治理、公司憲章與市場週期形成的動態公司委託。"
   lang="zh-TW"
 >
   <main class="mandate-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M34</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M34 / M35</p>
       <h1>公司委託議程</h1>
-      <p>每個市場週期會形成三項不同領域的公司級委託。每項都有專業、資本與實地三種解法，但本週期只能完成其中一項。</p>
+      <p>每個市場週期會形成三項不同領域的公司級委託。公司憲章會同時改變解法門檻、成本與報酬；本週期仍只能完成其中一項。</p>
       <nav>
         <a href="/caravan/play">返回遊戲</a>
         <a href="/caravan/governance">營運治理</a>
+        <a href="/caravan/constitution">公司憲章</a>
         <a href="/caravan/initiatives">長程工程</a>
       </nav>
     </header>
@@ -40,11 +41,11 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <script>
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import {
-    companyMandateAgenda,
-    completeCompanyMandate,
-    type CompanyMandate,
-    type MandateRoute,
-  } from '@scripts/games/caravan/data/mandates';
+    constitutionalMandateAgenda,
+    completeConstitutionalMandate,
+  } from '@scripts/games/caravan/data/constitutionalMandates';
+  import type { CompanyMandate, MandateRoute } from '@scripts/games/caravan/data/mandates';
+  import { CONSTITUTION_CLAUSES } from '@scripts/games/caravan/data/constitution';
 
   const emptyEl = document.getElementById('empty')!;
   const summaryEl = document.getElementById('summary')!;
@@ -91,11 +92,16 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     }
     emptyEl.hidden = true;
     summaryEl.hidden = false;
-    const agenda = companyMandateAgenda(save);
+    const agenda = constitutionalMandateAgenda(save);
     cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
-    cycleStateEl.textContent = agenda.completed
-      ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
-      : `目前資金 ${save.gold} G；請從三項委託中選擇一項完成。`;
+    const constitutionName = agenda.constitution
+      ? CONSTITUTION_CLAUSES[agenda.constitution].name
+      : '未制定條款';
+    cycleStateEl.textContent = agenda.constitutionWarnings.length > 0
+      ? agenda.constitutionWarnings.join(' ')
+      : agenda.completed
+        ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
+        : `目前資金 ${save.gold} G；公司憲章：${constitutionName}；請從三項委託中選擇一項完成。`;
 
     for (const mandate of agenda.mandates) {
       const card = document.createElement('article');
@@ -110,9 +116,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       );
       head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
       card.append(head, text('p', mandate.description, 'description'));
-
-      const reward = text('p', `獎勵：${rewardText(mandate)}`, 'reward');
-      card.append(reward);
+      card.append(text('p', `政策後獎勵：${rewardText(mandate)}`, 'reward'));
 
       const routes = document.createElement('div');
       routes.className = 'routes';
@@ -123,15 +127,19 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
           text('h3', route.name),
           text('p', route.description),
           text('p', `能力 ${route.score} / ${route.threshold}`, 'score'),
-          text('p', `成本：${routeCost(route)}`, 'cost'),
+          text('p', `政策後成本：${routeCost(route)}`, 'cost'),
         );
-        if (!route.eligible) {
-          routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
-        }
+        if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
         const button = document.createElement('button');
         button.type = 'button';
-        button.disabled = agenda.completed || !route.eligible;
-        button.textContent = agenda.completed ? '本週期已結算' : route.eligible ? `採用${route.name}` : '條件不足';
+        button.disabled = agenda.completed || !route.eligible || agenda.constitutionWarnings.length > 0;
+        button.textContent = agenda.completed
+          ? '本週期已結算'
+          : agenda.constitutionWarnings.length > 0
+            ? '憲章資料衝突'
+            : route.eligible
+              ? `採用${route.name}`
+              : '條件不足';
         button.addEventListener('click', () => {
           const latest = loadGame();
           if (!latest) {
@@ -139,9 +147,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
             return;
           }
           try {
-            const result = completeCompanyMandate(latest, mandate.id, route.id);
+            const result = completeConstitutionalMandate(latest, mandate.id, route.id);
             saveGame(latest);
-            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G 與聲望 +${result.reward.reputation}。`;
+            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}。`;
           } catch (error) {
             statusEl.textContent = error instanceof Error ? error.message : '委託結算失敗。';
           }

--- a/src/scripts/games/caravan/data/constitution.m35.test.ts
+++ b/src/scripts/games/caravan/data/constitution.m35.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { newGame } from '../save';
+import { companyMandateAgenda } from './mandates';
+import { constitutionalMandateAgenda, completeConstitutionalMandate } from './constitutionalMandates';
+import { companyConstitutionState, enactCompanyConstitution } from './constitution';
+
+function richSave() {
+  const save = newGame(123, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+  save.marketSeed = 9090;
+  save.gold = 1000;
+  save.reputation = 20;
+  save.wagonLevel = 5;
+  save.inventory['dried-rations'] = 20;
+  save.visitedBossDungeons = ['a', 'b', 'c'];
+  return save;
+}
+
+describe('M35 company constitution', () => {
+  it('keeps M34 exact when no clause is enacted', () => {
+    const save = richSave();
+    expect(constitutionalMandateAgenda(save).mandates).toEqual(companyMandateAgenda(save).mandates);
+  });
+
+  it('makes every clause a tradeoff rather than a free universal buff', () => {
+    const base = richSave();
+    const baseline = companyMandateAgenda(base);
+    for (const id of ['martial-priority', 'open-knowledge', 'fellowship-dividend', 'commercial-supremacy', 'exploration-duty'] as const) {
+      const save = richSave();
+      enactCompanyConstitution(save, id);
+      const agenda = constitutionalMandateAgenda(save);
+      expect(agenda.mandates).not.toEqual(baseline.mandates);
+      const allRoutes = agenda.mandates.flatMap((m) => m.routes);
+      expect(allRoutes.every((route) => route.goldCost >= 0 && Object.values(route.inventoryCost).every((n) => n >= 0))).toBe(true);
+    }
+  });
+
+  it('charges amendments after the first enactment and fails atomically', () => {
+    const save = richSave();
+    enactCompanyConstitution(save, 'open-knowledge');
+    save.gold = 39;
+    const before = JSON.stringify(save);
+    expect(() => enactCompanyConstitution(save, 'commercial-supremacy')).toThrow();
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('disables corrupt multiple clauses instead of stacking them', () => {
+    const save = richSave();
+    save.flags['company-constitution:open-knowledge'] = true;
+    save.flags['company-constitution:commercial-supremacy'] = true;
+    const state = companyConstitutionState(save);
+    expect(state.active).toBeNull();
+    expect(state.warnings.length).toBeGreaterThan(0);
+    expect(constitutionalMandateAgenda(save).mandates).toEqual(companyMandateAgenda(save).mandates);
+  });
+
+  it('settles the policy-adjusted cost and reward only once', () => {
+    const save = richSave();
+    enactCompanyConstitution(save, 'fellowship-dividend');
+    const agenda = constitutionalMandateAgenda(save);
+    const option = agenda.mandates.flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.eligible);
+    expect(option).toBeTruthy();
+    const beforeGold = save.gold;
+    const result = completeConstitutionalMandate(save, option!.mandate.id, option!.route.id);
+    expect(save.gold).toBe(beforeGold - option!.route.goldCost + result.reward.gold);
+    const snapshot = JSON.stringify(save);
+    expect(() => completeConstitutionalMandate(save, option!.mandate.id, option!.route.id)).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+});

--- a/src/scripts/games/caravan/data/constitution.ts
+++ b/src/scripts/games/caravan/data/constitution.ts
@@ -1,0 +1,96 @@
+import type { SaveData } from '../save';
+
+export type ConstitutionClauseId =
+  | 'martial-priority'
+  | 'open-knowledge'
+  | 'fellowship-dividend'
+  | 'commercial-supremacy'
+  | 'exploration-duty';
+
+export interface ConstitutionClauseDef {
+  id: ConstitutionClauseId;
+  name: string;
+  summary: string;
+  advantage: string;
+  cost: string;
+}
+
+export interface ConstitutionState {
+  active: ConstitutionClauseId | null;
+  warnings: string[];
+  amendmentGoldCost: number;
+  amendmentReputationCost: number;
+}
+
+export const CONSTITUTION_CLAUSE_ORDER: ConstitutionClauseId[] = [
+  'martial-priority',
+  'open-knowledge',
+  'fellowship-dividend',
+  'commercial-supremacy',
+  'exploration-duty',
+];
+
+export const CONSTITUTION_CLAUSES: Record<ConstitutionClauseId, ConstitutionClauseDef> = {
+  'martial-priority': {
+    id: 'martial-priority', name: '武力優先條款',
+    summary: '以護運、紀律與現場控制作為公司第一責任。',
+    advantage: '護運委託與實地解法更容易。',
+    cost: '交易委託的金幣與聲望報酬降低。',
+  },
+  'open-knowledge': {
+    id: 'open-knowledge', name: '知識公開條款',
+    summary: '要求地圖、技術與鑑定結果在公司內公開。',
+    advantage: '專業解法門檻降低，遺珍報酬提高。',
+    cost: '資本解法金幣成本提高。',
+  },
+  'fellowship-dividend': {
+    id: 'fellowship-dividend', name: '同袍分紅條款',
+    summary: '公司收益必須優先回饋共同承擔風險的旅伴。',
+    advantage: '羈絆與聲望報酬提高。',
+    cost: '所有委託的金幣報酬降低。',
+  },
+  'commercial-supremacy': {
+    id: 'commercial-supremacy', name: '商業至上條款',
+    summary: '公司所有決策以可持續現金流與交易權為核心。',
+    advantage: '交易委託與金幣報酬提高。',
+    cost: '實地解法需要更多乾糧。',
+  },
+  'exploration-duty': {
+    id: 'exploration-duty', name: '探索義務條款',
+    summary: '公司必須持續開拓未知路線並保存探索成果。',
+    advantage: '前線與遺珍委託門檻降低。',
+    cost: '所有可執行路線額外消耗一份補給。',
+  },
+};
+
+const flag = (id: ConstitutionClauseId): string => `company-constitution:${id}`;
+const enactedFlag = 'company-constitution:enacted';
+
+export function companyConstitutionState(save: SaveData): ConstitutionState {
+  const active = CONSTITUTION_CLAUSE_ORDER.filter((id) => save.flags[flag(id)] === true);
+  const warnings: string[] = [];
+  if (active.length > 1) warnings.push('偵測到多個公司憲章條款，政策效果暫停並視為未制定。');
+  const selected = active.length === 1 ? active[0] : null;
+  const amendedBefore = save.flags[enactedFlag] === true;
+  return {
+    active: selected,
+    warnings,
+    amendmentGoldCost: amendedBefore ? 40 : 0,
+    amendmentReputationCost: amendedBefore ? 2 : 0,
+  };
+}
+
+export function enactCompanyConstitution(save: SaveData, id: ConstitutionClauseId): ConstitutionState {
+  if (!CONSTITUTION_CLAUSE_ORDER.includes(id)) throw new Error(`未知公司憲章條款「${id}」`);
+  const current = companyConstitutionState(save);
+  if (current.active === id && current.warnings.length === 0) throw new Error('這項條款已經生效。');
+  if (save.gold < current.amendmentGoldCost) throw new Error(`金幣不足，需要 ${current.amendmentGoldCost} G。`);
+  if (save.reputation < current.amendmentReputationCost) throw new Error(`聲望不足，需要 ${current.amendmentReputationCost}。`);
+
+  save.gold -= current.amendmentGoldCost;
+  save.reputation -= current.amendmentReputationCost;
+  for (const clauseId of CONSTITUTION_CLAUSE_ORDER) delete save.flags[flag(clauseId)];
+  save.flags[flag(id)] = true;
+  save.flags[enactedFlag] = true;
+  return companyConstitutionState(save);
+}

--- a/src/scripts/games/caravan/data/constitutionalMandates.ts
+++ b/src/scripts/games/caravan/data/constitutionalMandates.ts
@@ -1,0 +1,161 @@
+import type { SaveData } from '../save';
+import {
+  companyMandateAgenda,
+  type CompanyMandate,
+  type MandateAgenda,
+  type MandateCompletion,
+  type MandateReward,
+  type MandateRoute,
+  type MandateRouteId,
+} from './mandates';
+import { companyConstitutionState, type ConstitutionClauseId } from './constitution';
+
+export interface ConstitutionalMandateAgenda extends MandateAgenda {
+  constitution: ConstitutionClauseId | null;
+  constitutionWarnings: string[];
+}
+
+function cloneReward(reward: MandateReward): MandateReward {
+  return { ...reward, inventory: { ...reward.inventory } };
+}
+
+function cloneRoute(route: MandateRoute): MandateRoute {
+  return {
+    ...route,
+    inventoryCost: { ...route.inventoryCost },
+    blockers: [...route.blockers],
+  };
+}
+
+function refreshEligibility(save: SaveData, route: MandateRoute): MandateRoute {
+  const blockers = route.blockers.filter((entry) =>
+    !entry.startsWith('能力分數 ') &&
+    !entry.startsWith('金幣不足') &&
+    !entry.includes('不足，需要')
+  );
+  if (route.score < route.threshold) blockers.push(`能力分數 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, blockers, eligible: blockers.length === 0 };
+}
+
+function applyClauseToMandate(
+  save: SaveData,
+  mandate: CompanyMandate,
+  clause: ConstitutionClauseId | null,
+): CompanyMandate {
+  const reward = cloneReward(mandate.reward);
+  const routes = mandate.routes.map(cloneRoute);
+  if (!clause) return { ...mandate, reward, routes };
+
+  if (clause === 'martial-priority') {
+    if (mandate.domain === 'escort') {
+      for (const route of routes) route.score += route.id === 'field' ? 2 : 1;
+    }
+    if (mandate.domain === 'trade') {
+      reward.gold = Math.max(0, Math.floor(reward.gold * 0.75));
+      reward.reputation = Math.max(0, reward.reputation - 1);
+    }
+  }
+
+  if (clause === 'open-knowledge') {
+    for (const route of routes) {
+      if (route.id === 'expertise') route.threshold = Math.max(1, route.threshold - 1);
+      if (route.id === 'capital') route.goldCost += 10 * mandate.difficulty;
+    }
+    if (mandate.domain === 'relic') reward.skillPoints += 1;
+  }
+
+  if (clause === 'fellowship-dividend') {
+    reward.gold = Math.max(0, Math.floor(reward.gold * 0.7));
+    reward.reputation += 1;
+    reward.bondAll += 1;
+  }
+
+  if (clause === 'commercial-supremacy') {
+    if (mandate.domain === 'trade') {
+      reward.gold += 20 + mandate.difficulty * 5;
+      for (const route of routes) if (route.id === 'capital') route.score += 2;
+    }
+    for (const route of routes) {
+      if (route.id === 'field') {
+        route.inventoryCost['dried-rations'] = (route.inventoryCost['dried-rations'] ?? 0) + 1;
+      }
+    }
+  }
+
+  if (clause === 'exploration-duty') {
+    if (mandate.domain === 'frontier' || mandate.domain === 'relic') {
+      for (const route of routes) route.threshold = Math.max(1, route.threshold - 1);
+    }
+    for (const route of routes) {
+      route.inventoryCost['dried-rations'] = (route.inventoryCost['dried-rations'] ?? 0) + 1;
+    }
+  }
+
+  return {
+    ...mandate,
+    reward,
+    routes: routes.map((route) => refreshEligibility(save, route)),
+  };
+}
+
+export function constitutionalMandateAgenda(save: SaveData): ConstitutionalMandateAgenda {
+  const base = companyMandateAgenda(save);
+  const constitution = companyConstitutionState(save);
+  return {
+    ...base,
+    constitution: constitution.active,
+    constitutionWarnings: constitution.warnings,
+    mandates: base.mandates.map((mandate) => applyClauseToMandate(save, mandate, constitution.active)),
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+export function completeConstitutionalMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): MandateCompletion {
+  const agenda = constitutionalMandateAgenda(save);
+  if (agenda.completed) throw new Error('本市場週期的公司委託已經完成。');
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到公司委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項公司委託已經結算。');
+  }
+
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: cloneReward(mandate.reward),
+    receipt: preciseReceipt,
+  };
+}


### PR DESCRIPTION
## Summary

- add five mutually exclusive company constitution clauses with explicit advantages and costs
- make the first enactment free and charge 40 G plus 2 reputation for later amendments
- safely disable policy effects when corrupted saves contain multiple active clauses
- wrap M34 company mandates with constitution-adjusted thresholds, scores, route costs, and rewards
- keep saves without a clause exactly compatible with the original M34 agenda
- settle the policy-adjusted route cost and reward atomically through a dedicated completion function
- update the existing `/caravan/mandates` page so players cannot bypass constitution effects through the old M34 settlement path
- add a player-facing `/caravan/constitution` page showing active policy, advantages, costs, amendment price, warnings, and latest-save revalidation
- add adversarial tests for legacy parity, clause tradeoffs, atomic amendment failure, corrupt multi-clause saves, and duplicate policy-adjusted rewards

## Game-design intent

M22-M34 created a deep chain from character origin and growth through companions, careers, charters, initiatives, payroll governance, chemistry, and dynamic company mandates. The remaining gap was normative identity: the company had systems and projects, but no explicit rule describing which values take priority when those systems conflict.

M35 turns company identity into a persistent strategic tradeoff. Martial priority favors escort and field control but sacrifices trade returns. Open knowledge lowers expertise barriers but raises capital costs. Fellowship dividends increase trust and reputation while reducing cash profit. Commercial supremacy strengthens trade returns but consumes more field supplies. Exploration duty makes frontier and relic work easier while imposing a universal supply obligation.

The constitution changes the actual mandate transaction, not just its UI. The existing mandate route now uses the same adjusted costs and rewards shown to the player, and amendment costs prevent free policy switching before every market-cycle decision.

## Player adversarial review

- no-clause saves produce the exact original M34 mandates
- every clause changes the agenda and includes a measurable cost, not a universal free buff
- all adjusted costs remain non-negative
- first enactment is free; later amendments require both gold and reputation
- insufficient amendment resources fail without changing any save data
- multiple active clause flags disable all policy effects and surface a warning instead of stacking benefits
- the mandate page blocks settlement while constitution data is corrupt
- completion recalculates the latest policy-adjusted agenda before spending resources
- policy-adjusted rewards cannot be claimed twice
- the old `/caravan/mandates` page now calls constitution-aware preview and settlement functions, preventing bypass
- no save-version, dependency, lockfile, asset, or generated-output changes

## Scope

- `src/scripts/games/caravan/data/constitution.ts`
- `src/scripts/games/caravan/data/constitutionalMandates.ts`
- `src/scripts/games/caravan/data/constitution.m35.test.ts`
- `src/pages/caravan/constitution.astro`
- `src/pages/caravan/mandates.astro`