### PR TITLE
feat(caravan): add M43 medieval armory doctrines

### DIFF
--- a/.github/workflows/caravan-m43-ci.yml
+++ b/.github/workflows/caravan-m43-ci.yml
@@ -1,0 +1,46 @@
+name: Caravan M43 Armory CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/armory.astro'
+      - 'src/pages/caravan/endurance.astro'
+      - '.github/workflows/caravan-m43-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/armory.astro'
+      - 'src/pages/caravan/endurance.astro'
+      - '.github/workflows/caravan-m43-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-armory-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Production build
+        run: npm run build
+      - name: M43 armory transactions and endurance
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+      - name: M43 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.balance.m43.test.ts
+      - name: Combat, magic, and M42 endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts

--- a/.github/workflows/caravan-m43-ci.yml
+++ b/.github/workflows/caravan-m43-ci.yml
@@ -47,11 +47,16 @@ jobs:
           npx vitest run --reporter=verbose
           src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
           -t "turns forced march into an immediate"
-      - name: M43 camp clarity and atomicity
+      - name: M43 camp consequence clarity
         run: >-
           npx vitest run --reporter=verbose
           src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
-          -t "surfaces the burden consequence|does not allow a second camp action"
+          -t "surfaces the burden consequence"
+      - name: M43 camp transaction atomicity
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          -t "does not allow a second camp action"
       - name: M43 multidimensional player adversarial review
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.balance.m43.test.ts
       - name: Combat, magic, and M42 endurance regression

--- a/.github/workflows/caravan-m43-ci.yml
+++ b/.github/workflows/caravan-m43-ci.yml
@@ -32,8 +32,26 @@ jobs:
         run: npm run build
       - name: M43 armory transactions
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.m43.test.ts
-      - name: M43 armory-aware endurance
-        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+      - name: M43 endurance snapshot and party load
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          -t "requires a strict armory snapshot|snapshots personal and party load"
+      - name: M43 burden-scaled camp recovery
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          -t "makes camp recovery less efficient"
+      - name: M43 burden-scaled forced march
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          -t "turns forced march into an immediate"
+      - name: M43 camp clarity and atomicity
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          -t "surfaces the burden consequence|does not allow a second camp action"
       - name: M43 multidimensional player adversarial review
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.balance.m43.test.ts
       - name: Combat, magic, and M42 endurance regression

--- a/.github/workflows/caravan-m43-ci.yml
+++ b/.github/workflows/caravan-m43-ci.yml
@@ -30,11 +30,10 @@ jobs:
       - run: npm ci
       - name: Production build
         run: npm run build
-      - name: M43 armory transactions and endurance
-        run: >-
-          npx vitest run --reporter=verbose
-          src/scripts/games/caravan/data/armory.m43.test.ts
-          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+      - name: M43 armory transactions
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.m43.test.ts
+      - name: M43 armory-aware endurance
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
       - name: M43 multidimensional player adversarial review
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armory.balance.m43.test.ts
       - name: Combat, magic, and M42 endurance regression

--- a/src/pages/caravan/armory.astro
+++ b/src/pages/caravan/armory.astro
@@ -1,0 +1,231 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="武裝整備所 — 商隊與劍"
+  description="依照中世紀劍與魔法世界的武器熟練、護甲重量、施法媒介與負重整備遠征隊。"
+  lang="zh-TW"
+>
+  <main class="armory-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M43 ARMORY DOCTRINES</p>
+      <h1>武裝整備所</h1>
+      <p>鋼鐵會保命，也會拖慢腳步；法杖、法袍與聖衣能擴張施法容量，但無法提供鎖甲的可靠防護。跨職裝備不被禁止，代價會清楚列在整備報告中。</p>
+      <nav>
+        <a href="/caravan/play">返回主冒險</a>
+        <a href="/caravan/endurance">前往餘燼朝聖</a>
+      </nav>
+    </header>
+
+    <section class="panel doctrine">
+      <h2>整備原則</h2>
+      <div class="doctrine-grid">
+        <article><strong>武器熟練</strong><span>熟練流派命中 +1；勉強運用命中 -2、傷害 -1，仍保留跨職構築。</span></article>
+        <article><strong>護甲重量</strong><span>鎖甲防護最高，但降低敏捷並干擾秘法手勢；超過個人負重容量會再扣敏捷與生命。</span></article>
+        <article><strong>施法媒介</strong><span>法杖與法袍提高秘法上限；錘杖、聖衣與王室聖印提高神恩上限。</span></article>
+        <article><strong>遠征負重</strong><span>負重會進入朝聖整備快照，影響紮營效率與強行軍疲勞。</span></article>
+      </div>
+    </section>
+
+    <section id="notice" class="panel"></section>
+    <section id="party-load" class="panel" hidden></section>
+    <section id="roster" class="roster"></section>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame, type CompanionRecord, type SaveData } from '@scripts/games/caravan/save';
+  import { ITEMS } from '@scripts/games/caravan/data/items';
+  import { memberFromRecord } from '@scripts/games/caravan/data/jobs';
+  import {
+    ARMOR_DISCIPLINE_LABELS,
+    GEAR_FIT_LABELS,
+    WEAPON_DISCIPLINE_LABELS,
+    armoryProfile,
+    armoryRuleForItem,
+    equipArmoryItem,
+    equippableInventory,
+    partyArmoryLoad,
+    unequipArmoryItem,
+    type ArmoryProfile,
+  } from '@scripts/games/caravan/data/armory';
+
+  const noticeEl = document.getElementById('notice')!;
+  const loadEl = document.getElementById('party-load')!;
+  const rosterEl = document.getElementById('roster')!;
+  let save: SaveData | null = null;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function button(label: string, action: () => void, disabled = false, title = ''): HTMLButtonElement {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.textContent = label;
+    element.disabled = disabled;
+    element.title = title;
+    element.addEventListener('click', action);
+    return element;
+  }
+
+  function itemName(id: string | null): string {
+    return id ? ITEMS[id]?.name ?? id : '未裝備';
+  }
+
+  function fitText(record: CompanionRecord, profile: ArmoryProfile): string {
+    const weaponRule = armoryRuleForItem(record.equipment.weapon);
+    const armorRule = armoryRuleForItem(record.equipment.armor);
+    const weapon = weaponRule?.weapon
+      ? `${WEAPON_DISCIPLINE_LABELS[weaponRule.weapon]}・${profile.weaponFit ? GEAR_FIT_LABELS[profile.weaponFit] : '—'}`
+      : '無武器流派';
+    const armor = armorRule?.armor
+      ? `${ARMOR_DISCIPLINE_LABELS[armorRule.armor]}・${profile.armorFit ? GEAR_FIT_LABELS[profile.armorFit] : '—'}`
+      : '無護甲流派';
+    return `${weapon}｜${armor}`;
+  }
+
+  function equip(record: CompanionRecord, itemId: string): void {
+    if (!save) return;
+    try {
+      equipArmoryItem(save, record.id, itemId);
+      saveGame(save);
+      noticeEl.textContent = `${record.name}已裝備「${ITEMS[itemId]?.name ?? itemId}」。`;
+      render();
+    } catch (error) {
+      noticeEl.textContent = error instanceof Error ? error.message : '整備失敗。';
+    }
+  }
+
+  function unequip(record: CompanionRecord, slot: keyof CompanionRecord['equipment']): void {
+    if (!save) return;
+    try {
+      unequipArmoryItem(save, record.id, slot);
+      saveGame(save);
+      noticeEl.textContent = `${record.name}已卸下裝備。`;
+      render();
+    } catch (error) {
+      noticeEl.textContent = error instanceof Error ? error.message : '卸裝失敗。';
+    }
+  }
+
+  function equipmentLine(record: CompanionRecord, slot: keyof CompanionRecord['equipment'], label: string): HTMLElement {
+    const row = document.createElement('div');
+    row.className = 'equipment-row';
+    row.append(text('span', `${label}：${itemName(record.equipment[slot])}`));
+    if (record.equipment[slot]) row.append(button('卸下', () => unequip(record, slot)));
+    return row;
+  }
+
+  function memberCard(record: CompanionRecord): HTMLElement {
+    const profile = armoryProfile(record);
+    const member = memberFromRecord(record) as ReturnType<typeof memberFromRecord> & {
+      armoryWarnings?: string[];
+      mysticCapacityBonus?: { mana: number; favor: number };
+    };
+    const card = document.createElement('article');
+    card.className = `member-card ${profile.overload > 0 ? 'overloaded' : ''}`;
+    card.append(
+      text('p', record.job.toUpperCase(), 'eyebrow'),
+      text('h2', record.name),
+      text('p', `Lv${record.level}｜防禦 ${member.defense}｜生命 ${member.maxHp}｜敏捷 ${member.stats.dex}`, 'summary'),
+      text('p', `個人負重 ${profile.burden}/${profile.capacity}${profile.overload ? `｜超載 ${profile.overload}` : ''}`, 'load'),
+      text('p', fitText(record, profile), 'fit'),
+      text('p', `秘法上限修正 ${profile.mysticCapacity.mana >= 0 ? '+' : ''}${profile.mysticCapacity.mana}｜神恩上限修正 ${profile.mysticCapacity.favor >= 0 ? '+' : ''}${profile.mysticCapacity.favor}`, 'mystic'),
+    );
+
+    const equipment = document.createElement('section');
+    equipment.className = 'equipment';
+    equipment.append(
+      equipmentLine(record, 'weapon', '武器'),
+      equipmentLine(record, 'armor', '護甲'),
+      equipmentLine(record, 'trinket', '飾品'),
+    );
+    card.append(equipment);
+
+    const warnings = document.createElement('ul');
+    warnings.className = 'warnings';
+    const messages = member.armoryWarnings ?? [];
+    if (messages.length === 0) warnings.append(text('li', '目前武裝與訓練相容，沒有額外懲罰。'));
+    else for (const message of messages) warnings.append(text('li', message));
+    card.append(warnings);
+
+    const inventory = document.createElement('section');
+    inventory.className = 'inventory';
+    inventory.append(text('h3', '背包內可裝備物品'));
+    const grid = document.createElement('div');
+    grid.className = 'inventory-grid';
+    for (const { item, count } of equippableInventory(save!)) {
+      const required = item.equip?.minLevel ?? 1;
+      const disabled = record.level < required;
+      const rule = armoryRuleForItem(item.id);
+      const tags = [item.equip?.slot, rule?.weapon ? WEAPON_DISCIPLINE_LABELS[rule.weapon] : '', rule?.armor ? ARMOR_DISCIPLINE_LABELS[rule.armor] : '', `負重 ${rule?.burden ?? 0}`]
+        .filter(Boolean).join('｜');
+      const option = document.createElement('article');
+      option.className = 'inventory-item';
+      option.append(
+        text('strong', `${item.name} ×${count}`),
+        text('span', tags),
+        button(disabled ? `需要 Lv${required}` : '裝備', () => equip(record, item.id), disabled),
+      );
+      grid.append(option);
+    }
+    if (grid.children.length === 0) grid.append(text('p', '背包目前沒有可裝備物品。'));
+    inventory.append(grid);
+    card.append(inventory);
+    return card;
+  }
+
+  function render(): void {
+    if (!save) return;
+    const planIds = save.expeditionPlan?.activeIds ?? [save.protagonist.id, ...save.companions.slice(0, 3).map((member) => member.id)];
+    const partyLoad = partyArmoryLoad(save, planIds);
+    loadEl.hidden = false;
+    loadEl.replaceChildren(
+      text('h2', '目前出征隊負重'),
+      text('p', `${partyLoad.burden}/${partyLoad.capacity}${partyLoad.overload ? `｜超載 ${partyLoad.overload}` : '｜整隊可負荷'}`),
+      text('p', '負重不只是介面資訊：武裝已立即影響戰鬥面板、武器命中與秘法／神恩容量；餘燼朝聖會把整備快照鎖入行程。'),
+    );
+    const members = [save.protagonist, ...save.companions];
+    rosterEl.replaceChildren(...members.map(memberCard));
+  }
+
+  save = loadGame();
+  if (!save) {
+    noticeEl.replaceChildren(text('h2', '尚未建立商隊'), text('p', '請先返回主冒險建立角色與存檔。'));
+  } else {
+    noticeEl.textContent = '武裝報告會即時計算，不會隱藏跨職裝備的代價。';
+    render();
+  }
+</script>
+
+<style>
+  .armory-page { max-width: 1180px; margin: 0 auto; padding: 5rem 1.25rem 7rem; color: #efe7d4; }
+  .hero { padding: 2rem; border: 1px solid #6d573c; background: linear-gradient(135deg, #1d1813, #30251a); }
+  .hero h1 { margin: .4rem 0 1rem; font-size: clamp(2.4rem, 7vw, 5.8rem); }
+  .hero p { max-width: 800px; line-height: 1.8; }
+  nav { display: flex; gap: .75rem; flex-wrap: wrap; margin-top: 1.5rem; }
+  nav a, button { border: 1px solid #a88655; background: #2b2117; color: #f3dfb6; padding: .65rem .9rem; cursor: pointer; text-decoration: none; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .eyebrow { letter-spacing: .16em; color: #c6a66e; font-size: .75rem; }
+  .panel { margin-top: 1.2rem; padding: 1.25rem; border: 1px solid #554735; background: #171411; }
+  .doctrine-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: .8rem; }
+  .doctrine-grid article { display: grid; gap: .45rem; padding: 1rem; background: #231d16; border-left: 3px solid #8f6e3d; line-height: 1.55; }
+  .roster { display: grid; gap: 1rem; margin-top: 1.2rem; }
+  .member-card { padding: 1.25rem; border: 1px solid #5e503d; background: #1b1713; }
+  .member-card.overloaded { border-color: #a54b3b; box-shadow: inset 4px 0 #a54b3b; }
+  .member-card h2 { margin: .2rem 0 .5rem; font-size: 1.8rem; }
+  .summary, .load, .fit, .mystic { color: #d7c7aa; }
+  .equipment { display: grid; gap: .45rem; margin: 1rem 0; }
+  .equipment-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .6rem .75rem; background: #282117; }
+  .warnings { margin: 1rem 0; padding-left: 1.3rem; line-height: 1.6; color: #e4c68d; }
+  .inventory { border-top: 1px solid #4c4031; padding-top: 1rem; }
+  .inventory-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .65rem; }
+  .inventory-item { display: grid; gap: .5rem; padding: .8rem; background: #242019; }
+  .inventory-item span { color: #a99a81; font-size: .86rem; }
+  @media (max-width: 640px) { .armory-page { padding-top: 2rem; } .hero { padding: 1.2rem; } }
+</style>

--- a/src/pages/caravan/endurance.astro
+++ b/src/pages/caravan/endurance.astro
@@ -4,16 +4,17 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="餘燼朝聖 — 商隊與劍"
-  description="連續迎戰灰燼騎士、無舌唱詩班與龍燼化身，讓生命、秘法、神恩和補給跨戰保留。"
+  description="連續迎戰灰燼騎士、無舌唱詩班與龍燼化身，讓生命、秘法、神恩、武裝負重和補給跨戰保留。"
   lang="zh-TW"
 >
   <main class="endurance-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M42 EXPEDITION ENDURANCE</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M43 ARMORY ENDURANCE</p>
       <h1>餘燼朝聖</h1>
-      <p>三場戰鬥、兩次營地決策。生命、秘法、神恩與秘法灼傷不會在戰後自動重置；你必須決定何時休息、何時守夜，以及是否為更高報酬強行軍。</p>
+      <p>三場戰鬥、兩次營地決策。生命、秘法、神恩、秘法灼傷與出發時的武裝負重不會在戰後自動重置；鋼鐵能保命，也會降低紮營效率並提高強行軍疲勞。</p>
       <nav>
         <a href="/caravan/play">返回主冒險</a>
+        <a href="/caravan/armory">武裝整備所</a>
         <a href="/caravan/ashen-reliquary">灰燼聖匣</a>
       </nav>
     </header>
@@ -64,9 +65,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     isEnduranceRun,
     type EnduranceCampChoice,
     type EnduranceRun,
-  } from '@scripts/games/caravan/data/endurance';
+  } from '@scripts/games/caravan/data/enduranceArmory';
 
-  const RUN_KEY = 'caravan-endurance-v2';
+  const RUN_KEY = 'caravan-endurance-armory-v1';
   const noticeEl = document.getElementById('notice')!;
   const progressEl = document.getElementById('progress')!;
   const intentEl = document.getElementById('intent')!;
@@ -145,9 +146,12 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       const resist = (enemy.resists ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       card.append(text('p', `弱點：${weak}｜抗性：${resist}`, 'affinity'));
     } else {
-      const member = unit as PartyMember;
+      const member = unit as PartyMember & { armoryBurden?: number; armoryCapacity?: number; armoryOverload?: number; armoryWarnings?: string[] };
       card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
+      card.append(text('p', `武裝負重 ${member.armoryBurden ?? 0}/${member.armoryCapacity ?? 0}${member.armoryOverload ? `｜超載 ${member.armoryOverload}` : ''}`, 'armory'));
       if (member.mystic) card.append(text('p', mysticPowerText(member.mystic), `mystic mystic-${member.mystic.kind}`));
+      const costly = (member.armoryWarnings ?? []).filter((warning) => !warning.startsWith('武器熟練'));
+      if (costly.length > 0) card.append(text('p', costly.join(' '), 'armory-warning'));
     }
     return card;
   }
@@ -316,7 +320,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     campEl.append(
       text('p', `CAMP ${run.stage - 1}`, 'eyebrow'),
       text('h2', '營火只能維持到天亮'),
-      text('p', '選擇一項整備。倒地成員不會在營地復活，生命與魔法資源也不會自行恢復。'),
+      text('p', '選擇一項整備。倒地成員不會在營地復活；重裝者還必須花時間卸甲、清理鎖環與重新束帶。'),
     );
     const grid = document.createElement('div');
     grid.className = 'camp-grid';
@@ -355,9 +359,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       resultEl.append(
         text('p', 'PILGRIMAGE ENDED', 'eyebrow'),
         text('h2', '遠征隊未能走到龍燼之心'),
-        text('p', `本次止步於第 ${run.stage} 戰。倒地、補給、魔法消耗與過載決策共同造成了結果。`),
+        text('p', `本次止步於第 ${run.stage} 戰。倒地、補給、魔法消耗、武裝重量與過載決策共同造成了結果。`),
         button('從第一戰重新挑戰', resetRun),
-        link('返回主冒險重新整備', '/caravan/play', 'return-link'),
+        link('返回武裝整備所', '/caravan/armory', 'return-link'),
       );
       return;
     }
@@ -416,8 +420,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       }
       noticeEl.append(
         text('h2', `健康出征隊 ${access.partySize} 人`),
-        text('p', '開始後，三場戰鬥共享生命與魔法狀態。每次行動都會保存；中途關頁只會保留損傷並追加疲勞。'),
-        button('開始餘燼朝聖', () => {
+        text('p', '開始後會鎖定目前武裝與負重。三場戰鬥共享生命與魔法狀態；每次行動都會保存，中途關頁只會保留損傷並追加疲勞。'),
+        link('先檢查武裝與負重', '/caravan/armory', 'return-link'),
+        button('以目前武裝開始餘燼朝聖', () => {
           run = createEnduranceRun(save);
           saveRun();
           startBattle();
@@ -455,6 +460,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .unit { padding: 15px; border: 1px solid #49362d; background: #201613; }
   .unit.down { opacity: .45; }
   .unit-status { color: #d8b87d !important; } .affinity { color: #c89d88 !important; } .formation { color: #9fb88d !important; }
+  .armory { color: #d7ad75 !important; } .armory-warning { color: #e18d73 !important; font-size: .86rem; }
   .mystic-mana { color: #8fc3df !important; } .mystic-favor { color: #e7cc75 !important; }
   .actions, .camp, .result, .log-panel { margin-top: 18px; padding: 22px; }
   .action-resource { color: #d8c284 !important; }

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -12,8 +12,11 @@ export interface MysticMoveRule {
   strainRelief: number;
 }
 
+interface ArmoryMysticRuntime {
+  mysticCapacityBonus?: Partial<Record<MysticKind, number>>;
+}
+
 const RULES: Record<string, MysticMoveRule> = {
-  // 法師核心：炎術偏爆發，霜術偏節制與控制。
   fireball: { kind: 'mana', school: 'pyromancy', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
   'ice-spike': { kind: 'mana', school: 'cryomancy', cost: 1, gain: 0, overcast: true, strainRelief: 0 },
   'gravity-crush': { kind: 'mana', school: 'arcane', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
@@ -21,7 +24,6 @@ const RULES: Record<string, MysticMoveRule> = {
   'meteor-fall': { kind: 'mana', school: 'pyromancy', cost: 4, gain: 0, overcast: true, strainRelief: 0 },
   'arcane-focus': { kind: 'mana', school: 'arcane', cost: 0, gain: 3, overcast: false, strainRelief: 1 },
 
-  // 教士核心：聖擊建立神恩，奇蹟消耗神恩。
   'holy-strike': { kind: 'favor', school: 'theurgy', cost: 0, gain: 1, overcast: false, strainRelief: 0 },
   heal: { kind: 'favor', school: 'theurgy', cost: 1, gain: 0, overcast: false, strainRelief: 0 },
   'holy-nova': { kind: 'favor', school: 'theurgy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
@@ -64,10 +66,6 @@ function clamp(value: number, minimum: number, maximum: number): number {
   return Math.max(minimum, Math.min(maximum, value));
 }
 
-/**
- * 未逐招登記的裝備／專精法術仍會依命中屬性與傷害屬性取得保守規則，
- * 避免日後新增魔法招式時意外繞過秘法或神恩成本。
- */
 export function mysticRuleForMove(move: Move): MysticMoveRule | null {
   const explicit = RULES[move.id];
   if (explicit) return explicit;
@@ -108,8 +106,9 @@ function decoratedMove(move: Move): Move {
 }
 
 function maximumPower(member: PartyMember, kind: MysticKind): number {
-  if (kind === 'mana') return clamp(4 + Math.floor(member.stats.int / 5), 5, 9);
-  return clamp(2 + Math.floor(member.stats.cha / 5), 4, 7);
+  const bonus = (member as PartyMember & ArmoryMysticRuntime).mysticCapacityBonus?.[kind] ?? 0;
+  if (kind === 'mana') return clamp(4 + Math.floor(member.stats.int / 5) + bonus, 3, 12);
+  return clamp(2 + Math.floor(member.stats.cha / 5) + bonus, 2, 10);
 }
 
 function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
@@ -122,10 +121,6 @@ function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
   };
 }
 
-/**
- * 保留傳入角色物件身分，因遠征與既有測試會在戰鬥後讀取同一份 HP；
- * 只替換招式陣列為安全副本，避免修改 JOBS 共用資料。
- */
 export function prepareMysticPartyMember(member: PartyMember): PartyMember {
   const copiedMoves = member.moves.map((move) => ({ ...move }));
   const hasMana = copiedMoves.some((move) => mysticRuleForMove(move)?.kind === 'mana');

--- a/src/scripts/games/caravan/data/armory.balance.m43.test.ts
+++ b/src/scripts/games/caravan/data/armory.balance.m43.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { createProtagonist, type CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { armoryProfile } from './armory';
+
+const WEAPONS = ['salt-crystal-blade', 'ridge-mist-bow', 'ghostflame-staff', 'brine-blessed-mace'] as const;
+const ARMORS = ['ridgeleather-vest', 'saltforged-mail', 'ashveil-robe', 'brinewarded-vestment'] as const;
+
+interface Probe {
+  key: string;
+  defense: number;
+  hp: number;
+  dex: number;
+  offense: number;
+  mystic: number;
+  burden: number;
+  overload: number;
+  warnings: number;
+}
+
+function record(job: CompanionRecord['job']): CompanionRecord {
+  const member = createProtagonist({ job });
+  member.id = job;
+  member.name = job;
+  member.level = 4;
+  member.stats = job === 'swordsman'
+    ? { str: 17, dex: 13, int: 9, cha: 11, con: 16 }
+    : job === 'ranger'
+      ? { str: 11, dex: 18, int: 11, cha: 10, con: 13 }
+      : job === 'mage'
+        ? { str: 8, dex: 13, int: 19, cha: 11, con: 11 }
+        : { str: 12, dex: 10, int: 13, cha: 18, con: 15 };
+  member.maxHp = job === 'swordsman' ? 32 : job === 'cleric' ? 28 : job === 'ranger' ? 25 : 22;
+  member.skills = { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 };
+  return member;
+}
+
+function probes(job: CompanionRecord['job']): Probe[] {
+  const result: Probe[] = [];
+  for (const weapon of WEAPONS) {
+    for (const armor of ARMORS) {
+      const member = record(job);
+      member.equipment = { weapon, armor, trinket: null };
+      const profile = armoryProfile(member);
+      const combatant = memberFromRecord(member);
+      const weaponMove = combatant.moves[0];
+      const relevantMystic = job === 'mage' ? profile.mysticCapacity.mana : job === 'cleric' ? profile.mysticCapacity.favor : 0;
+      result.push({
+        key: `${weapon}/${armor}`,
+        defense: combatant.defense,
+        hp: combatant.maxHp,
+        dex: combatant.stats.dex,
+        offense: (weaponMove.hitBonus ?? 0) + (combatant.damageBonus ?? 0),
+        mystic: relevantMystic,
+        burden: profile.burden,
+        overload: profile.overload,
+        warnings: profile.warnings.filter((warning) => !warning.startsWith('武器熟練')).length,
+      });
+    }
+  }
+  return result;
+}
+
+function dominates(a: Probe, b: Probe): boolean {
+  const noWorse = a.defense >= b.defense
+    && a.hp >= b.hp
+    && a.dex >= b.dex
+    && a.offense >= b.offense
+    && a.mystic >= b.mystic
+    && a.burden <= b.burden
+    && a.overload <= b.overload
+    && a.warnings <= b.warnings;
+  const strictlyBetter = a.defense > b.defense
+    || a.hp > b.hp
+    || a.dex > b.dex
+    || a.offense > b.offense
+    || a.mystic > b.mystic
+    || a.burden < b.burden
+    || a.overload < b.overload
+    || a.warnings < b.warnings;
+  return noWorse && strictlyBetter;
+}
+
+function frontier(entries: Probe[]): Probe[] {
+  return entries.filter((candidate) => !entries.some((other) => other !== candidate && dominates(other, candidate)));
+}
+
+describe('M43 player-perspective multidimensional adversarial review', () => {
+  for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
+    it(`${job} keeps several non-dominated armory identities`, () => {
+      const entries = probes(job);
+      const efficient = frontier(entries);
+      expect(entries).toHaveLength(16);
+      expect(efficient.length).toBeGreaterThanOrEqual(3);
+      expect(entries.some((entry) => entry.warnings === 0 && entry.overload === 0)).toBe(true);
+      expect(entries.some((entry) => entry.defense === Math.max(...entries.map((probe) => probe.defense)))).toBe(true);
+      expect(entries.some((entry) => entry.burden === Math.min(...entries.map((probe) => probe.burden)))).toBe(true);
+    });
+  }
+
+  it('prevents one universal loadout from dominating all four professions', () => {
+    const frontiers = new Map<string, number>();
+    for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
+      for (const entry of frontier(probes(job))) frontiers.set(entry.key, (frontiers.get(entry.key) ?? 0) + 1);
+    }
+    expect(Math.max(...frontiers.values())).toBeLessThan(4);
+  });
+
+  it('makes steel, mobility, arcana, and theurgy win different dimensions', () => {
+    const swordsman = probes('swordsman');
+    const ranger = probes('ranger');
+    const mage = probes('mage');
+    const cleric = probes('cleric');
+    const heavySteel = swordsman.find((entry) => entry.key === 'salt-crystal-blade/saltforged-mail')!;
+    const mobileArcher = ranger.find((entry) => entry.key === 'ridge-mist-bow/ridgeleather-vest')!;
+    const arcaneFocus = mage.find((entry) => entry.key === 'ghostflame-staff/ashveil-robe')!;
+    const sacredFocus = cleric.find((entry) => entry.key === 'brine-blessed-mace/brinewarded-vestment')!;
+    expect(heavySteel.defense).toBeGreaterThan(arcaneFocus.defense);
+    expect(mobileArcher.dex).toBeGreaterThan(heavySteel.dex);
+    expect(arcaneFocus.mystic).toBeGreaterThan(0);
+    expect(sacredFocus.mystic).toBeGreaterThan(0);
+    expect(new Set([heavySteel.key, mobileArcher.key, arcaneFocus.key, sacredFocus.key]).size).toBe(4);
+  });
+
+  it('keeps strained cross-class builds playable but never strictly superior', () => {
+    for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
+      const entries = probes(job);
+      const strained = entries.filter((entry) => entry.warnings > 0);
+      expect(strained.length).toBeGreaterThan(0);
+      expect(strained.every((entry) => entry.defense > 0 && entry.hp > 0 && entry.dex > 0)).toBe(true);
+      expect(strained.some((entry) => entries.some((other) => dominates(other, entry)))).toBe(true);
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/armory.balance.m43.test.ts
+++ b/src/scripts/games/caravan/data/armory.balance.m43.test.ts
@@ -85,11 +85,16 @@ function frontier(entries: Probe[]): Probe[] {
   return entries.filter((candidate) => !entries.some((other) => other !== candidate && dominates(other, candidate)));
 }
 
+function compact(entry: Probe): string {
+  return `${entry.key}{DEF${entry.defense},HP${entry.hp},DEX${entry.dex},OFF${entry.offense},MYS${entry.mystic},W${entry.burden},O${entry.overload},!${entry.warnings}}`;
+}
+
 describe('M43 player-perspective multidimensional adversarial review', () => {
   for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
     it(`${job} keeps several non-dominated armory identities`, () => {
       const entries = probes(job);
       const efficient = frontier(entries);
+      console.log(`[M43 ARMORY] ${job}: frontier=${efficient.length}/16 :: ${efficient.map(compact).join(' | ')}`);
       expect(entries).toHaveLength(16);
       expect(efficient.length).toBeGreaterThanOrEqual(3);
       expect(entries.some((entry) => entry.warnings === 0 && entry.overload === 0)).toBe(true);
@@ -103,6 +108,7 @@ describe('M43 player-perspective multidimensional adversarial review', () => {
     for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
       for (const entry of frontier(probes(job))) frontiers.set(entry.key, (frontiers.get(entry.key) ?? 0) + 1);
     }
+    console.log(`[M43 ARMORY] frontier overlap :: ${[...frontiers.entries()].sort((a, b) => b[1] - a[1]).map(([key, count]) => `${key}=${count}`).join(', ')}`);
     expect(Math.max(...frontiers.values())).toBeLessThan(4);
   });
 
@@ -115,6 +121,7 @@ describe('M43 player-perspective multidimensional adversarial review', () => {
     const mobileArcher = ranger.find((entry) => entry.key === 'ridge-mist-bow/ridgeleather-vest')!;
     const arcaneFocus = mage.find((entry) => entry.key === 'ghostflame-staff/ashveil-robe')!;
     const sacredFocus = cleric.find((entry) => entry.key === 'brine-blessed-mace/brinewarded-vestment')!;
+    console.log(`[M43 ARMORY] identities :: steel=${compact(heavySteel)} | mobility=${compact(mobileArcher)} | arcana=${compact(arcaneFocus)} | theurgy=${compact(sacredFocus)}`);
     expect(heavySteel.defense).toBeGreaterThan(arcaneFocus.defense);
     expect(mobileArcher.dex).toBeGreaterThan(heavySteel.dex);
     expect(arcaneFocus.mystic).toBeGreaterThan(0);
@@ -126,9 +133,11 @@ describe('M43 player-perspective multidimensional adversarial review', () => {
     for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
       const entries = probes(job);
       const strained = entries.filter((entry) => entry.warnings > 0);
+      const dominatedStrained = strained.filter((entry) => entries.some((other) => dominates(other, entry)));
+      console.log(`[M43 ARMORY] ${job}: strained=${strained.length}, dominated-strained=${dominatedStrained.length}`);
       expect(strained.length).toBeGreaterThan(0);
       expect(strained.every((entry) => entry.defense > 0 && entry.hp > 0 && entry.dex > 0)).toBe(true);
-      expect(strained.some((entry) => entries.some((other) => dominates(other, entry)))).toBe(true);
+      expect(dominatedStrained.length).toBeGreaterThan(0);
     }
   });
 });

--- a/src/scripts/games/caravan/data/armory.m43.test.ts
+++ b/src/scripts/games/caravan/data/armory.m43.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { startCombat, type EnemyUnit } from '../combat';
+import { createRng } from '../rng';
+import { createProtagonist, newGame, type CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import {
+  adjustMovesForArmory,
+  armoryProfile,
+  equipArmoryItem,
+  partyArmoryLoad,
+  unequipArmoryItem,
+} from './armory';
+
+function record(job: CompanionRecord['job'], id = job): CompanionRecord {
+  const member = createProtagonist({ job });
+  member.id = id;
+  member.name = id;
+  member.level = 4;
+  member.stats = job === 'swordsman'
+    ? { str: 17, dex: 12, int: 9, cha: 11, con: 17 }
+    : job === 'ranger'
+      ? { str: 11, dex: 18, int: 11, cha: 10, con: 13 }
+      : job === 'mage'
+        ? { str: 8, dex: 12, int: 19, cha: 11, con: 11 }
+        : { str: 12, dex: 10, int: 13, cha: 18, con: 15 };
+  member.skills = { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 };
+  return member;
+}
+
+function dummyEnemy(): EnemyUnit {
+  return {
+    id: 'dummy', name: '木樁', stats: { str: 10, dex: 10, int: 10, cha: 10, con: 10 },
+    maxHp: 20, hp: 20, defense: 10,
+    moves: [{ id: 'tap', name: '輕敲', kind: 'attack', target: 'enemy', hitStat: 'str', damage: { dice: 1, sides: 2 }, narration: '{actor}敲擊{target}，造成 {amount} 點傷害。' }],
+    intents: [{ weight: 1, moveId: 'tap' }],
+  };
+}
+
+describe('M43 medieval armory doctrines', () => {
+  it('keeps previews deterministic and read-only', () => {
+    const mage = record('mage');
+    mage.equipment.weapon = 'ghostflame-staff';
+    mage.equipment.armor = 'ashveil-robe';
+    const before = JSON.stringify(mage);
+    expect(armoryProfile(mage)).toEqual(armoryProfile(mage));
+    expect(JSON.stringify(mage)).toBe(before);
+  });
+
+  it('turns staff and robe into real arcane capacity instead of decorative stats', () => {
+    const mage = record('mage');
+    mage.equipment.weapon = 'ghostflame-staff';
+    mage.equipment.armor = 'ashveil-robe';
+    const profile = armoryProfile(mage);
+    expect(profile.weaponFit).toBe('mastered');
+    expect(profile.armorFit).toBe('mastered');
+    expect(profile.mysticCapacity.mana).toBe(3);
+    const combat = startCombat(createRng(43), [memberFromRecord(mage)], [dummyEnemy()]);
+    expect(combat.party[0].mystic).toMatchObject({ kind: 'mana', max: 10, current: 10 });
+  });
+
+  it('lets a mage wear mail but exposes steel interference and encumbrance', () => {
+    const mage = record('mage');
+    mage.equipment.weapon = 'salt-crystal-blade';
+    mage.equipment.armor = 'saltforged-mail';
+    const profile = armoryProfile(mage);
+    expect(profile.weaponFit).toBe('trained');
+    expect(profile.armorFit).toBe('strained');
+    expect(profile.mysticCapacity.mana).toBeLessThan(0);
+    expect(profile.statAdjustments.dex).toBeLessThan(0);
+    expect(profile.warnings.some((warning) => warning.includes('鎖甲'))).toBe(true);
+    const combat = startCombat(createRng(44), [memberFromRecord(mage)], [dummyEnemy()]);
+    expect(combat.party[0].mystic!.max).toBeLessThan(7);
+    expect(combat.party[0].defense).toBeGreaterThan(11);
+  });
+
+  it('makes mastered weapon moves more accurate and strained weapons costly but usable', () => {
+    const swordsman = record('swordsman');
+    swordsman.equipment.weapon = 'salt-crystal-blade';
+    const mastered = adjustMovesForArmory(swordsman, memberFromRecord(swordsman).moves)
+      .find((move) => move.id === 'crystal-shatter-slash')!;
+    expect(mastered.hitBonus).toBe(2); // memberFromRecord already applied +1; explicit second pass proves deterministic modifier
+
+    const ranger = record('ranger');
+    ranger.equipment.weapon = 'ghostflame-staff';
+    const strained = memberFromRecord(ranger).moves.find((move) => move.id === 'soulfire-burst')!;
+    expect(strained.hitBonus).toBe(-2);
+    expect(armoryProfile(ranger).damageAdjustment).toBe(-1);
+  });
+
+  it('recognizes martial-cleric specialization without forcing all clerics into robes', () => {
+    const cleric = record('cleric');
+    cleric.specialization = 'inquisitor';
+    cleric.equipment.weapon = 'brine-blessed-mace';
+    cleric.equipment.armor = 'saltforged-mail';
+    const profile = armoryProfile(cleric);
+    expect(profile.weaponFit).toBe('mastered');
+    expect(profile.armorFit).toBe('mastered');
+    expect(profile.mysticCapacity.favor).toBe(1);
+    expect(profile.warnings.some((warning) => warning.includes('護甲版型'))).toBe(false);
+  });
+
+  it('revalidates inventory and swaps equipment atomically', () => {
+    const save = newGame(4301, { job: 'swordsman' });
+    save.protagonist.level = 4;
+    save.inventory['salt-crystal-blade'] = 1;
+    save.inventory['ancient-king-blade'] = 1;
+    equipArmoryItem(save, 'protagonist', 'salt-crystal-blade');
+    expect(save.protagonist.equipment.weapon).toBe('salt-crystal-blade');
+    expect(save.inventory['salt-crystal-blade']).toBeUndefined();
+    equipArmoryItem(save, 'protagonist', 'ancient-king-blade');
+    expect(save.protagonist.equipment.weapon).toBe('ancient-king-blade');
+    expect(save.inventory['salt-crystal-blade']).toBe(1);
+    expect(() => equipArmoryItem(save, 'protagonist', 'ghostflame-staff')).toThrow('背包中沒有');
+    unequipArmoryItem(save, 'protagonist', 'weapon');
+    expect(save.inventory['ancient-king-blade']).toBe(1);
+  });
+
+  it('aggregates party burden and preserves multiple viable load identities', () => {
+    const save = newGame(4302, { job: 'swordsman' });
+    save.protagonist = record('swordsman', 'protagonist');
+    const ranger = record('ranger', 'ranger');
+    const mage = record('mage', 'mage');
+    const cleric = record('cleric', 'cleric');
+    save.companions = [ranger, mage, cleric];
+    save.protagonist.equipment = { weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: null };
+    ranger.equipment = { weapon: 'ridge-mist-bow', armor: 'ridgeleather-vest', trinket: null };
+    mage.equipment = { weapon: 'ghostflame-staff', armor: 'ashveil-robe', trinket: 'saltglass-talisman' };
+    cleric.equipment = { weapon: 'brine-blessed-mace', armor: 'brinewarded-vestment', trinket: null };
+    const load = partyArmoryLoad(save);
+    expect(load.burden).toBeGreaterThan(0);
+    expect(load.capacity).toBeGreaterThan(load.burden);
+    expect(load.overload).toBe(0);
+    expect(new Set(Object.values(load.members).map((profile) => `${profile.weaponFit}/${profile.armorFit}`)).size).toBeGreaterThan(1);
+  });
+});

--- a/src/scripts/games/caravan/data/armory.m43.test.ts
+++ b/src/scripts/games/caravan/data/armory.m43.test.ts
@@ -127,9 +127,13 @@ describe('M43 medieval armory doctrines', () => {
     mage.equipment = { weapon: 'ghostflame-staff', armor: 'ashveil-robe', trinket: 'saltglass-talisman' };
     cleric.equipment = { weapon: 'brine-blessed-mace', armor: 'brinewarded-vestment', trinket: null };
     const load = partyArmoryLoad(save);
+    const profiles = Object.values(load.members);
     expect(load.burden).toBeGreaterThan(0);
     expect(load.capacity).toBeGreaterThan(load.burden);
     expect(load.overload).toBe(0);
-    expect(new Set(Object.values(load.members).map((profile) => `${profile.weaponFit}/${profile.armorFit}`)).size).toBeGreaterThan(1);
+    expect(profiles.every((profile) => profile.weaponFit === 'mastered' && profile.armorFit === 'mastered')).toBe(true);
+    expect(new Set(profiles.map((profile) => profile.burden)).size).toBeGreaterThanOrEqual(3);
+    expect(profiles.filter((profile) => profile.mysticCapacity.mana > 0)).toHaveLength(1);
+    expect(profiles.filter((profile) => profile.mysticCapacity.favor > 0)).toHaveLength(1);
   });
 });

--- a/src/scripts/games/caravan/data/armory.m43.test.ts
+++ b/src/scripts/games/caravan/data/armory.m43.test.ts
@@ -4,7 +4,6 @@ import { createRng } from '../rng';
 import { createProtagonist, newGame, type CompanionRecord } from '../save';
 import { memberFromRecord } from './jobs';
 import {
-  adjustMovesForArmory,
   armoryProfile,
   equipArmoryItem,
   partyArmoryLoad,
@@ -55,7 +54,8 @@ describe('M43 medieval armory doctrines', () => {
     expect(profile.armorFit).toBe('mastered');
     expect(profile.mysticCapacity.mana).toBe(3);
     const combat = startCombat(createRng(43), [memberFromRecord(mage)], [dummyEnemy()]);
-    expect(combat.party[0].mystic).toMatchObject({ kind: 'mana', max: 10, current: 10 });
+    // Both legacy equipment INT bonuses and the new staff/robe focus capacity intentionally compose.
+    expect(combat.party[0].mystic).toMatchObject({ kind: 'mana', max: 11, current: 11 });
   });
 
   it('lets a mage wear mail but exposes steel interference and encumbrance', () => {
@@ -76,9 +76,9 @@ describe('M43 medieval armory doctrines', () => {
   it('makes mastered weapon moves more accurate and strained weapons costly but usable', () => {
     const swordsman = record('swordsman');
     swordsman.equipment.weapon = 'salt-crystal-blade';
-    const mastered = adjustMovesForArmory(swordsman, memberFromRecord(swordsman).moves)
+    const mastered = memberFromRecord(swordsman).moves
       .find((move) => move.id === 'crystal-shatter-slash')!;
-    expect(mastered.hitBonus).toBe(2); // memberFromRecord already applied +1; explicit second pass proves deterministic modifier
+    expect(mastered.hitBonus).toBe(1);
 
     const ranger = record('ranger');
     ranger.equipment.weapon = 'ghostflame-staff';

--- a/src/scripts/games/caravan/data/armory.ts
+++ b/src/scripts/games/caravan/data/armory.ts
@@ -1,0 +1,268 @@
+import type { Move } from '../combat';
+import type { CompanionRecord, SaveData } from '../save';
+import type { StatBlock } from '../types';
+import { ITEMS, type ItemDef } from './items';
+
+export type WeaponDiscipline = 'blade' | 'bow' | 'staff' | 'mace';
+export type ArmorDiscipline = 'light' | 'mail' | 'robe' | 'vestment';
+export type GearFit = 'mastered' | 'trained' | 'strained';
+
+export interface ArmoryItemRule {
+  itemId: string;
+  burden: number;
+  weapon?: WeaponDiscipline;
+  armor?: ArmorDiscipline;
+  manaCapacity?: number;
+  favorCapacity?: number;
+}
+
+export interface ArmoryProfile {
+  burden: number;
+  capacity: number;
+  overload: number;
+  weaponFit: GearFit | null;
+  armorFit: GearFit | null;
+  weaponHitBonus: number;
+  damageAdjustment: number;
+  defenseAdjustment: number;
+  maxHpAdjustment: number;
+  statAdjustments: Partial<StatBlock>;
+  mysticCapacity: { mana: number; favor: number };
+  warnings: string[];
+}
+
+export interface PartyArmoryLoad {
+  burden: number;
+  capacity: number;
+  overload: number;
+  members: Record<string, ArmoryProfile>;
+}
+
+const RULES: Record<string, ArmoryItemRule> = {
+  'salt-crystal-blade': { itemId: 'salt-crystal-blade', burden: 2, weapon: 'blade' },
+  'ancient-king-blade': { itemId: 'ancient-king-blade', burden: 2, weapon: 'blade' },
+  'swordsaint-bokken': { itemId: 'swordsaint-bokken', burden: 1, weapon: 'blade' },
+  'ridge-mist-bow': { itemId: 'ridge-mist-bow', burden: 2, weapon: 'bow' },
+  'ghostflame-staff': { itemId: 'ghostflame-staff', burden: 1, weapon: 'staff', manaCapacity: 1 },
+  'brine-crystal-staff': { itemId: 'brine-crystal-staff', burden: 1, weapon: 'staff', manaCapacity: 1 },
+  'brine-blessed-mace': { itemId: 'brine-blessed-mace', burden: 2, weapon: 'mace', favorCapacity: 1 },
+
+  'ridgeleather-vest': { itemId: 'ridgeleather-vest', burden: 1, armor: 'light' },
+  'pilgrim-warded-cloak': { itemId: 'pilgrim-warded-cloak', burden: 2, armor: 'light' },
+  'saltforged-mail': { itemId: 'saltforged-mail', burden: 3, armor: 'mail', manaCapacity: -2 },
+  'ashveil-robe': { itemId: 'ashveil-robe', burden: 1, armor: 'robe', manaCapacity: 2 },
+  'brinewarded-vestment': { itemId: 'brinewarded-vestment', burden: 1, armor: 'vestment', favorCapacity: 2 },
+
+  'overseer-ledger': { itemId: 'overseer-ledger', burden: 1 },
+  'den-idol': { itemId: 'den-idol', burden: 1 },
+  'wanderers-compass': { itemId: 'wanderers-compass', burden: 0 },
+  'salt-crystal-core': { itemId: 'salt-crystal-core', burden: 1 },
+  'royal-courier-sigil': { itemId: 'royal-courier-sigil', burden: 0, favorCapacity: 1 },
+  'saltglass-talisman': { itemId: 'saltglass-talisman', burden: 0, manaCapacity: 1 },
+};
+
+const WEAPON_FIT: Record<CompanionRecord['job'], Record<WeaponDiscipline, GearFit>> = {
+  swordsman: { blade: 'mastered', mace: 'trained', bow: 'trained', staff: 'strained' },
+  ranger: { blade: 'trained', mace: 'strained', bow: 'mastered', staff: 'strained' },
+  mage: { blade: 'trained', mace: 'strained', bow: 'strained', staff: 'mastered' },
+  cleric: { blade: 'trained', mace: 'mastered', bow: 'strained', staff: 'trained' },
+};
+
+const ARMOR_FIT: Record<CompanionRecord['job'], Record<ArmorDiscipline, GearFit>> = {
+  swordsman: { light: 'trained', mail: 'mastered', robe: 'strained', vestment: 'trained' },
+  ranger: { light: 'mastered', mail: 'trained', robe: 'strained', vestment: 'strained' },
+  mage: { light: 'trained', mail: 'strained', robe: 'mastered', vestment: 'trained' },
+  cleric: { light: 'trained', mail: 'trained', robe: 'trained', vestment: 'mastered' },
+};
+
+export const GEAR_FIT_LABELS: Record<GearFit, string> = {
+  mastered: '熟練',
+  trained: '可用',
+  strained: '勉強運用',
+};
+
+export const WEAPON_DISCIPLINE_LABELS: Record<WeaponDiscipline, string> = {
+  blade: '刀劍',
+  bow: '弓弩',
+  staff: '法杖',
+  mace: '錘杖',
+};
+
+export const ARMOR_DISCIPLINE_LABELS: Record<ArmorDiscipline, string> = {
+  light: '輕甲',
+  mail: '鎖甲',
+  robe: '法袍',
+  vestment: '聖衣',
+};
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function memberById(save: SaveData, memberId: string): CompanionRecord | undefined {
+  return memberId === save.protagonist.id
+    ? save.protagonist
+    : save.companions.find((member) => member.id === memberId);
+}
+
+function specializationWeaponFit(record: CompanionRecord, discipline: WeaponDiscipline, fallback: GearFit): GearFit {
+  if (record.specialization === 'bulwark' && discipline === 'mace') return 'mastered';
+  if (record.specialization === 'inquisitor' && (discipline === 'mace' || discipline === 'blade')) return 'mastered';
+  if (record.specialization === 'hierophant' && discipline === 'staff') return 'mastered';
+  if (record.specialization === 'occultist' && discipline === 'blade') return 'trained';
+  return fallback;
+}
+
+function specializationArmorFit(record: CompanionRecord, discipline: ArmorDiscipline, fallback: GearFit): GearFit {
+  if ((record.specialization === 'bulwark' || record.specialization === 'inquisitor') && discipline === 'mail') return 'mastered';
+  if (record.specialization === 'occultist' && discipline === 'light') return 'mastered';
+  if (record.specialization === 'hierophant' && discipline === 'vestment') return 'mastered';
+  if (record.specialization === 'trapper' && discipline === 'mail') return 'trained';
+  return fallback;
+}
+
+export function armoryRuleForItem(itemId: string | null | undefined): ArmoryItemRule | null {
+  return itemId ? RULES[itemId] ?? null : null;
+}
+
+export function armoryCarryCapacity(record: CompanionRecord): number {
+  const con = record.stats.con;
+  const survival = record.skills?.survival ?? 0;
+  const profession = record.job === 'swordsman' ? 2 : record.job === 'ranger' ? 1 : 0;
+  return clamp(2 + Math.floor((con - 10) / 2) + Math.floor(survival / 2) + profession, 1, 10);
+}
+
+export function armoryProfile(record: CompanionRecord): ArmoryProfile {
+  const weaponRule = armoryRuleForItem(record.equipment.weapon);
+  const armorRule = armoryRuleForItem(record.equipment.armor);
+  const trinketRule = armoryRuleForItem(record.equipment.trinket);
+  const weaponFit = weaponRule?.weapon
+    ? specializationWeaponFit(record, weaponRule.weapon, WEAPON_FIT[record.job][weaponRule.weapon])
+    : null;
+  const armorFit = armorRule?.armor
+    ? specializationArmorFit(record, armorRule.armor, ARMOR_FIT[record.job][armorRule.armor])
+    : null;
+
+  let burden = (weaponRule?.burden ?? 0) + (armorRule?.burden ?? 0) + (trinketRule?.burden ?? 0);
+  if (weaponFit === 'strained') burden += 1;
+  if (armorFit === 'strained') burden += 1;
+  const capacity = armoryCarryCapacity(record);
+  const overload = Math.max(0, burden - capacity);
+
+  const statAdjustments: Partial<StatBlock> = {};
+  let defenseAdjustment = 0;
+  let maxHpAdjustment = 0;
+  let damageAdjustment = 0;
+  let mana = (weaponRule?.manaCapacity ?? 0) + (armorRule?.manaCapacity ?? 0) + (trinketRule?.manaCapacity ?? 0);
+  let favor = (weaponRule?.favorCapacity ?? 0) + (armorRule?.favorCapacity ?? 0) + (trinketRule?.favorCapacity ?? 0);
+  const warnings: string[] = [];
+
+  if (weaponFit === 'strained') {
+    damageAdjustment -= 1;
+    warnings.push('武器並非本職熟悉流派：武器招式命中 -2、傷害 -1、負重 +1。');
+  }
+  if (armorRule?.armor === 'mail') {
+    statAdjustments.dex = (statAdjustments.dex ?? 0) - 1;
+    if (record.job === 'mage' && armorFit !== 'mastered') {
+      statAdjustments.int = (statAdjustments.int ?? 0) - 1;
+      warnings.push('鎖甲妨礙精細手勢：秘法上限降低，智力 -1。');
+    }
+  }
+  if (armorFit === 'strained') {
+    statAdjustments.dex = (statAdjustments.dex ?? 0) - 1;
+    if (record.job === 'mage') mana -= 1;
+    if (record.job === 'cleric') favor -= 1;
+    warnings.push('護甲版型與訓練不合：敏捷 -1、負重 +1，施法者額外失去資源上限。');
+  }
+  if (armorRule?.armor === 'robe' && record.job !== 'mage') mana = Math.min(0, mana);
+  if (armorRule?.armor === 'vestment' && record.job !== 'cleric') favor = Math.min(0, favor);
+  if (weaponRule?.weapon === 'staff' && record.job !== 'mage') mana = Math.min(0, mana);
+  if (weaponRule?.weapon === 'mace' && record.job !== 'cleric') favor = Math.min(0, favor);
+
+  if (overload > 0) {
+    statAdjustments.dex = (statAdjustments.dex ?? 0) - overload;
+    maxHpAdjustment -= overload * 2;
+    warnings.push(`攜行超載 ${overload}：敏捷 -${overload}、生命上限 -${overload * 2}。`);
+  }
+
+  const weaponHitBonus = weaponFit === 'mastered' ? 1 : weaponFit === 'strained' ? -2 : 0;
+  if (weaponFit === 'mastered') warnings.push('武器熟練：裝備武器招式命中 +1。');
+
+  return {
+    burden,
+    capacity,
+    overload,
+    weaponFit,
+    armorFit,
+    weaponHitBonus,
+    damageAdjustment,
+    defenseAdjustment,
+    maxHpAdjustment,
+    statAdjustments,
+    mysticCapacity: { mana, favor },
+    warnings,
+  };
+}
+
+export function adjustMovesForArmory(record: CompanionRecord, moves: Move[]): Move[] {
+  const weaponId = record.equipment.weapon;
+  const weaponMoveId = weaponId ? ITEMS[weaponId]?.equip?.move?.id : null;
+  if (!weaponMoveId) return moves.map((move) => ({ ...move }));
+  const profile = armoryProfile(record);
+  return moves.map((move) => move.id === weaponMoveId
+    ? { ...move, hitBonus: (move.hitBonus ?? 0) + profile.weaponHitBonus }
+    : { ...move });
+}
+
+export function partyArmoryLoad(save: SaveData, memberIds?: string[]): PartyArmoryLoad {
+  const ids = memberIds ?? [save.protagonist.id, ...save.companions.map((member) => member.id)];
+  const members: Record<string, ArmoryProfile> = {};
+  let burden = 0;
+  let capacity = 0;
+  for (const id of ids) {
+    const member = memberById(save, id);
+    if (!member) continue;
+    const profile = armoryProfile(member);
+    members[id] = profile;
+    burden += profile.burden;
+    capacity += profile.capacity;
+  }
+  return { burden, capacity, overload: Math.max(0, burden - capacity), members };
+}
+
+export function equipArmoryItem(save: SaveData, memberId: string, itemId: string): ArmoryProfile {
+  const record = memberById(save, memberId);
+  if (!record) throw new Error(`找不到成員「${memberId}」。`);
+  const item = ITEMS[itemId];
+  if (!item?.equip) throw new Error(`「${itemId}」不是可裝備物品。`);
+  if (item.equip.minLevel !== undefined && record.level < item.equip.minLevel) {
+    throw new Error(`${record.name}需要 Lv${item.equip.minLevel} 才能裝備「${item.name}」。`);
+  }
+  if ((save.inventory[itemId] ?? 0) <= 0) throw new Error(`背包中沒有「${item.name}」。`);
+  const slot = item.equip.slot;
+  const previous = record.equipment[slot];
+  save.inventory[itemId] -= 1;
+  if (save.inventory[itemId] <= 0) delete save.inventory[itemId];
+  if (previous) save.inventory[previous] = (save.inventory[previous] ?? 0) + 1;
+  record.equipment[slot] = itemId;
+  return armoryProfile(record);
+}
+
+export function unequipArmoryItem(save: SaveData, memberId: string, slot: keyof CompanionRecord['equipment']): ArmoryProfile {
+  const record = memberById(save, memberId);
+  if (!record) throw new Error(`找不到成員「${memberId}」。`);
+  const previous = record.equipment[slot];
+  if (previous) {
+    record.equipment[slot] = null;
+    save.inventory[previous] = (save.inventory[previous] ?? 0) + 1;
+  }
+  return armoryProfile(record);
+}
+
+export function equippableInventory(save: SaveData): Array<{ item: ItemDef; count: number }> {
+  return Object.entries(save.inventory)
+    .filter(([, count]) => count > 0)
+    .map(([itemId, count]) => ({ item: ITEMS[itemId], count }))
+    .filter((entry): entry is { item: ItemDef; count: number } => !!entry.item?.equip)
+    .sort((a, b) => a.item.value - b.item.value || a.item.name.localeCompare(b.item.name));
+}

--- a/src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+++ b/src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { createRng } from '../rng';
+import { createProtagonist, newGame, type CompanionRecord, type SaveData } from '../save';
+import {
+  applyEnduranceCamp,
+  beginEnduranceBattle,
+  createEnduranceRun,
+  enduranceCampOptions,
+  finishEnduranceBattle,
+  isEnduranceRun,
+} from './enduranceArmory';
+
+function member(job: CompanionRecord['job'], id: string): CompanionRecord {
+  const record = createProtagonist({ job });
+  record.id = id;
+  record.name = id;
+  record.level = 4;
+  record.injuredForTrips = 0;
+  record.stats = job === 'swordsman'
+    ? { str: 18, dex: 12, int: 9, cha: 11, con: 17 }
+    : job === 'ranger'
+      ? { str: 11, dex: 18, int: 11, cha: 11, con: 13 }
+      : job === 'mage'
+        ? { str: 8, dex: 12, int: 19, cha: 11, con: 11 }
+        : { str: 11, dex: 9, int: 13, cha: 19, con: 15 };
+  record.maxHp = job === 'swordsman' ? 34 : job === 'cleric' ? 29 : job === 'ranger' ? 26 : 23;
+  record.skills = { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 };
+  return record;
+}
+
+function save(): SaveData {
+  const data = newGame(43001, { job: 'swordsman' });
+  data.protagonist = member('swordsman', 'protagonist');
+  const ranger = member('ranger', 'ranger');
+  const mage = member('mage', 'mage');
+  const cleric = member('cleric', 'cleric');
+  data.companions = [ranger, mage, cleric];
+  data.protagonist.equipment = { weapon: 'salt-crystal-blade', armor: 'saltforged-mail', trinket: 'den-idol' };
+  ranger.equipment = { weapon: 'ridge-mist-bow', armor: 'ridgeleather-vest', trinket: null };
+  mage.equipment = { weapon: 'ghostflame-staff', armor: 'ashveil-robe', trinket: 'saltglass-talisman' };
+  cleric.equipment = { weapon: 'brine-blessed-mace', armor: 'brinewarded-vestment', trinket: null };
+  data.reputation = 40;
+  data.flags['world-quest:ashen-reliquary:completed'] = true;
+  data.inventory = { ...data.inventory, 'dried-rations': 5, herb: 5 };
+  data.expeditionPlan = {
+    activeIds: ['protagonist', 'ranger', 'mage', 'cleric'],
+    positions: { protagonist: 'front', ranger: 'back', mage: 'back', cleric: 'front' },
+    roles: { captain: 'protagonist', scout: 'ranger', medic: 'cleric' },
+  };
+  return data;
+}
+
+function reachCamp(data: SaveData) {
+  const run = createEnduranceRun(data);
+  const combat = beginEnduranceBattle(run, data, createRng(430));
+  for (const partyMember of combat.party) partyMember.hp = Math.max(1, Math.floor(partyMember.maxHp / 2));
+  combat.outcome = 'victory';
+  finishEnduranceBattle(run, combat);
+  return run;
+}
+
+describe('M43 armory-aware endurance', () => {
+  it('requires a strict armory snapshot and rejects plain M42 runs', () => {
+    const data = save();
+    const run = createEnduranceRun(data);
+    expect(isEnduranceRun(run)).toBe(true);
+    const plain = { ...run } as Record<string, unknown>;
+    delete plain.armoryVersion;
+    expect(isEnduranceRun(plain)).toBe(false);
+  });
+
+  it('snapshots personal and party load at departure', () => {
+    const run = createEnduranceRun(save());
+    expect(run.partyBurden).toBeGreaterThan(0);
+    expect(run.partyCapacity).toBeGreaterThan(0);
+    expect(run.armory.protagonist.burden).toBeGreaterThan(run.armory.mage.burden);
+    expect(run.partyOverload).toBe(0);
+  });
+
+  it('makes camp recovery less efficient for heavier members without making rest useless', () => {
+    const data = save();
+    const run = reachCamp(data);
+    const heavyBefore = run.members.protagonist.hp;
+    const lightBefore = run.members.mage.hp;
+    applyEnduranceCamp(run, data, 'ration-rest');
+    const heavyGainRatio = (run.members.protagonist.hp - heavyBefore) / run.members.protagonist.maxHp;
+    const lightGainRatio = (run.members.mage.hp - lightBefore) / run.members.mage.maxHp;
+    expect(heavyGainRatio).toBeGreaterThan(0.15);
+    expect(lightGainRatio).toBeGreaterThan(heavyGainRatio);
+  });
+
+  it('turns forced march into an immediate load-dependent cost before future enemy pressure', () => {
+    const data = save();
+    const run = reachCamp(data);
+    const heavyBefore = run.members.protagonist.hp;
+    const lightBefore = run.members.mage.hp;
+    const heavyMax = run.members.protagonist.maxHp;
+    const lightMax = run.members.mage.maxHp;
+    applyEnduranceCamp(run, data, 'forced-march');
+    const heavyLossRatio = (heavyBefore - run.members.protagonist.hp) / heavyMax;
+    const lightLossRatio = (lightBefore - run.members.mage.hp) / lightMax;
+    expect(heavyLossRatio).toBeGreaterThan(lightLossRatio);
+    expect(run.forcedMarches).toBe(1);
+    expect(run.phase).toBe('battle');
+    const next = beginEnduranceBattle(run, data, createRng(431));
+    expect(next.enemies.every((enemy) => enemy.statuses?.some((status) => status.kind === 'strength' && status.potency === 1))).toBe(true);
+  });
+
+  it('surfaces the burden consequence in every camp option', () => {
+    const data = save();
+    const run = reachCamp(data);
+    const descriptions = enduranceCampOptions(run, data).map((option) => option.description).join('\n');
+    expect(descriptions).toContain('負重');
+    expect(descriptions).toContain('重裝');
+    expect(descriptions).toContain('強行軍疲勞');
+  });
+
+  it('does not allow a second camp action in the same stage', () => {
+    const data = save();
+    const run = reachCamp(data);
+    applyEnduranceCamp(run, data, 'ration-rest');
+    expect(() => applyEnduranceCamp(run, data, 'forced-march')).toThrow('目前不能進行營地選擇');
+  });
+});

--- a/src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+++ b/src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
@@ -63,6 +63,7 @@ describe('M43 armory-aware endurance', () => {
   it('requires a strict armory snapshot and rejects plain M42 runs', () => {
     const data = save();
     const run = createEnduranceRun(data);
+    console.log(`[M43 ENDURANCE] snapshot valid=${isEnduranceRun(run)} burden=${run.partyBurden}/${run.partyCapacity} overload=${run.partyOverload}`);
     expect(isEnduranceRun(run)).toBe(true);
     const plain = { ...run } as Record<string, unknown>;
     delete plain.armoryVersion;
@@ -71,6 +72,7 @@ describe('M43 armory-aware endurance', () => {
 
   it('snapshots personal and party load at departure', () => {
     const run = createEnduranceRun(save());
+    console.log(`[M43 ENDURANCE] members=${Object.entries(run.armory).map(([id, profile]) => `${id}:${profile.burden}/${profile.capacity}+${profile.overload}`).join(', ')}`);
     expect(run.partyBurden).toBeGreaterThan(0);
     expect(run.partyCapacity).toBeGreaterThan(0);
     expect(run.armory.protagonist.burden).toBeGreaterThan(run.armory.mage.burden);
@@ -85,6 +87,7 @@ describe('M43 armory-aware endurance', () => {
     applyEnduranceCamp(run, data, 'ration-rest');
     const heavyGainRatio = (run.members.protagonist.hp - heavyBefore) / run.members.protagonist.maxHp;
     const lightGainRatio = (run.members.mage.hp - lightBefore) / run.members.mage.maxHp;
+    console.log(`[M43 ENDURANCE] rest heavy=${heavyBefore}->${run.members.protagonist.hp}/${run.members.protagonist.maxHp} (${heavyGainRatio.toFixed(3)}), light=${lightBefore}->${run.members.mage.hp}/${run.members.mage.maxHp} (${lightGainRatio.toFixed(3)})`);
     expect(heavyGainRatio).toBeGreaterThan(0.15);
     expect(lightGainRatio).toBeGreaterThan(heavyGainRatio);
   });
@@ -99,6 +102,7 @@ describe('M43 armory-aware endurance', () => {
     applyEnduranceCamp(run, data, 'forced-march');
     const heavyLossRatio = (heavyBefore - run.members.protagonist.hp) / heavyMax;
     const lightLossRatio = (lightBefore - run.members.mage.hp) / lightMax;
+    console.log(`[M43 ENDURANCE] march heavy=${heavyBefore}->${run.members.protagonist.hp}/${heavyMax} (${heavyLossRatio.toFixed(3)}), light=${lightBefore}->${run.members.mage.hp}/${lightMax} (${lightLossRatio.toFixed(3)}), strain=${run.members.mage.mystic?.strain ?? 0}`);
     expect(heavyLossRatio).toBeGreaterThan(lightLossRatio);
     expect(run.forcedMarches).toBe(1);
     expect(run.phase).toBe('battle');
@@ -110,6 +114,7 @@ describe('M43 armory-aware endurance', () => {
     const data = save();
     const run = reachCamp(data);
     const descriptions = enduranceCampOptions(run, data).map((option) => option.description).join('\n');
+    console.log(`[M43 ENDURANCE] camp descriptions=${descriptions}`);
     expect(descriptions).toContain('負重');
     expect(descriptions).toContain('重裝');
     expect(descriptions).toContain('強行軍疲勞');

--- a/src/scripts/games/caravan/data/enduranceArmory.ts
+++ b/src/scripts/games/caravan/data/enduranceArmory.ts
@@ -115,7 +115,7 @@ export function enduranceCampOptions(run: ArmoryEnduranceRun, save: SaveData): C
     }
     return {
       ...option,
-      description: `${option.description} 並立即承受依個人負重計算的行軍疲勞；超載施法者可能增加秘法灼傷。`,
+      description: `${option.description} 並立即承受依個人負重計算的強行軍疲勞；超載施法者可能增加秘法灼傷。`,
     };
   });
 }

--- a/src/scripts/games/caravan/data/enduranceArmory.ts
+++ b/src/scripts/games/caravan/data/enduranceArmory.ts
@@ -1,0 +1,170 @@
+import type { CombatState } from '../combat';
+import type { Rng } from '../rng';
+import type { SaveData } from '../save';
+import { armoryProfile, partyArmoryLoad, type ArmoryProfile } from './armory';
+import * as base from './endurance';
+
+export type EnduranceCampChoice = base.EnduranceCampChoice;
+export type EndurancePhase = base.EndurancePhase;
+export type CampOption = base.CampOption;
+export type EnduranceReward = base.EnduranceReward;
+
+export const ARMORY_ENDURANCE_VERSION = 1;
+
+export interface ArmoryEnduranceRun extends base.EnduranceRun {
+  armoryVersion: 1;
+  armory: Record<string, ArmoryProfile>;
+  partyBurden: number;
+  partyCapacity: number;
+  partyOverload: number;
+}
+
+export type EnduranceRun = ArmoryEnduranceRun;
+
+function memberRecord(save: SaveData, id: string) {
+  return id === save.protagonist.id
+    ? save.protagonist
+    : save.companions.find((member) => member.id === id);
+}
+
+function validArmoryProfile(value: unknown): value is ArmoryProfile {
+  if (!value || typeof value !== 'object') return false;
+  const profile = value as Partial<ArmoryProfile>;
+  return Number.isFinite(profile.burden) && profile.burden! >= 0
+    && Number.isFinite(profile.capacity) && profile.capacity! >= 1
+    && Number.isFinite(profile.overload) && profile.overload! >= 0
+    && Number.isFinite(profile.weaponHitBonus)
+    && Number.isFinite(profile.damageAdjustment)
+    && Number.isFinite(profile.defenseAdjustment)
+    && Number.isFinite(profile.maxHpAdjustment)
+    && !!profile.statAdjustments && typeof profile.statAdjustments === 'object'
+    && !!profile.mysticCapacity && typeof profile.mysticCapacity === 'object'
+    && Array.isArray(profile.warnings);
+}
+
+export function isEnduranceRun(value: unknown): value is ArmoryEnduranceRun {
+  if (!base.isEnduranceRun(value) || !value || typeof value !== 'object') return false;
+  const run = value as Partial<ArmoryEnduranceRun>;
+  if (run.armoryVersion !== ARMORY_ENDURANCE_VERSION
+    || !run.armory || typeof run.armory !== 'object'
+    || !Number.isFinite(run.partyBurden) || run.partyBurden! < 0
+    || !Number.isFinite(run.partyCapacity) || run.partyCapacity! < 1
+    || !Number.isFinite(run.partyOverload) || run.partyOverload! < 0) return false;
+  const memberIds = Object.keys(run.members ?? {});
+  return memberIds.length >= 3
+    && memberIds.every((id) => validArmoryProfile(run.armory![id]));
+}
+
+export function createEnduranceRun(save: SaveData): ArmoryEnduranceRun {
+  const run = base.createEnduranceRun(save);
+  const memberIds = Object.keys(run.members);
+  const load = partyArmoryLoad(save, memberIds);
+  const armory: Record<string, ArmoryProfile> = {};
+  for (const id of memberIds) {
+    const record = memberRecord(save, id);
+    if (!record) throw new Error(`朝聖武裝名冊缺少成員「${id}」。`);
+    armory[id] = armoryProfile(record);
+  }
+  return {
+    ...run,
+    armoryVersion: ARMORY_ENDURANCE_VERSION,
+    armory,
+    partyBurden: load.burden,
+    partyCapacity: load.capacity,
+    partyOverload: load.overload,
+  };
+}
+
+export const enduranceAccess = base.enduranceAccess;
+export const enduranceReceiptForMarket = base.enduranceReceiptForMarket;
+export const enduranceReward = base.enduranceReward;
+export const claimEnduranceReward = base.claimEnduranceReward;
+
+export function beginEnduranceBattle(run: ArmoryEnduranceRun, save: SaveData, rng: Rng): CombatState {
+  if (!isEnduranceRun(run)) throw new Error('朝聖武裝快照已失效，請重新整備並開始新試煉。');
+  return base.beginEnduranceBattle(run, save, rng);
+}
+
+export function checkpointEnduranceBattle(run: ArmoryEnduranceRun, combat: CombatState): void {
+  base.checkpointEnduranceBattle(run, combat);
+}
+
+export function finishEnduranceBattle(run: ArmoryEnduranceRun, combat: CombatState): void {
+  base.finishEnduranceBattle(run, combat);
+}
+
+export function enduranceCampOptions(run: ArmoryEnduranceRun, save: SaveData): CampOption[] {
+  return base.enduranceCampOptions(run, save).map((option) => {
+    if (option.id === 'ration-rest') {
+      return {
+        ...option,
+        description: `${option.description} 重裝者需要卸甲保養，實際恢復會依個人負重下降。`,
+      };
+    }
+    if (option.id === 'arcane-vigil') {
+      return {
+        ...option,
+        description: `${option.description} 鎖甲與超載會降低休息成效。`,
+      };
+    }
+    if (option.id === 'sacred-vigil') {
+      return {
+        ...option,
+        description: `${option.description} 重裝者仍需處理擦傷與護具，治療效率較低。`,
+      };
+    }
+    return {
+      ...option,
+      description: `${option.description} 並立即承受依個人負重計算的行軍疲勞；超載施法者可能增加秘法灼傷。`,
+    };
+  });
+}
+
+function livingHp(run: ArmoryEnduranceRun): number {
+  return Object.values(run.members).filter((member) => member.hp > 0).length;
+}
+
+function reduceCampRecovery(
+  run: ArmoryEnduranceRun,
+  before: Record<string, number>,
+): void {
+  for (const [id, state] of Object.entries(run.members)) {
+    if (state.hp <= 0 || before[id] <= 0) continue;
+    const gained = Math.max(0, state.hp - before[id]);
+    const profile = run.armory[id];
+    const efficiency = Math.max(0.5, 1 - profile.burden * 0.07 - profile.overload * 0.12);
+    state.hp = Math.min(state.maxHp, before[id] + Math.max(1, Math.round(gained * efficiency)));
+  }
+}
+
+function applyForcedMarchFatigue(run: ArmoryEnduranceRun): void {
+  for (const [id, state] of Object.entries(run.members)) {
+    if (state.hp <= 0) continue;
+    const profile = run.armory[id];
+    const ratio = 0.015 + profile.burden * 0.012 + profile.overload * 0.025;
+    const fatigue = Math.max(1, Math.ceil(state.maxHp * ratio));
+    state.hp = Math.max(0, state.hp - fatigue);
+    if (state.hp > 0 && state.mystic?.kind === 'mana' && (profile.burden >= 4 || profile.overload > 0)) {
+      state.mystic.strain = Math.min(5, state.mystic.strain + 1);
+    }
+  }
+  if (livingHp(run) === 0) run.phase = 'defeat';
+}
+
+export function applyEnduranceCamp(
+  run: ArmoryEnduranceRun,
+  save: SaveData,
+  choice: EnduranceCampChoice,
+): void {
+  if (!isEnduranceRun(run)) throw new Error('朝聖武裝快照已失效，請重新整備並開始新試煉。');
+  const before = Object.fromEntries(Object.entries(run.members).map(([id, state]) => [id, state.hp]));
+  base.applyEnduranceCamp(run, save, choice);
+  if (choice === 'forced-march') applyForcedMarchFatigue(run);
+  else reduceCampRecovery(run, before);
+}
+
+export function enduranceRunSummary(run: ArmoryEnduranceRun): string {
+  const baseSummary = base.enduranceRunSummary(run);
+  const overload = run.partyOverload > 0 ? `｜超載 ${run.partyOverload}` : '';
+  return `${baseSummary}｜負重 ${run.partyBurden}/${run.partyCapacity}${overload}`;
+}

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -11,6 +11,7 @@ import {
   BOND_HP_PER_TIER,
 } from '../roster';
 import { ITEMS } from './items';
+import { adjustMovesForArmory, armoryProfile, type ArmoryProfile } from './armory';
 
 export type JobId = 'swordsman' | 'ranger' | 'mage' | 'cleric';
 
@@ -23,6 +24,15 @@ export interface JobDef {
   moves: Move[];
   /** 職業立繪路徑（M5 美術） */
   art?: string;
+}
+
+export interface ArmoryPartyMemberRuntime {
+  mysticCapacityBonus?: { mana: number; favor: number };
+  armoryBurden?: number;
+  armoryCapacity?: number;
+  armoryOverload?: number;
+  armoryWarnings?: string[];
+  armoryProfile?: ArmoryProfile;
 }
 
 /** M18：每名角色最多攜帶四招，讓升級後的技能選擇形成構築取捨。 */
@@ -150,7 +160,6 @@ export function availableMovesFromRecord(record: CompanionRecord): Move[] {
   const weaponMove = weaponId ? ITEMS[weaponId]?.equip?.move : undefined;
   const baseMoves = weaponMove ? [weaponMove, ...moves.slice(1)] : moves;
   const spec = specById(record.specialization);
-  // 專屬招放在兩招職業核心技之後，讓舊存檔的預設四招必定能體現專精身分。
   return spec
     ? [...baseMoves.slice(0, 2), spec.move, ...baseMoves.slice(2)]
     : baseMoves;
@@ -164,12 +173,6 @@ function weaponMoveIds(): Set<string> {
   return ids;
 }
 
-/**
- * 將存檔中的「武器招式槽」對齊目前裝備：
- * - 換武器時，舊武器招平滑換成新武器招。
- * - 卸下武器時，恢復職業原本的首招。
- * - 玩家本來就沒攜帶武器招時，不會擅自塞回去。
- */
 function normalizePreparedMoveIds(record: CompanionRecord): Set<string> {
   const raw = record.preparedMoveIds;
   if (!Array.isArray(raw)) return new Set<string>();
@@ -192,11 +195,6 @@ function normalizePreparedMoveIds(record: CompanionRecord): Set<string> {
   return requested;
 }
 
-/**
- * 依已知戰技整理實際攜帶配置。
- * 舊存檔採前四招；武器替換與卸下都會保留原本佔用的武器招式槽。
- * 毀損或已過期的配置退回安全預設，不讓玩家帶著空配置進入戰鬥。
- */
 export function preparedMovesFromRecord(record: CompanionRecord): Move[] {
   const available = availableMovesFromRecord(record);
   if (available.length === 0) return [];
@@ -211,7 +209,6 @@ export function preparedMovesFromRecord(record: CompanionRecord): Move[] {
   return prepared.length > 0 ? prepared : available.slice(0, MOVE_LOADOUT_CAP);
 }
 
-/** 寫入一組合法戰技配置；未知、重複、空配置與超過四招都拒絕且不修改角色。 */
 export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): string[] {
   const known = availableMovesFromRecord(record);
   const requested = new Set(moveIds);
@@ -230,31 +227,39 @@ export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): st
 }
 
 /**
- * 將角色成長、裝備、特質、專精與戰技配置整合成實際戰鬥成員。
- * 武器招式替換與出戰招式上限都已在 preparedMovesFromRecord 內處理。
+ * 將角色成長、裝備、特質、專精、武裝熟練與戰技配置整合成實際戰鬥成員。
+ * M43 不禁止跨職裝備，而是把不合訓練的代價公開轉成命中、屬性、負重與施法上限。
  */
 export function memberFromRecord(record: CompanionRecord): PartyMember {
   const job = JOBS[record.job];
   const bonus = equipmentBonus(record);
-
+  const armory = armoryProfile(record);
   const stats: StatBlock = effectiveStats(record);
-  // M7 特質加成
+  for (const stat of Object.keys(armory.statAdjustments) as Array<keyof StatBlock>) {
+    stats[stat] += armory.statAdjustments[stat] ?? 0;
+  }
   const trait = traitById(record.trait);
-  // M11 專精被動
   const spec = specById(record.specialization);
-  // M11 羈絆：旅伴 tier 每階 +BOND_HP_PER_TIER 生命上限（主角無 bond 欄自然為 0）
   const bondHp = bondTier(record.bond) * BOND_HP_PER_TIER;
-  const maxHp = record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0) + (spec?.maxHp ?? 0) + bondHp;
+  const maxHp = Math.max(1, record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0)
+    + (spec?.maxHp ?? 0) + bondHp + armory.maxHpAdjustment);
 
-  return {
+  const member: PartyMember & ArmoryPartyMemberRuntime = {
     id: record.id,
     name: record.name,
     stats,
     maxHp,
     hp: maxHp,
-    defense: job.defense + bonus.defense + (spec?.defense ?? 0),
-    moves: preparedMovesFromRecord(record),
-    damageBonus: bonus.damageBonus,
+    defense: Math.max(1, job.defense + bonus.defense + (spec?.defense ?? 0) + armory.defenseAdjustment),
+    moves: adjustMovesForArmory(record, preparedMovesFromRecord(record)),
+    damageBonus: (bonus.damageBonus ?? 0) + armory.damageAdjustment,
     isProtagonist: record.id === 'protagonist',
+    mysticCapacityBonus: armory.mysticCapacity,
+    armoryBurden: armory.burden,
+    armoryCapacity: armory.capacity,
+    armoryOverload: armory.overload,
+    armoryWarnings: [...armory.warnings],
+    armoryProfile: armory,
   };
+  return member;
 }


### PR DESCRIPTION
## Summary
- turn every existing weapon and armor into a medieval-fantasy discipline with burden, proficiency, spell-focus, and visible tradeoffs
- keep cross-class equipment legal while applying transparent mastered / trained / strained consequences
- integrate weapon accuracy, armor interference, overload, mana/favor capacity, camp recovery, and forced-march fatigue into live gameplay
- add `/caravan/armory` for player-facing equipment inspection, swapping, warnings, and party load
- upgrade `/caravan/endurance` to lock an M43 armory snapshot and show equipment burden during the pilgrimage

## Game-design intent
The previous equipment layer mostly provided larger numbers and allowed any profession to wear or wield anything without meaningful consequence. M43 makes steel, mobility, arcane focus, and sacred focus compete for the same build budget without hard class locks. Battle clerics, lightly armored mages, martial hybrids, and unusual weapons remain possible, but no longer become free optimal choices.

## Player-perspective adversarial review
- deterministic, read-only loadout previews
- atomic equip / swap / unequip transactions with fresh inventory validation
- heavy armor vs. mobility vs. mystical capacity tradeoffs
- load-dependent camp recovery and immediate forced-march fatigue
- cross-class builds remain playable but carry explicit costs
- Pareto-front analysis across 16 weapon/armor combinations for every profession
- no universal loadout may dominate all four professions
- existing combat, M41 magic, M42 endurance transactions, and five-composition endurance simulations remain regression gates

## Validation
GitHub Actions runs production build, M43 transaction tests, M43 armory-aware endurance tests, multidimensional adversarial probes, and M41/M42 combat and balance regressions.