### PR TITLE
feat(caravan): add M37 company risk ledger

### DIFF
--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -4,16 +4,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="公司委託議程 — 商隊與劍"
-  description="依命運、職涯、特許、工程、治理、憲章、公司職務與市場週期形成的動態委託。"
+  description="依命運、職涯、特許、工程、治理、憲章、職務、風險與市場週期形成的動態委託。"
   lang="zh-TW"
 >
   <main class="mandate-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M36</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M37</p>
       <h1>公司委託議程</h1>
-      <p>公司憲章決定優先價值，公司官員把旅伴能力轉化為組織執行力；每個市場週期仍只能完成其中一項委託。</p>
+      <p>公司憲章決定優先價值，官員轉化旅伴能力，未解決危機則形成可見成本；每個市場週期仍只能完成其中一項委託。</p>
       <nav>
         <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/risks">風險帳本</a>
         <a href="/caravan/offices">公司職務</a>
         <a href="/caravan/governance">營運治理</a>
         <a href="/caravan/constitution">公司憲章</a>
@@ -34,6 +35,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <p id="cycle-state"></p>
     </section>
 
+    <section id="crisis" class="crisis" hidden></section>
     <section id="warnings" class="warnings" hidden></section>
     <section id="cards" class="cards"></section>
     <p id="status" class="status" aria-live="polite"></p>
@@ -43,9 +45,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <script>
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import {
-    officeMandateAgenda,
-    completeOfficeMandate,
-  } from '@scripts/games/caravan/data/officeMandates';
+    riskMandateAgenda,
+    completeRiskMandate,
+  } from '@scripts/games/caravan/data/riskMandates';
   import type { CompanyMandate, MandateRoute } from '@scripts/games/caravan/data/mandates';
   import { CONSTITUTION_CLAUSES } from '@scripts/games/caravan/data/constitution';
 
@@ -53,6 +55,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   const summaryEl = document.getElementById('summary')!;
   const cycleTitleEl = document.getElementById('cycle-title')!;
   const cycleStateEl = document.getElementById('cycle-state')!;
+  const crisisEl = document.getElementById('crisis')!;
   const warningsEl = document.getElementById('warnings')!;
   const cardsEl = document.getElementById('cards')!;
   const statusEl = document.getElementById('status')!;
@@ -89,15 +92,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     const save = loadGame();
     cardsEl.replaceChildren();
     warningsEl.replaceChildren();
+    crisisEl.replaceChildren();
     if (!save) {
       emptyEl.hidden = false;
       summaryEl.hidden = true;
+      crisisEl.hidden = true;
       warningsEl.hidden = true;
       return;
     }
     emptyEl.hidden = true;
     summaryEl.hidden = false;
-    const agenda = officeMandateAgenda(save);
+    const agenda = riskMandateAgenda(save);
     cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
     const constitutionName = agenda.constitution
       ? CONSTITUTION_CLAUSES[agenda.constitution].name
@@ -108,6 +113,19 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     cycleStateEl.textContent = agenda.completed
       ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
       : `目前資金 ${save.gold} G；公司憲章：${constitutionName}；官員津貼 ${agenda.officeUpkeep} G／委託。`;
+
+    const crisis = agenda.riskCrisis;
+    crisisEl.hidden = !crisis;
+    if (crisis) {
+      crisisEl.append(
+        text('strong', `${crisis.title}｜嚴重度 ${crisis.severity}`),
+        text('span', crisis.resolved ? '本週期危機已解決，委託不再受罰。' : `未解決：${crisis.mandatePenalty}`),
+      );
+      const link = document.createElement('a');
+      link.href = '/caravan/risks';
+      link.textContent = crisis.resolved ? '查看風險帳本' : '前往處理危機';
+      crisisEl.append(link);
+    }
 
     for (const mandate of agenda.mandates) {
       const card = document.createElement('article');
@@ -121,7 +139,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       );
       head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
       card.append(head, text('p', mandate.description, 'description'));
-      card.append(text('p', `政策與人事後獎勵：${rewardText(mandate)}`, 'reward'));
+      card.append(text('p', `政策、人事與風險後獎勵：${rewardText(mandate)}`, 'reward'));
 
       const routes = document.createElement('div');
       routes.className = 'routes';
@@ -132,7 +150,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
           text('h3', route.name),
           text('p', route.description),
           text('p', `能力 ${route.score} / ${route.threshold}`, 'score'),
-          text('p', `政策後成本：${routeCost(route)}`, 'cost'),
+          text('p', `最終成本：${routeCost(route)}`, 'cost'),
         );
         if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
         const button = document.createElement('button');
@@ -152,7 +170,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
             return;
           }
           try {
-            const result = completeOfficeMandate(latest, mandate.id, route.id);
+            const result = completeRiskMandate(latest, mandate.id, route.id);
             saveGame(latest);
             statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}。`;
           } catch (error) {
@@ -183,6 +201,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
   a { color: #e0bd78; }
   .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .crisis { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 14px 18px; border-left: 3px solid #b96050; background: #2a1915; }
+  .crisis span { flex: 1; color: #d3b7a8; }
   .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
   .warnings p { margin: 4px 0; }
   .cards { display: grid; gap: 18px; margin-top: 18px; }
@@ -201,5 +221,5 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
   button:disabled { opacity: .45; cursor: not-allowed; }
   .status { min-height: 1.6em; margin-top: 16px; }
-  @media (max-width: 820px) { .routes { grid-template-columns: 1fr; } .panel, .mandate-card > header { align-items: flex-start; flex-direction: column; } }
+  @media (max-width: 820px) { .routes { grid-template-columns: 1fr; } .panel, .mandate-card > header, .crisis { align-items: flex-start; flex-direction: column; } }
 </style>

--- a/src/pages/caravan/risks.astro
+++ b/src/pages/caravan/risks.astro
@@ -1,0 +1,222 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="公司風險帳本 — 商隊與劍"
+  description="追蹤財務、傷病、補給、治理與士氣風險，並處理當期公司危機。"
+  lang="zh-TW"
+>
+  <main class="risk-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M37</p>
+      <h1>公司風險帳本</h1>
+      <p>公司的選擇不只產生收益，也會累積壓力。帳本公開每一分風險來源；危機可用專業、資本或同袍方式處理，並形成不同的永久慣例。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/mandates">公司委託</a>
+        <a href="/caravan/governance">營運治理</a>
+        <a href="/caravan/offices">公司職務</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立旅程，再回來檢視公司壓力。</p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">RISK CYCLE</p>
+        <h2 id="summary-title"></h2>
+      </div>
+      <p id="summary-copy"></p>
+    </section>
+
+    <section id="practices" class="panel" hidden></section>
+    <section id="scores" class="score-grid"></section>
+    <section id="crisis" class="crisis-card" hidden></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    companyRiskCrisis,
+    companyRiskLedger,
+    resolveCompanyRisk,
+    type RiskResponseRoute,
+  } from '@scripts/games/caravan/data/risks';
+
+  const emptyEl = document.getElementById('empty')!;
+  const summaryEl = document.getElementById('summary')!;
+  const summaryTitleEl = document.getElementById('summary-title')!;
+  const summaryCopyEl = document.getElementById('summary-copy')!;
+  const practicesEl = document.getElementById('practices')!;
+  const scoresEl = document.getElementById('scores')!;
+  const crisisEl = document.getElementById('crisis')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function itemList(items: Record<string, number>): string {
+    const entries = Object.entries(items).filter(([, count]) => count > 0);
+    return entries.length > 0 ? entries.map(([id, count]) => `${id} ×${count}`).join('、') : '無';
+  }
+
+  function routeCost(route: RiskResponseRoute): string {
+    const parts: string[] = [];
+    if (route.goldCost > 0) parts.push(`${route.goldCost} G`);
+    if (Object.keys(route.inventoryCost).length > 0) parts.push(itemList(route.inventoryCost));
+    return parts.length > 0 ? parts.join('＋') : '無直接成本';
+  }
+
+  function render(): void {
+    const save = loadGame();
+    scoresEl.replaceChildren();
+    crisisEl.replaceChildren();
+    practicesEl.replaceChildren();
+    if (!save) {
+      emptyEl.hidden = false;
+      summaryEl.hidden = true;
+      practicesEl.hidden = true;
+      crisisEl.hidden = true;
+      return;
+    }
+    emptyEl.hidden = true;
+    summaryEl.hidden = false;
+    const ledger = companyRiskLedger(save);
+    const crisis = companyRiskCrisis(save);
+    summaryTitleEl.textContent = `市場週期 ${ledger.cycle}`;
+    summaryCopyEl.textContent = ledger.stable
+      ? '目前沒有任何風險維度達到危機門檻。'
+      : `最高風險 ${ledger.highestScore}；未解決危機會影響公司委託。`;
+
+    practicesEl.hidden = ledger.practices.length === 0;
+    if (ledger.practices.length > 0) {
+      practicesEl.append(
+        text('strong', '永久風險慣例'),
+        text('span', ledger.practices.map((id) => id === 'expertise' ? '內控慣例' : id === 'capital' ? '風險準備金' : '互助公約').join('、')),
+      );
+    }
+
+    for (const score of ledger.scores) {
+      const card = document.createElement('article');
+      card.className = `score-card level-${Math.min(3, score.score)}`;
+      const head = document.createElement('header');
+      head.append(text('h2', score.name), text('strong', String(score.score), 'score-value'));
+      card.append(head);
+      if (score.factors.length === 0) {
+        card.append(text('p', '目前沒有明顯風險來源。', 'muted'));
+      } else {
+        const list = document.createElement('div');
+        list.className = 'factor-list';
+        for (const factor of score.factors) {
+          const row = document.createElement('div');
+          row.className = factor.value > 0 ? 'factor risk' : 'factor relief';
+          row.append(
+            text('b', factor.value > 0 ? `+${factor.value}` : String(factor.value)),
+            text('span', `${factor.label}｜${factor.detail}`),
+          );
+          list.append(row);
+        }
+        card.append(list);
+      }
+      scoresEl.append(card);
+    }
+
+    crisisEl.hidden = !crisis;
+    if (!crisis) return;
+    const head = document.createElement('header');
+    const copy = document.createElement('div');
+    copy.append(
+      text('p', `${crisis.dimension.toUpperCase()} · 嚴重度 ${crisis.severity}`, 'eyebrow'),
+      text('h2', crisis.title),
+    );
+    head.append(copy, text('span', crisis.resolved ? '已解決' : '未解決', crisis.resolved ? 'resolved' : 'unresolved'));
+    crisisEl.append(head, text('p', crisis.description), text('p', `委託影響：${crisis.mandatePenalty}`, 'penalty'));
+
+    const routes = document.createElement('div');
+    routes.className = 'routes';
+    for (const route of crisis.routes) {
+      const routeEl = document.createElement('section');
+      routeEl.className = `route ${route.eligible ? 'eligible' : 'blocked'}`;
+      routeEl.append(
+        text('h3', route.name),
+        text('p', route.description),
+        text('p', `能力 ${route.score} / ${route.threshold}`, 'score-line'),
+        text('p', `成本：${routeCost(route)}`, 'cost'),
+        text('p', route.practiceAlreadyKnown ? '此永久慣例已建立，本次不重複堆疊。' : '首次使用會建立永久風險慣例。', 'practice-copy'),
+      );
+      if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.disabled = crisis.resolved || !route.eligible;
+      button.textContent = crisis.resolved ? '本週期已解決' : route.eligible ? `採用${route.name}` : '條件不足';
+      button.addEventListener('click', () => {
+        const latest = loadGame();
+        if (!latest) return;
+        try {
+          const result = resolveCompanyRisk(latest, route.id);
+          saveGame(latest);
+          statusEl.textContent = `已解決「${crisis.title}」；${result.learnedPractice ? '建立新的永久風險慣例。' : '既有慣例沒有重複堆疊。'}`;
+        } catch (error) {
+          statusEl.textContent = error instanceof Error ? error.message : '危機處理失敗。';
+        }
+        render();
+      });
+      routeEl.append(button);
+      routes.append(routeEl);
+    }
+    crisisEl.append(routes);
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #100f0d; color: #eee6d6; }
+  .risk-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .score-card, .crisis-card { border: 1px solid #4c4031; background: #1a1713; }
+  .hero { padding: 32px; background: linear-gradient(135deg, #251a14, #15110e); }
+  .eyebrow { margin: 0 0 7px; color: #caa05d; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
+  .hero > p:not(.eyebrow), .panel p, .score-card p, .crisis-card p, .status { color: #b9b0a2; line-height: 1.7; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
+  a { color: #e2bd77; }
+  .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .score-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; margin-top: 18px; }
+  .score-card { padding: 18px; }
+  .score-card header, .crisis-card header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; }
+  .score-value { font-size: 2rem; color: #d6b36d; }
+  .level-3 { border-color: #a85f50; }
+  .factor-list { display: grid; gap: 7px; }
+  .factor { display: grid; grid-template-columns: 36px 1fr; gap: 8px; font-size: .9rem; }
+  .factor.risk b { color: #e08b78; }
+  .factor.relief b { color: #a7cf8a; }
+  .muted { opacity: .7; }
+  .crisis-card { margin-top: 18px; padding: 24px; border-color: #8d5547; }
+  .resolved, .unresolved { padding: 6px 10px; border: 1px solid currentColor; }
+  .resolved { color: #a9cd8b; }
+  .unresolved { color: #df8a76; }
+  .penalty { padding: 12px; border-left: 3px solid #ba6552; background: #281814; }
+  .routes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+  .route { padding: 16px; border: 1px solid #44392d; background: #211c17; }
+  .route.eligible { border-color: #777043; }
+  .route.blocked { opacity: .65; }
+  .score-line { color: #d7bd84 !important; }
+  .cost { color: #d8a17e !important; }
+  .practice-copy { font-size: .85rem; }
+  .blockers { color: #df8f7b !important; }
+  button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c49a52; background: #a97935; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 820px) { .routes { grid-template-columns: 1fr; } .panel, .crisis-card header { flex-direction: column; } }
+</style>

--- a/src/scripts/games/caravan/data/riskMandates.ts
+++ b/src/scripts/games/caravan/data/riskMandates.ts
@@ -1,0 +1,138 @@
+import type { SaveData } from '../save';
+import {
+  officeMandateAgenda,
+} from './officeMandates';
+import type {
+  CompanyMandate,
+  MandateCompletion,
+  MandateReward,
+  MandateRoute,
+  MandateRouteId,
+} from './mandates';
+import { companyRiskCrisis, type CompanyRiskCrisis } from './risks';
+
+export type RiskMandateAgenda = ReturnType<typeof officeMandateAgenda> & {
+  riskCrisis: CompanyRiskCrisis | null;
+  riskPenaltyActive: boolean;
+};
+
+function cloneReward(reward: MandateReward): MandateReward {
+  return { ...reward, inventory: { ...reward.inventory } };
+}
+
+function cloneRoute(route: MandateRoute): MandateRoute {
+  return {
+    ...route,
+    inventoryCost: { ...route.inventoryCost },
+    blockers: [...route.blockers],
+  };
+}
+
+function refreshEligibility(save: SaveData, route: MandateRoute): MandateRoute {
+  const blockers = route.blockers.filter((entry) =>
+    !entry.startsWith('能力分數 ') &&
+    !entry.startsWith('金幣不足') &&
+    !entry.includes('不足，需要')
+  );
+  if (route.score < route.threshold) blockers.push(`能力分數 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, blockers, eligible: blockers.length === 0 };
+}
+
+function applyCrisisToMandate(save: SaveData, mandate: CompanyMandate, crisis: CompanyRiskCrisis): CompanyMandate {
+  const reward = cloneReward(mandate.reward);
+  const routes = mandate.routes.map(cloneRoute);
+  if (crisis.dimension === 'finance') {
+    reward.gold = Math.max(0, reward.gold - crisis.severity * 5);
+    for (const route of routes) if (route.id === 'capital') route.goldCost += crisis.severity * 10;
+  }
+  if (crisis.dimension === 'health') {
+    for (const route of routes) if (route.id === 'field') route.threshold += crisis.severity;
+  }
+  if (crisis.dimension === 'logistics') {
+    for (const route of routes) {
+      if (route.id === 'field') {
+        route.inventoryCost['dried-rations'] = (route.inventoryCost['dried-rations'] ?? 0) + crisis.severity;
+      }
+    }
+  }
+  if (crisis.dimension === 'governance') {
+    for (const route of routes) if (route.id === 'expertise') route.threshold += crisis.severity;
+  }
+  if (crisis.dimension === 'morale') {
+    reward.reputation = Math.max(0, reward.reputation - crisis.severity);
+    for (const route of routes) if (route.id === 'field') route.threshold += 1;
+  }
+  return {
+    ...mandate,
+    reward,
+    routes: routes.map((route) => refreshEligibility(save, route)),
+  };
+}
+
+export function riskMandateAgenda(save: SaveData): RiskMandateAgenda {
+  const base = officeMandateAgenda(save);
+  const crisis = companyRiskCrisis(save);
+  const active = !!crisis && !crisis.resolved;
+  return {
+    ...base,
+    riskCrisis: crisis,
+    riskPenaltyActive: active,
+    mandates: active
+      ? base.mandates.map((mandate) => applyCrisisToMandate(save, mandate, crisis))
+      : base.mandates,
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+/** 使用最新風險、憲章與職務資料原子結算公司委託。 */
+export function completeRiskMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): MandateCompletion {
+  const agenda = riskMandateAgenda(save);
+  if (agenda.completed) throw new Error('本市場週期的公司委託已經完成。');
+  const organizationWarnings = [...agenda.constitutionWarnings, ...agenda.officeWarnings];
+  if (organizationWarnings.length > 0) throw new Error(organizationWarnings.join('；'));
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到公司委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項公司委託已經結算。');
+  }
+
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: cloneReward(mandate.reward),
+    receipt: preciseReceipt,
+  };
+}

--- a/src/scripts/games/caravan/data/risks.m37.test.ts
+++ b/src/scripts/games/caravan/data/risks.m37.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import { officeMandateAgenda } from './officeMandates';
+import { completeRiskMandate, riskMandateAgenda } from './riskMandates';
+import { companyRiskCrisis, companyRiskLedger, resolveCompanyRisk } from './risks';
+
+function companion(id: string, index: number): CompanionRecord {
+  return {
+    id,
+    name: `旅伴${index}`,
+    job: index % 2 === 0 ? 'swordsman' : 'ranger',
+    level: 5,
+    xp: 320,
+    stats: { str: 14, dex: 14, int: 10, cha: 10, con: 12 },
+    maxHp: 28,
+    injuredForTrips: 0,
+    trait: 'greedy',
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+function stableSave(): SaveData {
+  const save = newGame(100, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+  save.marketSeed = 7000;
+  save.gold = 1000;
+  save.inventory['dried-rations'] = 20;
+  return save;
+}
+
+function pressuredSave(): SaveData {
+  const save = newGame(200, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+  save.marketSeed = 8100;
+  save.gold = 100;
+  save.wagonLevel = 6;
+  save.inventory['dried-rations'] = 30;
+  save.companions = [1, 2, 3, 4, 5].map((index) => companion(`c${index}`, index));
+  save.flags['company-initiative:escort-network:1:expertise'] = true;
+  save.flags['company-initiative:frontier-office:1:capital'] = true;
+  save.flags['company-initiative:trade-consortium:1:field'] = true;
+  save.flags['operating-stance:ambitious'] = true;
+  return save;
+}
+
+describe('M37 company risk ledger', () => {
+  it('keeps M36 mandates exact for stable companies and never mutates previews', () => {
+    const save = stableSave();
+    const before = JSON.stringify(save);
+    expect(companyRiskLedger(save).stable).toBe(true);
+    expect(riskMandateAgenda(save).mandates).toEqual(officeMandateAgenda(save).mandates);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('creates a deterministic finance crisis and applies visible mandate penalties', () => {
+    const save = pressuredSave();
+    const before = JSON.stringify(save);
+    const first = companyRiskCrisis(save);
+    const second = companyRiskCrisis(save);
+    expect(first).toEqual(second);
+    expect(first?.dimension).toBe('finance');
+    expect(first?.resolved).toBe(false);
+    const base = officeMandateAgenda(save);
+    const risky = riskMandateAgenda(save);
+    expect(risky.riskPenaltyActive).toBe(true);
+    expect(risky.mandates.some((mandate, index) => mandate.reward.gold < base.mandates[index].reward.gold)).toBe(true);
+    expect(risky.mandates.some((mandate, index) => {
+      const route = mandate.routes.find((entry) => entry.id === 'capital')!;
+      const baseRoute = base.mandates[index].routes.find((entry) => entry.id === 'capital')!;
+      return route.goldCost > baseRoute.goldCost;
+    })).toBe(true);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('resolves a crisis atomically, learns one permanent practice, and cannot repeat', () => {
+    const save = pressuredSave();
+    const crisis = companyRiskCrisis(save)!;
+    const route = crisis.routes.find((entry) => entry.id === 'capital')!;
+    expect(route.eligible).toBe(true);
+    const beforeGold = save.gold;
+    const result = resolveCompanyRisk(save, 'capital');
+    expect(save.gold).toBe(beforeGold - route.goldCost);
+    expect(result.learnedPractice).toBe(true);
+    expect(save.flags['company-risk-practice:capital']).toBe(true);
+    expect(companyRiskCrisis(save)?.resolved).toBe(true);
+    expect(riskMandateAgenda(save).mandates).toEqual(officeMandateAgenda(save).mandates);
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveCompanyRisk(save, 'capital')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('revalidates stale resources before crisis settlement without partial mutation', () => {
+    const save = pressuredSave();
+    const route = companyRiskCrisis(save)!.routes.find((entry) => entry.id === 'capital')!;
+    expect(route.eligible).toBe(true);
+    save.gold = route.goldCost - 1;
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveCompanyRisk(save, 'capital')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('makes risk practices reduce later exposure without stacking duplicates', () => {
+    const save = pressuredSave();
+    const before = companyRiskLedger(save).scores.find((entry) => entry.dimension === 'finance')!.score;
+    save.flags['company-risk-practice:capital'] = true;
+    const after = companyRiskLedger(save).scores.find((entry) => entry.dimension === 'finance')!.score;
+    expect(after).toBe(Math.max(0, before - 1));
+    save.flags['company-risk-practice:capital'] = true;
+    expect(companyRiskLedger(save).scores.find((entry) => entry.dimension === 'finance')!.score).toBe(after);
+  });
+
+  it('uses the risk-adjusted reward in the real mandate settlement', () => {
+    const save = pressuredSave();
+    save.protagonist.stats = { str: 30, dex: 30, int: 30, cha: 30, con: 30 };
+    save.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+    save.protagonist.growth = { potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } } as never;
+    const agenda = riskMandateAgenda(save);
+    const option = agenda.mandates.flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.eligible);
+    expect(option).toBeTruthy();
+    const beforeGold = save.gold;
+    const result = completeRiskMandate(save, option!.mandate.id, option!.route.id);
+    expect(save.gold).toBe(beforeGold - option!.route.goldCost + result.reward.gold);
+    const snapshot = JSON.stringify(save);
+    expect(() => completeRiskMandate(save, option!.mandate.id, option!.route.id)).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('treats the next market seed as an independent crisis cycle', () => {
+    const save = pressuredSave();
+    resolveCompanyRisk(save, 'capital');
+    const oldReceipt = `company-risk-cycle:${save.marketSeed}`;
+    expect(save.flags[oldReceipt]).toBe(true);
+    save.marketSeed += 1;
+    const next = companyRiskCrisis(save);
+    expect(next).not.toBeNull();
+    expect(next?.resolved).toBe(false);
+    expect(save.flags[oldReceipt]).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/risks.ts
+++ b/src/scripts/games/caravan/data/risks.ts
@@ -1,0 +1,351 @@
+import type { SaveData } from '../save';
+import { companyConstitutionState } from './constitution';
+import { governedPayrollBreakdown } from './governance';
+import { acceptedOperationalInitiatives } from './operations';
+import { COMPANY_OFFICES, companyOfficeState } from './offices';
+
+export type CompanyRiskDimension = 'finance' | 'health' | 'logistics' | 'governance' | 'morale';
+export type RiskResponseRouteId = 'expertise' | 'capital' | 'solidarity';
+
+export interface CompanyRiskFactor {
+  id: string;
+  dimension: CompanyRiskDimension;
+  label: string;
+  value: number;
+  detail: string;
+}
+
+export interface CompanyRiskScore {
+  dimension: CompanyRiskDimension;
+  name: string;
+  score: number;
+  factors: CompanyRiskFactor[];
+}
+
+export interface CompanyRiskLedger {
+  cycle: number;
+  scores: CompanyRiskScore[];
+  highest: CompanyRiskDimension;
+  highestScore: number;
+  stable: boolean;
+  practices: RiskResponseRouteId[];
+  warnings: string[];
+}
+
+export interface RiskResponseRoute {
+  id: RiskResponseRouteId;
+  name: string;
+  description: string;
+  score: number;
+  threshold: number;
+  goldCost: number;
+  inventoryCost: Record<string, number>;
+  eligible: boolean;
+  blockers: string[];
+  practiceAlreadyKnown: boolean;
+}
+
+export interface CompanyRiskCrisis {
+  cycle: number;
+  dimension: CompanyRiskDimension;
+  title: string;
+  description: string;
+  severity: 1 | 2 | 3;
+  resolved: boolean;
+  receipt: string;
+  mandatePenalty: string;
+  routes: RiskResponseRoute[];
+}
+
+export interface RiskResolution {
+  cycle: number;
+  dimension: CompanyRiskDimension;
+  routeId: RiskResponseRouteId;
+  receipt: string;
+  learnedPractice: boolean;
+}
+
+const DIMENSION_NAMES: Record<CompanyRiskDimension, string> = {
+  finance: '財務曝險',
+  health: '傷病負荷',
+  logistics: '補給韌性',
+  governance: '治理失焦',
+  morale: '同袍士氣',
+};
+
+const CRISES: Record<CompanyRiskDimension, { title: string; description: string; penalty: string }> = {
+  finance: {
+    title: '現金流斷層',
+    description: '固定維護、人事與遠征薪餉已逼近公司可動用現金。',
+    penalty: '資本解法成本提高，所有委託現金報酬下降。',
+  },
+  health: {
+    title: '傷病連鎖',
+    description: '傷員比例提高，健康成員必須反覆承擔額外工作。',
+    penalty: '實地解法門檻提高。',
+  },
+  logistics: {
+    title: '補給斷裂',
+    description: '現有乾糧與運輸能力不足以支撐公司的活動規模。',
+    penalty: '實地解法需要額外乾糧。',
+  },
+  governance: {
+    title: '權責失焦',
+    description: '工程、憲章、職務或營運資料之間出現過多例外與警告。',
+    penalty: '專業解法門檻提高。',
+  },
+  morale: {
+    title: '營地離心',
+    description: '低羈絆與重複缺陷讓旅伴對風險分配失去信任。',
+    penalty: '實地解法門檻提高，聲望報酬下降。',
+  },
+};
+
+const DIMENSION_ORDER: CompanyRiskDimension[] = ['finance', 'health', 'logistics', 'governance', 'morale'];
+const ROUTE_ORDER: RiskResponseRouteId[] = ['expertise', 'capital', 'solidarity'];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function bondTier(value: number | undefined): number {
+  const bond = value ?? 0;
+  if (bond >= 9) return 3;
+  if (bond >= 5) return 2;
+  if (bond >= 2) return 1;
+  return 0;
+}
+
+function activeStance(save: SaveData): 'balanced' | 'lean' | 'ambitious' {
+  const active = (['balanced', 'lean', 'ambitious'] as const)
+    .filter((id) => save.flags[`operating-stance:${id}`] === true);
+  return active.length === 1 ? active[0] : 'balanced';
+}
+
+function practiceFlag(routeId: RiskResponseRouteId): string {
+  return `company-risk-practice:${routeId}`;
+}
+
+function cycleReceipt(cycle: number): string {
+  return `company-risk-cycle:${cycle}`;
+}
+
+function addFactor(
+  factors: CompanyRiskFactor[],
+  dimension: CompanyRiskDimension,
+  id: string,
+  label: string,
+  value: number,
+  detail: string,
+): void {
+  if (value !== 0) factors.push({ id, dimension, label, value, detail });
+}
+
+function burdenDuplication(save: SaveData): number {
+  const counts = new Map<string, number>();
+  for (const member of [save.protagonist, ...save.companions]) {
+    const burden = member.genesis?.burdenId;
+    if (burden) counts.set(burden, (counts.get(burden) ?? 0) + 1);
+  }
+  return [...counts.values()].reduce((sum, count) => sum + Math.max(0, count - 1), 0);
+}
+
+export function companyRiskLedger(save: SaveData): CompanyRiskLedger {
+  const cycle = Math.max(0, Math.floor(save.marketSeed));
+  const factors: CompanyRiskFactor[] = [];
+  const payroll = governedPayrollBreakdown(save);
+  const officeState = companyOfficeState(save);
+  const constitution = companyConstitutionState(save);
+  const initiatives = acceptedOperationalInitiatives(save);
+  const stance = activeStance(save);
+  const roster = [save.protagonist, ...save.companions];
+  const healthyCompanions = save.companions.filter((member) => member.injuredForTrips === 0);
+
+  if (payroll.total > save.gold) {
+    addFactor(factors, 'finance', 'payroll-over-cash', '薪餉超過現金', 3, `${payroll.total} G > ${save.gold} G`);
+  } else if (payroll.total * 2 > save.gold) {
+    addFactor(factors, 'finance', 'payroll-half-cash', '現金緩衝不足', 2, `現金不足兩次薪餉`);
+  } else if (payroll.total * 4 > save.gold) {
+    addFactor(factors, 'finance', 'payroll-quarter-cash', '現金緩衝偏薄', 1, `現金不足四次薪餉`);
+  }
+  if (payroll.fixedUpkeep >= 20) {
+    addFactor(factors, 'finance', 'heavy-upkeep', '固定維護偏高', 1, `${payroll.fixedUpkeep} G`);
+  }
+  if (stance === 'ambitious') addFactor(factors, 'finance', 'ambitious-exposure', '擴張營運曝險', 1, '擴張姿態提高固定承諾');
+  if (save.flags[practiceFlag('capital')] === true) addFactor(factors, 'finance', 'capital-practice', '風險準備金', -1, '永久財務慣例');
+
+  const injured = roster.filter((member) => member.injuredForTrips > 0).length;
+  if (injured > 0) addFactor(factors, 'health', 'injured-members', '現有傷員', Math.min(3, injured), `${injured} 人養傷`);
+  if (injured > 0 && injured * 2 >= roster.length) {
+    addFactor(factors, 'health', 'injury-concentration', '傷病集中', 1, '至少半數成員受傷');
+  }
+  if (save.flags[practiceFlag('solidarity')] === true) addFactor(factors, 'health', 'solidarity-health', '互助公約', -1, '永久照護慣例');
+
+  const rations = save.inventory['dried-rations'] ?? 0;
+  const fieldNeed = Math.max(1, healthyCompanions.length);
+  if (save.companions.length > 0 && rations === 0) {
+    addFactor(factors, 'logistics', 'no-rations', '乾糧耗盡', 3, '沒有任何乾糧');
+  } else if (rations < fieldNeed) {
+    addFactor(factors, 'logistics', 'low-rations', '乾糧不足一輪', 2, `${rations} / ${fieldNeed}`);
+  } else if (rations < fieldNeed * 2) {
+    addFactor(factors, 'logistics', 'thin-rations', '乾糧緩衝偏薄', 1, `${rations} / ${fieldNeed * 2}`);
+  }
+  if (save.wagonLevel <= 0 && initiatives.accepted.length >= 2) {
+    addFactor(factors, 'logistics', 'asset-mismatch', '工程超過運輸底盤', 1, '多項工程但馬車未升級');
+  }
+  if (constitution.active === 'exploration-duty') {
+    addFactor(factors, 'logistics', 'exploration-obligation', '探索補給義務', 1, '公司憲章要求持續前進');
+  }
+  if (save.flags[practiceFlag('expertise')] === true) addFactor(factors, 'logistics', 'expertise-logistics', '內控慣例', -1, '永久流程慣例');
+
+  if (officeState.warnings.length > 0) {
+    addFactor(factors, 'governance', 'office-warnings', '職務資料例外', Math.min(2, officeState.warnings.length), `${officeState.warnings.length} 項`);
+  }
+  if (constitution.warnings.length > 0) {
+    addFactor(factors, 'governance', 'constitution-warnings', '憲章資料例外', Math.min(2, constitution.warnings.length), `${constitution.warnings.length} 項`);
+  }
+  if (payroll.warnings.length > 0) {
+    addFactor(factors, 'governance', 'operating-warnings', '營運收據例外', Math.min(2, payroll.warnings.length), `${payroll.warnings.length} 項`);
+  }
+  if (initiatives.warnings.length > 0) {
+    addFactor(factors, 'governance', 'initiative-warnings', '工程收據例外', Math.min(2, initiatives.warnings.length), `${initiatives.warnings.length} 項`);
+  }
+  if (save.flags[practiceFlag('expertise')] === true) addFactor(factors, 'governance', 'expertise-governance', '內控慣例', -1, '永久治理慣例');
+
+  const bondSum = save.companions.reduce((sum, member) => sum + bondTier(member.bond), 0);
+  if (save.companions.length >= 2 && bondSum === 0) {
+    addFactor(factors, 'morale', 'no-bond', '缺乏共同經歷', 2, '所有旅伴仍無羈絆階級');
+  } else if (save.companions.length > 0 && bondSum < save.companions.length) {
+    addFactor(factors, 'morale', 'thin-bond', '羈絆覆蓋不足', 1, `階級合計 ${bondSum}`);
+  }
+  const duplicatedBurden = burdenDuplication(save);
+  if (duplicatedBurden > 0) {
+    addFactor(factors, 'morale', 'shared-burdens', '重複缺陷互相放大', Math.min(2, duplicatedBurden), `${duplicatedBurden} 個重疊缺陷`);
+  }
+  if (constitution.active === 'fellowship-dividend') addFactor(factors, 'morale', 'fellowship-clause', '同袍分紅保障', -1, '公司憲章降低離心風險');
+  if (save.flags[practiceFlag('solidarity')] === true) addFactor(factors, 'morale', 'solidarity-morale', '互助公約', -1, '永久同袍慣例');
+
+  const scores = DIMENSION_ORDER.map((dimension) => ({
+    dimension,
+    name: DIMENSION_NAMES[dimension],
+    score: clamp(factors.filter((entry) => entry.dimension === dimension).reduce((sum, entry) => sum + entry.value, 0), 0, 6),
+    factors: factors.filter((entry) => entry.dimension === dimension),
+  }));
+  const highestScore = Math.max(...scores.map((entry) => entry.score));
+  const tied = scores.filter((entry) => entry.score === highestScore);
+  const highest = tied[(cycle + save.createdAt) % tied.length]?.dimension ?? 'finance';
+  const practices = ROUTE_ORDER.filter((routeId) => save.flags[practiceFlag(routeId)] === true);
+  return {
+    cycle,
+    scores,
+    highest,
+    highestScore,
+    stable: highestScore < 3,
+    practices,
+    warnings: [...officeState.warnings, ...constitution.warnings, ...payroll.warnings, ...initiatives.warnings],
+  };
+}
+
+function expertiseProfile(dimension: CompanyRiskDimension): { stat: 'str' | 'dex' | 'int' | 'cha' | 'con'; skill: string; domain: string } {
+  switch (dimension) {
+    case 'finance': return { stat: 'cha', skill: 'negotiation', domain: 'trade' };
+    case 'health': return { stat: 'con', skill: 'survival', domain: 'fellowship' };
+    case 'logistics': return { stat: 'dex', skill: 'scouting', domain: 'frontier' };
+    case 'governance': return { stat: 'int', skill: 'lore', domain: 'relic' };
+    case 'morale': return { stat: 'cha', skill: 'negotiation', domain: 'fellowship' };
+  }
+}
+
+function responseRoutes(save: SaveData, dimension: CompanyRiskDimension, severity: 1 | 2 | 3): RiskResponseRoute[] {
+  const threshold = 6 + severity * 2;
+  const profile = expertiseProfile(dimension);
+  const officeState = companyOfficeState(save);
+  const matchingOffice = officeState.assignments.filter((entry) => COMPANY_OFFICES[entry.officeId].domain === profile.domain).length;
+  const expertiseScore = Math.floor((save.protagonist.stats[profile.stat] ?? 0) / 4) +
+    (save.protagonist.skills?.[profile.skill] ?? 0) +
+    (save.protagonist.growth?.potential?.[profile.stat] ?? 0) + matchingOffice;
+  const capitalScore = Math.floor(save.gold / 60) + Math.max(0, Math.floor(save.wagonLevel)) +
+    Math.min(4, acceptedOperationalInitiatives(save).accepted.length) + (activeStance(save) === 'ambitious' ? 2 : 0);
+  const healthy = save.companions.filter((member) => member.injuredForTrips === 0);
+  const solidarityScore = Math.min(4, healthy.length) +
+    Math.min(5, healthy.reduce((sum, member) => sum + bondTier(member.bond), 0)) +
+    Math.min(3, healthy.filter((member) => member.genesis && member.growth).length);
+
+  return ROUTE_ORDER.map((routeId) => {
+    const score = routeId === 'expertise' ? expertiseScore : routeId === 'capital' ? capitalScore : solidarityScore;
+    const goldCost = routeId === 'expertise' ? severity * 5 : routeId === 'capital' ? severity * 25 : 0;
+    const inventoryCost = routeId === 'solidarity' ? { 'dried-rations': severity } : {};
+    const blockers: string[] = [];
+    if (score < threshold) blockers.push(`能力分數 ${score}，需要 ${threshold}`);
+    if (save.gold < goldCost) blockers.push(`金幣不足，需要 ${goldCost} G`);
+    for (const [itemId, count] of Object.entries(inventoryCost)) {
+      if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+    }
+    return {
+      id: routeId,
+      name: routeId === 'expertise' ? '專業整頓' : routeId === 'capital' ? '資本緩衝' : '同袍協議',
+      description: routeId === 'expertise'
+        ? '以對應屬性、技能、潛力與公司官員修正流程。'
+        : routeId === 'capital'
+          ? '以現金、馬車與既有工程建立短期緩衝。'
+          : '以健康旅伴、身世理解與羈絆重新分配風險。',
+      score,
+      threshold,
+      goldCost,
+      inventoryCost,
+      eligible: blockers.length === 0,
+      blockers,
+      practiceAlreadyKnown: save.flags[practiceFlag(routeId)] === true,
+    };
+  });
+}
+
+export function companyRiskCrisis(save: SaveData): CompanyRiskCrisis | null {
+  const ledger = companyRiskLedger(save);
+  if (ledger.stable) return null;
+  const severity = clamp(ledger.highestScore - 2, 1, 3) as 1 | 2 | 3;
+  const definition = CRISES[ledger.highest];
+  return {
+    cycle: ledger.cycle,
+    dimension: ledger.highest,
+    title: definition.title,
+    description: definition.description,
+    severity,
+    resolved: save.flags[cycleReceipt(ledger.cycle)] === true,
+    receipt: cycleReceipt(ledger.cycle),
+    mandatePenalty: definition.penalty,
+    routes: responseRoutes(save, ledger.highest, severity),
+  };
+}
+
+/** 原子化解決當期公司危機，並永久記錄首次使用的風險慣例。 */
+export function resolveCompanyRisk(save: SaveData, routeId: RiskResponseRouteId): RiskResolution {
+  const crisis = companyRiskCrisis(save);
+  if (!crisis) throw new Error('目前沒有達到門檻的公司危機。');
+  if (crisis.resolved) throw new Error('本市場週期的公司危機已經解決。');
+  const route = crisis.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到危機解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+  const preciseReceipt = `company-risk:${crisis.cycle}:${crisis.dimension}:${routeId}`;
+  if (save.flags[preciseReceipt] === true || save.flags[crisis.receipt] === true) throw new Error('這項危機已經結算。');
+
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  if (routeId === 'expertise') save.reputation += 1;
+  if (routeId === 'solidarity') {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + 1;
+  }
+  const learnedPractice = save.flags[practiceFlag(routeId)] !== true;
+  save.flags[practiceFlag(routeId)] = true;
+  save.flags[crisis.receipt] = true;
+  save.flags[preciseReceipt] = true;
+  return {
+    cycle: crisis.cycle,
+    dimension: crisis.dimension,
+    routeId,
+    receipt: preciseReceipt,
+    learnedPractice,
+  };
+}


### PR DESCRIPTION
## Summary

- add a transparent five-dimension company risk ledger covering finance, health, logistics, governance, and morale
- derive risk from governed payroll, fixed upkeep, operating stance, injuries, supplies, wagon/initiative mismatch, constitution obligations, office/initiative warnings, companion bonds, and repeated burdens
- create one deterministic crisis per market cycle only when a risk dimension reaches the crisis threshold
- expose expertise, capital, and solidarity responses with different ability models, costs, and permanent non-stacking practices
- apply unresolved crisis penalties to the real M36 company mandate agenda and settlement path
- keep stable companies and resolved cycles exactly compatible with M36 mandate values
- add a player-facing `/caravan/risks` page with complete factor breakdowns, crisis routes, costs, blockers, practices, and latest-save revalidation
- update `/caravan/mandates` to show crisis penalties and use risk-aware settlement so the system cannot be bypassed
- add adversarial tests for parity, determinism, read-only previews, stale resources, duplicate resolution, practice caps, real adjusted rewards, and cycle independence

## Game-design intent

M22-M36 created a deep positive progression chain from character origin through growth, careers, companions, charters, initiatives, governance, constitutions, dynamic mandates, and company offices. The remaining weakness was consequence pressure: systems created benefits and costs, but those costs did not accumulate into a legible organizational problem the player could actively manage.

M37 turns existing decisions into an explicit risk economy. An ambitious company with heavy upkeep can face a cash-flow break; injured rosters create health pressure; exploration obligations and low rations create logistics pressure; corrupted or contradictory organizational data creates governance pressure; low bonds and repeated burdens create morale pressure. Crises are deterministic for the current market cycle and visibly modify company mandates until resolved.

The three response routes create persistent company identity. Expertise establishes internal controls, capital establishes a reserve, and solidarity establishes a mutual-aid pact. Each practice is learned only once and reduces relevant future exposure without allowing infinite stacking.

## Player adversarial review

- stable saves produce the exact M36 mandate agenda and no hidden penalties
- identical saves and market seeds produce identical ledgers, crises, severity, routes, and costs
- previewing risks never mutates the save
- risk factors show every positive and negative contribution instead of hiding a single score
- unresolved crises apply domain-specific mandate penalties rather than universal lockouts
- players may accept a penalized mandate or resolve the crisis first
- crisis execution recalculates the latest save, so stale gold or supplies fail before mutation
- each cycle has one shared resolution receipt and one precise route receipt
- permanent practices are boolean and cannot stack repeatedly
- resolving a crisis immediately restores the current cycle mandate agenda to M36 values
- risk-aware mandate settlement uses the same adjusted cost and reward shown in the UI
- changing marketSeed creates a new independent crisis cycle while preserving prior receipts
- no save-version, dependency, lockfile, asset, or generated-output changes

## Scope

- `src/scripts/games/caravan/data/risks.ts`
- `src/scripts/games/caravan/data/riskMandates.ts`
- `src/scripts/games/caravan/data/risks.m37.test.ts`
- `src/pages/caravan/risks.astro`
- `src/pages/caravan/mandates.astro`