### PR TITLE
feat(caravan): add M38 companion retention contracts

### DIFF
--- a/.github/workflows/caravan-ci.yml
+++ b/.github/workflows/caravan-ci.yml
@@ -1,0 +1,52 @@
+name: Caravan CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/caravan-ci.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/caravan-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: caravan-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-retention-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Build production site
+        run: npm run build
+
+      - name: Run M38 adversarial tests
+        run: >-
+          npx vitest run
+          src/scripts/games/caravan/data/retention.m38.test.ts
+          src/scripts/games/caravan/data/retention.contractCosts.m38.test.ts

--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -4,16 +4,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="公司委託議程 — 商隊與劍"
-  description="依命運、職涯、特許、工程、治理、憲章、職務、風險與市場週期形成的動態委託。"
+  description="依命運、職涯、特許、工程、治理、憲章、職務、風險、留任與市場週期形成的動態委託。"
   lang="zh-TW"
 >
   <main class="mandate-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M37</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M38</p>
       <h1>公司委託議程</h1>
-      <p>公司憲章決定優先價值，官員轉化旅伴能力，未解決危機則形成可見成本；每個市場週期仍只能完成其中一項委託。</p>
+      <p>公司憲章決定優先價值，官員轉化旅伴能力，風險與留任承諾形成可見成本；每個市場週期仍只能完成其中一項委託。</p>
       <nav>
         <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/retention">旅伴留任</a>
         <a href="/caravan/risks">風險帳本</a>
         <a href="/caravan/offices">公司職務</a>
         <a href="/caravan/governance">營運治理</a>
@@ -36,6 +37,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     </section>
 
     <section id="crisis" class="crisis" hidden></section>
+    <section id="retention" class="retention" hidden></section>
     <section id="warnings" class="warnings" hidden></section>
     <section id="cards" class="cards"></section>
     <p id="status" class="status" aria-live="polite"></p>
@@ -45,9 +47,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <script>
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import {
-    riskMandateAgenda,
-    completeRiskMandate,
-  } from '@scripts/games/caravan/data/riskMandates';
+    retentionMandateAgenda,
+    completeRetentionMandate,
+  } from '@scripts/games/caravan/data/retentionMandates';
   import type { CompanyMandate, MandateRoute } from '@scripts/games/caravan/data/mandates';
   import { CONSTITUTION_CLAUSES } from '@scripts/games/caravan/data/constitution';
 
@@ -56,6 +58,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   const cycleTitleEl = document.getElementById('cycle-title')!;
   const cycleStateEl = document.getElementById('cycle-state')!;
   const crisisEl = document.getElementById('crisis')!;
+  const retentionEl = document.getElementById('retention')!;
   const warningsEl = document.getElementById('warnings')!;
   const cardsEl = document.getElementById('cards')!;
   const statusEl = document.getElementById('status')!;
@@ -93,26 +96,32 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     cardsEl.replaceChildren();
     warningsEl.replaceChildren();
     crisisEl.replaceChildren();
+    retentionEl.replaceChildren();
     if (!save) {
       emptyEl.hidden = false;
       summaryEl.hidden = true;
       crisisEl.hidden = true;
+      retentionEl.hidden = true;
       warningsEl.hidden = true;
       return;
     }
     emptyEl.hidden = true;
     summaryEl.hidden = false;
-    const agenda = riskMandateAgenda(save);
+    const agenda = retentionMandateAgenda(save);
     cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
     const constitutionName = agenda.constitution
       ? CONSTITUTION_CLAUSES[agenda.constitution].name
       : '未制定條款';
-    const allWarnings = [...agenda.constitutionWarnings, ...agenda.officeWarnings];
+    const allWarnings = [
+      ...agenda.constitutionWarnings,
+      ...agenda.officeWarnings,
+      ...agenda.retentionWarnings,
+    ];
     warningsEl.hidden = allWarnings.length === 0;
     for (const warning of allWarnings) warningsEl.append(text('p', warning));
     cycleStateEl.textContent = agenda.completed
       ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
-      : `目前資金 ${save.gold} G；公司憲章：${constitutionName}；官員津貼 ${agenda.officeUpkeep} G／委託。`;
+      : `資金 ${save.gold} G；憲章：${constitutionName}；官員津貼 ${agenda.officeUpkeep} G；留任保障 ${agenda.securityStipend} G；合夥分成 ${Math.round(agenda.partnershipShareRate * 100)}%。`;
 
     const crisis = agenda.riskCrisis;
     crisisEl.hidden = !crisis;
@@ -127,6 +136,19 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       crisisEl.append(link);
     }
 
+    const dispute = agenda.retentionDispute;
+    retentionEl.hidden = !dispute;
+    if (dispute) {
+      retentionEl.append(
+        text('strong', `${dispute.memberName}留任爭議｜嚴重度 ${dispute.disputeSeverity}`),
+        text('span', `志向：${dispute.aspirationName}。現金報酬下降；對應領域的實地門檻提高。`),
+      );
+      const link = document.createElement('a');
+      link.href = '/caravan/retention';
+      link.textContent = '前往談判留任契約';
+      retentionEl.append(link);
+    }
+
     for (const mandate of agenda.mandates) {
       const card = document.createElement('article');
       card.className = 'mandate-card';
@@ -139,7 +161,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       );
       head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
       card.append(head, text('p', mandate.description, 'description'));
-      card.append(text('p', `政策、人事與風險後獎勵：${rewardText(mandate)}`, 'reward'));
+      card.append(text('p', `政策、人事、風險與留任後獎勵：${rewardText(mandate)}`, 'reward'));
 
       const routes = document.createElement('div');
       routes.className = 'routes';
@@ -170,9 +192,12 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
             return;
           }
           try {
-            const result = completeRiskMandate(latest, mandate.id, route.id);
+            const result = completeRetentionMandate(latest, mandate.id, route.id);
             saveGame(latest);
-            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}。`;
+            const partnership = result.partnershipBondIds.length > 0
+              ? `；${result.partnershipBondIds.length} 名合夥旅伴羈絆 +1`
+              : '';
+            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}${partnership}。`;
           } catch (error) {
             statusEl.textContent = error instanceof Error ? error.message : '委託結算失敗。';
           }
@@ -201,8 +226,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
   a { color: #e0bd78; }
   .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
-  .crisis { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 14px 18px; border-left: 3px solid #b96050; background: #2a1915; }
-  .crisis span { flex: 1; color: #d3b7a8; }
+  .crisis, .retention { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 14px 18px; }
+  .crisis { border-left: 3px solid #b96050; background: #2a1915; }
+  .retention { border-left: 3px solid #b98545; background: #2a2115; }
+  .crisis span, .retention span { flex: 1; color: #d3b7a8; }
   .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
   .warnings p { margin: 4px 0; }
   .cards { display: grid; gap: 18px; margin-top: 18px; }
@@ -221,5 +248,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
   button:disabled { opacity: .45; cursor: not-allowed; }
   .status { min-height: 1.6em; margin-top: 16px; }
-  @media (max-width: 820px) { .routes { grid-template-columns: 1fr; } .panel, .mandate-card > header, .crisis { align-items: flex-start; flex-direction: column; } }
+  @media (max-width: 820px) {
+    .routes { grid-template-columns: 1fr; }
+    .panel, .mandate-card > header, .crisis, .retention { align-items: flex-start; flex-direction: column; }
+  }
 </style>

--- a/src/pages/caravan/retention.astro
+++ b/src/pages/caravan/retention.astro
@@ -1,0 +1,247 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="旅伴志向與留任 — 商隊與劍"
+  description="檢視旅伴志向、滿意度、留任爭議與長期契約。"
+  lang="zh-TW"
+>
+  <main class="retention-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M38</p>
+      <h1>旅伴志向與留任</h1>
+      <p>命運、職涯、羈絆、官職、憲章、治理與危機會共同形成留任意願。契約能穩定旅伴，但也會永久改變公司委託的成本與報酬。</p>
+      <nav>
+        <a href="/caravan/play">返回遊戲</a>
+        <a href="/caravan/mandates">公司委託</a>
+        <a href="/caravan/offices">公司職務</a>
+        <a href="/caravan/risks">風險帳本</a>
+        <a href="/caravan/companions">旅伴身世</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>目前沒有旅伴</h2>
+      <p>先在酒館招募旅伴，再回來檢視其長期志向。</p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">RETENTION BOARD</p>
+        <h2 id="summary-title"></h2>
+      </div>
+      <p id="summary-copy"></p>
+    </section>
+
+    <section id="dispute" class="dispute" hidden></section>
+    <section id="warnings" class="warnings" hidden></section>
+    <section id="cards" class="cards"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    RETENTION_CONTRACTS,
+    companyRetentionState,
+    retentionContractOffer,
+    signRetentionContract,
+    terminateRetentionContract,
+    type RetentionContractId,
+  } from '@scripts/games/caravan/data/retention';
+
+  const CONTRACT_ORDER: RetentionContractId[] = ['security', 'autonomy', 'partnership'];
+  const emptyEl = document.getElementById('empty')!;
+  const summaryEl = document.getElementById('summary')!;
+  const summaryTitleEl = document.getElementById('summary-title')!;
+  const summaryCopyEl = document.getElementById('summary-copy')!;
+  const disputeEl = document.getElementById('dispute')!;
+  const warningsEl = document.getElementById('warnings')!;
+  const cardsEl = document.getElementById('cards')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function render(): void {
+    const save = loadGame();
+    cardsEl.replaceChildren();
+    warningsEl.replaceChildren();
+    disputeEl.replaceChildren();
+    if (!save || save.companions.length === 0) {
+      emptyEl.hidden = false;
+      summaryEl.hidden = true;
+      disputeEl.hidden = true;
+      warningsEl.hidden = true;
+      return;
+    }
+
+    emptyEl.hidden = true;
+    summaryEl.hidden = false;
+    const state = companyRetentionState(save);
+    summaryTitleEl.textContent = `有效契約 ${state.activeContracts} / 3`;
+    summaryCopyEl.textContent = `目前資金 ${save.gold} G、聲望 ${save.reputation}；改約需支付新契約成本與額外 20 G／1 聲望。`;
+
+    warningsEl.hidden = state.warnings.length === 0;
+    for (const warning of state.warnings) warningsEl.append(text('p', warning));
+
+    disputeEl.hidden = !state.dispute;
+    if (state.dispute) {
+      disputeEl.append(
+        text('strong', `${state.dispute.memberName}提出留任爭議｜嚴重度 ${state.dispute.disputeSeverity}`),
+        text('span', `滿意度 ${state.dispute.satisfaction}；志向為${state.dispute.aspirationName}。未處理時，公司委託現金報酬下降，對應領域實地門檻提高。`),
+      );
+    }
+
+    for (const profile of state.profiles) {
+      const card = document.createElement('article');
+      card.className = `retention-card ${profile.dispute ? 'at-risk' : ''}`;
+      const head = document.createElement('header');
+      const heading = document.createElement('div');
+      heading.append(
+        text('p', profile.aspiration.toUpperCase(), 'eyebrow'),
+        text('h2', profile.memberName),
+      );
+      head.append(
+        heading,
+        text('span', `滿意度 ${profile.satisfaction}`, profile.dispute ? 'score danger' : 'score'),
+      );
+      card.append(
+        head,
+        text('p', `長期志向：${profile.aspirationName}｜目前契約：${profile.contractName ?? '無'}`, 'profile-copy'),
+      );
+
+      const factors = document.createElement('div');
+      factors.className = 'factors';
+      for (const factor of profile.factors) {
+        const row = document.createElement('div');
+        row.className = `factor ${factor.value >= 0 ? 'positive' : 'negative'}`;
+        row.append(
+          text('span', factor.label),
+          text('small', factor.detail),
+          text('strong', `${factor.value >= 0 ? '+' : ''}${factor.value}`),
+        );
+        factors.append(row);
+      }
+      card.append(factors);
+
+      if (profile.contract) {
+        const current = document.createElement('section');
+        current.className = 'current-contract';
+        current.append(
+          text('strong', profile.contractName ?? ''),
+          text('span', RETENTION_CONTRACTS[profile.contract].description),
+        );
+        const terminate = document.createElement('button');
+        terminate.type = 'button';
+        terminate.className = 'secondary';
+        terminate.textContent = '支付 10 G／1 聲望解約';
+        terminate.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) return;
+          try {
+            terminateRetentionContract(latest, profile.memberId);
+            saveGame(latest);
+            statusEl.textContent = `已與${profile.memberName}解除留任契約。再次簽約將增加重啟成本。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '解約失敗。';
+          }
+          render();
+        });
+        current.append(terminate);
+        card.append(current);
+      }
+
+      const offers = document.createElement('div');
+      offers.className = 'offers';
+      for (const contractId of CONTRACT_ORDER) {
+        const offer = retentionContractOffer(save, profile.memberId, contractId);
+        const offerEl = document.createElement('section');
+        offerEl.className = `offer ${offer.eligible ? 'eligible' : 'blocked'}`;
+        offerEl.append(
+          text('h3', offer.contractName),
+          text('p', offer.description),
+          text('p', `簽約成本：${offer.goldCost} G｜聲望 ${offer.reputationCost}`, 'cost'),
+        );
+        if (!offer.eligible) offerEl.append(text('p', offer.blockers.join('；'), 'blockers'));
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.disabled = !offer.eligible;
+        button.textContent = offer.eligible
+          ? profile.contract ? '改訂此契約' : '簽訂此契約'
+          : '條件不足';
+        button.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) return;
+          try {
+            signRetentionContract(latest, profile.memberId, contractId);
+            saveGame(latest);
+            statusEl.textContent = `已與${profile.memberName}簽訂${offer.contractName}。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '簽約失敗。';
+          }
+          render();
+        });
+        offerEl.append(button);
+        offers.append(offerEl);
+      }
+      card.append(offers);
+      cardsEl.append(card);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #11100d; color: #eee6d5; }
+  .retention-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .retention-card { border: 1px solid #4a4032; background: #1a1713; }
+  .hero { padding: 32px; background: linear-gradient(135deg, #241c13, #15120e); }
+  .eyebrow { margin: 0 0 7px; color: #c9a45e; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
+  .hero > p:not(.eyebrow), .profile-copy, .offer p, .panel p, .status { color: #b9b0a1; line-height: 1.7; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
+  a { color: #e0bd78; }
+  .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
+  .dispute { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 16px 18px; border-left: 3px solid #c2644f; background: #2d1915; }
+  .dispute span { color: #d8b8a8; }
+  .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
+  .warnings p { margin: 4px 0; }
+  .cards { display: grid; gap: 18px; margin-top: 18px; }
+  .retention-card { padding: 24px; }
+  .retention-card.at-risk { border-color: #9b4e42; }
+  .retention-card > header { display: flex; justify-content: space-between; gap: 18px; align-items: flex-start; }
+  .score { padding: 7px 11px; border: 1px solid #6d5a37; color: #e2c17e; white-space: nowrap; }
+  .score.danger { border-color: #9b4e42; color: #ef9e8b; }
+  .factors { display: grid; gap: 7px; margin: 16px 0; }
+  .factor { display: grid; grid-template-columns: minmax(150px, 1fr) 2fr auto; gap: 12px; align-items: center; padding: 9px 11px; background: #211d17; }
+  .factor small { color: #91887b; }
+  .factor.positive strong { color: #a9c681; }
+  .factor.negative strong { color: #e28f7b; }
+  .current-contract { display: grid; gap: 6px; padding: 14px; border-left: 3px solid #a77c36; background: #251e14; }
+  .current-contract span { color: #b9b0a1; }
+  .offers { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+  .offer { padding: 16px; border: 1px solid #443a2d; background: #201c17; }
+  .offer.eligible { border-color: #77683d; }
+  .offer.blocked { opacity: .68; }
+  .cost { color: #d7a17e !important; }
+  .blockers { color: #df8f7b !important; }
+  button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button.secondary { background: transparent; color: #e0bd78; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 860px) {
+    .offers { grid-template-columns: 1fr; }
+    .panel, .retention-card > header, .dispute { align-items: flex-start; flex-direction: column; }
+    .factor { grid-template-columns: 1fr auto; }
+    .factor small { grid-column: 1 / -1; }
+  }
+</style>

--- a/src/scripts/games/caravan/data/retention.contractCosts.m38.test.ts
+++ b/src/scripts/games/caravan/data/retention.contractCosts.m38.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type CompanionRecord } from '../save';
+import { registerCompanionOrigin } from './companionOrigins';
+import {
+  companyRetentionState,
+  retentionContractOffer,
+  signRetentionContract,
+  terminateRetentionContract,
+} from './retention';
+
+function veteran(): CompanionRecord {
+  return {
+    id: 'veteran',
+    name: '資深旅伴',
+    job: 'mage',
+    level: 5,
+    xp: 320,
+    stats: { str: 10, dex: 12, int: 16, cha: 14, con: 12 },
+    maxHp: 25,
+    injuredForTrips: 0,
+    trait: 'learned',
+    equipment: { weapon: null, armor: null, trinket: null },
+    bond: 5,
+    skills: { lore: 5, negotiation: 4 },
+  };
+}
+
+describe('M38 retention contract lifecycle costs', () => {
+  it('charges amendment, termination, and restart costs without free switching', () => {
+    const save = newGame(1400, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+    save.gold = 500;
+    save.reputation = 10;
+    save.inventory['dried-rations'] = 20;
+    save.companions = [veteran()];
+    registerCompanionOrigin(save, 'veteran');
+
+    const security = retentionContractOffer(save, 'veteran', 'security');
+    expect(security.goldCost).toBe(40);
+    expect(security.reputationCost).toBe(0);
+    signRetentionContract(save, 'veteran', 'security');
+
+    const amendment = retentionContractOffer(save, 'veteran', 'partnership');
+    expect(amendment.goldCost).toBe(45);
+    expect(amendment.reputationCost).toBe(2);
+    signRetentionContract(save, 'veteran', 'partnership');
+    expect(companyRetentionState(save).profiles[0].contract).toBe('partnership');
+
+    const beforeTerminationGold = save.gold;
+    const beforeTerminationReputation = save.reputation;
+    terminateRetentionContract(save, 'veteran');
+    expect(save.gold).toBe(beforeTerminationGold - 10);
+    expect(save.reputation).toBe(beforeTerminationReputation - 1);
+
+    const restart = retentionContractOffer(save, 'veteran', 'security');
+    expect(restart.goldCost).toBe(50);
+    expect(restart.reputationCost).toBe(0);
+  });
+});

--- a/src/scripts/games/caravan/data/retention.m38.test.ts
+++ b/src/scripts/games/caravan/data/retention.m38.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import { registerCompanionOrigin } from './companionOrigins';
+import { riskMandateAgenda } from './riskMandates';
+import {
+  companyRetentionState,
+  retentionContractOffer,
+  signRetentionContract,
+  terminateRetentionContract,
+} from './retention';
+import { completeRetentionMandate, retentionMandateAgenda } from './retentionMandates';
+
+function companion(id: string, index: number): CompanionRecord {
+  return {
+    id,
+    name: `旅伴${index}`,
+    job: index % 2 === 0 ? 'ranger' : 'mage',
+    level: 5,
+    xp: 320,
+    stats: { str: 12, dex: 15, int: 15, cha: 14, con: 12 },
+    maxHp: 26,
+    injuredForTrips: 0,
+    trait: index % 2 === 0 ? 'nimble' : 'learned',
+    equipment: { weapon: null, armor: null, trinket: null },
+    bond: 5,
+    skills: { martial: 2, scouting: 4, lore: 4, negotiation: 4, survival: 2 },
+  };
+}
+
+function preparedSave(count = 1): SaveData {
+  const save = newGame(900, { job: 'cleric', trait: 'charming', allocation: { cha: 3 } });
+  save.marketSeed = 9300;
+  save.gold = 2000;
+  save.reputation = 30;
+  save.wagonLevel = 5;
+  save.inventory['dried-rations'] = 50;
+  save.protagonist.stats = { str: 30, dex: 30, int: 30, cha: 30, con: 30 };
+  save.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+  save.protagonist.growth = { potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } } as never;
+  save.companions = Array.from({ length: count }, (_, index) => companion(`c${index + 1}`, index + 1));
+  for (const member of save.companions) registerCompanionOrigin(save, member.id);
+  return save;
+}
+
+function seedWithDomain(save: SaveData, domain: string): void {
+  for (let seed = 9300; seed < 9350; seed++) {
+    save.marketSeed = seed;
+    if (riskMandateAgenda(save).mandates.some((mandate) => mandate.domain === domain)) return;
+  }
+  throw new Error(`找不到包含 ${domain} 的測試週期`);
+}
+
+describe('M38 companion retention', () => {
+  it('keeps M37 exact when there are no contracts or disputes', () => {
+    const save = preparedSave(0);
+    expect(retentionMandateAgenda(save).mandates).toEqual(riskMandateAgenda(save).mandates);
+  });
+
+  it('derives deterministic aspiration and transparent satisfaction without mutation', () => {
+    const save = preparedSave(1);
+    save.companions[0].careerMilestones = [{ level: 2, pathId: 'negotiation', score: 12 }];
+    const before = JSON.stringify(save);
+    const first = companyRetentionState(save);
+    const second = companyRetentionState(save);
+    expect(first).toEqual(second);
+    expect(first.profiles[0].aspiration).toBe('trade');
+    expect(first.profiles[0].factors.some((factor) => factor.id === 'baseline')).toBe(true);
+    expect(first.dispute).toBeNull();
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('makes security and autonomy contracts produce real recurring tradeoffs', () => {
+    const securitySave = preparedSave(1);
+    const beforeSecurity = riskMandateAgenda(securitySave);
+    const offer = retentionContractOffer(securitySave, 'c1', 'security');
+    expect(offer.eligible).toBe(true);
+    signRetentionContract(securitySave, 'c1', 'security');
+    const secured = retentionMandateAgenda(securitySave);
+    expect(secured.mandates.every((mandate, index) =>
+      mandate.reward.gold === Math.max(0, beforeSecurity.mandates[index].reward.gold - 3)
+    )).toBe(true);
+
+    const autonomySave = preparedSave(1);
+    autonomySave.companions[0].careerMilestones = [{ level: 2, pathId: 'scouting', score: 12 }];
+    autonomySave.companions[0].bond = 2;
+    seedWithDomain(autonomySave, 'frontier');
+    expect(retentionContractOffer(autonomySave, 'c1', 'autonomy').eligible).toBe(true);
+    signRetentionContract(autonomySave, 'c1', 'autonomy');
+    const base = riskMandateAgenda(autonomySave).mandates.find((mandate) => mandate.domain === 'frontier')!;
+    const adjusted = retentionMandateAgenda(autonomySave).mandates.find((mandate) => mandate.domain === 'frontier')!;
+    const baseField = base.routes.find((route) => route.id === 'field')!;
+    const adjustedField = adjusted.routes.find((route) => route.id === 'field')!;
+    expect(adjustedField.score).toBe(baseField.score + 1);
+    expect(adjustedField.inventoryCost['dried-rations']).toBe((baseField.inventoryCost['dried-rations'] ?? 0) + 1);
+  });
+
+  it('settles partnership share and bond exactly once through the real mandate path', () => {
+    const save = preparedSave(1);
+    save.companions[0].careerMilestones = [{ level: 2, pathId: 'negotiation', score: 12 }];
+    save.companions[0].bond = 5;
+    signRetentionContract(save, 'c1', 'partnership');
+    const agenda = retentionMandateAgenda(save);
+    const base = riskMandateAgenda(save);
+    expect(agenda.mandates.every((mandate, index) =>
+      mandate.reward.gold === Math.floor(base.mandates[index].reward.gold * 0.9)
+    )).toBe(true);
+    const option = agenda.mandates.flatMap((mandate) =>
+      mandate.routes.map((route) => ({ mandate, route }))
+    ).find(({ route }) => route.eligible)!;
+    const beforeGold = save.gold;
+    const beforeBond = save.companions[0].bond!;
+    const result = completeRetentionMandate(save, option.mandate.id, option.route.id);
+    expect(save.gold).toBe(beforeGold - option.route.goldCost + result.reward.gold);
+    expect(save.companions[0].bond).toBe(beforeBond + result.reward.bondAll + 1);
+    expect(result.partnershipBondIds).toEqual(['c1']);
+    const snapshot = JSON.stringify(save);
+    expect(() => completeRetentionMandate(save, option.mandate.id, option.route.id)).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('enforces contract caps, blocks corrupt duplicates, and revalidates stale resources', () => {
+    const save = preparedSave(4);
+    for (const id of ['c1', 'c2', 'c3']) signRetentionContract(save, id, 'security');
+    expect(retentionContractOffer(save, 'c4', 'security').eligible).toBe(false);
+
+    const stale = preparedSave(1);
+    stale.companions[0].bond = 5;
+    const offer = retentionContractOffer(stale, 'c1', 'partnership');
+    expect(offer.eligible).toBe(true);
+    stale.gold = offer.goldCost - 1;
+    const snapshot = JSON.stringify(stale);
+    expect(() => signRetentionContract(stale, 'c1', 'partnership')).toThrow();
+    expect(JSON.stringify(stale)).toBe(snapshot);
+
+    save.flags['company-retention:c1:partnership'] = true;
+    const corrupt = companyRetentionState(save);
+    expect(corrupt.warnings.length).toBeGreaterThan(0);
+    const agenda = retentionMandateAgenda(save);
+    const option = agenda.mandates.flatMap((mandate) => mandate.routes.map((route) => ({ mandate, route })))
+      .find(({ route }) => route.eligible);
+    if (option) {
+      const before = JSON.stringify(save);
+      expect(() => completeRetentionMandate(save, option.mandate.id, option.route.id)).toThrow();
+      expect(JSON.stringify(save)).toBe(before);
+    }
+  });
+
+  it('creates a visible retention dispute and makes contract termination costly', () => {
+    const save = preparedSave(1);
+    const member = save.companions[0];
+    member.careerMilestones = [{ level: 2, pathId: 'negotiation', score: 12 }];
+    member.trait = 'greedy';
+    member.genesis = undefined;
+    member.growth = undefined;
+    member.injuredForTrips = 1;
+    member.bond = 0;
+    save.flags['company-constitution:martial-priority'] = true;
+    seedWithDomain(save, 'trade');
+    const state = companyRetentionState(save);
+    expect(state.dispute?.memberId).toBe('c1');
+    expect(state.dispute?.disputeSeverity).toBeGreaterThan(0);
+    const base = riskMandateAgenda(save);
+    const adjusted = retentionMandateAgenda(save);
+    expect(adjusted.mandates.every((mandate, index) =>
+      mandate.reward.gold <= base.mandates[index].reward.gold
+    )).toBe(true);
+    const baseTrade = base.mandates.find((mandate) => mandate.domain === 'trade')!;
+    const adjustedTrade = adjusted.mandates.find((mandate) => mandate.domain === 'trade')!;
+    expect(adjustedTrade.routes.find((route) => route.id === 'field')!.threshold)
+      .toBeGreaterThan(baseTrade.routes.find((route) => route.id === 'field')!.threshold);
+
+    const contractSave = preparedSave(1);
+    signRetentionContract(contractSave, 'c1', 'security');
+    const beforeGold = contractSave.gold;
+    const beforeReputation = contractSave.reputation;
+    terminateRetentionContract(contractSave, 'c1');
+    expect(contractSave.gold).toBe(beforeGold - 10);
+    expect(contractSave.reputation).toBe(beforeReputation - 1);
+    expect(companyRetentionState(contractSave).profiles[0].contract).toBeNull();
+  });
+});

--- a/src/scripts/games/caravan/data/retention.ts
+++ b/src/scripts/games/caravan/data/retention.ts
@@ -1,0 +1,405 @@
+import type { CompanionRecord, SaveData } from '../save';
+import { companyConstitutionState } from './constitution';
+import { COMPANY_OFFICES, companyOfficeState } from './offices';
+import { companyRiskCrisis } from './risks';
+
+export type CompanionAspirationId = 'escort' | 'frontier' | 'trade' | 'fellowship' | 'relic';
+export type RetentionContractId = 'security' | 'autonomy' | 'partnership';
+
+export interface RetentionFactor {
+  id: string;
+  label: string;
+  value: number;
+  detail: string;
+}
+
+export interface CompanionRetentionProfile {
+  memberId: string;
+  memberName: string;
+  aspiration: CompanionAspirationId;
+  aspirationName: string;
+  satisfaction: number;
+  factors: RetentionFactor[];
+  contract: RetentionContractId | null;
+  contractName: string | null;
+  dispute: boolean;
+  disputeSeverity: 0 | 1 | 2 | 3;
+}
+
+export interface CompanyRetentionState {
+  profiles: CompanionRetentionProfile[];
+  activeContracts: number;
+  dispute: CompanionRetentionProfile | null;
+  warnings: string[];
+}
+
+export interface RetentionContractOffer {
+  memberId: string;
+  memberName: string;
+  contractId: RetentionContractId;
+  contractName: string;
+  description: string;
+  goldCost: number;
+  reputationCost: number;
+  eligible: boolean;
+  blockers: string[];
+}
+
+export const ASPIRATION_NAMES: Record<CompanionAspirationId, string> = {
+  escort: '武勳與護運',
+  frontier: '遠境與探索',
+  trade: '財富與交易',
+  fellowship: '同袍與安定',
+  relic: '知識與遺珍',
+};
+
+export const RETENTION_CONTRACTS: Record<RetentionContractId, { name: string; description: string }> = {
+  security: {
+    name: '安全保障契約',
+    description: '提高留任滿意度；每項公司委託固定支付 3 G 保障津貼。',
+  },
+  autonomy: {
+    name: '行動自主契約',
+    description: '對應志向領域的實地能力提高，但每次實地解法額外消耗一份乾糧。',
+  },
+  partnership: {
+    name: '利益合夥契約',
+    description: '大幅提高留任滿意度並在完成委託後增加羈絆；所有委託現金報酬分成 10%。',
+  },
+};
+
+const ASPIRATION_ORDER: CompanionAspirationId[] = ['escort', 'frontier', 'trade', 'fellowship', 'relic'];
+const CONTRACT_ORDER: RetentionContractId[] = ['security', 'autonomy', 'partnership'];
+const MAX_CONTRACTS = 3;
+
+function bondTier(value: number | undefined): number {
+  const bond = value ?? 0;
+  if (bond >= 9) return 3;
+  if (bond >= 5) return 2;
+  if (bond >= 2) return 1;
+  return 0;
+}
+
+function contractFlag(memberId: string, contractId: RetentionContractId): string {
+  return `company-retention:${memberId}:${contractId}`;
+}
+
+function historyFlag(memberId: string): string {
+  return `company-retention-history:${memberId}`;
+}
+
+function activeStance(save: SaveData): 'balanced' | 'lean' | 'ambitious' {
+  const active = (['balanced', 'lean', 'ambitious'] as const)
+    .filter((id) => save.flags[`operating-stance:${id}`] === true);
+  return active.length === 1 ? active[0] : 'balanced';
+}
+
+function aspirationFromCareer(record: CompanionRecord): CompanionAspirationId | null {
+  const latest = [...(record.careerMilestones ?? [])]
+    .sort((a, b) => b.level - a.level)[0]?.pathId;
+  switch (latest) {
+    case 'martial': return 'escort';
+    case 'scouting': return 'frontier';
+    case 'negotiation': return 'trade';
+    case 'survival': return 'fellowship';
+    case 'lore': return 'relic';
+    default: return null;
+  }
+}
+
+export function companionAspiration(record: CompanionRecord): CompanionAspirationId {
+  const career = aspirationFromCareer(record);
+  if (career) return career;
+  if (record.trait === 'greedy') return 'trade';
+  if (record.trait === 'frugal') return 'fellowship';
+  switch (record.genesis?.lifepathId) {
+    case 'brawny': return 'escort';
+    case 'nimble': return 'frontier';
+    case 'charming': return 'trade';
+    case 'tough': return 'fellowship';
+    case 'learned': return 'relic';
+    case 'seasoned': return ASPIRATION_ORDER[record.id.length % ASPIRATION_ORDER.length];
+  }
+  switch (record.job) {
+    case 'swordsman': return 'escort';
+    case 'ranger': return 'frontier';
+    case 'mage': return 'relic';
+    case 'cleric': return 'fellowship';
+  }
+}
+
+function completedMandateDomain(save: SaveData): CompanionAspirationId | null {
+  const cycle = Math.max(0, Math.floor(save.marketSeed));
+  const prefix = `company-mandate:${cycle}:`;
+  const key = Object.keys(save.flags)
+    .find((flag) => flag.startsWith(prefix) && save.flags[flag] === true);
+  if (!key) return null;
+  const mandateId = key.slice(prefix.length).split(':')[0];
+  const domain = mandateId.split('-')[0] as CompanionAspirationId;
+  return ASPIRATION_ORDER.includes(domain) ? domain : null;
+}
+
+function constitutionModifier(save: SaveData, aspiration: CompanionAspirationId): RetentionFactor | null {
+  const clause = companyConstitutionState(save).active;
+  if (!clause) return null;
+  const aligned: Partial<Record<CompanionAspirationId, string[]>> = {
+    escort: ['martial-priority'],
+    frontier: ['exploration-duty'],
+    trade: ['commercial-supremacy'],
+    fellowship: ['fellowship-dividend'],
+    relic: ['open-knowledge', 'exploration-duty'],
+  };
+  const conflicts: Partial<Record<CompanionAspirationId, string[]>> = {
+    escort: ['commercial-supremacy'],
+    frontier: ['commercial-supremacy'],
+    trade: ['martial-priority', 'fellowship-dividend'],
+    fellowship: ['commercial-supremacy', 'martial-priority'],
+    relic: ['martial-priority'],
+  };
+  if (aligned[aspiration]?.includes(clause)) {
+    return { id: 'constitution-aligned', label: '公司憲章符合志向', value: 2, detail: clause };
+  }
+  if (conflicts[aspiration]?.includes(clause)) {
+    return { id: 'constitution-conflict', label: '公司憲章違背志向', value: aspiration === 'fellowship' ? -2 : -1, detail: clause };
+  }
+  return null;
+}
+
+function preferredStance(aspiration: CompanionAspirationId): 'balanced' | 'lean' | 'ambitious' {
+  if (aspiration === 'escort' || aspiration === 'trade') return 'ambitious';
+  if (aspiration === 'frontier') return 'lean';
+  return 'balanced';
+}
+
+function burdenAspiration(record: CompanionRecord): CompanionAspirationId | null {
+  switch (record.genesis?.burdenId) {
+    case 'str': return 'escort';
+    case 'dex': return 'frontier';
+    case 'cha': return 'trade';
+    case 'con': return 'fellowship';
+    case 'int': return 'relic';
+    default: return null;
+  }
+}
+
+function profileFor(
+  save: SaveData,
+  record: CompanionRecord,
+  contract: RetentionContractId | null,
+): CompanionRetentionProfile {
+  const aspiration = companionAspiration(record);
+  const factors: RetentionFactor[] = [
+    { id: 'baseline', label: '基本留任意願', value: 5, detail: '所有旅伴的共同基準' },
+  ];
+  const tier = bondTier(record.bond);
+  if (tier > 0) factors.push({ id: 'bond', label: '共同經歷與羈絆', value: tier, detail: `羈絆階級 ${tier}` });
+  if (!record.genesis || !record.growth) {
+    factors.push({ id: 'unregistered', label: '身世尚未登記', value: -1, detail: '公司尚未真正理解其長期目標' });
+  }
+
+  const office = companyOfficeState(save).assignments.find((entry) => entry.memberId === record.id);
+  if (office) {
+    const domain = COMPANY_OFFICES[office.officeId].domain;
+    factors.push({
+      id: 'office',
+      label: domain === aspiration ? '職務符合志向' : '獲得公司職責',
+      value: domain === aspiration ? 2 : 1,
+      detail: COMPANY_OFFICES[office.officeId].name,
+    });
+  }
+
+  const constitution = constitutionModifier(save, aspiration);
+  if (constitution) factors.push(constitution);
+  const stance = activeStance(save);
+  if (stance === preferredStance(aspiration)) {
+    factors.push({ id: 'stance', label: '營運姿態符合期待', value: 1, detail: stance });
+  }
+
+  const completed = completedMandateDomain(save);
+  if (completed) {
+    factors.push({
+      id: 'mandate',
+      label: completed === aspiration ? '公司本期投入其志向' : '公司本期忽略其志向',
+      value: completed === aspiration ? 2 : -1,
+      detail: ASPIRATION_NAMES[completed],
+    });
+  }
+
+  if (record.injuredForTrips > 0) {
+    factors.push({ id: 'injured', label: '帶傷承擔公司責任', value: -2, detail: `仍需休養 ${record.injuredForTrips} 趟` });
+  }
+  const crisis = companyRiskCrisis(save);
+  if (crisis && !crisis.resolved) {
+    if (crisis.dimension === 'morale') factors.push({ id: 'morale-crisis', label: '營地離心', value: -2, detail: crisis.title });
+    else if (crisis.dimension === 'health' || crisis.dimension === 'governance') {
+      factors.push({ id: 'company-crisis', label: '公司危機壓力', value: -1, detail: crisis.title });
+    }
+  }
+  if (burdenAspiration(record) === aspiration) {
+    factors.push({ id: 'burden', label: '命運缺陷阻礙志向', value: -1, detail: record.genesis?.burdenId ?? '' });
+  }
+  if (record.trait === 'greedy' && aspiration === 'trade') {
+    factors.push({ id: 'trait-aligned', label: '個性追求與志向一致', value: 1, detail: 'greedy' });
+  }
+  if (record.trait === 'frugal' && aspiration === 'fellowship') {
+    factors.push({ id: 'trait-aligned', label: '個性追求與志向一致', value: 1, detail: 'frugal' });
+  }
+
+  if (contract) {
+    const bonus = contract === 'security' ? 3 : contract === 'autonomy' ? 2 : 4;
+    factors.push({ id: `contract-${contract}`, label: RETENTION_CONTRACTS[contract].name, value: bonus, detail: '公司已作出長期承諾' });
+  }
+
+  const satisfaction = factors.reduce((sum, factor) => sum + factor.value, 0);
+  const disputeSeverity = satisfaction <= 0 ? 3 : satisfaction === 1 ? 2 : satisfaction === 2 ? 1 : 0;
+  return {
+    memberId: record.id,
+    memberName: record.name,
+    aspiration,
+    aspirationName: ASPIRATION_NAMES[aspiration],
+    satisfaction,
+    factors,
+    contract,
+    contractName: contract ? RETENTION_CONTRACTS[contract].name : null,
+    dispute: disputeSeverity > 0,
+    disputeSeverity,
+  };
+}
+
+function rawContractMap(save: SaveData): { accepted: Map<string, RetentionContractId>; warnings: string[] } {
+  const accepted = new Map<string, RetentionContractId>();
+  const warnings: string[] = [];
+  const validMembers = new Set(save.companions.map((member) => member.id));
+
+  for (const member of save.companions) {
+    const active = CONTRACT_ORDER.filter((contractId) => save.flags[contractFlag(member.id, contractId)] === true);
+    if (active.length > 1) {
+      warnings.push(`${member.name}同時存在多份留任契約，所有契約效果停用。`);
+      continue;
+    }
+    if (active.length === 1) accepted.set(member.id, active[0]);
+  }
+
+  for (const key of Object.keys(save.flags)) {
+    if (!key.startsWith('company-retention:') || save.flags[key] !== true) continue;
+    const body = key.slice('company-retention:'.length);
+    const contractId = CONTRACT_ORDER.find((id) => body.endsWith(`:${id}`));
+    const memberId = contractId ? body.slice(0, -(contractId.length + 1)) : '';
+    if (!contractId || !validMembers.has(memberId)) warnings.push(`留任契約「${key}」找不到有效旅伴或契約類型。`);
+  }
+
+  const ordered = [...accepted.entries()].sort(([a], [b]) => a.localeCompare(b));
+  if (ordered.length > MAX_CONTRACTS) {
+    warnings.push(`有效留任契約超過 ${MAX_CONTRACTS} 份，僅採計旅伴編號排序中的前三份。`);
+    accepted.clear();
+    for (const [memberId, contractId] of ordered.slice(0, MAX_CONTRACTS)) accepted.set(memberId, contractId);
+  }
+  return { accepted, warnings };
+}
+
+export function companyRetentionState(save: SaveData): CompanyRetentionState {
+  const contracts = rawContractMap(save);
+  const profiles = save.companions
+    .map((member) => profileFor(save, member, contracts.accepted.get(member.id) ?? null))
+    .sort((a, b) => a.memberId.localeCompare(b.memberId));
+  const dispute = profiles
+    .filter((profile) => profile.dispute)
+    .sort((a, b) => a.satisfaction - b.satisfaction || a.memberId.localeCompare(b.memberId))[0] ?? null;
+  return {
+    profiles,
+    activeContracts: contracts.accepted.size,
+    dispute,
+    warnings: contracts.warnings,
+  };
+}
+
+function hasMatchingCareer(record: CompanionRecord, aspiration: CompanionAspirationId): boolean {
+  return aspirationFromCareer(record) === aspiration;
+}
+
+export function retentionContractOffer(
+  save: SaveData,
+  memberId: string,
+  contractId: RetentionContractId,
+): RetentionContractOffer {
+  const contract = RETENTION_CONTRACTS[contractId];
+  if (!contract) throw new Error(`未知留任契約「${contractId}」`);
+  const member = save.companions.find((entry) => entry.id === memberId);
+  if (!member) throw new Error(`找不到旅伴「${memberId}」`);
+  const state = companyRetentionState(save);
+  const profile = state.profiles.find((entry) => entry.memberId === memberId)!;
+  const blockers: string[] = [];
+  const current = profile.contract;
+  let goldCost = contractId === 'security' ? 15 + member.level * 5 : contractId === 'partnership' ? 25 : 0;
+  let reputationCost = contractId === 'autonomy' || contractId === 'partnership' ? 1 : 0;
+
+  if (state.warnings.length > 0) blockers.push(...state.warnings);
+  if (current === contractId) blockers.push('目前已採用此契約。');
+  if (!current && state.activeContracts >= MAX_CONTRACTS) blockers.push(`公司最多同時維持 ${MAX_CONTRACTS} 份留任契約。`);
+  if (current && current !== contractId) {
+    goldCost += 20;
+    reputationCost += 1;
+  } else if (!current && save.flags[historyFlag(memberId)] === true) {
+    goldCost += 10;
+  }
+
+  if (contractId === 'autonomy') {
+    if (!member.genesis || !member.growth) blockers.push('行動自主契約要求先完成身世登記。');
+    const office = companyOfficeState(save).assignments.find((entry) => entry.memberId === memberId);
+    const officeMatches = office && COMPANY_OFFICES[office.officeId].domain === profile.aspiration;
+    if (bondTier(member.bond) < 1) blockers.push('行動自主契約需要羈絆階級至少 1。');
+    if (!hasMatchingCareer(member, profile.aspiration) && !officeMatches) blockers.push('需要匹配志向的職涯或公司職務。');
+  }
+  if (contractId === 'partnership') {
+    if (!member.genesis || !member.growth) blockers.push('利益合夥契約要求先完成身世登記。');
+    if (bondTier(member.bond) < 2) blockers.push('利益合夥契約需要羈絆階級至少 2。');
+  }
+  if (save.gold < goldCost) blockers.push(`金幣不足，需要 ${goldCost} G。`);
+  if (save.reputation < reputationCost) blockers.push(`聲望不足，需要 ${reputationCost}。`);
+
+  return {
+    memberId,
+    memberName: member.name,
+    contractId,
+    contractName: contract.name,
+    description: contract.description,
+    goldCost,
+    reputationCost,
+    eligible: blockers.length === 0,
+    blockers,
+  };
+}
+
+/** 原子簽訂或改訂留任契約。 */
+export function signRetentionContract(
+  save: SaveData,
+  memberId: string,
+  contractId: RetentionContractId,
+): CompanionRetentionProfile {
+  const offer = retentionContractOffer(save, memberId, contractId);
+  if (!offer.eligible) throw new Error(offer.blockers.join('；'));
+  const state = companyRetentionState(save);
+  const current = state.profiles.find((profile) => profile.memberId === memberId)?.contract;
+  save.gold -= offer.goldCost;
+  save.reputation -= offer.reputationCost;
+  if (current) save.flags[contractFlag(memberId, current)] = false;
+  save.flags[contractFlag(memberId, contractId)] = true;
+  save.flags[historyFlag(memberId)] = true;
+  return companyRetentionState(save).profiles.find((profile) => profile.memberId === memberId)!;
+}
+
+/** 解約需要支付違約補償，避免每個委託前免費切換。 */
+export function terminateRetentionContract(save: SaveData, memberId: string): void {
+  const state = companyRetentionState(save);
+  if (state.warnings.length > 0) throw new Error(state.warnings.join('；'));
+  const profile = state.profiles.find((entry) => entry.memberId === memberId);
+  if (!profile?.contract) throw new Error('此旅伴目前沒有有效留任契約。');
+  const goldCost = 10;
+  const reputationCost = 1;
+  if (save.gold < goldCost) throw new Error(`解約補償需要 ${goldCost} G。`);
+  if (save.reputation < reputationCost) throw new Error(`解約需要 ${reputationCost} 聲望。`);
+  save.gold -= goldCost;
+  save.reputation -= reputationCost;
+  save.flags[contractFlag(memberId, profile.contract)] = false;
+  save.flags[historyFlag(memberId)] = true;
+}

--- a/src/scripts/games/caravan/data/retentionMandates.ts
+++ b/src/scripts/games/caravan/data/retentionMandates.ts
@@ -1,0 +1,177 @@
+import type { SaveData } from '../save';
+import {
+  riskMandateAgenda,
+} from './riskMandates';
+import type {
+  CompanyMandate,
+  MandateCompletion,
+  MandateReward,
+  MandateRoute,
+  MandateRouteId,
+} from './mandates';
+import {
+  companyRetentionState,
+  type CompanionRetentionProfile,
+} from './retention';
+
+export interface RetentionMandateAgenda extends ReturnType<typeof riskMandateAgenda> {
+  retentionProfiles: CompanionRetentionProfile[];
+  retentionWarnings: string[];
+  retentionDispute: CompanionRetentionProfile | null;
+  securityStipend: number;
+  partnershipShareRate: number;
+}
+
+export interface RetentionMandateCompletion extends MandateCompletion {
+  partnershipBondIds: string[];
+}
+
+function cloneReward(reward: MandateReward): MandateReward {
+  return { ...reward, inventory: { ...reward.inventory } };
+}
+
+function cloneRoute(route: MandateRoute): MandateRoute {
+  return {
+    ...route,
+    inventoryCost: { ...route.inventoryCost },
+    blockers: [...route.blockers],
+  };
+}
+
+function refreshEligibility(save: SaveData, route: MandateRoute): MandateRoute {
+  const blockers = route.blockers.filter((entry) =>
+    !entry.startsWith('能力分數 ') &&
+    !entry.startsWith('金幣不足') &&
+    !entry.includes('不足，需要')
+  );
+  if (route.score < route.threshold) blockers.push(`能力分數 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, blockers, eligible: blockers.length === 0 };
+}
+
+function applyRetentionToMandate(
+  save: SaveData,
+  mandate: CompanyMandate,
+  profiles: CompanionRetentionProfile[],
+  dispute: CompanionRetentionProfile | null,
+): CompanyMandate {
+  const reward = cloneReward(mandate.reward);
+  const routes = mandate.routes.map(cloneRoute);
+  const securityCount = profiles.filter((profile) => profile.contract === 'security').length;
+  const partnershipCount = profiles.filter((profile) => profile.contract === 'partnership').length;
+  const autonomyCount = profiles.filter((profile) =>
+    profile.contract === 'autonomy' && profile.aspiration === mandate.domain
+  ).length;
+
+  reward.gold = Math.max(0, reward.gold - securityCount * 3);
+  if (partnershipCount > 0) {
+    reward.gold = Math.max(0, Math.floor(reward.gold * (1 - Math.min(0.3, partnershipCount * 0.1))));
+  }
+
+  if (autonomyCount > 0) {
+    for (const route of routes) {
+      if (route.id !== 'field') continue;
+      route.score += Math.min(2, autonomyCount);
+      route.inventoryCost['dried-rations'] = (route.inventoryCost['dried-rations'] ?? 0) + autonomyCount;
+    }
+  }
+
+  if (dispute) {
+    reward.gold = Math.max(0, reward.gold - dispute.disputeSeverity * 2);
+    if (mandate.domain === dispute.aspiration) {
+      reward.reputation = Math.max(0, reward.reputation - 1);
+      for (const route of routes) {
+        if (route.id === 'field') route.threshold += dispute.disputeSeverity;
+      }
+    }
+  }
+
+  return {
+    ...mandate,
+    reward,
+    routes: routes.map((route) => refreshEligibility(save, route)),
+  };
+}
+
+export function retentionMandateAgenda(save: SaveData): RetentionMandateAgenda {
+  const base = riskMandateAgenda(save);
+  const retention = companyRetentionState(save);
+  const securityCount = retention.profiles.filter((profile) => profile.contract === 'security').length;
+  const partnershipCount = retention.profiles.filter((profile) => profile.contract === 'partnership').length;
+  return {
+    ...base,
+    retentionProfiles: retention.profiles,
+    retentionWarnings: retention.warnings,
+    retentionDispute: retention.dispute,
+    securityStipend: securityCount * 3,
+    partnershipShareRate: Math.min(0.3, partnershipCount * 0.1),
+    mandates: base.mandates.map((mandate) =>
+      applyRetentionToMandate(save, mandate, retention.profiles, retention.dispute)
+    ),
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+/** 使用最新風險、憲章、職務與留任契約原子結算公司委託。 */
+export function completeRetentionMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): RetentionMandateCompletion {
+  const agenda = retentionMandateAgenda(save);
+  if (agenda.completed) throw new Error('本市場週期的公司委託已經完成。');
+  const organizationWarnings = [
+    ...agenda.constitutionWarnings,
+    ...agenda.officeWarnings,
+    ...agenda.retentionWarnings,
+  ];
+  if (organizationWarnings.length > 0) throw new Error(organizationWarnings.join('；'));
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到公司委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項公司委託已經結算。');
+  }
+
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+  const partnershipBondIds = agenda.retentionProfiles
+    .filter((profile) => profile.contract === 'partnership')
+    .map((profile) => profile.memberId);
+  for (const memberId of partnershipBondIds) {
+    const member = save.companions.find((entry) => entry.id === memberId);
+    if (member) member.bond = (member.bond ?? 0) + 1;
+  }
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: cloneReward(mandate.reward),
+    receipt: preciseReceipt,
+    partnershipBondIds,
+  };
+}

--- a/src/scripts/games/caravan/data/retentionMandates.ts
+++ b/src/scripts/games/caravan/data/retentionMandates.ts
@@ -14,13 +14,13 @@ import {
   type CompanionRetentionProfile,
 } from './retention';
 
-export interface RetentionMandateAgenda extends ReturnType<typeof riskMandateAgenda> {
+export type RetentionMandateAgenda = ReturnType<typeof riskMandateAgenda> & {
   retentionProfiles: CompanionRetentionProfile[];
   retentionWarnings: string[];
   retentionDispute: CompanionRetentionProfile | null;
   securityStipend: number;
   partnershipShareRate: number;
-}
+};
 
 export interface RetentionMandateCompletion extends MandateCompletion {
   partnershipBondIds: string[];


### PR DESCRIPTION
## Summary

- add deterministic companion aspirations derived from career milestones, traits, registered origins, and jobs
- calculate transparent satisfaction from bond tiers, matching offices, constitution alignment, operating stance, current-cycle mandate priorities, injuries, company crises, burdens, and active retention contracts
- create visible retention disputes only when satisfaction falls to 2 or below, avoiding random or hidden departures
- add security, autonomy, and partnership contracts with distinct prerequisites, signing costs, recurring mandate obligations, and anti-switching costs
- limit the company to three valid contracts and one contract per companion
- apply security stipends, partnership revenue shares, autonomy field bonuses/supply costs, and unresolved dispute penalties to the real M37 mandate agenda and settlement path
- grant partnership bond only through the real one-per-cycle mandate settlement receipt
- add a player-facing `/caravan/retention` page with aspiration factors, satisfaction, disputes, offers, blockers, signing, amendment, and termination
- update `/caravan/mandates` to display retention obligations and use retention-aware settlement so contracts cannot be bypassed
- add adversarial tests for parity, determinism, recurring tradeoffs, contract caps, corrupt duplicates, stale resources, disputes, amendment/restart costs, termination costs, and duplicate partnership rewards
- add a permanent `Caravan CI` workflow that installs locked dependencies, builds the Astro production site, and runs the M38 adversarial tests

## Game-design intent

M31-M37 made companions increasingly relevant through origins, growth, careers, chemistry, offices, mandates, and company risk, but companions still lacked personal agency. M38 gives every companion a long-term aspiration and a transparent reason to remain satisfied or raise a retention dispute.

The system deliberately avoids random desertion. Players can inspect every satisfaction factor and either accept a limited mandate penalty or negotiate a persistent contract. Security guarantees consume fixed cash, autonomy improves matching field execution while consuming more supplies, and partnership shares revenue while deepening bond after successful company work.

## Player adversarial review

- saves with no companions, contracts, or disputes produce the exact M37 mandate agenda
- aspiration and satisfaction previews are deterministic and read-only
- normal healthy registered companions do not create surprise penalties
- one companion cannot hold multiple valid contracts and the company cannot exceed three valid contracts
- security guarantees subtract 3 G from every mandate reward
- autonomy adds matching-domain field ability and an equal recurring ration obligation
- partnership reduces all mandate cash rewards by 10% per partner, capped at 30%, and grants bond only after a valid mandate settlement
- changing contracts adds 20 G and 1 reputation; terminating costs 10 G and 1 reputation; re-signing adds a restart surcharge
- stale gold or reputation is revalidated immediately before signing without partial mutation
- corrupt duplicate contracts disable their effects, surface warnings, and block mandate settlement
- unresolved disputes reduce cash rewards and raise matching-domain field thresholds instead of causing an opaque immediate departure
- the mandate page and settlement function use the same final retention-adjusted costs and rewards
- no save-version, dependency, lockfile, asset, or generated-output changes

## Verification

- GitHub Actions `Caravan CI` run 1 completed successfully
- `npm ci` succeeded using the committed lockfile
- `npm run build` completed successfully under Node.js 22
- `retention.m38.test.ts` and `retention.contractCosts.m38.test.ts` completed successfully through Vitest
- Vercel did not run because the account hit its build-rate limit; this was a platform quota rejection rather than a compile failure

## Scope

- `src/scripts/games/caravan/data/retention.ts`
- `src/scripts/games/caravan/data/retentionMandates.ts`
- `src/scripts/games/caravan/data/retention.m38.test.ts`
- `src/scripts/games/caravan/data/retention.contractCosts.m38.test.ts`
- `src/pages/caravan/retention.astro`
- `src/pages/caravan/mandates.astro`
- `.github/workflows/caravan-ci.yml`