### PR TITLE
feat(caravan): add M36 company office appointments

### DIFF
--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -4,16 +4,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="公司委託議程 — 商隊與劍"
-  description="依命運、職涯、特許、工程、治理、公司憲章與市場週期形成的動態公司委託。"
+  description="依命運、職涯、特許、工程、治理、憲章、公司職務與市場週期形成的動態委託。"
   lang="zh-TW"
 >
   <main class="mandate-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M34 / M35</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M36</p>
       <h1>公司委託議程</h1>
-      <p>每個市場週期會形成三項不同領域的公司級委託。公司憲章會同時改變解法門檻、成本與報酬；本週期仍只能完成其中一項。</p>
+      <p>公司憲章決定優先價值，公司官員把旅伴能力轉化為組織執行力；每個市場週期仍只能完成其中一項委託。</p>
       <nav>
         <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/offices">公司職務</a>
         <a href="/caravan/governance">營運治理</a>
         <a href="/caravan/constitution">公司憲章</a>
         <a href="/caravan/initiatives">長程工程</a>
@@ -33,6 +34,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <p id="cycle-state"></p>
     </section>
 
+    <section id="warnings" class="warnings" hidden></section>
     <section id="cards" class="cards"></section>
     <p id="status" class="status" aria-live="polite"></p>
   </main>
@@ -41,9 +43,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <script>
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import {
-    constitutionalMandateAgenda,
-    completeConstitutionalMandate,
-  } from '@scripts/games/caravan/data/constitutionalMandates';
+    officeMandateAgenda,
+    completeOfficeMandate,
+  } from '@scripts/games/caravan/data/officeMandates';
   import type { CompanyMandate, MandateRoute } from '@scripts/games/caravan/data/mandates';
   import { CONSTITUTION_CLAUSES } from '@scripts/games/caravan/data/constitution';
 
@@ -51,6 +53,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   const summaryEl = document.getElementById('summary')!;
   const cycleTitleEl = document.getElementById('cycle-title')!;
   const cycleStateEl = document.getElementById('cycle-state')!;
+  const warningsEl = document.getElementById('warnings')!;
   const cardsEl = document.getElementById('cards')!;
   const statusEl = document.getElementById('status')!;
 
@@ -85,29 +88,31 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   function render(): void {
     const save = loadGame();
     cardsEl.replaceChildren();
+    warningsEl.replaceChildren();
     if (!save) {
       emptyEl.hidden = false;
       summaryEl.hidden = true;
+      warningsEl.hidden = true;
       return;
     }
     emptyEl.hidden = true;
     summaryEl.hidden = false;
-    const agenda = constitutionalMandateAgenda(save);
+    const agenda = officeMandateAgenda(save);
     cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
     const constitutionName = agenda.constitution
       ? CONSTITUTION_CLAUSES[agenda.constitution].name
       : '未制定條款';
-    cycleStateEl.textContent = agenda.constitutionWarnings.length > 0
-      ? agenda.constitutionWarnings.join(' ')
-      : agenda.completed
-        ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
-        : `目前資金 ${save.gold} G；公司憲章：${constitutionName}；請從三項委託中選擇一項完成。`;
+    const allWarnings = [...agenda.constitutionWarnings, ...agenda.officeWarnings];
+    warningsEl.hidden = allWarnings.length === 0;
+    for (const warning of allWarnings) warningsEl.append(text('p', warning));
+    cycleStateEl.textContent = agenda.completed
+      ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
+      : `目前資金 ${save.gold} G；公司憲章：${constitutionName}；官員津貼 ${agenda.officeUpkeep} G／委託。`;
 
     for (const mandate of agenda.mandates) {
       const card = document.createElement('article');
       card.className = 'mandate-card';
       if (agenda.completedMandateId === mandate.id) card.classList.add('completed');
-
       const head = document.createElement('header');
       const titleWrap = document.createElement('div');
       titleWrap.append(
@@ -116,7 +121,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       );
       head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
       card.append(head, text('p', mandate.description, 'description'));
-      card.append(text('p', `政策後獎勵：${rewardText(mandate)}`, 'reward'));
+      card.append(text('p', `政策與人事後獎勵：${rewardText(mandate)}`, 'reward'));
 
       const routes = document.createElement('div');
       routes.className = 'routes';
@@ -132,11 +137,11 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
         if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
         const button = document.createElement('button');
         button.type = 'button';
-        button.disabled = agenda.completed || !route.eligible || agenda.constitutionWarnings.length > 0;
+        button.disabled = agenda.completed || !route.eligible || allWarnings.length > 0;
         button.textContent = agenda.completed
           ? '本週期已結算'
-          : agenda.constitutionWarnings.length > 0
-            ? '憲章資料衝突'
+          : allWarnings.length > 0
+            ? '組織資料衝突'
             : route.eligible
               ? `採用${route.name}`
               : '條件不足';
@@ -147,7 +152,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
             return;
           }
           try {
-            const result = completeConstitutionalMandate(latest, mandate.id, route.id);
+            const result = completeOfficeMandate(latest, mandate.id, route.id);
             saveGame(latest);
             statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}。`;
           } catch (error) {
@@ -178,6 +183,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
   a { color: #e0bd78; }
   .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
+  .warnings p { margin: 4px 0; }
   .cards { display: grid; gap: 18px; margin-top: 18px; }
   .mandate-card { padding: 24px; }
   .mandate-card.completed { border-color: #9e7d42; }

--- a/src/pages/caravan/offices.astro
+++ b/src/pages/caravan/offices.astro
@@ -1,0 +1,192 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="公司職務席位 — 商隊與劍"
+  description="依旅伴命運、潛力、職涯、技能與羈絆任命公司官員。"
+  lang="zh-TW"
+>
+  <main class="office-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M36</p>
+      <h1>公司職務席位</h1>
+      <p>旅伴不再只是出征人手。任命合格官員能強化對應公司委託，但每席都會從委託金幣報酬中支付 3 G 津貼。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/mandates">公司委託</a>
+        <a href="/caravan/companions">旅伴身世</a>
+        <a href="/caravan/constitution">公司憲章</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立旅程並招募旅伴，再回來設置公司職務。</p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">OFFICE BOARD</p>
+        <h2 id="summary-title"></h2>
+      </div>
+      <p id="summary-copy"></p>
+    </section>
+
+    <section id="warnings" class="warnings" hidden></section>
+    <section id="cards" class="cards"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    COMPANY_OFFICES,
+    COMPANY_OFFICE_ORDER,
+    appointCompanyOfficer,
+    companyOfficeState,
+    dismissCompanyOfficer,
+    officeCandidate,
+    type CompanyOfficeId,
+  } from '@scripts/games/caravan/data/offices';
+
+  const emptyEl = document.getElementById('empty')!;
+  const summaryEl = document.getElementById('summary')!;
+  const summaryTitleEl = document.getElementById('summary-title')!;
+  const summaryCopyEl = document.getElementById('summary-copy')!;
+  const warningsEl = document.getElementById('warnings')!;
+  const cardsEl = document.getElementById('cards')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function render(): void {
+    const save = loadGame();
+    cardsEl.replaceChildren();
+    warningsEl.replaceChildren();
+    if (!save) {
+      emptyEl.hidden = false;
+      summaryEl.hidden = true;
+      return;
+    }
+    emptyEl.hidden = true;
+    summaryEl.hidden = false;
+    const state = companyOfficeState(save);
+    summaryTitleEl.textContent = `已設置 ${state.assignments.length} / 3 席`;
+    summaryCopyEl.textContent = `目前資金 ${save.gold} G；有效席位每個市場委託支付 3 G 官員津貼。`;
+    warningsEl.hidden = state.warnings.length === 0;
+    for (const warning of state.warnings) warningsEl.append(text('p', warning));
+
+    for (const officeId of COMPANY_OFFICE_ORDER) {
+      const def = COMPANY_OFFICES[officeId];
+      const assignment = state.assignments.find((entry) => entry.officeId === officeId);
+      const card = document.createElement('article');
+      card.className = 'office-card';
+      const head = document.createElement('header');
+      const copy = document.createElement('div');
+      copy.append(text('p', def.domain.toUpperCase(), 'eyebrow'), text('h2', def.name));
+      head.append(copy, text('span', assignment ? `Tier ${assignment.tier}` : '空缺', 'badge'));
+      card.append(head, text('p', def.description, 'description'));
+      if (assignment) {
+        const current = document.createElement('div');
+        current.className = 'current';
+        current.append(
+          text('strong', assignment.memberName),
+          text('span', `資格 ${assignment.qualification}｜羈絆階級 ${assignment.bondTier}`),
+        );
+        const dismiss = document.createElement('button');
+        dismiss.type = 'button';
+        dismiss.className = 'secondary';
+        dismiss.textContent = '撤除職務';
+        dismiss.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) return;
+          try {
+            dismissCompanyOfficer(latest, officeId);
+            saveGame(latest);
+            statusEl.textContent = `已撤除${def.name}。重新任命此席位需支付 25 G。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '撤職失敗。';
+          }
+          render();
+        });
+        current.append(dismiss);
+        card.append(current);
+      }
+
+      const candidates = document.createElement('div');
+      candidates.className = 'candidates';
+      for (const companion of save.companions) {
+        const candidate = officeCandidate(save, officeId, companion.id);
+        const row = document.createElement('div');
+        row.className = `candidate ${candidate.eligible ? 'eligible' : 'blocked'}`;
+        const body = document.createElement('div');
+        body.append(
+          text('strong', companion.name),
+          text('span', `資格 ${candidate.qualification} / ${candidate.threshold}｜任命 ${candidate.appointmentCost} G`),
+        );
+        if (!candidate.eligible) body.append(text('small', candidate.blockers.join('；')));
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.disabled = !candidate.eligible;
+        button.textContent = candidate.eligible ? '任命' : '不可任命';
+        button.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) return;
+          try {
+            const result = appointCompanyOfficer(latest, officeId, companion.id);
+            saveGame(latest);
+            statusEl.textContent = `${result.memberName} 已就任${def.name}（Tier ${result.tier}）。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '任命失敗。';
+          }
+          render();
+        });
+        row.append(body, button);
+        candidates.append(row);
+      }
+      if (save.companions.length === 0) candidates.append(text('p', '目前沒有旅伴可供任命。'));
+      card.append(candidates);
+      cardsEl.append(card);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #11100d; color: #eee6d5; }
+  .office-page { width: min(1120px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .office-card { border: 1px solid #4a4032; background: #1a1713; }
+  .hero { padding: 32px; background: linear-gradient(135deg, #241c13, #15120e); }
+  .eyebrow { margin: 0 0 7px; color: #c9a45e; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  h1, h2, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
+  .hero > p:not(.eyebrow), .description, .panel p, .candidate span, .candidate small, .status { color: #b9b0a1; line-height: 1.65; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
+  a { color: #e0bd78; }
+  .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
+  .warnings p { margin: 4px 0; }
+  .cards { display: grid; gap: 18px; margin-top: 18px; }
+  .office-card { padding: 22px; }
+  .office-card > header { display: flex; justify-content: space-between; gap: 16px; }
+  .badge { padding: 6px 10px; border: 1px solid #6b5938; color: #d9b972; height: fit-content; }
+  .current { display: flex; justify-content: space-between; align-items: center; gap: 14px; padding: 14px; margin: 14px 0; background: #252018; border-left: 3px solid #a88443; }
+  .current > span { color: #c7bca9; }
+  .candidates { display: grid; gap: 9px; margin-top: 14px; }
+  .candidate { display: flex; justify-content: space-between; gap: 14px; align-items: center; padding: 12px; border: 1px solid #41382d; background: #201c17; }
+  .candidate > div { display: grid; gap: 4px; }
+  .candidate.blocked { opacity: .62; }
+  button { padding: 9px 13px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; white-space: nowrap; }
+  button.secondary { background: transparent; color: #dfbd7c; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 720px) { .panel, .current, .candidate { align-items: flex-start; flex-direction: column; } }
+</style>

--- a/src/scripts/games/caravan/data/officeMandates.ts
+++ b/src/scripts/games/caravan/data/officeMandates.ts
@@ -1,0 +1,116 @@
+import type { SaveData } from '../save';
+import type {
+  CompanyMandate,
+  MandateCompletion,
+  MandateReward,
+  MandateRoute,
+  MandateRouteId,
+} from './mandates';
+import {
+  constitutionalMandateAgenda,
+  type ConstitutionalMandateAgenda,
+} from './constitutionalMandates';
+import { companyOfficeState, COMPANY_OFFICES } from './offices';
+
+export interface OfficeMandateAgenda extends ConstitutionalMandateAgenda {
+  officeWarnings: string[];
+  officeUpkeep: number;
+}
+
+function cloneReward(reward: MandateReward): MandateReward {
+  return { ...reward, inventory: { ...reward.inventory } };
+}
+
+function cloneRoute(route: MandateRoute): MandateRoute {
+  return { ...route, inventoryCost: { ...route.inventoryCost }, blockers: [...route.blockers] };
+}
+
+function refreshEligibility(save: SaveData, route: MandateRoute): MandateRoute {
+  const blockers = route.blockers.filter((entry) =>
+    !entry.startsWith('能力分數 ') &&
+    !entry.startsWith('金幣不足') &&
+    !entry.includes('不足，需要')
+  );
+  if (route.score < route.threshold) blockers.push(`能力分數 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, blockers, eligible: blockers.length === 0 };
+}
+
+function applyOfficesToMandate(save: SaveData, mandate: CompanyMandate): CompanyMandate {
+  const state = companyOfficeState(save);
+  const reward = cloneReward(mandate.reward);
+  reward.gold = Math.max(0, reward.gold - state.assignments.length * 3);
+  const routes = mandate.routes.map(cloneRoute);
+  const assignment = state.assignments.find((entry) => COMPANY_OFFICES[entry.officeId].domain === mandate.domain);
+  if (assignment) {
+    for (const route of routes) {
+      if (route.id === 'expertise') route.score += assignment.tier;
+      if (route.id === 'field' && assignment.bondTier >= 2) route.score += 1;
+    }
+  }
+  return {
+    ...mandate,
+    reward,
+    routes: routes.map((route) => refreshEligibility(save, route)),
+  };
+}
+
+export function officeMandateAgenda(save: SaveData): OfficeMandateAgenda {
+  const base = constitutionalMandateAgenda(save);
+  const state = companyOfficeState(save);
+  return {
+    ...base,
+    officeWarnings: state.warnings,
+    officeUpkeep: state.assignments.length * 3,
+    mandates: base.mandates.map((mandate) => applyOfficesToMandate(save, mandate)),
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+export function completeOfficeMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): MandateCompletion {
+  const agenda = officeMandateAgenda(save);
+  if (agenda.constitutionWarnings.length > 0) throw new Error(agenda.constitutionWarnings.join('；'));
+  if (agenda.officeWarnings.length > 0) throw new Error(agenda.officeWarnings.join('；'));
+  if (agenda.completed) throw new Error('本市場週期的公司委託已經完成。');
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到公司委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項公司委託已經結算。');
+  }
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: cloneReward(mandate.reward),
+    receipt: preciseReceipt,
+  };
+}

--- a/src/scripts/games/caravan/data/offices.m36.test.ts
+++ b/src/scripts/games/caravan/data/offices.m36.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { newGame } from '../save';
+import { registerCompanionOrigin } from './companionOrigins';
+import { constitutionalMandateAgenda } from './constitutionalMandates';
+import { appointCompanyOfficer, companyOfficeState, dismissCompanyOfficer, officeCandidate } from './offices';
+import { completeOfficeMandate, officeMandateAgenda } from './officeMandates';
+
+function officeSave() {
+  const save = newGame(777, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+  save.marketSeed = 8181;
+  save.gold = 1000;
+  save.reputation = 20;
+  save.wagonLevel = 5;
+  save.inventory['dried-rations'] = 20;
+  save.visitedBossDungeons = ['a', 'b', 'c'];
+  save.companions.push(
+    {
+      id: 'sera', name: '瑟拉', job: 'mage', level: 5, xp: 320,
+      stats: { str: 8, dex: 11, int: 19, cha: 12, con: 10 }, maxHp: 22,
+      injuredForTrips: 0, trait: 'learned', equipment: { weapon: null, armor: null, trinket: null },
+      skills: { lore: 5 }, bond: 9,
+    },
+    {
+      id: 'doran', name: '多蘭', job: 'swordsman', level: 5, xp: 320,
+      stats: { str: 19, dex: 11, int: 9, cha: 10, con: 15 }, maxHp: 30,
+      injuredForTrips: 0, trait: 'brawny', equipment: { weapon: null, armor: null, trinket: null },
+      skills: { martial: 5 }, bond: 9,
+    },
+    {
+      id: 'mira', name: '米拉', job: 'ranger', level: 5, xp: 320,
+      stats: { str: 10, dex: 19, int: 11, cha: 10, con: 13 }, maxHp: 25,
+      injuredForTrips: 0, trait: 'nimble', equipment: { weapon: null, armor: null, trinket: null },
+      skills: { scouting: 5 }, bond: 9,
+    },
+    {
+      id: 'lian', name: '蓮', job: 'cleric', level: 5, xp: 320,
+      stats: { str: 10, dex: 9, int: 12, cha: 19, con: 15 }, maxHp: 28,
+      injuredForTrips: 0, trait: 'charming', equipment: { weapon: null, armor: null, trinket: null },
+      skills: { negotiation: 5, survival: 4 }, bond: 9,
+    },
+  );
+  for (const companion of save.companions) registerCompanionOrigin(save, companion.id);
+  return save;
+}
+
+describe('M36 company offices', () => {
+  it('keeps M35 exact when no office is appointed', () => {
+    const save = officeSave();
+    const base = constitutionalMandateAgenda(save);
+    const office = officeMandateAgenda(save);
+    expect(office.mandates).toEqual(base.mandates);
+    expect(office.officeUpkeep).toBe(0);
+  });
+
+  it('requires registered qualified healthy companions and charges appointments', () => {
+    const save = officeSave();
+    const candidate = officeCandidate(save, 'relic-curator', 'sera');
+    expect(candidate.eligible).toBe(true);
+    expect(candidate.appointmentCost).toBe(0);
+    const beforeGold = save.gold;
+    appointCompanyOfficer(save, 'relic-curator', 'sera');
+    expect(save.gold).toBe(beforeGold);
+    dismissCompanyOfficer(save, 'relic-curator');
+    const rehire = officeCandidate(save, 'relic-curator', 'sera');
+    expect(rehire.appointmentCost).toBe(25);
+  });
+
+  it('limits the company to three seats and one seat per companion', () => {
+    const save = officeSave();
+    appointCompanyOfficer(save, 'relic-curator', 'sera');
+    expect(officeCandidate(save, 'escort-marshal', 'sera').eligible).toBe(false);
+    appointCompanyOfficer(save, 'escort-marshal', 'doran');
+    appointCompanyOfficer(save, 'surveyor', 'mira');
+    expect(companyOfficeState(save).assignments).toHaveLength(3);
+    expect(officeCandidate(save, 'trade-director', 'lian').eligible).toBe(false);
+  });
+
+  it('adds domain expertise but subtracts visible and settled officer upkeep', () => {
+    const save = officeSave();
+    const base = constitutionalMandateAgenda(save);
+    appointCompanyOfficer(save, 'relic-curator', 'sera');
+    const agenda = officeMandateAgenda(save);
+    expect(agenda.officeUpkeep).toBe(3);
+    const relic = agenda.mandates.find((entry) => entry.domain === 'relic');
+    const baseRelic = base.mandates.find((entry) => entry.domain === 'relic');
+    if (relic && baseRelic) {
+      expect(relic.routes.find((route) => route.id === 'expertise')!.score)
+        .toBeGreaterThan(baseRelic.routes.find((route) => route.id === 'expertise')!.score);
+    }
+    for (let index = 0; index < agenda.mandates.length; index++) {
+      expect(agenda.mandates[index].reward.gold).toBe(Math.max(0, base.mandates[index].reward.gold - 3));
+    }
+    const option = agenda.mandates.flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.eligible);
+    expect(option).toBeTruthy();
+    const beforeGold = save.gold;
+    const result = completeOfficeMandate(save, option!.mandate.id, option!.route.id);
+    expect(save.gold).toBe(beforeGold - option!.route.goldCost + result.reward.gold);
+  });
+
+  it('disables corrupt duplicate assignments instead of stacking bonuses', () => {
+    const save = officeSave();
+    save.flags['company-office:relic-curator:sera'] = true;
+    save.flags['company-office:relic-curator:doran'] = true;
+    const state = companyOfficeState(save);
+    expect(state.assignments.some((entry) => entry.officeId === 'relic-curator')).toBe(false);
+    expect(state.warnings.length).toBeGreaterThan(0);
+    const agenda = officeMandateAgenda(save);
+    expect(agenda.officeWarnings.length).toBeGreaterThan(0);
+    const before = JSON.stringify(save);
+    const option = agenda.mandates.flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.eligible);
+    expect(() => completeOfficeMandate(save, option!.mandate.id, option!.route.id)).toThrow();
+    expect(JSON.stringify(save)).toBe(before);
+  });
+});

--- a/src/scripts/games/caravan/data/offices.ts
+++ b/src/scripts/games/caravan/data/offices.ts
@@ -1,0 +1,203 @@
+import type { CompanionRecord, SaveData } from '../save';
+
+export type CompanyOfficeId = 'escort-marshal' | 'surveyor' | 'trade-director' | 'fellowship-delegate' | 'relic-curator';
+export type OfficeDomain = 'escort' | 'frontier' | 'trade' | 'fellowship' | 'relic';
+
+export interface CompanyOfficeDef {
+  id: CompanyOfficeId;
+  name: string;
+  domain: OfficeDomain;
+  stat: 'str' | 'dex' | 'int' | 'cha' | 'con';
+  skill: 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+  career: 'martial' | 'scouting' | 'lore' | 'negotiation' | 'survival';
+  description: string;
+}
+
+export interface OfficeAssignment {
+  officeId: CompanyOfficeId;
+  memberId: string;
+  memberName: string;
+  qualification: number;
+  tier: 1 | 2;
+  bondTier: number;
+}
+
+export interface CompanyOfficeState {
+  assignments: OfficeAssignment[];
+  warnings: string[];
+}
+
+export interface OfficeCandidate {
+  officeId: CompanyOfficeId;
+  memberId: string;
+  memberName: string;
+  qualification: number;
+  threshold: number;
+  eligible: boolean;
+  blockers: string[];
+  appointmentCost: number;
+}
+
+export const COMPANY_OFFICES: Record<CompanyOfficeId, CompanyOfficeDef> = {
+  'escort-marshal': {
+    id: 'escort-marshal', name: '護運總管', domain: 'escort', stat: 'str', skill: 'martial', career: 'martial',
+    description: '統籌護衛、路障與武裝通行規則。',
+  },
+  surveyor: {
+    id: 'surveyor', name: '測繪官', domain: 'frontier', stat: 'dex', skill: 'scouting', career: 'scouting',
+    description: '管理路線情報、前線標記與失落支線。',
+  },
+  'trade-director': {
+    id: 'trade-director', name: '商務監', domain: 'trade', stat: 'cha', skill: 'negotiation', career: 'negotiation',
+    description: '負責合約、擔保與跨鎮價格秩序。',
+  },
+  'fellowship-delegate': {
+    id: 'fellowship-delegate', name: '同袍代表', domain: 'fellowship', stat: 'con', skill: 'survival', career: 'survival',
+    description: '代表旅伴協調分工、休養與風險分配。',
+  },
+  'relic-curator': {
+    id: 'relic-curator', name: '遺珍學監', domain: 'relic', stat: 'int', skill: 'lore', career: 'lore',
+    description: '主持鑑定、檔案與危險知識的保管。',
+  },
+};
+
+export const COMPANY_OFFICE_ORDER = Object.keys(COMPANY_OFFICES) as CompanyOfficeId[];
+const MAX_OFFICES = 3;
+const QUALIFICATION_THRESHOLD = 8;
+
+function assignmentPrefix(officeId: CompanyOfficeId): string {
+  return `company-office:${officeId}:`;
+}
+
+function historyFlag(officeId: CompanyOfficeId): string {
+  return `company-office-history:${officeId}`;
+}
+
+function bondTier(value: number | undefined): number {
+  const bond = value ?? 0;
+  if (bond >= 9) return 3;
+  if (bond >= 5) return 2;
+  if (bond >= 2) return 1;
+  return 0;
+}
+
+function qualification(record: CompanionRecord, officeId: CompanyOfficeId): number {
+  const office = COMPANY_OFFICES[officeId];
+  const stat = Math.floor((record.stats[office.stat] ?? 0) / 4);
+  const skill = record.skills?.[office.skill] ?? 0;
+  const potential = record.growth?.potential?.[office.stat] ?? 0;
+  const career = (record.careerMilestones ?? []).some((entry) => entry.pathId === office.career) ? 2 : 0;
+  return stat + skill + potential + career + bondTier(record.bond);
+}
+
+function activeKeys(save: SaveData, officeId: CompanyOfficeId): string[] {
+  const prefix = assignmentPrefix(officeId);
+  return Object.keys(save.flags).filter((key) => key.startsWith(prefix) && save.flags[key] === true);
+}
+
+export function companyOfficeState(save: SaveData): CompanyOfficeState {
+  const assignments: OfficeAssignment[] = [];
+  const warnings: string[] = [];
+  const usedMembers = new Set<string>();
+
+  for (const officeId of COMPANY_OFFICE_ORDER) {
+    const keys = activeKeys(save, officeId);
+    if (keys.length > 1) {
+      warnings.push(`${COMPANY_OFFICES[officeId].name}同時存在多名任職者，該席位不採計。`);
+      continue;
+    }
+    if (keys.length === 0) continue;
+    const memberId = keys[0].slice(assignmentPrefix(officeId).length);
+    const record = save.companions.find((member) => member.id === memberId);
+    if (!record) {
+      warnings.push(`${COMPANY_OFFICES[officeId].name}的任職者已不在商隊，該席位不採計。`);
+      continue;
+    }
+    if (usedMembers.has(memberId)) {
+      warnings.push(`${record.name}同時擔任多個公司職務，相關重複席位不採計。`);
+      continue;
+    }
+    if (!record.genesis || !record.growth) {
+      warnings.push(`${record.name}尚未完成身世登記，${COMPANY_OFFICES[officeId].name}不採計。`);
+      continue;
+    }
+    const score = qualification(record, officeId);
+    if (score < QUALIFICATION_THRESHOLD) {
+      warnings.push(`${record.name}已不符合${COMPANY_OFFICES[officeId].name}資格，該席位不採計。`);
+      continue;
+    }
+    usedMembers.add(memberId);
+    assignments.push({
+      officeId,
+      memberId,
+      memberName: record.name,
+      qualification: score,
+      tier: score >= 12 ? 2 : 1,
+      bondTier: bondTier(record.bond),
+    });
+  }
+  if (assignments.length > MAX_OFFICES) {
+    warnings.push(`有效公司職務超過 ${MAX_OFFICES} 席，僅採計固定順序中的前三席。`);
+  }
+  return { assignments: assignments.slice(0, MAX_OFFICES), warnings };
+}
+
+export function officeCandidate(save: SaveData, officeId: CompanyOfficeId, memberId: string): OfficeCandidate {
+  const office = COMPANY_OFFICES[officeId];
+  if (!office) throw new Error(`未知公司職務「${officeId}」`);
+  const record = save.companions.find((member) => member.id === memberId);
+  if (!record) throw new Error(`找不到旅伴「${memberId}」`);
+  const state = companyOfficeState(save);
+  const blockers: string[] = [];
+  const score = qualification(record, officeId);
+  if (!record.genesis || !record.growth) blockers.push('旅伴尚未完成身世登記。');
+  if (record.injuredForTrips > 0) blockers.push('旅伴正在養傷。');
+  if (score < QUALIFICATION_THRESHOLD) blockers.push(`資格分數 ${score}，需要 ${QUALIFICATION_THRESHOLD}。`);
+  const current = state.assignments.find((entry) => entry.officeId === officeId);
+  if (current?.memberId === memberId) blockers.push('目前已由此旅伴擔任。');
+  const otherOffice = state.assignments.find((entry) => entry.memberId === memberId && entry.officeId !== officeId);
+  if (otherOffice) blockers.push(`此旅伴已擔任${COMPANY_OFFICES[otherOffice.officeId].name}。`);
+  if (!current && state.assignments.length >= MAX_OFFICES) blockers.push(`公司最多設置 ${MAX_OFFICES} 席職務。`);
+  const cost = current || save.flags[historyFlag(officeId)] === true ? 25 : state.assignments.length * 10;
+  if (save.gold < cost) blockers.push(`金幣不足，需要 ${cost} G。`);
+  return {
+    officeId,
+    memberId,
+    memberName: record.name,
+    qualification: score,
+    threshold: QUALIFICATION_THRESHOLD,
+    eligible: blockers.length === 0,
+    blockers,
+    appointmentCost: cost,
+  };
+}
+
+/** 原子任命或撤換職務。 */
+export function appointCompanyOfficer(save: SaveData, officeId: CompanyOfficeId, memberId: string): OfficeAssignment {
+  const candidate = officeCandidate(save, officeId, memberId);
+  if (!candidate.eligible) throw new Error(candidate.blockers.join('；'));
+  const state = companyOfficeState(save);
+  const current = state.assignments.find((entry) => entry.officeId === officeId);
+  save.gold -= candidate.appointmentCost;
+  if (current) save.flags[`${assignmentPrefix(officeId)}${current.memberId}`] = false;
+  save.flags[`${assignmentPrefix(officeId)}${memberId}`] = true;
+  save.flags[historyFlag(officeId)] = true;
+  const record = save.companions.find((member) => member.id === memberId)!;
+  const score = qualification(record, officeId);
+  return {
+    officeId,
+    memberId,
+    memberName: record.name,
+    qualification: score,
+    tier: score >= 12 ? 2 : 1,
+    bondTier: bondTier(record.bond),
+  };
+}
+
+export function dismissCompanyOfficer(save: SaveData, officeId: CompanyOfficeId): void {
+  const state = companyOfficeState(save);
+  const current = state.assignments.find((entry) => entry.officeId === officeId);
+  if (!current) throw new Error(`${COMPANY_OFFICES[officeId].name}目前沒有有效任職者。`);
+  save.flags[`${assignmentPrefix(officeId)}${current.memberId}`] = false;
+  save.flags[historyFlag(officeId)] = true;
+}


### PR DESCRIPTION
## Summary

- add five company office seats tied to escort, frontier, trade, fellowship, and relic mandate domains
- qualify companions through registered origins, relevant stats, skills, growth potential, career milestones, and bond tiers
- limit the company to three active offices and one office per companion
- charge escalating first-seat costs and 25 G for later reappointments so players cannot freely optimize before each mandate
- disable invalid, duplicate, missing, unregistered, or underqualified assignments instead of stacking corrupted benefits
- apply office tier bonuses to matching mandate expertise routes and high-bond field routes
- subtract a 3 G stipend from every mandate reward per valid office, making offices a strategic obligation rather than a free buff
- route the existing `/caravan/mandates` page through office-aware preview and settlement so office costs cannot be bypassed
- add a player-facing `/caravan/offices` page with candidate qualification, costs, blockers, appointments, dismissals, warnings, and latest-save revalidation
- add adversarial tests for M35 parity, qualification, seat limits, appointment costs, reward upkeep, corrupt assignments, and atomic settlement

## Game-design intent

M31 gave companions formal histories and careers, but they still functioned mostly as expedition members. M36 turns mature companions into organizational leaders. A registered mage with high lore, intellectual potential, career history, and bond can become a relic curator; a seasoned martial companion can become escort marshal. These appointments convert character-building decisions into company capabilities.

Offices are deliberately not pure bonuses. Each valid seat permanently reduces company-mandate cash rewards by 3 G, first-time expansion gets progressively more expensive, and replacing a previously used seat costs 25 G. Players must decide whether a stronger expertise or field solution is worth the ongoing stipend.

## Player adversarial review

- saves with no offices produce the exact M35 mandate agenda
- companions must exist, be healthy, registered, and meet a qualification threshold
- qualification combines stat, skill, growth potential, matching career, and bond tier
- one companion cannot hold multiple valid offices and the company cannot exceed three valid seats
- first office costs 0 G, the second 10 G, the third 20 G; reused or replaced seats cost 25 G
- a matching office raises the domain expertise route by tier 1 or 2; bond tier 2+ adds one field point
- every valid office subtracts 3 G from all mandate rewards, clamped at zero
- the office-aware completion function settles the same adjusted reward shown to the player
- duplicate office holders, missing members, underqualified members, and multi-office corruption disable affected seats and surface warnings
- settlement is blocked while office data is corrupt, with no save mutation
- no save-version, dependency, lockfile, asset, or generated-output changes

## Scope

- `src/scripts/games/caravan/data/offices.ts`
- `src/scripts/games/caravan/data/officeMandates.ts`
- `src/scripts/games/caravan/data/offices.m36.test.ts`
- `src/pages/caravan/offices.astro`
- `src/pages/caravan/mandates.astro`