### PR TITLE
feat(caravan): add M44 spellcraft counterplay

### DIFF
--- a/.github/workflows/caravan-m44-ci.yml
+++ b/.github/workflows/caravan-m44-ci.yml
@@ -1,0 +1,45 @@
+name: Caravan M44 Spellcraft CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - '.github/workflows/caravan-m44-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - '.github/workflows/caravan-m44-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-spellcraft-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Production build
+        run: npm run build
+      - name: M44 spellcraft transactions and abuse paths
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts
+      - name: M44 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+      - name: M42 expedition and M43 armory regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts

--- a/.github/workflows/caravan-m44-ci.yml
+++ b/.github/workflows/caravan-m44-ci.yml
@@ -39,6 +39,10 @@ jobs:
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "makes hostile priests"
       - name: M44 illegal target abuse paths
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "rejects player-side illegal targets"
+      - name: M44 live salt-wraith and bandit-priest integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "live salt wraith and bandit priest"
+      - name: M44 live reliquary cantor spell coherence
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "live tongueless cantor"
 
       - name: M44 pressure versus ward Pareto
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts -t "real Pareto tradeoff"

--- a/.github/workflows/caravan-m44-ci.yml
+++ b/.github/workflows/caravan-m44-ci.yml
@@ -26,20 +26,55 @@ jobs:
       - run: npm ci
       - name: Production build
         run: npm run build
-      - name: M44 spellcraft transactions and abuse paths
-        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts
-      - name: M44 multidimensional player adversarial review
-        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M44 ward recovery and refresh
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "turns arcane recovery"
+      - name: M44 magic-only ward separation
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "wards only magical damage"
+      - name: M44 full ward status blocking
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "fully warded spells"
+      - name: M44 hostile mage resource cycle
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "makes enemy mages"
+      - name: M44 hostile priest resource cycle
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "makes hostile priests"
+      - name: M44 illegal target abuse paths
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.m44.test.ts -t "rejects player-side illegal targets"
+
+      - name: M44 pressure versus ward Pareto
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts -t "real Pareto tradeoff"
+      - name: M44 pure martial exhaustion window
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts -t "pure martial party functional"
+      - name: M44 physical threat anti-ward-spam
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts -t "purely physical threat"
+      - name: M44 dual-caster ward banking cap
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts -t "dual casters cannot bank"
+
       - name: Core combat and M41 magic regression
         run: >-
           npx vitest run --reporter=verbose
           src/scripts/games/caravan/combat.test.ts
           src/scripts/games/caravan/data/arcana.m41.test.ts
-      - name: M42 expedition and M43 armory regression
+
+      - name: M42 balanced composition probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "balanced party has viable"
+      - name: M42 martial composition probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "martial party with cleric"
+      - name: M42 pure martial composition probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "pure martial party has viable"
+      - name: M42 double-mage composition probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "double-mage party"
+      - name: M42 no-cleric composition probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "party without cleric"
+      - name: M42 composition spread probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "composition win rates"
+      - name: M42 camp-policy diversity probe
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts -t "camp policy uses"
+
+      - name: M42 expedition state regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.m42.test.ts
+      - name: M43 armory and endurance regression
         run: >-
           npx vitest run --reporter=verbose
-          src/scripts/games/caravan/data/endurance.m42.test.ts
-          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
           src/scripts/games/caravan/data/armory.m43.test.ts
           src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
           src/scripts/games/caravan/data/armory.balance.m43.test.ts

--- a/docs/caravan-m44-spellcraft.md
+++ b/docs/caravan-m44-spellcraft.md
@@ -1,0 +1,23 @@
+# M44 Spellcraft Counterplay
+
+M44 turns magic from a damage-color/resource-bar layer into a readable tactical exchange.
+
+## Player-facing rules
+
+- Arcane focus and battlefield prayer are recovery actions that can place one non-stacking ward on an ally.
+- Wards absorb only the next magical hit and do not protect against swords, arrows, poison fangs, or other physical attacks.
+- A fully absorbed magical hit cannot sneak its rider status through the ward.
+- Hostile casters use the same mana/favor rules as the party and never receive free overcasting.
+- When a hostile caster cannot afford its intended spell, its visible intent changes to arcane focus or battlefield prayer.
+- Real encounters covered by the rule include the salt wraith, bandit priest, and the Tongueless Cantor in the Ashen Reliquary.
+- The Tongueless Cantor uses one coherent ghostly-mana pool for both Silent Chorus and Lament Touch; its holy-looking chorus is an occult imitation rather than divine favor.
+
+## Adversarial gameplay gates
+
+- Pressure and ward play must remain Pareto alternatives: pressure wins damage tempo, ward play wins survival/resource posture.
+- Pure martial parties must retain a response window because hostile casters exhaust resources.
+- Ward spam must not help against purely physical threats.
+- Multiple casters cannot bank multiple ward charges on one target.
+- Player target legality is revalidated in the engine; UI manipulation cannot attack allies or ward enemies.
+- Live encounter data is tested, not only synthetic fixtures.
+- M41 magic, M42 endurance composition probes, M43 armory, and core combat remain regression gates.

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -20,7 +20,7 @@ export interface Move {
   hitBonus?: number;
   damage?: { dice: number; sides: number; bonusStat?: Stat };
   heal?: { dice: number; sides: number; bonusStat?: Stat };
-  /** 命中後附加狀態（M7）：poison 每回合行動前扣 potency；stun 跳過一次行動；strength 出手傷害 +potency */
+  /** M44：ward 為一次性魔法護法；remaining 代表可抵擋的命中次數。 */
   applyStatus?: { kind: StatusKind; duration: number; potency?: number };
   /** M15 傷害屬性（attack 專用）；無＝中性 */
   element?: Element;
@@ -36,7 +36,7 @@ export const ELEMENT_LABELS: Record<Element, string> = {
   slash: '斬', pierce: '刺', blunt: '打', fire: '火', frost: '冰', holy: '聖',
 };
 
-export type StatusKind = 'poison' | 'stun' | 'strength';
+export type StatusKind = 'poison' | 'stun' | 'strength' | 'ward';
 export interface StatusEffect { kind: StatusKind; remaining: number; potency: number; }
 
 /** M41：法師使用秘法、教士使用神恩；strain 僅對秘法過載有意義。 */
@@ -52,9 +52,9 @@ export interface CombatantBase {
   maxHp: number; hp: number; defense: number; moves: Move[];
   /** M14 鐵匠強化：武器 +N 固定傷害加值 */
   damageBonus?: number;
-  /** 進行中狀態效果（M7，戰鬥 runtime） */
+  /** 進行中狀態效果（M7/M44，戰鬥 runtime） */
   statuses?: StatusEffect[];
-  /** M41 戰鬥中的秘法／神恩，不寫回角色存檔。 */
+  /** M41 戰鬥中的秘法／神恩，不寫回角色存檔。M44 起敵方施法者也遵守同規則。 */
   mystic?: MysticPower;
   /** 立繪路徑（M5 美術） */
   art?: string;
@@ -115,8 +115,9 @@ export interface PartyActionResult {
 }
 
 export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]): CombatState {
-  // M41：保留角色物件身分，只替換安全招式副本並初始化戰鬥資源。
+  // M41/M44：雙方施法者共用同一套招式裝飾、秘法／神恩容量與恢復手段。
   for (const member of party) prepareMysticPartyMember(member);
+  for (const enemy of enemies) prepareMysticPartyMember(enemy);
   // Interleave party and enemies for initialization roll order (骰序不可更動——既有測試依賴)
   const all = [];
   const maxLen = Math.max(party.length, enemies.length);
@@ -133,13 +134,14 @@ export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]
   };
   for (const enemy of enemies) {
     if (enemy.maxPoise !== undefined && enemy.poise === undefined) enemy.poise = enemy.maxPoise;
-    state.enemyIntents[enemy.id] = rng.weightedPick(
-      enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
-    );
+    state.enemyIntents[enemy.id] = chooseEnemyIntent(rng, enemy);
   }
   state.log.push({ kind: 'info', text: '戰鬥開始！' });
   for (const member of party) {
     if (member.mystic) state.log.push({ kind: 'info', text: `${member.name}：${mysticPowerText(member.mystic)}。` });
+  }
+  for (const enemy of enemies) {
+    if (enemy.mystic) state.log.push({ kind: 'info', text: `${enemy.name}顯露施法氣息：${mysticPowerText(enemy.mystic)}。` });
   }
   return state;
 }
@@ -208,7 +210,9 @@ function applyDamage(state: CombatState, target: CombatantBase, amount: number):
   }
 }
 
-const STATUS_LABEL: Record<StatusKind, string> = { poison: '中毒', stun: '暈眩', strength: '強化' };
+const STATUS_LABEL: Record<StatusKind, string> = {
+  poison: '中毒', stun: '暈眩', strength: '強化', ward: '護法',
+};
 
 function tickStatuses(state: CombatState, actor: CombatantBase): boolean {
   if (!actor.statuses?.length) return true;
@@ -223,6 +227,7 @@ function tickStatuses(state: CombatState, actor: CombatantBase): boolean {
       st.remaining -= 1;
       canAct = false;
     }
+    // M44 ward 是命中次數制，由魔法傷害真正打中時才消耗，不隨持有者回合自然衰減。
   }
   actor.statuses = actor.statuses.filter((st) => st.remaining > 0);
   return canAct && actor.hp > 0;
@@ -253,8 +258,12 @@ function performMove(
     const spec = move.applyStatus;
     target.statuses ??= [];
     const existing = target.statuses.find((s) => s.kind === spec.kind);
-    if (existing) existing.remaining = Math.max(existing.remaining, spec.duration);
-    else target.statuses.push({ kind: spec.kind, remaining: spec.duration, potency: spec.potency ?? 0 });
+    if (existing) {
+      existing.remaining = Math.max(existing.remaining, spec.duration);
+      existing.potency = Math.max(existing.potency, spec.potency ?? 0);
+    } else {
+      target.statuses.push({ kind: spec.kind, remaining: spec.duration, potency: spec.potency ?? 0 });
+    }
     state.log.push({ kind: 'action', text: fillNarration(move.narration, actor.name, target.name, 0) });
     state.log.push({ kind: 'info', text: `${target.name}獲得${STATUS_LABEL[spec.kind]}狀態！` });
     return;
@@ -297,6 +306,24 @@ function performMove(
       amount = Math.max(1, Math.round(baseAmount * 0.5));
     }
   }
+
+  // M44：護法只反制真正的魔法招式，不會把劍、箭、毒牙等物理威脅也一併作廢。
+  let wardAbsorbed = 0;
+  const spellRule = mysticRuleForMove(move);
+  if (spellRule) {
+    const ward = target.statuses?.find((status) => status.kind === 'ward' && status.remaining > 0);
+    if (ward) {
+      wardAbsorbed = Math.min(amount, ward.potency);
+      amount = Math.max(0, amount - wardAbsorbed);
+      ward.remaining -= 1;
+      target.statuses = target.statuses!.filter((status) => status.remaining > 0);
+      state.log.push({
+        kind: 'info',
+        text: `${target.name}的護法削去了 ${wardAbsorbed} 點魔法傷害！`,
+      });
+    }
+  }
+
   state.log.push({ kind: 'damage', text: fillNarration(move.narration, actor.name, target.name, amount) });
   if (hitWeakness) state.log.push({ kind: 'info', text: `擊中弱點！${target.name}被${ELEMENT_LABELS[move.element!]}屬性重創！` });
   else if (foe && move.element && foe.resists?.includes(move.element)) {
@@ -314,12 +341,17 @@ function performMove(
       state.log.push({ kind: 'info', text: `${foe.name}的架勢被徹底打散——破防！下一次行動陷入暈眩！` });
     }
   }
-  if (move.applyStatus && target.hp > 0) {
+  const fullyWarded = !!spellRule && wardAbsorbed > 0 && amount === 0;
+  if (move.applyStatus && target.hp > 0 && !fullyWarded) {
     const spec = move.applyStatus;
     target.statuses ??= [];
     const existing = target.statuses.find((s) => s.kind === spec.kind);
-    if (existing) existing.remaining = Math.max(existing.remaining, spec.duration);
-    else target.statuses.push({ kind: spec.kind, remaining: spec.duration, potency: spec.potency ?? 0 });
+    if (existing) {
+      existing.remaining = Math.max(existing.remaining, spec.duration);
+      existing.potency = Math.max(existing.potency, spec.potency ?? 0);
+    } else {
+      target.statuses.push({ kind: spec.kind, remaining: spec.duration, potency: spec.potency ?? 0 });
+    }
     state.log.push({ kind: 'info', text: `${target.name}陷入${STATUS_LABEL[spec.kind]}狀態！` });
   }
 }
@@ -408,6 +440,34 @@ function finishMysticAction(state: CombatState, actor: PartyMember, move: Move, 
   state.log.push({ kind: 'info', text: `${actor.name}：${mysticPowerText(actor.mystic)}。` });
 }
 
+function enemyRecoveryMove(enemy: EnemyUnit): Move | undefined {
+  if (!enemy.mystic) return undefined;
+  const id = enemy.mystic.kind === 'mana' ? 'arcane-focus' : 'field-prayer';
+  return enemy.moves.find((move) => move.id === id);
+}
+
+/**
+ * M44：敵人不會偷偷過載。若抽到付不起的法術，意圖直接改成公開的恢復／護持行動。
+ * 若資料損壞到沒有恢復招式，退回任何仍可合法執行的招式，避免 AI 卡死。
+ */
+function chooseEnemyIntent(rng: Rng, enemy: EnemyUnit): string {
+  const intendedId = rng.weightedPick(
+    enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
+  );
+  const intended = enemy.moves.find((move) => move.id === intendedId) ?? enemy.moves[0];
+  if (intended && partyMoveAvailability(enemy, intended).allowed) return intended.id;
+  const recovery = enemyRecoveryMove(enemy);
+  if (recovery) return recovery.id;
+  const fallback = enemy.moves.find((move) => partyMoveAvailability(enemy, move).allowed);
+  return fallback?.id ?? intendedId;
+}
+
+function validPartyTarget(state: CombatState, actor: PartyMember, move: Move, target: CombatantBase): boolean {
+  if (move.target === 'self') return target.id === actor.id;
+  if (move.target === 'ally') return state.party.some((member) => member.id === target.id && member.hp > 0);
+  return state.enemies.some((enemy) => enemy.id === target.id && enemy.hp > 0);
+}
+
 export function partyAct(
   rng: Rng,
   state: CombatState,
@@ -421,6 +481,9 @@ export function partyAct(
   const targetFound = [...state.party, ...state.enemies].find((c) => c.id === targetId);
   if (!actor || !move || !targetFound || state.outcome !== 'ongoing') {
     return { acted: false, overcast: false, backlash: 0, reason: '行動資料無效。' };
+  }
+  if (!validPartyTarget(state, actor, move, targetFound)) {
+    return { acted: false, overcast: false, backlash: 0, reason: '這個招式不能指定該目標。' };
   }
   const availability = partyMoveAvailability(actor, move, options);
   if (!availability.allowed) {
@@ -457,22 +520,51 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
   const enemy = state.enemies.find((e) => e.id === enemyId);
   if (!enemy || state.outcome !== 'ongoing') return;
   if (!tickStatuses(state, enemy)) {
-    state.enemyIntents[enemyId] = rng.weightedPick(
-      enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
-    );
+    state.enemyIntents[enemyId] = chooseEnemyIntent(rng, enemy);
     checkOutcome(state);
     if (state.outcome === 'ongoing') advanceTurn(state);
     return;
   }
-  const moveId = state.enemyIntents[enemyId] ?? enemy.moves[0].id;
-  const move = enemy.moves.find((m) => m.id === moveId) ?? enemy.moves[0];
+
+  const intendedId = state.enemyIntents[enemyId] ?? enemy.moves[0].id;
+  let move = enemy.moves.find((candidate) => candidate.id === intendedId) ?? enemy.moves[0];
+  let availability = partyMoveAvailability(enemy, move);
+  if (!availability.allowed) {
+    move = enemyRecoveryMove(enemy)
+      ?? enemy.moves.find((candidate) => partyMoveAvailability(enemy, candidate).allowed)
+      ?? move;
+    availability = partyMoveAvailability(enemy, move);
+  }
+  if (!availability.allowed) {
+    state.log.push({ kind: 'info', text: `${enemy.name}無法完成預定行動，施法節奏被迫中斷。` });
+    state.enemyIntents[enemyId] = chooseEnemyIntent(rng, enemy);
+    advanceTurn(state);
+    return;
+  }
+
+  const mystic = beginMysticAction(state, enemy, move, availability);
   let target: CombatantBase;
-  if (move.kind === 'support' && move.heal) {
-    const aliveEnemies = state.enemies.filter((e) => e.hp > 0);
+  if (move.kind === 'support') {
+    const aliveEnemies = state.enemies.filter((candidate) => candidate.hp > 0);
     if (aliveEnemies.length === 0) return;
-    target = aliveEnemies.reduce(
-      (most, e) => (e.maxHp - e.hp > most.maxHp - most.hp ? e : most), aliveEnemies[0]
-    );
+    if (move.target === 'self') {
+      target = enemy;
+    } else if (move.heal) {
+      target = aliveEnemies.reduce(
+        (most, candidate) => (
+          candidate.maxHp - candidate.hp > most.maxHp - most.hp ? candidate : most
+        ),
+        aliveEnemies[0]
+      );
+    } else {
+      // 護法優先交給生命比例最低的同伴，讓玩家可從公開意圖判斷其防守企圖。
+      target = aliveEnemies.reduce(
+        (lowest, candidate) => (
+          candidate.hp / candidate.maxHp < lowest.hp / lowest.maxHp ? candidate : lowest
+        ),
+        aliveEnemies[0]
+      );
+    }
   } else {
     const aliveParty = state.party.filter((p) => p.hp > 0);
     if (aliveParty.length === 0) return;
@@ -489,6 +581,7 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
       }
     }
   }
+
   const strengthBonus = move.kind === 'attack' ? consumeStrength(enemy) : 0;
   if (move.kind === 'attack' && move.area) {
     for (const member of state.party.filter((partyMember) => partyMember.hp > 0)) {
@@ -497,9 +590,8 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
   } else {
     performMove(rng, state, enemy, move, target, strengthBonus);
   }
-  state.enemyIntents[enemyId] = rng.weightedPick(
-    enemy.intents.map((it) => ({ weight: it.weight, value: it.moveId }))
-  );
+  finishMysticAction(state, enemy, move, mystic.overcast);
+  state.enemyIntents[enemyId] = chooseEnemyIntent(rng, enemy);
   checkOutcome(state);
   if (state.outcome === 'ongoing') advanceTurn(state);
 }
@@ -525,7 +617,7 @@ export function useItemInCombat(state: CombatState, actorId: string, use: ItemCo
   } else {
     target.statuses = target.statuses ?? [];
     target.statuses.push({ kind: use.status.kind, remaining: use.status.duration, potency: use.status.potency ?? 0 });
-    state.log.push({ kind: 'info', text: `${actor.name}使用${use.name}，${target.name}獲得強化！` });
+    state.log.push({ kind: 'info', text: `${actor.name}使用${use.name}，${target.name}獲得${STATUS_LABEL[use.status.kind]}！` });
   }
   advanceTurn(state);
 }
@@ -539,8 +631,16 @@ export function attemptRetreat(rng: Rng, state: CombatState): void {
       .map((id) => aliveParty.find((p) => p.id === id))
       .find((p) => p !== undefined)!;
     state.log.push({ kind: 'retreat', text: `${rear.name}殿後掩護撤退……` });
-    const attackMove = aliveEnemy.moves.find((m) => m.kind === 'attack');
-    if (attackMove) performMove(rng, state, aliveEnemy, attackMove, rear, consumeStrength(aliveEnemy));
+    // M44：撤退追擊也不能繞過敵方秘法資源；只選當下合法的攻擊。
+    const attackMove = aliveEnemy.moves.find(
+      (move) => move.kind === 'attack' && partyMoveAvailability(aliveEnemy, move).allowed
+    );
+    if (attackMove) {
+      const availability = partyMoveAvailability(aliveEnemy, attackMove);
+      const mystic = beginMysticAction(state, aliveEnemy, attackMove, availability);
+      performMove(rng, state, aliveEnemy, attackMove, rear, consumeStrength(aliveEnemy));
+      finishMysticAction(state, aliveEnemy, attackMove, mystic.overcast);
+    }
   }
   state.outcome = 'retreated';
   state.log.push({ kind: 'retreat', text: '商隊撤出了戰鬥。' });

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -23,6 +23,11 @@ const RULES: Record<string, MysticMoveRule> = {
   'frost-bind': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
   'meteor-fall': { kind: 'mana', school: 'pyromancy', cost: 4, gain: 0, overcast: true, strainRelief: 0 },
   'arcane-focus': { kind: 'mana', school: 'arcane', cost: 0, gain: 3, overcast: false, strainRelief: 1 },
+  // M44：鹽晶亡魂的投刃由寒鹽魔力凝成，敵方同樣受秘法資源限制。
+  'salt-shard-throw': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
+  // M44：兩個 Lv4 法師專精的代表招式明確歸屬學派，不再只靠元素 fallback 推斷。
+  'chain-lightning': { kind: 'mana', school: 'pyromancy', cost: 3, gain: 0, overcast: true, strainRelief: 0 },
+  'corrosive-curse': { kind: 'mana', school: 'arcane', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
 
   'holy-strike': { kind: 'favor', school: 'theurgy', cost: 0, gain: 1, overcast: false, strainRelief: 0 },
   heal: { kind: 'favor', school: 'theurgy', cost: 1, gain: 0, overcast: false, strainRelief: 0 },
@@ -44,22 +49,29 @@ export const MYSTIC_SCHOOL_LABELS: Record<MysticSchool, string> = {
   theurgy: '神術',
 };
 
+/**
+ * M44：秘法恢復不再只是空過一回合。
+ * 施法者在收束魔力時，可把護幕覆到一名隊友身上；護法只抵擋下一次魔法命中。
+ */
 export const ARCANE_FOCUS_MOVE: Move = {
   id: 'arcane-focus',
-  name: '秘法專注',
+  name: '秘法護持',
   kind: 'support',
-  target: 'self',
+  target: 'ally',
   hitStat: 'int',
-  narration: '{actor}收束散亂的魔力，在呼吸間重新排列符文。',
+  applyStatus: { kind: 'ward', duration: 1, potency: 4 },
+  narration: '{actor}收束散亂的魔力，將重排的符文化作護幕覆在{target}身上。',
 };
 
+/** M44：戰地禱告同時把一次神聖護佑交給一名隊友。 */
 export const FIELD_PRAYER_MOVE: Move = {
   id: 'field-prayer',
-  name: '戰地禱告',
+  name: '戰地祝禱',
   kind: 'support',
-  target: 'self',
+  target: 'ally',
   hitStat: 'cha',
-  narration: '{actor}低聲重申誓詞，讓神恩再次回應。',
+  applyStatus: { kind: 'ward', duration: 1, potency: 3 },
+  narration: '{actor}低聲重申誓詞，讓神恩回應並護佑{target}。',
 };
 
 function clamp(value: number, minimum: number, maximum: number): number {
@@ -121,6 +133,10 @@ function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
   };
 }
 
+/**
+ * 雖沿用 M41 名稱，M44 開始敵人也會走同一條初始化路徑。
+ * EnemyUnit 在結構上相容 PartyMember（額外欄位不影響），因此可共享同一套魔力公平規則。
+ */
 export function prepareMysticPartyMember(member: PartyMember): PartyMember {
   const copiedMoves = member.moves.map((move) => ({ ...move }));
   const hasMana = copiedMoves.some((move) => mysticRuleForMove(move)?.kind === 'mana');

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -25,6 +25,9 @@ const RULES: Record<string, MysticMoveRule> = {
   'arcane-focus': { kind: 'mana', school: 'arcane', cost: 0, gain: 3, overcast: false, strainRelief: 1 },
   // M44：鹽晶亡魂的投刃由寒鹽魔力凝成，敵方同樣受秘法資源限制。
   'salt-shard-throw': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
+  // M44：無舌領唱者是以亡魂秘法模仿聖歌，不應同時要求另一條神恩資源。
+  'reliquary-silent-chorus': { kind: 'mana', school: 'arcane', cost: 3, gain: 0, overcast: false, strainRelief: 0 },
+  'reliquary-lament-touch': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
   // M44：兩個 Lv4 法師專精的代表招式明確歸屬學派，不再只靠元素 fallback 推斷。
   'chain-lightning': { kind: 'mana', school: 'pyromancy', cost: 3, gain: 0, overcast: true, strainRelief: 0 },
   'corrosive-curse': { kind: 'mana', school: 'arcane', cost: 2, gain: 0, overcast: true, strainRelief: 0 },

--- a/src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+++ b/src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+
+function scriptedRng(values: number[] = [20, 1]): Rng {
+  let index = 0;
+  const take = () => values[index++ % Math.max(1, values.length)] ?? 10;
+  return {
+    next: () => 0,
+    roll: take,
+    d20: take,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+const strike: Move = {
+  id: 'strike', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 1, bonusStat: 'str' }, narration: '{actor}揮擊{target}，造成 {amount} 點傷害！',
+};
+const shot: Move = {
+  id: 'quick-shot', name: '疾射', kind: 'attack', target: 'enemy', hitStat: 'dex',
+  damage: { dice: 1, sides: 1, bonusStat: 'dex' }, narration: '{actor}射擊{target}，造成 {amount} 點傷害！',
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 1, bonusStat: 'int' }, narration: '{actor}以火球轟擊{target}，造成 {amount} 點傷害！',
+};
+const saltSpell: Move = {
+  id: 'salt-shard-throw', name: '鹽刃投擲', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'frost',
+  damage: { dice: 1, sides: 1, bonusStat: 'int' }, narration: '{actor}凝成寒鹽刃射向{target}，造成 {amount} 點傷害！',
+};
+const dagger: Move = {
+  id: 'dagger', name: '短刀', kind: 'attack', target: 'enemy', hitStat: 'dex',
+  damage: { dice: 1, sides: 1, bonusStat: 'dex' }, narration: '{actor}以短刀刺向{target}，造成 {amount} 點傷害！',
+};
+
+function fighter(): PartyMember {
+  return {
+    id: 'fighter', name: '前衛', stats: { str: 16, dex: 12, int: 8, cha: 8, con: 16 },
+    maxHp: 50, hp: 50, defense: 10, moves: [strike], formationRow: 'front',
+  };
+}
+function ranger(): PartyMember {
+  return {
+    id: 'ranger', name: '游俠', stats: { str: 10, dex: 16, int: 10, cha: 10, con: 12 },
+    maxHp: 38, hp: 38, defense: 10, moves: [shot], formationRow: 'back',
+  };
+}
+function mage(): PartyMember {
+  return {
+    id: 'mage', name: '法師', stats: { str: 8, dex: 14, int: 16, cha: 10, con: 10 },
+    maxHp: 34, hp: 34, defense: 10, moves: [fireball], formationRow: 'back',
+  };
+}
+function spellblade(mixed = false): EnemyUnit {
+  const moves = mixed ? [saltSpell, dagger] : [saltSpell];
+  return {
+    id: 'spellblade', name: '寒鹽術士', stats: { str: 8, dex: 12, int: 12, cha: 8, con: 12 },
+    maxHp: 70, hp: 70, defense: 8, moves,
+    intents: mixed
+      ? [{ weight: 2, moveId: 'salt-shard-throw' }, { weight: 1, moveId: 'dagger' }]
+      : [{ weight: 1, moveId: 'salt-shard-throw' }],
+  };
+}
+
+function forceTurn(state: ReturnType<typeof startCombat>, id: string): void {
+  state.turnIndex = state.order.indexOf(id);
+}
+
+interface Probe {
+  enemyHp: number;
+  frontHp: number;
+  mageMana: number;
+  partyActions: number;
+}
+
+function twoCycleProbe(policy: 'pressure' | 'warded'): Probe {
+  const front = fighter();
+  const caster = mage();
+  const foe = spellblade();
+  const state = startCombat(scriptedRng([20, 19, 1]), [front, caster], [foe]);
+  let partyActions = 0;
+
+  // Cycle 1: mage chooses immediate damage or sacrifices tempo for protection/resource posture.
+  forceTurn(state, caster.id);
+  if (policy === 'pressure') partyAct(scriptedRng([20, 1]), state, caster.id, 'fireball', foe.id);
+  else partyAct(scriptedRng([10]), state, caster.id, 'arcane-focus', front.id);
+  partyActions += 1;
+
+  forceTurn(state, foe.id);
+  state.enemyIntents[foe.id] = 'salt-shard-throw';
+  enemyAct(scriptedRng([20, 1]), state, foe.id);
+
+  forceTurn(state, front.id);
+  partyAct(scriptedRng([20, 1]), state, front.id, 'strike', foe.id);
+  partyActions += 1;
+
+  // Cycle 2: both plans now attack; warded plan has paid one earlier action for survival and mana posture.
+  forceTurn(state, caster.id);
+  partyAct(scriptedRng([20, 1]), state, caster.id, 'fireball', foe.id);
+  partyActions += 1;
+
+  forceTurn(state, foe.id);
+  state.enemyIntents[foe.id] = 'salt-shard-throw';
+  enemyAct(scriptedRng([20, 1]), state, foe.id);
+
+  return {
+    enemyHp: foe.hp,
+    frontHp: front.hp,
+    mageMana: caster.mystic?.current ?? 0,
+    partyActions,
+  };
+}
+
+function dominates(a: Probe, b: Probe): boolean {
+  const noWorse = a.enemyHp <= b.enemyHp
+    && a.frontHp >= b.frontHp
+    && a.mageMana >= b.mageMana
+    && a.partyActions <= b.partyActions;
+  const strictlyBetter = a.enemyHp < b.enemyHp
+    || a.frontHp > b.frontHp
+    || a.mageMana > b.mageMana
+    || a.partyActions < b.partyActions;
+  return noWorse && strictlyBetter;
+}
+
+describe('M44 player-perspective multidimensional adversarial review', () => {
+  it('creates a real Pareto tradeoff between pressure and warded spellcraft', () => {
+    const pressure = twoCycleProbe('pressure');
+    const warded = twoCycleProbe('warded');
+    console.log(`[M44 SPELLCRAFT] pressure=${JSON.stringify(pressure)} warded=${JSON.stringify(warded)}`);
+
+    expect(pressure.enemyHp).toBeLessThan(warded.enemyHp); // 壓力流更快削血
+    expect(warded.frontHp).toBeGreaterThan(pressure.frontHp); // 護法流保留更多前排生命
+    expect(warded.mageMana).toBeGreaterThan(pressure.mageMana); // 護持同時建立更健康的資源姿態
+    expect(dominates(pressure, warded)).toBe(false);
+    expect(dominates(warded, pressure)).toBe(false);
+  });
+
+  it('keeps a pure martial party functional because hostile magic has an exhaustion window', () => {
+    const front = fighter();
+    const back = ranger();
+    const foe = spellblade();
+    front.maxHp = front.hp = 80;
+    const state = startCombat(scriptedRng([20, 19, 1]), [front, back], [foe]);
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      forceTurn(state, front.id);
+      partyAct(scriptedRng([20, 1]), state, front.id, 'strike', foe.id);
+      forceTurn(state, back.id);
+      partyAct(scriptedRng([20, 1]), state, back.id, 'quick-shot', foe.id);
+      forceTurn(state, foe.id);
+      state.enemyIntents[foe.id] = 'salt-shard-throw';
+      enemyAct(scriptedRng([20, 1]), state, foe.id);
+    }
+
+    expect(foe.mystic?.current).toBe(0);
+    expect(state.enemyIntents[foe.id]).toBe('arcane-focus');
+    expect(front.hp).toBeGreaterThan(0);
+    expect(foe.hp).toBeLessThan(70);
+    console.log(`[M44 SPELLCRAFT] martial-window frontHp=${front.hp} foeHp=${foe.hp} next=${state.enemyIntents[foe.id]}`);
+  });
+
+  it('does not reward ward spam against a purely physical threat', () => {
+    const front = fighter();
+    const caster = mage();
+    const foe: EnemyUnit = {
+      id: 'thug', name: '重裝打手', stats: { str: 14, dex: 10, int: 8, cha: 8, con: 14 },
+      maxHp: 60, hp: 60, defense: 8, moves: [dagger], intents: [{ weight: 1, moveId: 'dagger' }],
+    };
+    const state = startCombat(scriptedRng([20, 19, 1]), [front, caster], [foe]);
+
+    forceTurn(state, caster.id);
+    partyAct(scriptedRng([10]), state, caster.id, 'arcane-focus', front.id);
+    const before = front.hp;
+    forceTurn(state, foe.id);
+    enemyAct(scriptedRng([20, 1]), state, foe.id);
+
+    expect(front.hp).toBeLessThan(before);
+    expect(front.statuses?.some((status) => status.kind === 'ward')).toBe(true);
+    console.log(`[M44 SPELLCRAFT] physical-threat ward-preserved=${front.statuses?.some((status) => status.kind === 'ward')} hp=${front.hp}`);
+  });
+
+  it('caps repeated protection at one pending magical hit so dual casters cannot bank an invulnerable shield', () => {
+    const front = fighter();
+    const mageA = mage();
+    mageA.id = 'mage-a';
+    mageA.name = '法師甲';
+    const mageB = mage();
+    mageB.id = 'mage-b';
+    mageB.name = '法師乙';
+    const foe = spellblade(true);
+    const state = startCombat(scriptedRng([20, 19, 18, 1]), [front, mageA, mageB], [foe]);
+
+    forceTurn(state, mageA.id);
+    partyAct(scriptedRng([10]), state, mageA.id, 'arcane-focus', front.id);
+    forceTurn(state, mageB.id);
+    partyAct(scriptedRng([10]), state, mageB.id, 'arcane-focus', front.id);
+
+    expect(front.statuses?.find((status) => status.kind === 'ward')).toMatchObject({ remaining: 1, potency: 4 });
+  });
+});

--- a/src/scripts/games/caravan/data/spellcraft.m44.test.ts
+++ b/src/scripts/games/caravan/data/spellcraft.m44.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+
+function scriptedRng(values: number[]): Rng {
+  let index = 0;
+  const take = () => values[index++ % Math.max(1, values.length)] ?? 10;
+  return {
+    next: () => 0,
+    roll: take,
+    d20: take,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+const strike: Move = {
+  id: 'strike', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 1 }, narration: '{actor}揮擊{target}，造成 {amount} 點傷害！',
+};
+
+const meteor: Move = {
+  id: 'meteor-fall', name: '隕石墜', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 1 }, narration: '{actor}召來隕石砸向{target}，造成 {amount} 點傷害！',
+};
+
+const saltSpell: Move = {
+  id: 'salt-shard-throw', name: '鹽刃投擲', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'frost',
+  damage: { dice: 1, sides: 1 }, narration: '{actor}凝出寒鹽之刃射向{target}，造成 {amount} 點傷害！',
+};
+
+const frostBind: Move = {
+  id: 'frost-bind', name: '寒冰束縛', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'frost',
+  damage: { dice: 1, sides: 1 }, applyStatus: { kind: 'stun', duration: 1 },
+  narration: '{actor}以寒冰束縛{target}，造成 {amount} 點傷害！',
+};
+
+const banditMend: Move = {
+  id: 'bandit-mend', name: '禁咒止血', kind: 'support', target: 'ally', hitStat: 'cha',
+  heal: { dice: 1, sides: 1 }, narration: '{actor}為{target}止血，恢復 {amount} 點生命。',
+};
+
+function member(id: string, moves: Move[], stats: PartyMember['stats'] = { str: 14, dex: 12, int: 10, cha: 10, con: 14 }): PartyMember {
+  return { id, name: id, stats, maxHp: 40, hp: 40, defense: 10, moves };
+}
+
+function casterEnemy(id: string, moves: Move[], intents?: EnemyUnit['intents']): EnemyUnit {
+  return {
+    id,
+    name: id,
+    stats: { str: 8, dex: 8, int: 12, cha: 14, con: 10 },
+    maxHp: 40,
+    hp: 40,
+    defense: 8,
+    moves,
+    intents: intents ?? moves.map((move) => ({ weight: 1, moveId: move.id })),
+  };
+}
+
+function forceTurn(state: ReturnType<typeof startCombat>, id: string): void {
+  state.turnIndex = state.order.indexOf(id);
+}
+
+describe('M44 spellcraft counterplay', () => {
+  it('turns arcane recovery into a one-charge ally ward without stacking charges', () => {
+    const mage = member('mage', [meteor], { str: 8, dex: 14, int: 16, cha: 10, con: 10 });
+    const guard = member('guard', [strike]);
+    const dummy = casterEnemy('dummy', [strike]);
+    const state = startCombat(scriptedRng([20, 19, 1]), [mage, guard], [dummy]);
+
+    forceTurn(state, mage.id);
+    partyAct(scriptedRng([20, 1]), state, mage.id, 'meteor-fall', dummy.id);
+    expect(mage.mystic?.current).toBe(3);
+
+    forceTurn(state, mage.id);
+    partyAct(scriptedRng([10]), state, mage.id, 'arcane-focus', guard.id);
+    expect(mage.mystic?.current).toBe(6);
+    expect(guard.statuses?.find((status) => status.kind === 'ward')).toMatchObject({ remaining: 1, potency: 4 });
+
+    forceTurn(state, mage.id);
+    partyAct(scriptedRng([10]), state, mage.id, 'arcane-focus', guard.id);
+    expect(guard.statuses?.find((status) => status.kind === 'ward')).toMatchObject({ remaining: 1, potency: 4 });
+  });
+
+  it('wards only magical damage while leaving physical attacks untouched', () => {
+    const guard = member('guard', [strike]);
+    guard.statuses = [{ kind: 'ward', remaining: 1, potency: 4 }];
+    const caster = casterEnemy('salt-wraith', [saltSpell, strike], [
+      { weight: 1, moveId: 'salt-shard-throw' },
+      { weight: 1, moveId: 'strike' },
+    ]);
+    const state = startCombat(scriptedRng([20, 1]), [guard], [caster]);
+
+    state.enemyIntents[caster.id] = 'salt-shard-throw';
+    forceTurn(state, caster.id);
+    enemyAct(scriptedRng([20, 1]), state, caster.id);
+    expect(guard.hp).toBe(40); // 1 點魔法傷害被 4 點護法完全吃掉
+    expect(guard.statuses?.some((status) => status.kind === 'ward')).toBe(false);
+
+    guard.statuses = [{ kind: 'ward', remaining: 1, potency: 4 }];
+    state.enemyIntents[caster.id] = 'strike';
+    forceTurn(state, caster.id);
+    enemyAct(scriptedRng([20, 1]), state, caster.id);
+    expect(guard.hp).toBe(39);
+    expect(guard.statuses?.find((status) => status.kind === 'ward')?.remaining).toBe(1);
+  });
+
+  it('fully warded spells do not sneak their magical rider status through zero damage', () => {
+    const guard = member('guard', [strike]);
+    guard.statuses = [{ kind: 'ward', remaining: 1, potency: 4 }];
+    const caster = casterEnemy('binder', [frostBind]);
+    const state = startCombat(scriptedRng([20, 1]), [guard], [caster]);
+
+    forceTurn(state, caster.id);
+    enemyAct(scriptedRng([20, 1]), state, caster.id);
+    expect(guard.hp).toBe(40);
+    expect(guard.statuses?.some((status) => status.kind === 'stun')).toBe(false);
+  });
+
+  it('makes enemy mages spend mana, then publicly switch to recovery instead of free overcasting', () => {
+    const guard = member('guard', [strike]);
+    guard.maxHp = guard.hp = 100;
+    const caster = casterEnemy('salt-wraith', [saltSpell]);
+    const state = startCombat(scriptedRng([20, 1]), [guard], [caster]);
+    expect(caster.mystic).toMatchObject({ kind: 'mana', current: 6, max: 6, strain: 0 });
+
+    for (const expected of [4, 2, 0]) {
+      forceTurn(state, caster.id);
+      enemyAct(scriptedRng([20, 1]), state, caster.id);
+      expect(caster.mystic?.current).toBe(expected);
+    }
+    expect(state.enemyIntents[caster.id]).toBe('arcane-focus');
+
+    forceTurn(state, caster.id);
+    enemyAct(scriptedRng([10]), state, caster.id);
+    expect(caster.mystic?.current).toBe(3);
+    expect(caster.mystic?.strain).toBe(0);
+    expect(caster.hp).toBe(40);
+    expect(caster.statuses?.some((status) => status.kind === 'ward')).toBe(true);
+  });
+
+  it('makes hostile priests alternate spent favor with visible prayer recovery', () => {
+    const guard = member('guard', [strike]);
+    const priest = casterEnemy('bandit-priest', [banditMend]);
+    priest.hp = 30;
+    const state = startCombat(scriptedRng([20, 1]), [guard], [priest]);
+    expect(priest.mystic).toMatchObject({ kind: 'favor', current: 1 });
+
+    forceTurn(state, priest.id);
+    enemyAct(scriptedRng([1]), state, priest.id);
+    expect(priest.hp).toBe(31);
+    expect(priest.mystic?.current).toBe(0);
+    expect(state.enemyIntents[priest.id]).toBe('field-prayer');
+
+    forceTurn(state, priest.id);
+    enemyAct(scriptedRng([10]), state, priest.id);
+    expect(priest.mystic?.current).toBe(1);
+    expect(priest.statuses?.some((status) => status.kind === 'ward')).toBe(true);
+  });
+
+  it('rejects player-side illegal targets instead of trusting the UI to prevent abuse', () => {
+    const mage = member('mage', [meteor], { str: 8, dex: 14, int: 16, cha: 10, con: 10 });
+    const ally = member('ally', [strike]);
+    const foe = casterEnemy('foe', [strike]);
+    const state = startCombat(scriptedRng([20, 19, 1]), [mage, ally], [foe]);
+
+    forceTurn(state, mage.id);
+    const attackAlly = partyAct(scriptedRng([20, 1]), state, mage.id, 'meteor-fall', ally.id);
+    expect(attackAlly).toMatchObject({ acted: false, reason: '這個招式不能指定該目標。' });
+    expect(ally.hp).toBe(40);
+
+    forceTurn(state, mage.id);
+    const wardEnemy = partyAct(scriptedRng([10]), state, mage.id, 'arcane-focus', foe.id);
+    expect(wardEnemy).toMatchObject({ acted: false, reason: '這個招式不能指定該目標。' });
+    expect(foe.statuses?.some((status) => status.kind === 'ward')).toBe(false);
+  });
+});

--- a/src/scripts/games/caravan/data/spellcraft.m44.test.ts
+++ b/src/scripts/games/caravan/data/spellcraft.m44.test.ts
@@ -8,6 +8,9 @@ import {
   type PartyMember,
 } from '../combat';
 import type { Rng } from '../rng';
+import { mysticRuleForMove } from './arcana';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+import { ENCOUNTERS } from './enemies';
 
 function scriptedRng(values: number[]): Rng {
   let index = 0;
@@ -180,5 +183,52 @@ describe('M44 spellcraft counterplay', () => {
     const wardEnemy = partyAct(scriptedRng([10]), state, mage.id, 'arcane-focus', foe.id);
     expect(wardEnemy).toMatchObject({ acted: false, reason: '這個招式不能指定該目標。' });
     expect(foe.statuses?.some((status) => status.kind === 'ward') ?? false).toBe(false);
+  });
+
+  it('wires the live salt wraith and bandit priest into the same fair resource rules', () => {
+    const guard = member('guard', [strike]);
+    guard.maxHp = guard.hp = 100;
+
+    const saltState = startCombat(scriptedRng([20, 19, 1]), [guard], ENCOUNTERS.enc_salt_crystals());
+    const wraith = saltState.enemies.find((enemy) => enemy.id === 'salt-wraith-1')!;
+    expect(wraith.mystic).toMatchObject({ kind: 'mana', current: 6, max: 6 });
+    expect(wraith.moves.find((move) => move.id === 'salt-shard-throw')?.name).toContain('秘法 2');
+    expect(wraith.moves.some((move) => move.id === 'arcane-focus')).toBe(true);
+
+    const raidState = startCombat(scriptedRng([20, 19, 18, 1]), [guard], ENCOUNTERS.enc_bandit_raid());
+    const priest = raidState.enemies.find((enemy) => enemy.id === 'bandit-medic-1')!;
+    expect(priest.mystic).toMatchObject({ kind: 'favor', current: 1 });
+    expect(priest.moves.find((move) => move.id === 'bandit-mend')?.name).toContain('神恩 1');
+    expect(priest.moves.some((move) => move.id === 'field-prayer')).toBe(true);
+  });
+
+  it('keeps the live tongueless cantor on one coherent亡魂秘法 resource instead of deadlocking half its kit', () => {
+    const guard = member('guard', [strike]);
+    guard.maxHp = guard.hp = 120;
+    const encounter = createReliquaryEncounter(2);
+    const cantor = encounter.find((enemy) => enemy.id === 'reliquary-tongueless-cantor')!;
+    const state = startCombat(scriptedRng([20, 19, 18, 17, 1]), [guard], encounter);
+
+    expect(cantor.mystic).toMatchObject({ kind: 'mana', current: 7, max: 7 });
+    const chorus = cantor.moves.find((move) => move.id === 'reliquary-silent-chorus')!;
+    const lament = cantor.moves.find((move) => move.id === 'reliquary-lament-touch')!;
+    expect(mysticRuleForMove(chorus)).toMatchObject({ kind: 'mana', school: 'arcane', cost: 3 });
+    expect(mysticRuleForMove(lament)).toMatchObject({ kind: 'mana', school: 'cryomancy', cost: 2 });
+
+    forceTurn(state, cantor.id);
+    state.enemyIntents[cantor.id] = chorus.id;
+    enemyAct(scriptedRng([20, 1, 1, 1]), state, cantor.id);
+    expect(cantor.mystic?.current).toBe(4);
+
+    forceTurn(state, cantor.id);
+    state.enemyIntents[cantor.id] = lament.id;
+    enemyAct(scriptedRng([20, 1]), state, cantor.id);
+    expect(cantor.mystic?.current).toBe(2);
+
+    forceTurn(state, cantor.id);
+    state.enemyIntents[cantor.id] = chorus.id;
+    enemyAct(scriptedRng([10]), state, cantor.id);
+    expect(cantor.mystic?.current).toBe(5);
+    expect(state.log.some((entry) => entry.text.includes('無法調用神恩'))).toBe(false);
   });
 });

--- a/src/scripts/games/caravan/data/spellcraft.m44.test.ts
+++ b/src/scripts/games/caravan/data/spellcraft.m44.test.ts
@@ -101,7 +101,7 @@ describe('M44 spellcraft counterplay', () => {
     state.enemyIntents[caster.id] = 'salt-shard-throw';
     forceTurn(state, caster.id);
     enemyAct(scriptedRng([20, 1]), state, caster.id);
-    expect(guard.hp).toBe(40); // 1 點魔法傷害被 4 點護法完全吃掉
+    expect(guard.hp).toBe(40);
     expect(guard.statuses?.some((status) => status.kind === 'ward')).toBe(false);
 
     guard.statuses = [{ kind: 'ward', remaining: 1, potency: 4 }];
@@ -179,6 +179,6 @@ describe('M44 spellcraft counterplay', () => {
     forceTurn(state, mage.id);
     const wardEnemy = partyAct(scriptedRng([10]), state, mage.id, 'arcane-focus', foe.id);
     expect(wardEnemy).toMatchObject({ acted: false, reason: '這個招式不能指定該目標。' });
-    expect(foe.statuses?.some((status) => status.kind === 'ward')).toBe(false);
+    expect(foe.statuses?.some((status) => status.kind === 'ward') ?? false).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- make arcane focus and battlefield prayer tactically meaningful by letting the caster place a one-charge ward on an ally while recovering mana/favor
- make wards absorb only mystical damage, with full absorption also blocking a spell's attached status rider
- initialize hostile spellcasters with the same mana/favor rules as the party
- force exhausted enemy casters to telegraph recovery instead of silently overcasting for free
- classify salt-wraith magic and mage specialization spells explicitly by mystical school
- fix the live Ashen Reliquary Tongueless Cantor so Silent Chorus and Lament Touch share one coherent ghostly-mana resource instead of deadlocking half its kit
- enforce enemy/ally/self target legality in `partyAct` instead of trusting UI-only targeting
- make retreat pursuit respect hostile spell resources as well
- document the M44 player-facing spellcraft rules and gameplay gates

## Player-facing design intent
M41 made magic a resource bar, but most magical actions still behaved like ordinary attacks with costs. M44 adds a readable response loop: enemy magic is telegraphed and resource-limited, while the party can spend tempo on warded recovery. Wards are intentionally one-charge and magic-only, so they cannot replace armor, guarding, healing, or damage pressure.

## Multidimensional adversarial review
The M44 suite checks:
- ward vs physical and magical damage separation
- full ward absorption vs attached magical stun/status riders
- enemy mana/favor consumption, exhaustion, public recovery intent, and no enemy overcast
- hostile priest heal/prayer cycling
- illegal ally/enemy/self target abuse paths
- pressure vs warded play as a Pareto tradeoff across enemy HP, front-line HP, mana posture, and action tempo
- pure martial viability through enemy exhaustion windows
- no ward benefit against purely physical threats
- dual-caster ward refresh capped at one pending magical hit
- live salt-wraith and bandit-priest integration using production encounter factories
- live Tongueless Cantor school/resource coherence using the production Ashen Reliquary encounter
- regression against core combat, M41 magic, M42 endurance/composition diversity, and M43 armory/balance tests

## Validation
`Caravan M44 Spellcraft CI` runs production build, M44 rule/integration tests, M44 multidimensional player probes, core combat/M41 regression, all M42 composition/camp-policy gates, and M43 armory/endurance/Pareto regression.