### PR TITLE
feat(caravan): add M39 Ashen Reliquary world quest

### DIFF
--- a/.github/workflows/caravan-m39-balance-ci.yml
+++ b/.github/workflows/caravan-m39-balance-ci.yml
@@ -1,0 +1,33 @@
+name: Caravan M39 Balance CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - '.github/workflows/caravan-m39-balance-ci.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - '.github/workflows/caravan-m39-balance-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  reliquary-adversarial-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Run M39 world quest and balance tests
+        run: >-
+          npx vitest run
+          src/scripts/games/caravan/data/ashenReliquary.m39.test.ts
+          src/scripts/games/caravan/data/ashenReliquary.balance.m39.test.ts

--- a/.github/workflows/caravan-m39-ci.yml
+++ b/.github/workflows/caravan-m39-ci.yml
@@ -1,0 +1,49 @@
+name: Caravan M39 CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/caravan-m39-ci.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/caravan-m39-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: caravan-m39-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-world-quest-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Build production site
+        run: npm run build
+
+      - name: Run M39 adversarial tests
+        run: npx vitest run src/scripts/games/caravan/data/ashenReliquary.m39.test.ts

--- a/src/pages/caravan/ashen-reliquary.astro
+++ b/src/pages/caravan/ashen-reliquary.astro
@@ -1,0 +1,264 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="灰燼聖匣 — 商隊與劍"
+  description="深入失落修道院，面對亡者聖歌、古龍心火與三種不可逆的奇幻結局。"
+  lang="zh-TW"
+>
+  <main class="quest-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M39 WORLD QUEST</p>
+      <h1>灰燼聖匣</h1>
+      <p class="premise">王領、白燭教會與法師塔都在尋找一只從焚毀修道院中甦醒的聖匣。裡面不是聖骨，而是一顆仍在跳動的古龍心火。</p>
+      <nav>
+        <a href="/caravan/play">返回冒險</a>
+        <a href="/caravan/mandates">行會委託</a>
+        <a href="/caravan/constitution">商會誓約</a>
+        <a href="/caravan/offices">行會職司</a>
+        <a href="/caravan/retention">同袍承諾</a>
+      </nav>
+    </header>
+
+    <section id="empty" class="panel" hidden>
+      <h2>找不到商隊存檔</h2>
+      <p>先建立一支商隊，再接受灰燼聖匣的委託。</p>
+    </section>
+
+    <section id="locked" class="panel locked" hidden>
+      <div>
+        <p class="eyebrow">SEALED NOTICE</p>
+        <h2>黑蠟委託尚未對你開放</h2>
+      </div>
+      <p id="unlock-reason"></p>
+    </section>
+
+    <section id="summary" class="panel" hidden>
+      <div>
+        <p class="eyebrow">ASHEN RELIQUARY</p>
+        <h2 id="summary-title"></h2>
+      </div>
+      <p id="summary-copy"></p>
+    </section>
+
+    <section id="warning" class="warning" hidden></section>
+    <section id="ending" class="ending" hidden></section>
+    <section id="stages" class="stages"></section>
+    <p id="status" class="status" aria-live="polite"></p>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import {
+    ashenReliquaryState,
+    resolveAshenReliquary,
+    type ReliquaryEndingId,
+    type ReliquaryRoute,
+    type ReliquaryRouteId,
+    type ReliquaryStageId,
+  } from '@scripts/games/caravan/data/ashenReliquary';
+
+  const ITEM_NAMES: Record<string, string> = {
+    torch: '火把', herb: '藥草', bandage: '繃帶', 'dried-rations': '乾糧',
+    'tattered-map': '殘破地圖', 'spice-pouch': '香料包', 'war-tonic': '戰鬥藥劑', ore: '礦石',
+  };
+  const ENDING_NAMES: Record<ReliquaryEndingId, string> = {
+    sealed: '聖焰重封', claimed: '龍燼入手', shattered: '聖匣粉碎',
+  };
+  const ENDING_TEXT: Record<ReliquaryEndingId, string> = {
+    sealed: '你讓古龍心火重新沉睡。白燭教會將協助遺珍與同袍委託，但日後每份行會收益都要繳納少量什一稅。',
+    claimed: '你把龍燼心核帶回商隊。秘法研究得到巨大突破，但詛咒會腐壞糧草並損害商隊在正統勢力中的名聲。',
+    shattered: '你擊碎聖匣，把龍骨碎片製成戰旗。護運隊伍士氣高昂，但匣中失傳的知識再也無法復原。',
+  };
+
+  const emptyEl = document.getElementById('empty')!;
+  const lockedEl = document.getElementById('locked')!;
+  const unlockReasonEl = document.getElementById('unlock-reason')!;
+  const summaryEl = document.getElementById('summary')!;
+  const summaryTitleEl = document.getElementById('summary-title')!;
+  const summaryCopyEl = document.getElementById('summary-copy')!;
+  const warningEl = document.getElementById('warning')!;
+  const endingEl = document.getElementById('ending')!;
+  const stagesEl = document.getElementById('stages')!;
+  const statusEl = document.getElementById('status')!;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function itemList(items: Record<string, number>): string {
+    const entries = Object.entries(items).filter(([, count]) => count > 0);
+    return entries.length === 0
+      ? '無'
+      : entries.map(([id, count]) => `${ITEM_NAMES[id] ?? id} ×${count}`).join('、');
+  }
+
+  function routeCost(route: ReliquaryRoute): string {
+    const parts: string[] = [];
+    if (route.goldCost > 0) parts.push(`${route.goldCost} G`);
+    if (route.reputationCost > 0) parts.push(`聲望 ${route.reputationCost}`);
+    if (Object.values(route.inventoryCost).some((count) => count > 0)) parts.push(itemList(route.inventoryCost));
+    return parts.length > 0 ? parts.join('＋') : '無直接成本';
+  }
+
+  function rewardText(route: ReliquaryRoute): string {
+    const parts = [`${route.reward.gold >= 0 ? '+' : ''}${route.reward.gold} G`, `聲望 ${route.reward.reputation >= 0 ? '+' : ''}${route.reward.reputation}`];
+    if (Object.values(route.reward.inventory).some((count) => count > 0)) parts.push(itemList(route.reward.inventory));
+    if (route.reward.skillPoints > 0) parts.push(`技能點 +${route.reward.skillPoints}`);
+    if (route.reward.bondAll > 0) parts.push(`全旅伴羈絆 +${route.reward.bondAll}`);
+    if (route.reward.flag) parts.push('獨特遺物');
+    return parts.join('｜');
+  }
+
+  function render(): void {
+    const save = loadGame();
+    stagesEl.replaceChildren();
+    warningEl.replaceChildren();
+    endingEl.replaceChildren();
+    if (!save) {
+      emptyEl.hidden = false;
+      lockedEl.hidden = true;
+      summaryEl.hidden = true;
+      return;
+    }
+
+    emptyEl.hidden = true;
+    const state = ashenReliquaryState(save);
+    lockedEl.hidden = state.unlocked;
+    unlockReasonEl.textContent = state.unlockReason;
+    summaryEl.hidden = !state.unlocked;
+    if (!state.unlocked) return;
+
+    summaryTitleEl.textContent = state.completed
+      ? '聖匣的命運已經決定'
+      : `目前進度：第 ${state.currentStage ?? 1} 幕`;
+    summaryCopyEl.textContent = `金幣 ${save.gold} G｜聲望 ${save.reputation}｜三幕各只能選擇一條路線，最終決定不可逆。`;
+
+    warningEl.hidden = state.warnings.length === 0;
+    for (const warning of state.warnings) warningEl.append(text('p', warning));
+
+    endingEl.hidden = !state.completed || !state.ending;
+    if (state.completed && state.ending) {
+      endingEl.append(
+        text('p', 'WORLD STATE', 'eyebrow'),
+        text('h2', ENDING_NAMES[state.ending]),
+        text('p', ENDING_TEXT[state.ending]),
+        text('p', '這個結局已開始影響後續行會委託。', 'ending-note'),
+      );
+    }
+
+    for (const stage of state.stages) {
+      const article = document.createElement('article');
+      article.className = `stage ${stage.locked ? 'locked-stage' : ''} ${stage.completedRouteId ? 'completed-stage' : ''}`;
+      const head = document.createElement('header');
+      const heading = document.createElement('div');
+      heading.append(text('p', `ACT ${stage.id}`, 'eyebrow'), text('h2', stage.title));
+      const stateLabel = stage.completedRouteId
+        ? '已完成'
+        : stage.locked
+          ? '尚未抵達'
+          : state.currentStage === stage.id
+            ? '當前幕'
+            : '待命';
+      head.append(heading, text('span', stateLabel, 'badge'));
+      article.append(head, text('p', stage.description, 'stage-copy'));
+
+      const routes = document.createElement('div');
+      routes.className = 'routes';
+      for (const route of stage.routes) {
+        const routeEl = document.createElement('section');
+        routeEl.className = `route ${route.eligible ? 'eligible' : 'blocked'}`;
+        routeEl.append(
+          text('h3', route.name),
+          text('p', route.description),
+          text('p', `能力 ${route.score} / ${route.threshold}`, 'score'),
+          text('p', `代價：${routeCost(route)}`, 'cost'),
+          text('p', `結果：${rewardText(route)}`, 'reward'),
+        );
+        if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        const available = !state.completed
+          && state.currentStage === stage.id
+          && !stage.completedRouteId
+          && state.warnings.length === 0
+          && route.eligible;
+        button.disabled = !available;
+        button.textContent = stage.completedRouteId
+          ? stage.completedRouteId === route.id ? '已選擇此路線' : '本幕已由其他路線完成'
+          : state.currentStage !== stage.id
+            ? '尚未抵達此幕'
+            : state.warnings.length > 0
+              ? '世界狀態衝突'
+              : route.eligible
+                ? route.ending ? `決定結局：${route.name}` : `採用：${route.name}`
+                : '條件不足';
+        button.addEventListener('click', () => {
+          const latest = loadGame();
+          if (!latest) return;
+          try {
+            const result = resolveAshenReliquary(latest, stage.id as ReliquaryStageId, route.id as ReliquaryRouteId);
+            saveGame(latest);
+            const ending = result.ending ? `；結局「${ENDING_NAMES[result.ending]}」已確立` : '';
+            statusEl.textContent = `已完成第 ${result.stageId} 幕「${route.name}」${ending}。`;
+          } catch (error) {
+            statusEl.textContent = error instanceof Error ? error.message : '聖匣遠征結算失敗。';
+          }
+          render();
+        });
+        routeEl.append(button);
+        routes.append(routeEl);
+      }
+      article.append(routes);
+      stagesEl.append(article);
+    }
+  }
+
+  render();
+</script>
+
+<style>
+  :global(body) { background: #100c0b; color: #f0e7d6; }
+  .quest-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
+  .hero, .panel, .stage { border: 1px solid #4c382d; background: #191210; }
+  .hero { padding: 34px; background: radial-gradient(circle at 80% 15%, #4b1d13 0, transparent 32%), linear-gradient(135deg, #271711, #100c0b); }
+  .eyebrow { margin: 0 0 7px; color: #d49a5b; font-size: .72rem; letter-spacing: .18em; text-transform: uppercase; }
+  h1, h2, h3, p { margin-top: 0; }
+  h1 { margin-bottom: 12px; font-size: clamp(2.4rem, 6vw, 5rem); }
+  .premise, .stage-copy, .route p, .panel p, .ending p, .status { color: #bdb0a1; line-height: 1.75; }
+  nav { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 22px; }
+  a { color: #e3b870; }
+  .panel { display: flex; justify-content: space-between; align-items: center; gap: 20px; margin-top: 18px; padding: 20px 24px; }
+  .panel.locked { border-left: 3px solid #7b5540; }
+  .warning { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2c1714; }
+  .warning p { margin: 4px 0; }
+  .ending { margin-top: 18px; padding: 28px; border: 1px solid #8d643b; background: radial-gradient(circle at 10% 50%, #4b2118, transparent 38%), #211713; }
+  .ending-note { color: #e3b870 !important; }
+  .stages { display: grid; gap: 18px; margin-top: 18px; }
+  .stage { padding: 24px; }
+  .stage > header { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
+  .stage.completed-stage { border-color: #8b6b3f; }
+  .stage.locked-stage { opacity: .62; }
+  .badge { padding: 6px 10px; border: 1px solid #69503b; color: #d8ad68; white-space: nowrap; }
+  .routes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+  .route { display: flex; flex-direction: column; padding: 17px; border: 1px solid #42332a; background: #211814; }
+  .route.eligible { border-color: #80613d; }
+  .route.blocked { opacity: .72; }
+  .score { color: #d6bd89 !important; }
+  .cost { color: #d89d7c !important; }
+  .reward { color: #aecd8b !important; }
+  .blockers { color: #e08f7b !important; }
+  button { width: 100%; margin-top: auto; padding: 11px; border: 1px solid #d0a25c; background: #a96b31; color: #160d08; font: inherit; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .42; cursor: not-allowed; }
+  .status { min-height: 1.6em; margin-top: 16px; }
+  @media (max-width: 860px) {
+    .routes { grid-template-columns: 1fr; }
+    .panel, .stage > header { flex-direction: column; align-items: flex-start; }
+  }
+</style>

--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -3,39 +3,40 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="公司委託議程 — 商隊與劍"
-  description="依命運、職涯、特許、工程、治理、憲章、職務、風險、留任與市場週期形成的動態委託。"
+  title="行會委託與黑蠟文書 — 商隊與劍"
+  description="商會誓約、同袍職司、旅途危兆與世界任務共同形成的劍與魔法委託。"
   lang="zh-TW"
 >
   <main class="mandate-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M34–M38</p>
-      <h1>公司委託議程</h1>
-      <p>公司憲章決定優先價值，官員轉化旅伴能力，風險與留任承諾形成可見成本；每個市場週期仍只能完成其中一項委託。</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · GUILD HALL</p>
+      <h1>行會委託與黑蠟文書</h1>
+      <p>領主、教會、法師塔與邊境氏族都在爭奪商路。你的誓約、同袍與曾經作出的選擇，會改變每份委託真正需要付出的代價。</p>
       <nav>
-        <a href="/caravan/play">返回遊戲</a>
-        <a href="/caravan/retention">旅伴留任</a>
-        <a href="/caravan/risks">風險帳本</a>
-        <a href="/caravan/offices">公司職務</a>
-        <a href="/caravan/governance">營運治理</a>
-        <a href="/caravan/constitution">公司憲章</a>
-        <a href="/caravan/initiatives">長程工程</a>
+        <a href="/caravan/play">返回冒險</a>
+        <a class="quest-link" href="/caravan/ashen-reliquary">接受黑蠟委託：灰燼聖匣</a>
+        <a href="/caravan/retention">同袍承諾</a>
+        <a href="/caravan/risks">旅團危兆</a>
+        <a href="/caravan/offices">行會職司</a>
+        <a href="/caravan/constitution">商會誓約</a>
+        <a href="/caravan/initiatives">長程建設</a>
       </nav>
     </header>
 
     <section id="empty" class="panel" hidden>
       <h2>找不到商隊存檔</h2>
-      <p>先建立旅程，再回來查看本週期議程。</p>
+      <p>先建立旅程，再回來查看本期行會文書。</p>
     </section>
 
     <section id="summary" class="panel" hidden>
       <div>
-        <p class="eyebrow">MARKET CYCLE</p>
+        <p class="eyebrow">GUILD CYCLE</p>
         <h2 id="cycle-title"></h2>
       </div>
       <p id="cycle-state"></p>
     </section>
 
+    <section id="world-state" class="world-state" hidden></section>
     <section id="crisis" class="crisis" hidden></section>
     <section id="retention" class="retention" hidden></section>
     <section id="warnings" class="warnings" hidden></section>
@@ -47,9 +48,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <script>
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import {
-    retentionMandateAgenda,
-    completeRetentionMandate,
-  } from '@scripts/games/caravan/data/retentionMandates';
+    fantasyMandateAgenda,
+    completeFantasyMandate,
+  } from '@scripts/games/caravan/data/fantasyMandates';
   import type { CompanyMandate, MandateRoute } from '@scripts/games/caravan/data/mandates';
   import { CONSTITUTION_CLAUSES } from '@scripts/games/caravan/data/constitution';
 
@@ -57,11 +58,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   const summaryEl = document.getElementById('summary')!;
   const cycleTitleEl = document.getElementById('cycle-title')!;
   const cycleStateEl = document.getElementById('cycle-state')!;
+  const worldStateEl = document.getElementById('world-state')!;
   const crisisEl = document.getElementById('crisis')!;
   const retentionEl = document.getElementById('retention')!;
   const warningsEl = document.getElementById('warnings')!;
   const cardsEl = document.getElementById('cards')!;
   const statusEl = document.getElementById('status')!;
+
+  const ITEM_NAMES: Record<string, string> = {
+    torch: '火把', herb: '藥草', bandage: '繃帶', 'dried-rations': '乾糧',
+    'tattered-map': '殘破地圖', 'spice-pouch': '香料包', 'war-tonic': '戰鬥藥劑', ore: '礦石',
+  };
 
   const text = (tag: string, value: string, className?: string): HTMLElement => {
     const element = document.createElement(tag);
@@ -72,7 +79,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function itemList(items: Record<string, number>): string {
     const entries = Object.entries(items).filter(([, count]) => count > 0);
-    return entries.length > 0 ? entries.map(([id, count]) => `${id} ×${count}`).join('、') : '無';
+    return entries.length > 0
+      ? entries.map(([id, count]) => `${ITEM_NAMES[id] ?? id} ×${count}`).join('、')
+      : '無';
   }
 
   function rewardText(mandate: CompanyMandate): string {
@@ -97,42 +106,59 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     warningsEl.replaceChildren();
     crisisEl.replaceChildren();
     retentionEl.replaceChildren();
+    worldStateEl.replaceChildren();
     if (!save) {
       emptyEl.hidden = false;
       summaryEl.hidden = true;
+      worldStateEl.hidden = true;
       crisisEl.hidden = true;
       retentionEl.hidden = true;
       warningsEl.hidden = true;
       return;
     }
+
     emptyEl.hidden = true;
     summaryEl.hidden = false;
-    const agenda = retentionMandateAgenda(save);
-    cycleTitleEl.textContent = `市場週期 ${agenda.cycle}`;
-    const constitutionName = agenda.constitution
+    const agenda = fantasyMandateAgenda(save);
+    cycleTitleEl.textContent = `行會週期 ${agenda.cycle}`;
+    const oathName = agenda.constitution
       ? CONSTITUTION_CLAUSES[agenda.constitution].name
-      : '未制定條款';
+      : '尚未立下商會誓約';
     const allWarnings = [
       ...agenda.constitutionWarnings,
       ...agenda.officeWarnings,
       ...agenda.retentionWarnings,
+      ...agenda.reliquaryWarnings,
     ];
     warningsEl.hidden = allWarnings.length === 0;
     for (const warning of allWarnings) warningsEl.append(text('p', warning));
+
     cycleStateEl.textContent = agenda.completed
-      ? `本週期已完成 ${agenda.completedMandateId ?? '一項委託'}（${agenda.completedRouteId ?? '已結算'}）。`
-      : `資金 ${save.gold} G；憲章：${constitutionName}；官員津貼 ${agenda.officeUpkeep} G；留任保障 ${agenda.securityStipend} G；合夥分成 ${Math.round(agenda.partnershipShareRate * 100)}%。`;
+      ? `本期已完成 ${agenda.completedMandateId ?? '一份文書'}（${agenda.completedRouteId ?? '已結算'}）。`
+      : `資金 ${save.gold} G；商會誓約：${oathName}；職司俸金 ${agenda.officeUpkeep} G；撫卹承諾 ${agenda.securityStipend} G；分贓盟約 ${Math.round(agenda.partnershipShareRate * 100)}%。`;
+
+    worldStateEl.hidden = !agenda.reliquaryEffect;
+    if (agenda.reliquaryEffect) {
+      worldStateEl.append(
+        text('strong', '灰燼聖匣的餘波'),
+        text('span', agenda.reliquaryEffect),
+      );
+      const link = document.createElement('a');
+      link.href = '/caravan/ashen-reliquary';
+      link.textContent = '查看世界任務結局';
+      worldStateEl.append(link);
+    }
 
     const crisis = agenda.riskCrisis;
     crisisEl.hidden = !crisis;
     if (crisis) {
       crisisEl.append(
-        text('strong', `${crisis.title}｜嚴重度 ${crisis.severity}`),
-        text('span', crisis.resolved ? '本週期危機已解決，委託不再受罰。' : `未解決：${crisis.mandatePenalty}`),
+        text('strong', `${crisis.title}｜危兆 ${crisis.severity}`),
+        text('span', crisis.resolved ? '本期危兆已平息。' : `尚未平息：${crisis.mandatePenalty}`),
       );
       const link = document.createElement('a');
       link.href = '/caravan/risks';
-      link.textContent = crisis.resolved ? '查看風險帳本' : '前往處理危機';
+      link.textContent = crisis.resolved ? '查看旅團危兆' : '前往處理危兆';
       crisisEl.append(link);
     }
 
@@ -140,12 +166,12 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     retentionEl.hidden = !dispute;
     if (dispute) {
       retentionEl.append(
-        text('strong', `${dispute.memberName}留任爭議｜嚴重度 ${dispute.disputeSeverity}`),
-        text('span', `志向：${dispute.aspirationName}。現金報酬下降；對應領域的實地門檻提高。`),
+        text('strong', `${dispute.memberName}要求重議誓約｜嚴重度 ${dispute.disputeSeverity}`),
+        text('span', `此人的志向是「${dispute.aspirationName}」。未處理時，分贓與對應領域的實地行動會受到影響。`),
       );
       const link = document.createElement('a');
       link.href = '/caravan/retention';
-      link.textContent = '前往談判留任契約';
+      link.textContent = '前往商議同袍承諾';
       retentionEl.append(link);
     }
 
@@ -156,12 +182,12 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       const head = document.createElement('header');
       const titleWrap = document.createElement('div');
       titleWrap.append(
-        text('p', `${mandate.domain.toUpperCase()} · 難度 ${mandate.difficulty}`, 'eyebrow'),
+        text('p', `${mandate.domain.toUpperCase()} · 危險度 ${mandate.difficulty}`, 'eyebrow'),
         text('h2', mandate.title),
       );
       head.append(titleWrap, text('span', `${mandate.primaryStat.toUpperCase()} / ${mandate.primarySkill}`, 'domain-tag'));
       card.append(head, text('p', mandate.description, 'description'));
-      card.append(text('p', `政策、人事、風險與留任後獎勵：${rewardText(mandate)}`, 'reward'));
+      card.append(text('p', `最終報酬：${rewardText(mandate)}`, 'reward'));
 
       const routes = document.createElement('div');
       routes.className = 'routes';
@@ -172,34 +198,31 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
           text('h3', route.name),
           text('p', route.description),
           text('p', `能力 ${route.score} / ${route.threshold}`, 'score'),
-          text('p', `最終成本：${routeCost(route)}`, 'cost'),
+          text('p', `代價：${routeCost(route)}`, 'cost'),
         );
         if (!route.eligible) routeEl.append(text('p', route.blockers.join('；'), 'blockers'));
         const button = document.createElement('button');
         button.type = 'button';
         button.disabled = agenda.completed || !route.eligible || allWarnings.length > 0;
         button.textContent = agenda.completed
-          ? '本週期已結算'
+          ? '本期文書已結算'
           : allWarnings.length > 0
-            ? '組織資料衝突'
+            ? '誓章資料衝突'
             : route.eligible
-              ? `採用${route.name}`
+              ? `採用：${route.name}`
               : '條件不足';
         button.addEventListener('click', () => {
           const latest = loadGame();
-          if (!latest) {
-            statusEl.textContent = '存檔已不存在。';
-            return;
-          }
+          if (!latest) return;
           try {
-            const result = completeRetentionMandate(latest, mandate.id, route.id);
+            const result = completeFantasyMandate(latest, mandate.id, route.id);
             saveGame(latest);
             const partnership = result.partnershipBondIds.length > 0
-              ? `；${result.partnershipBondIds.length} 名合夥旅伴羈絆 +1`
+              ? `；${result.partnershipBondIds.length} 名分贓盟友羈絆 +1`
               : '';
-            statusEl.textContent = `已完成「${mandate.title}」的${route.name}；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}${partnership}。`;
+            statusEl.textContent = `已完成「${mandate.title}」；獲得 ${result.reward.gold} G、聲望 +${result.reward.reputation}${partnership}。`;
           } catch (error) {
-            statusEl.textContent = error instanceof Error ? error.message : '委託結算失敗。';
+            statusEl.textContent = error instanceof Error ? error.message : '行會文書結算失敗。';
           }
           render();
         });
@@ -215,21 +238,23 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 </script>
 
 <style>
-  :global(body) { background: #11100d; color: #eee6d5; }
+  :global(body) { background: #100d0b; color: #eee6d5; }
   .mandate-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
-  .hero, .panel, .mandate-card { border: 1px solid #4a4032; background: #1a1713; }
-  .hero { padding: 32px; background: linear-gradient(135deg, #241c13, #15120e); }
-  .eyebrow { margin: 0 0 7px; color: #c9a45e; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
+  .hero, .panel, .mandate-card { border: 1px solid #4a3b30; background: #191411; }
+  .hero { padding: 32px; background: radial-gradient(circle at 80% 10%, #3f1d13, transparent 35%), linear-gradient(135deg, #241913, #12100d); }
+  .eyebrow { margin: 0 0 7px; color: #cfa35f; font-size: .72rem; letter-spacing: .17em; text-transform: uppercase; }
   h1, h2, h3, p { margin-top: 0; }
   h1 { margin-bottom: 12px; font-size: clamp(2.1rem, 5vw, 4.2rem); }
   .hero > p:not(.eyebrow), .description, .route p, .panel p, .status { color: #b9b0a1; line-height: 1.7; }
   nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; }
   a { color: #e0bd78; }
+  .quest-link { padding: 4px 9px; border: 1px solid #a5613c; background: #351b13; color: #f0bd78; }
   .panel { display: flex; justify-content: space-between; gap: 20px; align-items: center; margin-top: 18px; padding: 20px 24px; }
-  .crisis, .retention { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 14px 18px; }
+  .world-state, .crisis, .retention { display: flex; gap: 16px; align-items: center; margin-top: 18px; padding: 14px 18px; }
+  .world-state { border-left: 3px solid #b87543; background: #2a1b14; }
   .crisis { border-left: 3px solid #b96050; background: #2a1915; }
   .retention { border-left: 3px solid #b98545; background: #2a2115; }
-  .crisis span, .retention span { flex: 1; color: #d3b7a8; }
+  .world-state span, .crisis span, .retention span { flex: 1; color: #d3b7a8; }
   .warnings { margin-top: 18px; padding: 14px 18px; border-left: 3px solid #bd5f4e; background: #2b1916; }
   .warnings p { margin: 4px 0; }
   .cards { display: grid; gap: 18px; margin-top: 18px; }
@@ -239,17 +264,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .domain-tag { padding: 6px 10px; border: 1px solid #5b4a31; color: #d9b972; white-space: nowrap; }
   .reward { padding: 12px; background: #211d16; border-left: 3px solid #b88a3f; }
   .routes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
-  .route { padding: 16px; border: 1px solid #443a2d; background: #201c17; }
+  .route { display: flex; flex-direction: column; padding: 16px; border: 1px solid #443a2d; background: #201c17; }
   .route.eligible { border-color: #7c7044; }
   .route.blocked { opacity: .68; }
   .score { color: #d7bd84 !important; }
   .cost { color: #d7a17e !important; }
   .blockers { color: #df8f7b !important; }
-  button { width: 100%; margin-top: 12px; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
+  button { width: 100%; margin-top: auto; padding: 11px; border: 1px solid #c39b54; background: #a97934; color: #160f08; font: inherit; font-weight: 700; cursor: pointer; }
   button:disabled { opacity: .45; cursor: not-allowed; }
   .status { min-height: 1.6em; margin-top: 16px; }
   @media (max-width: 820px) {
     .routes { grid-template-columns: 1fr; }
-    .panel, .mandate-card > header, .crisis, .retention { align-items: flex-start; flex-direction: column; }
+    .panel, .mandate-card > header, .world-state, .crisis, .retention { align-items: flex-start; flex-direction: column; }
   }
 </style>

--- a/src/scripts/games/caravan/data/ashenReliquary.balance.m39.test.ts
+++ b/src/scripts/games/caravan/data/ashenReliquary.balance.m39.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type SaveData } from '../save';
+import { ashenReliquaryState, resolveAshenReliquary } from './ashenReliquary';
+
+function save(): SaveData {
+  const data = newGame(3910, { job: 'swordsman', trait: 'brawny', allocation: { str: 3 } });
+  data.reputation = 50;
+  data.gold = 1000;
+  data.inventory = {
+    ...data.inventory,
+    torch: 10,
+    herb: 10,
+    bandage: 10,
+    'dried-rations': 20,
+    'tattered-map': 10,
+    'spice-pouch': 10,
+    'war-tonic': 10,
+    ore: 10,
+  };
+  data.protagonist.stats = { str: 30, dex: 30, int: 30, cha: 30, con: 30 };
+  data.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+  data.protagonist.growth = { potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } } as never;
+  return data;
+}
+
+describe('M39 reliquary balance guardrails', () => {
+  it('keeps every route cost and threshold non-negative', () => {
+    const data = save();
+    const routes = ashenReliquaryState(data).stages.flatMap((stage) => stage.routes);
+    expect(routes.every((route) =>
+      route.threshold > 0
+      && route.goldCost >= 0
+      && route.reputationCost >= 0
+      && Object.values(route.inventoryCost).every((count) => count >= 0)
+    )).toBe(true);
+  });
+
+  it('makes every final ending carry both an advantage and a persistent cost', () => {
+    const endings = [
+      ['seal-reliquary', 'sealed'],
+      ['claim-ember', 'claimed'],
+      ['shatter-vessel', 'shattered'],
+    ] as const;
+    for (const [route, ending] of endings) {
+      const data = save();
+      resolveAshenReliquary(data, 1, 'read-runes');
+      resolveAshenReliquary(data, 2, 'decode-lament');
+      resolveAshenReliquary(data, 3, route);
+      expect(data.flags[`ashen-reliquary:ending:${ending}`]).toBe(true);
+      if (ending === 'sealed') expect(data.flags['relic:saint-ember']).toBe(true);
+      if (ending === 'claimed') {
+        expect(data.flags['relic:ember-heart']).toBe(true);
+        expect(data.flags['curse:dragon-ember']).toBe(true);
+      }
+      if (ending === 'shattered') expect(data.flags['relic:dragonbone-shard']).toBe(true);
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/ashenReliquary.m39.test.ts
+++ b/src/scripts/games/caravan/data/ashenReliquary.m39.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { newGame, type SaveData } from '../save';
+import {
+  ashenReliquaryState,
+  resolveAshenReliquary,
+  type ReliquaryEndingId,
+  type ReliquaryRouteId,
+} from './ashenReliquary';
+import { fantasyMandateAgenda } from './fantasyMandates';
+import { retentionMandateAgenda } from './retentionMandates';
+
+function preparedSave(): SaveData {
+  const save = newGame(3900, { job: 'mage', trait: 'learned', allocation: { int: 3 } });
+  save.marketSeed = 12000;
+  save.reputation = 60;
+  save.gold = 2000;
+  save.wagonLevel = 5;
+  save.inventory = {
+    ...save.inventory,
+    torch: 20,
+    herb: 20,
+    bandage: 20,
+    'dried-rations': 40,
+    'tattered-map': 20,
+    'spice-pouch': 20,
+    'war-tonic': 20,
+    ore: 20,
+  };
+  save.protagonist.stats = { str: 30, dex: 30, int: 30, cha: 30, con: 30 };
+  save.protagonist.skills = { martial: 5, scouting: 5, lore: 5, negotiation: 5, survival: 5 };
+  save.protagonist.growth = { potential: { str: 5, dex: 5, int: 5, cha: 5, con: 5 } } as never;
+  return save;
+}
+
+function completePrelude(save: SaveData): void {
+  resolveAshenReliquary(save, 1, 'read-runes');
+  resolveAshenReliquary(save, 2, 'decode-lament');
+}
+
+function finish(save: SaveData, route: ReliquaryRouteId): ReliquaryEndingId {
+  completePrelude(save);
+  return resolveAshenReliquary(save, 3, route).ending!;
+}
+
+function seedWithDomain(save: SaveData, domain: string): void {
+  for (let seed = 12000; seed < 12100; seed++) {
+    save.marketSeed = seed;
+    if (retentionMandateAgenda(save).mandates.some((mandate) => mandate.domain === domain)) return;
+  }
+  throw new Error(`找不到包含 ${domain} 的測試週期`);
+}
+
+describe('M39 Ashen Reliquary world quest', () => {
+  it('is deterministic and read-only while previewing all nine routes', () => {
+    const save = preparedSave();
+    const before = JSON.stringify(save);
+    const first = ashenReliquaryState(save);
+    const second = ashenReliquaryState(save);
+    expect(first).toEqual(second);
+    expect(first.unlocked).toBe(true);
+    expect(first.currentStage).toBe(1);
+    expect(first.stages.flatMap((stage) => stage.routes)).toHaveLength(9);
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it('does not unlock low-reputation mundane companies without knowledge access', () => {
+    const save = preparedSave();
+    save.reputation = 0;
+    save.flags = {};
+    expect(ashenReliquaryState(save).unlocked).toBe(false);
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveAshenReliquary(save, 1, 'read-runes')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('enforces stage order and exactly one route per act', () => {
+    const save = preparedSave();
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveAshenReliquary(save, 2, 'decode-lament')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+
+    resolveAshenReliquary(save, 1, 'read-runes');
+    const afterFirst = JSON.stringify(save);
+    expect(() => resolveAshenReliquary(save, 1, 'shield-march')).toThrow();
+    expect(JSON.stringify(save)).toBe(afterFirst);
+    expect(ashenReliquaryState(save).currentStage).toBe(2);
+  });
+
+  it('revalidates stale resources before mutation', () => {
+    const save = preparedSave();
+    const route = ashenReliquaryState(save).stages[0].routes.find((entry) => entry.id === 'read-runes')!;
+    expect(route.eligible).toBe(true);
+    save.inventory.torch = 0;
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveAshenReliquary(save, 1, 'read-runes')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('creates one irreversible ending and awards its unique relic once', () => {
+    const save = preparedSave();
+    const ending = finish(save, 'seal-reliquary');
+    expect(ending).toBe('sealed');
+    expect(save.flags['world-quest:ashen-reliquary:completed']).toBe(true);
+    expect(save.flags['ashen-reliquary:ending:sealed']).toBe(true);
+    expect(save.flags['relic:saint-ember']).toBe(true);
+    expect(ashenReliquaryState(save).currentStage).toBeNull();
+    const snapshot = JSON.stringify(save);
+    expect(() => resolveAshenReliquary(save, 3, 'claim-ember')).toThrow();
+    expect(JSON.stringify(save)).toBe(snapshot);
+  });
+
+  it('disables corrupt multiple endings instead of stacking world-state benefits', () => {
+    const save = preparedSave();
+    finish(save, 'seal-reliquary');
+    save.flags['ashen-reliquary:ending:claimed'] = true;
+    const state = ashenReliquaryState(save);
+    expect(state.ending).toBeNull();
+    expect(state.warnings.length).toBeGreaterThan(0);
+    expect(fantasyMandateAgenda(save).reliquaryEnding).toBeNull();
+    expect(fantasyMandateAgenda(save).mandates).toEqual(retentionMandateAgenda(save).mandates);
+  });
+
+  it('turns each ending into a different mandate tradeoff', () => {
+    const sealed = preparedSave();
+    finish(sealed, 'seal-reliquary');
+    const sealedBase = retentionMandateAgenda(sealed);
+    const sealedAgenda = fantasyMandateAgenda(sealed);
+    expect(sealedAgenda.mandates.every((mandate, index) =>
+      mandate.reward.gold === Math.max(0, sealedBase.mandates[index].reward.gold - 2)
+    )).toBe(true);
+
+    const claimed = preparedSave();
+    finish(claimed, 'claim-ember');
+    seedWithDomain(claimed, 'relic');
+    const claimedBase = retentionMandateAgenda(claimed);
+    const claimedAgenda = fantasyMandateAgenda(claimed);
+    const baseRelic = claimedBase.mandates.find((mandate) => mandate.domain === 'relic')!;
+    const changedRelic = claimedAgenda.mandates.find((mandate) => mandate.domain === 'relic')!;
+    expect(changedRelic.routes.find((route) => route.id === 'expertise')!.score)
+      .toBe(baseRelic.routes.find((route) => route.id === 'expertise')!.score + 2);
+    expect(claimedAgenda.mandates.every((mandate, index) => {
+      const field = mandate.routes.find((route) => route.id === 'field')!;
+      const baseField = claimedBase.mandates[index].routes.find((route) => route.id === 'field')!;
+      return (field.inventoryCost['dried-rations'] ?? 0) === (baseField.inventoryCost['dried-rations'] ?? 0) + 1;
+    })).toBe(true);
+
+    const shattered = preparedSave();
+    finish(shattered, 'shatter-vessel');
+    seedWithDomain(shattered, 'escort');
+    const shatteredBase = retentionMandateAgenda(shattered);
+    const shatteredAgenda = fantasyMandateAgenda(shattered);
+    const baseEscort = shatteredBase.mandates.find((mandate) => mandate.domain === 'escort')!;
+    const changedEscort = shatteredAgenda.mandates.find((mandate) => mandate.domain === 'escort')!;
+    expect(changedEscort.routes.find((route) => route.id === 'field')!.score)
+      .toBe(baseEscort.routes.find((route) => route.id === 'field')!.score + 1);
+  });
+
+  it('keeps pre-M39 saves exactly compatible when the quest has no ending', () => {
+    const save = preparedSave();
+    expect(fantasyMandateAgenda(save).mandates).toEqual(retentionMandateAgenda(save).mandates);
+    expect(fantasyMandateAgenda(save).reliquaryEnding).toBeNull();
+  });
+});

--- a/src/scripts/games/caravan/data/ashenReliquary.ts
+++ b/src/scripts/games/caravan/data/ashenReliquary.ts
@@ -1,0 +1,375 @@
+import type { CompanionRecord, SaveData } from '../save';
+import { companyConstitutionState } from './constitution';
+import { COMPANY_OFFICES, companyOfficeState } from './offices';
+import { companyRetentionState } from './retention';
+
+export type ReliquaryStageId = 1 | 2 | 3;
+export type ReliquaryEndingId = 'sealed' | 'claimed' | 'shattered';
+export type ReliquaryRouteId =
+  | 'read-runes' | 'shield-march' | 'hidden-path'
+  | 'consecrate-choir' | 'decode-lament' | 'parley-echoes'
+  | 'seal-reliquary' | 'claim-ember' | 'shatter-vessel';
+
+export interface ReliquaryReward {
+  gold: number;
+  reputation: number;
+  inventory: Record<string, number>;
+  skillPoints: number;
+  bondAll: number;
+  flag?: string;
+}
+
+export interface ReliquaryRoute {
+  id: ReliquaryRouteId;
+  name: string;
+  description: string;
+  score: number;
+  threshold: number;
+  goldCost: number;
+  reputationCost: number;
+  inventoryCost: Record<string, number>;
+  reward: ReliquaryReward;
+  eligible: boolean;
+  blockers: string[];
+  ending?: ReliquaryEndingId;
+}
+
+export interface ReliquaryStage {
+  id: ReliquaryStageId;
+  title: string;
+  description: string;
+  routes: ReliquaryRoute[];
+  completedRouteId: ReliquaryRouteId | null;
+  locked: boolean;
+}
+
+export interface AshenReliquaryState {
+  unlocked: boolean;
+  unlockReason: string;
+  completed: boolean;
+  ending: ReliquaryEndingId | null;
+  currentStage: ReliquaryStageId | null;
+  stages: ReliquaryStage[];
+  warnings: string[];
+}
+
+export interface ReliquaryResolution {
+  stageId: ReliquaryStageId;
+  routeId: ReliquaryRouteId;
+  reward: ReliquaryReward;
+  ending: ReliquaryEndingId | null;
+  receipt: string;
+}
+
+const ENDINGS: ReliquaryEndingId[] = ['sealed', 'claimed', 'shattered'];
+const STAGE_ROUTES: Record<ReliquaryStageId, ReliquaryRouteId[]> = {
+  1: ['read-runes', 'shield-march', 'hidden-path'],
+  2: ['consecrate-choir', 'decode-lament', 'parley-echoes'],
+  3: ['seal-reliquary', 'claim-ember', 'shatter-vessel'],
+};
+
+function bondTier(value: number | undefined): number {
+  const bond = value ?? 0;
+  if (bond >= 9) return 3;
+  if (bond >= 5) return 2;
+  if (bond >= 2) return 1;
+  return 0;
+}
+
+function potential(record: CompanionRecord, stat: 'str' | 'dex' | 'int' | 'cha' | 'con'): number {
+  return record.growth?.potential?.[stat] ?? 0;
+}
+
+function skill(record: CompanionRecord, id: string): number {
+  return record.skills?.[id] ?? 0;
+}
+
+function careerCount(save: SaveData, pathId: string): number {
+  return [save.protagonist, ...save.companions].filter((member) =>
+    (member.careerMilestones ?? []).some((milestone) => milestone.pathId === pathId)
+  ).length;
+}
+
+function healthyCompanions(save: SaveData): CompanionRecord[] {
+  return save.companions.filter((member) => member.injuredForTrips <= 0);
+}
+
+function officeBonus(save: SaveData, domain: 'escort' | 'frontier' | 'trade' | 'fellowship' | 'relic'): number {
+  const state = companyOfficeState(save);
+  return state.assignments
+    .filter((assignment) => COMPANY_OFFICES[assignment.officeId].domain === domain)
+    .reduce((sum, assignment) => sum + assignment.tier, 0);
+}
+
+function clauseBonus(save: SaveData, clauseId: string): number {
+  return companyConstitutionState(save).active === clauseId ? 2 : 0;
+}
+
+function knownPractice(save: SaveData, id: 'expertise' | 'capital' | 'solidarity'): number {
+  return save.flags[`company-risk-practice:${id}`] === true ? 1 : 0;
+}
+
+function completedRoute(save: SaveData, stage: ReliquaryStageId): ReliquaryRouteId | null {
+  const prefix = `ashen-reliquary:stage:${stage}:`;
+  const matches = Object.keys(save.flags).filter((key) => key.startsWith(prefix) && save.flags[key] === true);
+  if (matches.length !== 1) return null;
+  const id = matches[0].slice(prefix.length) as ReliquaryRouteId;
+  return STAGE_ROUTES[stage].includes(id) ? id : null;
+}
+
+function endingFromSave(save: SaveData): ReliquaryEndingId | null {
+  const active = ENDINGS.filter((ending) => save.flags[`ashen-reliquary:ending:${ending}`] === true);
+  return active.length === 1 ? active[0] : null;
+}
+
+function reward(
+  gold: number,
+  reputation: number,
+  inventory: Record<string, number> = {},
+  skillPoints = 0,
+  bondAll = 0,
+  flag?: string,
+): ReliquaryReward {
+  return { gold, reputation, inventory, skillPoints, bondAll, flag };
+}
+
+function refreshEligibility(save: SaveData, route: Omit<ReliquaryRoute, 'eligible' | 'blockers'>): ReliquaryRoute {
+  const blockers: string[] = [];
+  if (route.score < route.threshold) blockers.push(`能力 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  if (save.reputation < route.reputationCost) blockers.push(`聲望不足，需要 ${route.reputationCost}`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, eligible: blockers.length === 0, blockers };
+}
+
+function stageOneRoutes(save: SaveData): ReliquaryRoute[] {
+  const hero = save.protagonist;
+  const runeScore = Math.floor(hero.stats.int / 4) + skill(hero, 'lore') + potential(hero, 'int')
+    + officeBonus(save, 'relic') + clauseBonus(save, 'open-knowledge') + knownPractice(save, 'expertise');
+  const shieldScore = Math.floor(hero.stats.str / 4) + skill(hero, 'martial') + potential(hero, 'str')
+    + officeBonus(save, 'escort') + clauseBonus(save, 'martial-priority');
+  const pathScore = Math.floor(hero.stats.dex / 4) + skill(hero, 'scouting') + potential(hero, 'dex')
+    + officeBonus(save, 'frontier') + clauseBonus(save, 'exploration-duty');
+  return [
+    refreshEligibility(save, {
+      id: 'read-runes', name: '以古符熄滅灰燼風',
+      description: '解讀聖匣守衛留下的龍語封印，從魔法風暴的節點間穿行。',
+      score: runeScore, threshold: 8, goldCost: 0, reputationCost: 0,
+      inventoryCost: { torch: 1, herb: 1 }, reward: reward(10, 1, { 'tattered-map': 1 }),
+    }),
+    refreshEligibility(save, {
+      id: 'shield-march', name: '結盾穿越亡者堤道',
+      description: '由護衛承受灰燼騎士的衝鋒，硬生生奪下通往地窟的石橋。',
+      score: shieldScore, threshold: 8, goldCost: 0, reputationCost: 0,
+      inventoryCost: { bandage: 1 }, reward: reward(16, 1, { ore: 1 }),
+    }),
+    refreshEligibility(save, {
+      id: 'hidden-path', name: '追隨妖火尋找隱道',
+      description: '讓斥候辨認不受詛咒侵蝕的獸徑，繞過堤道上的亡魂軍列。',
+      score: pathScore, threshold: 8, goldCost: 0, reputationCost: 0,
+      inventoryCost: { 'dried-rations': 2 }, reward: reward(8, 1, { torch: 1 }),
+    }),
+  ];
+}
+
+function stageTwoRoutes(save: SaveData): ReliquaryRoute[] {
+  const hero = save.protagonist;
+  const clerics = [hero, ...save.companions].filter((member) => member.job === 'cleric').length;
+  const registered = save.companions.filter((member) => !!member.genesis && !!member.growth).length;
+  const healthyBond = healthyCompanions(save).reduce((sum, member) => sum + bondTier(member.bond), 0);
+  const retention = companyRetentionState(save);
+  const partners = retention.profiles.filter((profile) => profile.contract === 'partnership').length;
+  const sanctifyScore = Math.floor(hero.stats.cha / 4) + skill(hero, 'survival') + clerics * 2
+    + officeBonus(save, 'fellowship') + clauseBonus(save, 'fellowship-dividend') + knownPractice(save, 'solidarity');
+  const decodeScore = Math.floor(hero.stats.int / 4) + skill(hero, 'lore') + potential(hero, 'int')
+    + careerCount(save, 'lore') + officeBonus(save, 'relic') + clauseBonus(save, 'open-knowledge');
+  const parleyScore = Math.floor(hero.stats.cha / 4) + skill(hero, 'negotiation') + potential(hero, 'cha')
+    + partners * 2 + Math.min(3, healthyBond) + Math.min(2, registered) + officeBonus(save, 'trade');
+  return [
+    refreshEligibility(save, {
+      id: 'consecrate-choir', name: '重唱失落聖歌',
+      description: '由牧師與同袍接續被詛咒吞沒的禱詞，使無聲唱詩班重新記起自己的名字。',
+      score: sanctifyScore, threshold: 10, goldCost: 0, reputationCost: 1,
+      inventoryCost: { herb: 2 }, reward: reward(12, 2, { bandage: 1 }, 0, 1),
+    }),
+    refreshEligibility(save, {
+      id: 'decode-lament', name: '解讀黑曜哀歌',
+      description: '從牆上的燒蝕譜記重建封印儀式，找出聖匣真正的主人。',
+      score: decodeScore, threshold: 10, goldCost: 0, reputationCost: 0,
+      inventoryCost: { 'tattered-map': 1 }, reward: reward(8, 2, { herb: 1 }, 1),
+    }),
+    refreshEligibility(save, {
+      id: 'parley-echoes', name: '與死者回聲立約',
+      description: '以分贓誓言與真名交換通行，承諾不讓聖匣再次成為王侯的武器。',
+      score: parleyScore, threshold: 10, goldCost: 25, reputationCost: 0,
+      inventoryCost: { 'spice-pouch': 1 }, reward: reward(30, 1, {}, 0, 2),
+    }),
+  ];
+}
+
+function stageThreeRoutes(save: SaveData): ReliquaryRoute[] {
+  const hero = save.protagonist;
+  const stageOne = completedRoute(save, 1);
+  const stageTwo = completedRoute(save, 2);
+  const clerics = [hero, ...save.companions].filter((member) => member.job === 'cleric').length;
+  const relicAspirants = companyRetentionState(save).profiles.filter((profile) => profile.aspiration === 'relic').length;
+  const sealScore = Math.floor(hero.stats.int / 4) + skill(hero, 'lore') + clerics * 2
+    + officeBonus(save, 'relic') + clauseBonus(save, 'open-knowledge')
+    + (stageOne === 'read-runes' ? 2 : 0) + (stageTwo === 'consecrate-choir' || stageTwo === 'decode-lament' ? 2 : 0);
+  const claimScore = Math.floor(Math.max(hero.stats.int, hero.stats.cha) / 4) + skill(hero, 'lore')
+    + skill(hero, 'negotiation') + potential(hero, 'int') + relicAspirants
+    + clauseBonus(save, 'commercial-supremacy') + (stageTwo === 'parley-echoes' ? 2 : 0);
+  const shatterScore = Math.floor(hero.stats.str / 4) + skill(hero, 'martial') + potential(hero, 'str')
+    + officeBonus(save, 'escort') + clauseBonus(save, 'martial-priority')
+    + (stageOne === 'shield-march' ? 2 : 0);
+  return [
+    refreshEligibility(save, {
+      id: 'seal-reliquary', name: '以聖火重新封印',
+      description: '接受教會與亡者共同見證，讓龍燼沉睡，保留其知識但拒絕使用其力量。',
+      score: sealScore, threshold: 13, goldCost: 0, reputationCost: 2,
+      inventoryCost: { herb: 2, bandage: 1 },
+      reward: reward(35, 6, { 'tattered-map': 1 }, 1, 1, 'relic:saint-ember'), ending: 'sealed',
+    }),
+    refreshEligibility(save, {
+      id: 'claim-ember', name: '奪取龍燼心核',
+      description: '承受聖匣詛咒，把古龍殘火帶回商隊；力量巨大，但教會與旅伴都會記得這個選擇。',
+      score: claimScore, threshold: 13, goldCost: 40, reputationCost: 0,
+      inventoryCost: { 'war-tonic': 1 },
+      reward: reward(110, -2, {}, 2, 0, 'relic:ember-heart'), ending: 'claimed',
+    }),
+    refreshEligibility(save, {
+      id: 'shatter-vessel', name: '擊碎聖匣與龍骨鎖',
+      description: '拒絕所有王權、教權與法師塔的索求，將危險知識連同容器一併毀滅。',
+      score: shatterScore, threshold: 13, goldCost: 0, reputationCost: 0,
+      inventoryCost: { bandage: 2, ore: 1 },
+      reward: reward(60, 4, { ore: 3 }, 0, 1, 'relic:dragonbone-shard'), ending: 'shattered',
+    }),
+  ];
+}
+
+function warnings(save: SaveData): string[] {
+  const result: string[] = [];
+  for (const stage of [1, 2, 3] as ReliquaryStageId[]) {
+    const prefix = `ashen-reliquary:stage:${stage}:`;
+    const active = Object.keys(save.flags).filter((key) => key.startsWith(prefix) && save.flags[key] === true);
+    if (active.length > 1) result.push(`灰燼聖匣第 ${stage} 幕同時存在多條路線收據。`);
+  }
+  const endings = ENDINGS.filter((ending) => save.flags[`ashen-reliquary:ending:${ending}`] === true);
+  if (endings.length > 1) result.push('灰燼聖匣同時存在多個結局，所有結局效果停用。');
+  return result;
+}
+
+export function ashenReliquaryState(save: SaveData): AshenReliquaryState {
+  const completedRoutes = {
+    1: completedRoute(save, 1),
+    2: completedRoute(save, 2),
+    3: completedRoute(save, 3),
+  };
+  const unlocked = save.reputation >= 25
+    || companyConstitutionState(save).active === 'open-knowledge'
+    || officeBonus(save, 'relic') > 0;
+  const ending = endingFromSave(save);
+  const completed = save.flags['world-quest:ashen-reliquary:completed'] === true && ending !== null;
+  const currentStage: ReliquaryStageId | null = completed
+    ? null
+    : !completedRoutes[1] ? 1 : !completedRoutes[2] ? 2 : 3;
+  const stages: ReliquaryStage[] = [
+    {
+      id: 1,
+      title: '第一幕：灰燼堤道',
+      description: '通往山腹修道院的堤道被灰燼騎士與龍火風暴封鎖。',
+      routes: stageOneRoutes(save),
+      completedRouteId: completedRoutes[1],
+      locked: currentStage !== 1 && !completedRoutes[1],
+    },
+    {
+      id: 2,
+      title: '第二幕：無聲唱詩窟',
+      description: '失去舌頭的修士亡魂仍在反覆演唱一段無聲聖歌。',
+      routes: stageTwoRoutes(save),
+      completedRouteId: completedRoutes[2],
+      locked: !completedRoutes[1],
+    },
+    {
+      id: 3,
+      title: '第三幕：龍燼聖匣',
+      description: '聖匣中的古龍心火醒來，要求商隊在封印、力量與毀滅之間作出選擇。',
+      routes: stageThreeRoutes(save),
+      completedRouteId: completedRoutes[3],
+      locked: !completedRoutes[2],
+    },
+  ];
+  return {
+    unlocked,
+    unlockReason: unlocked
+      ? '商隊已取得足夠聲望、秘法學識或遺珍官員的引薦。'
+      : '需要聲望 25、知識公開誓約，或一名有效遺珍學監。',
+    completed,
+    ending,
+    currentStage,
+    stages,
+    warnings: warnings(save),
+  };
+}
+
+function applyReward(save: SaveData, gained: ReliquaryReward): void {
+  save.gold += gained.gold;
+  save.reputation += gained.reputation;
+  for (const [itemId, count] of Object.entries(gained.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (gained.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + gained.skillPoints;
+  if (gained.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + gained.bondAll;
+  }
+  if (gained.flag) save.flags[gained.flag] = true;
+}
+
+/** 使用最新存檔重新預覽，再原子結算單一幕。 */
+export function resolveAshenReliquary(
+  save: SaveData,
+  stageId: ReliquaryStageId,
+  routeId: ReliquaryRouteId,
+): ReliquaryResolution {
+  const state = ashenReliquaryState(save);
+  if (!state.unlocked) throw new Error(state.unlockReason);
+  if (state.warnings.length > 0) throw new Error(state.warnings.join('；'));
+  if (state.completed) throw new Error('灰燼聖匣的命運已經決定。');
+  if (state.currentStage !== stageId) throw new Error(`目前只能處理第 ${state.currentStage ?? 0} 幕。`);
+  const stage = state.stages.find((entry) => entry.id === stageId)!;
+  const route = stage.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`第 ${stageId} 幕不存在路線「${routeId}」。`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+  const stageReceipt = `ashen-reliquary:stage:${stageId}:${route.id}`;
+  const stagePrefix = `ashen-reliquary:stage:${stageId}:`;
+  if (Object.keys(save.flags).some((key) => key.startsWith(stagePrefix) && save.flags[key] === true)) {
+    throw new Error(`第 ${stageId} 幕已經完成。`);
+  }
+
+  save.gold -= route.goldCost;
+  save.reputation -= route.reputationCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, route.reward);
+  save.flags[stageReceipt] = true;
+
+  let ending: ReliquaryEndingId | null = null;
+  if (stageId === 3) {
+    if (!route.ending) throw new Error('最終幕路線缺少結局。');
+    ending = route.ending;
+    save.flags[`ashen-reliquary:ending:${ending}`] = true;
+    save.flags['world-quest:ashen-reliquary:completed'] = true;
+    if (ending === 'claimed') save.flags['curse:dragon-ember'] = true;
+  }
+
+  return {
+    stageId,
+    routeId: route.id,
+    reward: { ...route.reward, inventory: { ...route.reward.inventory } },
+    ending,
+    receipt: stageReceipt,
+  };
+}

--- a/src/scripts/games/caravan/data/fantasyMandates.ts
+++ b/src/scripts/games/caravan/data/fantasyMandates.ts
@@ -1,0 +1,182 @@
+import type { SaveData } from '../save';
+import {
+  retentionMandateAgenda,
+} from './retentionMandates';
+import type {
+  CompanyMandate,
+  MandateCompletion,
+  MandateReward,
+  MandateRoute,
+  MandateRouteId,
+} from './mandates';
+import { ashenReliquaryState, type ReliquaryEndingId } from './ashenReliquary';
+
+export type FantasyMandateAgenda = ReturnType<typeof retentionMandateAgenda> & {
+  reliquaryEnding: ReliquaryEndingId | null;
+  reliquaryEffect: string | null;
+  reliquaryWarnings: string[];
+};
+
+export interface FantasyMandateCompletion extends MandateCompletion {
+  partnershipBondIds: string[];
+  reliquaryEnding: ReliquaryEndingId | null;
+}
+
+function cloneReward(reward: MandateReward): MandateReward {
+  return { ...reward, inventory: { ...reward.inventory } };
+}
+
+function cloneRoute(route: MandateRoute): MandateRoute {
+  return {
+    ...route,
+    inventoryCost: { ...route.inventoryCost },
+    blockers: [...route.blockers],
+  };
+}
+
+function refreshEligibility(save: SaveData, route: MandateRoute): MandateRoute {
+  const blockers = route.blockers.filter((entry) =>
+    !entry.startsWith('能力分數 ') &&
+    !entry.startsWith('金幣不足') &&
+    !entry.includes('不足，需要')
+  );
+  if (route.score < route.threshold) blockers.push(`能力分數 ${route.score}，需要 ${route.threshold}`);
+  if (save.gold < route.goldCost) blockers.push(`金幣不足，需要 ${route.goldCost} G`);
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    if ((save.inventory[itemId] ?? 0) < count) blockers.push(`${itemId} 不足，需要 ${count}`);
+  }
+  return { ...route, blockers, eligible: blockers.length === 0 };
+}
+
+function applyEnding(
+  save: SaveData,
+  mandate: CompanyMandate,
+  ending: ReliquaryEndingId | null,
+): CompanyMandate {
+  if (!ending) return mandate;
+  const reward = cloneReward(mandate.reward);
+  const routes = mandate.routes.map(cloneRoute);
+
+  if (ending === 'sealed') {
+    // 聖焰由修道會保管：獲得宗教與遺珍協助，但所有委託需繳納少量聖堂什一稅。
+    reward.gold = Math.max(0, reward.gold - 2);
+    if (mandate.domain === 'relic' || mandate.domain === 'fellowship') {
+      for (const route of routes) if (route.id === 'expertise') route.score += 1;
+    }
+  }
+
+  if (ending === 'claimed') {
+    // 龍燼心核強化秘法，但詛咒使補給腐敗並損害名聲。
+    reward.reputation = Math.max(0, reward.reputation - 1);
+    if (mandate.domain === 'relic') {
+      for (const route of routes) if (route.id === 'expertise') route.score += 2;
+    }
+    for (const route of routes) {
+      if (route.id === 'field') {
+        route.inventoryCost['dried-rations'] = (route.inventoryCost['dried-rations'] ?? 0) + 1;
+      }
+    }
+  }
+
+  if (ending === 'shattered') {
+    // 龍骨碎片成為護衛圖騰；代價是遺失聖匣中的古代知識。
+    if (mandate.domain === 'escort') {
+      for (const route of routes) if (route.id === 'field') route.score += 1;
+    }
+    if (mandate.domain === 'relic') {
+      reward.reputation = Math.max(0, reward.reputation - 1);
+      for (const route of routes) if (route.id === 'expertise') route.threshold += 1;
+    }
+  }
+
+  return {
+    ...mandate,
+    reward,
+    routes: routes.map((route) => refreshEligibility(save, route)),
+  };
+}
+
+function effectText(ending: ReliquaryEndingId | null): string | null {
+  if (ending === 'sealed') return '聖焰封印：遺珍與同袍專業能力提高，但每項委託繳納 2 G 聖堂什一稅。';
+  if (ending === 'claimed') return '龍燼詛咒：遺珍專業能力大幅提高，但實地行動多耗乾糧，委託聲望受損。';
+  if (ending === 'shattered') return '龍骨戰旗：護運實地能力提高，但遺珍研究更困難且聲望報酬下降。';
+  return null;
+}
+
+export function fantasyMandateAgenda(save: SaveData): FantasyMandateAgenda {
+  const base = retentionMandateAgenda(save);
+  const reliquary = ashenReliquaryState(save);
+  const ending = reliquary.completed && reliquary.warnings.length === 0 ? reliquary.ending : null;
+  return {
+    ...base,
+    reliquaryEnding: ending,
+    reliquaryEffect: effectText(ending),
+    reliquaryWarnings: reliquary.warnings,
+    mandates: base.mandates.map((mandate) => applyEnding(save, mandate, ending)),
+  };
+}
+
+function applyReward(save: SaveData, reward: MandateReward): void {
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  for (const [itemId, count] of Object.entries(reward.inventory)) {
+    if (count > 0) save.inventory[itemId] = (save.inventory[itemId] ?? 0) + count;
+  }
+  if (reward.bondAll > 0) {
+    for (const companion of save.companions) companion.bond = (companion.bond ?? 0) + reward.bondAll;
+  }
+  if (reward.skillPoints > 0) save.protagonist.skillPoints = (save.protagonist.skillPoints ?? 0) + reward.skillPoints;
+}
+
+/** 使用最新誓約、官職、危機、旅伴承諾與世界任務結局原子結算行會委託。 */
+export function completeFantasyMandate(
+  save: SaveData,
+  mandateId: string,
+  routeId: MandateRouteId,
+): FantasyMandateCompletion {
+  const agenda = fantasyMandateAgenda(save);
+  if (agenda.completed) throw new Error('本市場週期的行會委託已經完成。');
+  const warnings = [
+    ...agenda.constitutionWarnings,
+    ...agenda.officeWarnings,
+    ...agenda.retentionWarnings,
+    ...agenda.reliquaryWarnings,
+  ];
+  if (warnings.length > 0) throw new Error(warnings.join('；'));
+  const mandate = agenda.mandates.find((entry) => entry.id === mandateId);
+  if (!mandate) throw new Error(`找不到行會委託「${mandateId}」`);
+  const route = mandate.routes.find((entry) => entry.id === routeId);
+  if (!route) throw new Error(`找不到解法「${routeId}」`);
+  if (!route.eligible) throw new Error(route.blockers.join('；'));
+
+  const preciseReceipt = `company-mandate:${agenda.cycle}:${mandate.id}:${route.id}`;
+  if (save.flags[agenda.receipt] === true || save.flags[preciseReceipt] === true) {
+    throw new Error('這項行會委託已經結算。');
+  }
+
+  save.gold -= route.goldCost;
+  for (const [itemId, count] of Object.entries(route.inventoryCost)) {
+    save.inventory[itemId] = (save.inventory[itemId] ?? 0) - count;
+  }
+  applyReward(save, mandate.reward);
+
+  const partnershipBondIds = agenda.retentionProfiles
+    .filter((profile) => profile.contract === 'partnership')
+    .map((profile) => profile.memberId);
+  for (const memberId of partnershipBondIds) {
+    const member = save.companions.find((entry) => entry.id === memberId);
+    if (member) member.bond = (member.bond ?? 0) + 1;
+  }
+
+  save.flags[agenda.receipt] = true;
+  save.flags[preciseReceipt] = true;
+  return {
+    cycle: agenda.cycle,
+    mandateId: mandate.id,
+    routeId: route.id,
+    reward: cloneReward(mandate.reward),
+    receipt: preciseReceipt,
+    partnershipBondIds,
+    reliquaryEnding: agenda.reliquaryEnding,
+  };
+}


### PR DESCRIPTION
## Summary

- add the three-act **Ashen Reliquary** sword-and-sorcery world quest with nine character-driven routes
- make origin stats, skills, growth potential, companion careers, guild oaths, offices, risk practices, bonds, and retention promises create different solutions
- add three irreversible endings: reseal the saint-fire, claim the dragon ember, or shatter the reliquary
- award one unique relic and permanent world-state flag per ending, with the claimed ending also carrying a dragon-ember curse
- carry each ending into real guild mandates with a persistent benefit and an explicit cost
- replace the player-facing corporate mandate language with guild writs, oaths, offices, omens, companion promises, church tithes, curses, and lost lore
- expose the quest directly from the guild writ page instead of hiding it in another management dashboard
- add read-only preview, strict stage ordering, latest-save resource revalidation, one-route-per-act receipts, mutually exclusive endings, and old-save parity
- add production-build CI plus dedicated world-quest and ending-balance adversarial tests

## World-design correction

M33-M38 added meaningful systemic tradeoffs, but too much of their presentation resembled a modern company dashboard. M39 corrects that direction by turning the systems into concrete medieval fantasy consequences: the White Candle Church, dead choristers, dragon-fire runes, mercenary shield formations, forbidden bargains, curses, relics, tithes, and destroyed lore.

The quest is not a renamed spreadsheet. It is a playable three-act expedition with irreversible narrative choices. The outcome continues to affect later guild writs, so the world remembers what the player did.

## Player adversarial review

- previews are deterministic and do not mutate saves
- low-reputation mundane caravans cannot access the black-wax writ without knowledge or a relic officer
- players cannot skip acts or complete two routes in one act
- execution recalculates current resources and fails atomically when supplies changed in another tab
- the final relic and ending reward can be claimed only once
- corrupted multi-route or multi-ending saves disable all ending bonuses and surface warnings
- pre-M39 saves with no ending receive exactly the M38 mandate values
- every ending has a permanent advantage and a persistent cost; no ending is a universal free buff
- the guild page and settlement function use the same post-ending costs and rewards

## Verification

- `Caravan CI` run 3: success; M38 regression tests passed
- `Caravan M39 CI` run 1: success; `npm ci`, Astro production build, and the main M39 adversarial suite passed
- `Caravan M39 Balance CI` run 1: success; world-quest flow and ending-balance guardrails passed
- the PR is mergeable without conflicts

## Scope

- `src/scripts/games/caravan/data/ashenReliquary.ts`
- `src/scripts/games/caravan/data/fantasyMandates.ts`
- `src/scripts/games/caravan/data/ashenReliquary.m39.test.ts`
- `src/scripts/games/caravan/data/ashenReliquary.balance.m39.test.ts`
- `src/pages/caravan/ashen-reliquary.astro`
- `src/pages/caravan/mandates.astro`
- `.github/workflows/caravan-m39-ci.yml`
- `.github/workflows/caravan-m39-balance-ci.yml`