### PR TITLE
feat(caravan): add M45 interruptible rituals

### DIFF
--- a/.github/workflows/caravan-m45-ci.yml
+++ b/.github/workflows/caravan-m45-ci.yml
@@ -1,0 +1,68 @@
+name: Caravan M45 Ritual CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m45-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m45-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M45 ritual lifecycle and live encounters
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/rituals.m45.test.ts
+
+      - name: M45 multidimensional player response review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M42 composition and camp-policy diversity regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M42 expedition state regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts

--- a/docs/.m45-pr-placeholder
+++ b/docs/.m45-pr-placeholder
@@ -1,1 +1,0 @@
-M45 review branch marker. Remove before merge.

--- a/docs/.m45-pr-placeholder
+++ b/docs/.m45-pr-placeholder
@@ -1,0 +1,1 @@
+M45 review branch marker. Remove before merge.

--- a/docs/caravan-m45-interruptible-rituals.md
+++ b/docs/caravan-m45-interruptible-rituals.md
@@ -1,0 +1,40 @@
+# M45 Interruptible Rituals
+
+M45 makes dangerous fantasy abilities readable battlefield events instead of ordinary buttons with larger numbers.
+
+## Player-facing rules
+
+- Only encounter-defining abilities use ritual preparation; ordinary attacks and minor spells remain immediate.
+- A marked ritual spends one enemy action preparing and deals no damage during that preparation.
+- The enemy's intent openly tells the player that the ritual will complete on the caster's next action.
+- Stun cancels a prepared ritual. Weakness hits can also break poise and create the same stun interruption window.
+- A ritual that is not interrupted resolves through the normal combat engine and pays its original mana/favor cost exactly once.
+- Interruption is optional, not mandatory. Players may instead guard, apply a magical ward, pressure the caster, or accept the hit and preserve resources.
+- Interrupting one ritual does not permanently lock the caster; future ritual attempts remain possible.
+
+## Live encounter integration
+
+- Tongueless Cantor: `reliquary-silent-chorus` becomes the Silent Chorus Ritual.
+- Dragon Ember Avatar: `reliquary-ember-breath` becomes a telegraphed Dragon-Heart Breath and explicitly costs 4 mana as pyromancy.
+- The first Ashen Reliquary battle remains the baseline guard/weakness encounter and does not gain ritual overhead.
+
+## Multidimensional adversarial gameplay gates
+
+The player-perspective probes compare four responses to the same ritual:
+
+1. Interrupt with stun/poise break: strongest immediate survival, spends control tempo.
+2. Ward while recovering mana: preserves magical posture and reduces incoming magic, but the ritual still resolves.
+3. Brace with guard: protects the frontline without requiring a caster or control move.
+4. Pressure: accepts more incoming risk in exchange for faster boss damage.
+
+Acceptance requirements:
+
+- Each response must own a different advantage; no strategy may dominate all measured dimensions.
+- A pure martial party without a ritual-interrupt move must remain able to survive and make progress.
+- Ritual preparation cannot deal damage or consume the spell resource early.
+- A resolved ritual pays its resource only once.
+- Ordinary attacks and minor spells remain one-action moves.
+- One successful interrupt cannot permanently disable future ritual attempts.
+- M40 live Reliquary combat, M41 magic, M42 endurance/composition diversity, M43 armory, and M44 spellcraft counterplay remain regression gates.
+
+This is an automated adversarial gameplay review, not a substitute for several-hour human playtesting.

--- a/src/pages/caravan/ashen-reliquary-battle.astro
+++ b/src/pages/caravan/ashen-reliquary-battle.astro
@@ -5,17 +5,20 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <BaseLayout title="灰燼聖匣戰鬥 — 商隊與劍" description="迎戰灰燼騎士、無舌唱詩班與龍燼化身。" lang="zh-TW">
   <main class="battle-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M41 ARCANE &amp; FAITH</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M45 RITUAL COUNTERPLAY</p>
       <h1 id="battle-title">灰燼聖匣戰鬥</h1>
-      <p id="battle-copy">弱點、護勢、敵方意圖、秘法、神恩與 Boss 激怒都會影響這場戰鬥。</p>
-      <nav><a href="/caravan/ashen-reliquary">返回灰燼聖匣</a><a href="/caravan/play">返回主冒險</a></nav>
+      <p id="battle-copy">讀取敵方意圖，在輸出、防守、護法與中斷儀式之間做選擇。</p>
+      <nav><a href="/caravan/ashen-reliquary">返回灰燼聖匣</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/play">返回主冒險</a></nav>
     </header>
+
     <section id="notice" class="panel"></section>
     <section id="intent" class="intent" hidden></section>
+
     <section id="battlefield" class="battlefield" hidden>
       <div><p class="eyebrow">ENEMIES</p><div id="enemies" class="units"></div></div>
       <div><p class="eyebrow">EXPEDITION PARTY</p><div id="party" class="units"></div></div>
     </section>
+
     <section id="actions" class="actions" hidden></section>
     <section id="result" class="result" hidden></section>
     <section class="log-panel"><p class="eyebrow">BATTLE CHRONICLE</p><div id="log" class="log"></div></section>
@@ -26,7 +29,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   import { loadGame, saveGame } from '@scripts/games/caravan/save';
   import { createRng, type Rng } from '@scripts/games/caravan/rng';
   import {
-    ELEMENT_LABELS, attemptRetreat, currentActor, enemyAct, partyAct, partyMoveAvailability, startCombat,
+    ELEMENT_LABELS, attemptRetreat, currentActor, partyAct, partyMoveAvailability, startCombat,
     type CombatState, type EnemyUnit, type Move, type PartyMember,
   } from '@scripts/games/caravan/combat';
   import { mysticPowerText } from '@scripts/games/caravan/data/arcana';
@@ -36,6 +39,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     type ReliquaryBattleStage,
   } from '@scripts/games/caravan/data/ashenReliquaryCombat';
   import { beginReliquaryBattleAttempt, finishReliquaryBattleAttempt } from '@scripts/games/caravan/data/ashenReliquaryAttempts';
+  import {
+    ritualChargeFor, ritualEnemyAct, ritualIntentText,
+  } from '@scripts/games/caravan/data/rituals.m45';
 
   const titleEl = document.getElementById('battle-title')!;
   const copyEl = document.getElementById('battle-copy')!;
@@ -53,6 +59,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   let rng: Rng | null = null;
   let settled = false;
 
+  const STATUS_LABEL: Record<string, string> = {
+    poison: '中毒', stun: '暈眩', strength: '強化', ward: '護法',
+  };
+
   const text = (tag: string, value: string, className?: string): HTMLElement => {
     const element = document.createElement(tag);
     if (className) element.className = className;
@@ -62,15 +72,24 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function unitCard(unit: PartyMember | EnemyUnit): HTMLElement {
     const card = document.createElement('article');
-    card.className = `unit ${unit.hp <= 0 ? 'down' : ''}`;
     const enemy = 'intents' in unit ? unit as EnemyUnit : null;
-    const statuses = (unit.statuses ?? []).map((status) => `${status.kind} ${status.remaining}`).join('、');
+    const charging = enemy && combat ? ritualChargeFor(combat, enemy.id) : null;
+    card.className = `unit ${unit.hp <= 0 ? 'down' : ''} ${charging ? 'channeling' : ''}`;
+    const statuses = (unit.statuses ?? [])
+      .map((status) => `${STATUS_LABEL[status.kind] ?? status.kind} ${status.remaining}`)
+      .join('、');
     const poise = enemy?.maxPoise !== undefined ? `｜護勢 ${enemy.poise ?? enemy.maxPoise}/${enemy.maxPoise}` : '';
-    card.append(text('h3', unit.name), text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${statuses ? `｜${statuses}` : ''}`, 'unit-status'));
+    card.append(
+      text('h3', unit.name),
+      text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${statuses ? `｜${statuses}` : ''}`, 'unit-status'),
+    );
+
     if (enemy) {
       const weak = (enemy.weaknesses ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       const resist = (enemy.resists ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       card.append(text('p', `弱點：${weak}｜抗性：${resist}`, 'affinity'));
+      if (enemy.mystic) card.append(text('p', mysticPowerText(enemy.mystic), `mystic mystic-${enemy.mystic.kind}`));
+      if (charging) card.append(text('p', '⚠ 儀式蓄力中：在它下次行動前中斷', 'ritual-warning'));
     } else {
       const member = unit as PartyMember;
       card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
@@ -87,17 +106,19 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function renderIntent(): void {
     if (!combat || combat.outcome !== 'ongoing') { intentEl.hidden = true; return; }
-    const lines = combat.enemies.filter((enemy) => enemy.hp > 0).map((enemy) => {
-      const move = enemy.moves.find((entry) => entry.id === combat!.enemyIntents[enemy.id]);
-      return `${enemy.name}：${move?.name ?? '未知意圖'}`;
-    });
-    intentEl.replaceChildren(text('strong', `第 ${combat.round} 輪｜敵方意圖`), text('span', lines.join('　')));
+    const lines = combat.enemies
+      .filter((enemy) => enemy.hp > 0)
+      .map((enemy) => `${enemy.name}：${ritualIntentText(combat!, enemy)}`);
+    intentEl.replaceChildren(
+      text('strong', `第 ${combat.round} 輪｜敵方意圖`),
+      text('span', lines.join('　')),
+    );
     intentEl.hidden = lines.length === 0;
   }
 
   function renderLog(): void {
     logEl.replaceChildren();
-    for (const entry of combat?.log.slice(-24) ?? []) logEl.append(text('p', entry.text, entry.kind));
+    for (const entry of combat?.log.slice(-28) ?? []) logEl.append(text('p', entry.text, entry.kind));
   }
 
   function button(
@@ -133,7 +154,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     const className = overcast ? 'overcast' : undefined;
     const prefix = overcast ? `禁式過載（反噬 ${availability.backlash}）・` : '';
     if (move.kind === 'guard' || move.target === 'self') {
-      return [button(`${prefix}${move.name}`, () => act(actor.id, move.id, actor.id, overcast), className, !availability.allowed, availability.reason)];
+      return [button(
+        `${prefix}${move.name}`,
+        () => act(actor.id, move.id, actor.id, overcast),
+        className,
+        !availability.allowed,
+        availability.reason,
+      )];
     }
     return targetsFor(move).map((target) => button(
       `${prefix}${move.name} → ${target.name}`,
@@ -151,22 +178,34 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     return buttons;
   }
 
+  function ritualAdvice(): string {
+    if (!combat) return '';
+    const charging = combat.enemies.find((enemy) => enemy.hp > 0 && ritualChargeFor(combat!, enemy.id));
+    if (!charging) return '';
+    return `｜⚠ ${charging.name}正在完成儀式：暈眩、陷阱、盾擊或以弱點打空護勢都能中斷；也可以改採架盾、護法或搶殺。`;
+  }
+
   function renderActions(): void {
     actionsEl.replaceChildren();
     const actorInfo = combat ? currentActor(combat) : null;
-    if (!combat || combat.outcome !== 'ongoing' || actorInfo?.side !== 'party') { actionsEl.hidden = true; return; }
+    if (!combat || combat.outcome !== 'ongoing' || actorInfo?.side !== 'party') {
+      actionsEl.hidden = true;
+      return;
+    }
     const actor = combat.party.find((member) => member.id === actorInfo.id)!;
     actionsEl.hidden = false;
     const resource = actor.mystic ? `｜${mysticPowerText(actor.mystic)}` : '';
+    const baseHint = actor.mystic?.kind === 'mana'
+      ? '秘法可以換取爆發或護持；敵人蓄力時，控制與弱點破勢的價值會提高。'
+      : actor.mystic?.kind === 'favor'
+        ? '神恩必須先建立再消耗；祝禱可護住隊友，但會犧牲當回合輸出。'
+        : '物理職業不消耗魔力；利用盾擊、陷阱、弱點破勢或直接壓血都能處理儀式。';
     actionsEl.append(
       text('h2', `${actor.name}的行動${resource}`),
-      text('p', actor.mystic?.kind === 'mana'
-        ? '炎術消耗高、霜術較節制；秘法不足時可承受反噬過載，專注能恢復秘法並降低灼傷。'
-        : actor.mystic?.kind === 'favor'
-          ? '聖擊與戰地禱告建立神恩；治療、聖光與戰吟必須消耗神恩。'
-          : '根據敵方意圖、弱點與護勢選擇戰技。'),
+      text('p', `${baseHint}${ritualAdvice()}`),
     );
-    const grid = document.createElement('div'); grid.className = 'action-grid';
+    const grid = document.createElement('div');
+    grid.className = 'action-grid';
     for (const move of actor.moves) grid.append(...moveButtons(actor, move));
     grid.append(button('撤退並承受傷勢', retreat, 'retreat'));
     actionsEl.append(grid);
@@ -176,8 +215,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     if (!combat || !rng) return;
     let safety = 0;
     while (combat.outcome === 'ongoing' && currentActor(combat)?.side === 'enemy' && safety < 30) {
-      const actor = currentActor(combat); if (!actor) break;
-      enemyAct(rng, combat, actor.id); safety += 1;
+      const actor = currentActor(combat);
+      if (!actor) break;
+      ritualEnemyAct(rng, combat, actor.id);
+      safety += 1;
     }
   }
 
@@ -185,17 +226,21 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     if (!combat || !rng || settled) return;
     const result = partyAct(rng, combat, actorId, moveId, targetId, { overcast });
     if (result.acted) runEnemyTurns();
-    settleOutcome(); render();
+    settleOutcome();
+    render();
   }
 
   function retreat(): void {
     if (!combat || !rng || settled) return;
-    attemptRetreat(rng, combat); settleOutcome(); render();
+    attemptRetreat(rng, combat);
+    settleOutcome();
+    render();
   }
 
   function settleOutcome(): void {
     if (!combat || !stage || settled || combat.outcome === 'ongoing') return;
-    const latest = loadGame(); if (!latest) return;
+    const latest = loadGame();
+    if (!latest) return;
     try {
       let receipt = '';
       if (combat.outcome === 'victory') receipt = completeReliquaryBattle(latest, stage);
@@ -205,72 +250,117 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
         latest.protagonist.injuredForTrips = Math.max(latest.protagonist.injuredForTrips, 1);
         injured.push('protagonist');
       }
-      saveGame(latest); settled = true; resultEl.hidden = false;
+      saveGame(latest);
+      settled = true;
+      resultEl.hidden = false;
       resultEl.replaceChildren(
         text('p', combat.outcome === 'victory' ? 'VICTORY' : combat.outcome === 'retreated' ? 'RETREAT' : 'DEFEAT', 'eyebrow'),
         text('h2', combat.outcome === 'victory' ? `${RELIQUARY_BATTLE_NAMES[stage]}獲勝` : '遠征隊退出戰場'),
-        text('p', combat.outcome === 'victory' ? `勝利收據已寫入：${receipt}。現在可以返回本幕選擇解法。` : '本幕尚未通過，整備後可以再次挑戰。'),
+        text('p', combat.outcome === 'victory'
+          ? `勝利收據已寫入：${receipt}。現在可以返回本幕選擇解法。`
+          : '本幕尚未通過，整備後可以再次挑戰。'),
         text('p', `養傷：${injured.join('、') || '無'}`, 'injuries'),
       );
-      const link = document.createElement('a'); link.href = '/caravan/ashen-reliquary'; link.className = 'return-link';
-      link.textContent = combat.outcome === 'victory' ? '返回聖匣選擇本幕解法' : '返回聖匣整備'; resultEl.append(link);
+      const link = document.createElement('a');
+      link.href = '/caravan/ashen-reliquary';
+      link.className = 'return-link';
+      link.textContent = combat.outcome === 'victory' ? '返回聖匣選擇本幕解法' : '返回聖匣整備';
+      resultEl.append(link);
     } catch (error) {
       resultEl.hidden = false;
       resultEl.replaceChildren(text('p', error instanceof Error ? error.message : '戰鬥結算失敗。'));
     }
   }
 
-  function render(): void { renderUnits(); renderIntent(); renderActions(); renderLog(); }
+  function render(): void {
+    renderUnits();
+    renderIntent();
+    renderActions();
+    renderLog();
+  }
 
   function boot(): void {
-    if (!stage) { noticeEl.append(text('h2', '無效的戰鬥幕次'), text('p', '請從灰燼聖匣任務頁進入。')); return; }
-    const save = loadGame(); if (!save) { noticeEl.append(text('h2', '找不到商隊存檔')); return; }
+    if (!stage) {
+      noticeEl.append(text('h2', '無效的戰鬥幕次'), text('p', '請從灰燼聖匣任務頁進入。'));
+      return;
+    }
+    const save = loadGame();
+    if (!save) {
+      noticeEl.append(text('h2', '找不到商隊存檔'));
+      return;
+    }
     const access = reliquaryBattleAccess(save, stage);
     titleEl.textContent = RELIQUARY_BATTLE_NAMES[stage];
     copyEl.textContent = stage === 1
-      ? '灰燼騎士會架盾與激怒；聖與鈍擊可破勢，法師必須管理秘法。'
+      ? '灰燼騎士會架盾與激怒；聖與鈍擊可破勢。這一幕是理解防守與弱點的基準戰。'
       : stage === 2
-        ? '唱詩班會施放全隊震波與暈眩；教士需要以聖擊建立神恩維持治療。'
-        : '龍燼化身會範圍吐息並在半血激怒；冰、聖屬性與施法資源是關鍵。';
-    if (!access.allowed) { noticeEl.append(text('h2', access.completed ? '戰鬥已完成' : '目前無法進入'), text('p', access.reason)); return; }
+        ? '無舌領唱者的「無聲聖歌」會先準備一回合。你可以破勢中斷，也能改用護法、防守或搶先擊殺。'
+        : '龍燼化身的「心火吐息」會先蓄力；冰與聖可破勢，但不是唯一答案，護法與承傷同樣可行。';
+    if (!access.allowed) {
+      noticeEl.append(text('h2', access.completed ? '戰鬥已完成' : '目前無法進入'), text('p', access.reason));
+      return;
+    }
     const attempt = beginReliquaryBattleAttempt(save, stage);
     saveGame(save);
     const party = buildReliquaryParty(save);
     noticeEl.append(
       text('h2', `出征隊 ${party.length} 人`),
-      text('p', attempt.abandonmentPenalty ?? '使用目前出征編成；受傷旅伴不會被帶入。中途關頁會留下戰鬥嘗試收據。'),
+      text('p', attempt.abandonmentPenalty ?? '使用目前出征編成；儀式大招會提前公開。中途關頁仍會留下戰鬥嘗試收據。'),
     );
     rng = createRng((save.createdAt + save.marketSeed + stage * 7919) >>> 0);
     combat = startCombat(rng, party, createReliquaryEncounter(stage));
-    battlefieldEl.hidden = false; runEnemyTurns(); settleOutcome(); render();
+    battlefieldEl.hidden = false;
+    runEnemyTurns();
+    settleOutcome();
+    render();
   }
 
   boot();
 </script>
 
 <style>
-  :global(body) { background: #0f0b0a; color: #efe5d3; }
-  .battle-page { width: min(1180px, calc(100% - 28px)); margin: 0 auto; padding: 42px 0 80px; }
-  .hero, .panel, .actions, .log-panel, .result { border: 1px solid #4b352c; background: #19110f; }
-  .hero { padding: 34px; background: radial-gradient(circle at 78% 18%, #572016 0, transparent 32%), linear-gradient(135deg, #261611, #0f0b0a); }
-  .eyebrow { margin: 0 0 7px; color: #d59a59; font-size: .72rem; letter-spacing: .18em; text-transform: uppercase; }
-  h1, h2, h3, p { margin-top: 0; } h1 { margin-bottom: 12px; font-size: clamp(2.2rem, 6vw, 4.6rem); }
-  .hero p, .panel p, .actions p, .unit p, .result p { color: #bcae9e; line-height: 1.7; }
-  nav { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 20px; } a { color: #e4b66c; }
-  .panel { display: flex; justify-content: space-between; gap: 18px; margin-top: 18px; padding: 18px 22px; }
-  .intent { display: flex; gap: 16px; margin-top: 18px; padding: 14px 18px; border-left: 3px solid #c06b44; background: #2b1713; }
-  .battlefield { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; margin-top: 18px; }
-  .units { display: grid; gap: 10px; } .unit { padding: 15px; border: 1px solid #49372e; background: #201714; } .unit.down { opacity: .45; }
-  .unit-status { color: #d5b77e !important; } .affinity { color: #c69c89 !important; } .formation { color: #9db78a !important; }
-  .mystic { margin-bottom: 0; font-weight: 700; } .mystic-mana { color: #8fb9df !important; } .mystic-favor { color: #e0ca80 !important; }
-  .actions, .result, .log-panel { margin-top: 18px; padding: 22px; }
-  .action-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
-  button, .return-link { display: block; padding: 11px 12px; border: 1px solid #d1a25c; background: #a96b31; color: #160d08; font: inherit; font-weight: 700; cursor: pointer; text-align: center; text-decoration: none; }
-  button:disabled { opacity: .38; cursor: not-allowed; }
-  button.overcast { border-color: #d06155; background: #6e241f; color: #f4d8cc; }
-  button.retreat { background: transparent; color: #db9d84; border-color: #8e5141; }
-  .return-link { width: fit-content; margin-top: 14px; } .injuries { color: #d58c78 !important; }
-  .log { max-height: 360px; overflow: auto; } .log p { margin: 0; padding: 7px 0; border-bottom: 1px solid #2f241f; color: #bcae9e; }
-  .log p.damage { color: #d79a82; } .log p.heal, .log p.victory { color: #a9c783; } .log p.info { color: #d2bb84; }
-  @media (max-width: 820px) { .battlefield, .action-grid { grid-template-columns: 1fr; } .panel, .intent { flex-direction: column; } }
+  :global(body) { margin: 0; background: #100d0a; color: #eadfc9; }
+  .battle-page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 38px 0 70px; font-family: Georgia, 'Noto Serif TC', serif; }
+  .hero { border-bottom: 1px solid #6e5437; padding-bottom: 22px; margin-bottom: 20px; }
+  .hero h1 { margin: 6px 0 10px; font-size: clamp(30px, 5vw, 54px); color: #f0d59a; }
+  .hero p { max-width: 850px; line-height: 1.7; }
+  nav { display: flex; gap: 14px; flex-wrap: wrap; }
+  nav a, .return-link { color: #e9c276; }
+  .eyebrow { margin: 0; letter-spacing: .16em; font: 700 11px/1.4 system-ui, sans-serif; color: #b99a69; }
+  .panel, .intent, .actions, .result, .log-panel { background: #19140f; border: 1px solid #4d3b28; border-radius: 10px; padding: 16px; margin: 14px 0; }
+  .intent { border-color: #8e6935; display: grid; gap: 8px; }
+  .intent span { line-height: 1.7; color: #f2d9a0; }
+  .battlefield { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 16px; }
+  .units { display: grid; gap: 10px; }
+  .unit { background: #17120e; border: 1px solid #443426; border-left: 4px solid #755c3d; border-radius: 8px; padding: 12px 14px; transition: border-color .15s ease; }
+  .unit.channeling { border-color: #bd7f38; box-shadow: 0 0 0 1px #7b4d20 inset; }
+  .unit.down { opacity: .46; }
+  .unit h3 { margin: 0 0 7px; color: #eed29a; }
+  .unit p { margin: 5px 0; font-size: 14px; line-height: 1.45; }
+  .unit-status { color: #d8c9b4; }
+  .affinity { color: #bdb09d; }
+  .formation { color: #a6b7c7; }
+  .mystic-mana { color: #9cb9ee; }
+  .mystic-favor { color: #edd690; }
+  .ritual-warning { color: #ffbd68; font-weight: 700; }
+  .actions h2, .result h2 { margin: 0 0 8px; }
+  .actions > p { color: #cfc0aa; line-height: 1.7; }
+  .action-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 9px; }
+  button { appearance: none; text-align: left; border: 1px solid #72583b; border-radius: 7px; background: #241b12; color: #eadfc9; padding: 11px 12px; cursor: pointer; line-height: 1.4; }
+  button:hover:not(:disabled) { border-color: #d5a85f; background: #302217; }
+  button:disabled { opacity: .42; cursor: not-allowed; }
+  button.overcast { border-color: #a45148; color: #efb4aa; }
+  button.retreat { border-color: #66504a; color: #c7aaa4; }
+  .log { max-height: 360px; overflow: auto; }
+  .log p { margin: 7px 0; padding-bottom: 7px; border-bottom: 1px solid #2c231b; line-height: 1.5; }
+  .log .damage { color: #efc1a5; }
+  .log .heal { color: #b8d7a7; }
+  .log .info { color: #d7c59f; }
+  .log .victory { color: #f4d77f; font-weight: 700; }
+  .result { border-color: #8f713d; }
+  .injuries { color: #cda99e; }
+  @media (max-width: 760px) {
+    .battlefield { grid-template-columns: 1fr; }
+    .battle-page { width: min(100% - 20px, 1180px); padding-top: 18px; }
+  }
 </style>

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -28,6 +28,8 @@ const RULES: Record<string, MysticMoveRule> = {
   // M44：無舌領唱者是以亡魂秘法模仿聖歌，不應同時要求另一條神恩資源。
   'reliquary-silent-chorus': { kind: 'mana', school: 'arcane', cost: 3, gain: 0, overcast: false, strainRelief: 0 },
   'reliquary-lament-touch': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
+  // M45：心火吐息是古龍心火術式，不再被當成無限免費的魅力系普通攻擊。
+  'reliquary-ember-breath': { kind: 'mana', school: 'pyromancy', cost: 4, gain: 0, overcast: false, strainRelief: 0 },
   // M44：兩個 Lv4 法師專精的代表招式明確歸屬學派，不再只靠元素 fallback 推斷。
   'chain-lightning': { kind: 'mana', school: 'pyromancy', cost: 3, gain: 0, overcast: true, strainRelief: 0 },
   'corrosive-curse': { kind: 'mana', school: 'arcane', cost: 2, gain: 0, overcast: true, strainRelief: 0 },

--- a/src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+++ b/src/scripts/games/caravan/data/rituals.balance.m45.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import {
+  partyAct,
+  startCombat,
+  type CombatState,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { ritualEnemyAct, ritualChargeFor } from './rituals.m45';
+
+function scriptedRng(values: number[] = [12, 6, 12, 6, 12, 6]): Rng {
+  let index = 0;
+  const take = () => values[index++ % Math.max(1, values.length)] ?? 10;
+  return {
+    next: () => 0,
+    roll: take,
+    d20: take,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+const strike: Move = {
+  id: 'strike', name: '長劍斬', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 4, bonusStat: 'str' }, narration: '{actor}斬向{target}，造成 {amount} 點傷害！',
+};
+const guardMove: Move = {
+  id: 'guard', name: '架盾', kind: 'guard', target: 'self', hitStat: 'str',
+  narration: '{actor}壓低重心舉盾守住陣線。',
+};
+const stunBash: Move = {
+  id: 'shield-bash', name: '盾牆猛擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'blunt',
+  damage: { dice: 1, sides: 1 }, applyStatus: { kind: 'stun', duration: 1 },
+  narration: '{actor}以盾牆撞向{target}，造成 {amount} 點傷害！',
+};
+const shot: Move = {
+  id: 'quick-shot', name: '疾射', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce',
+  damage: { dice: 1, sides: 4, bonusStat: 'dex' }, narration: '{actor}射向{target}，造成 {amount} 點傷害！',
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 4, bonusStat: 'int' }, narration: '{actor}以火球轟向{target}，造成 {amount} 點傷害！',
+};
+const ritual: Move = {
+  id: 'reliquary-silent-chorus', name: '無聲聖歌', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'frost', area: true,
+  damage: { dice: 1, sides: 6, bonusStat: 'int' }, narration: '{actor}放出死寂聖歌掃過{target}，造成 {amount} 點傷害！',
+};
+
+function fighter(withControl = true): PartyMember {
+  return {
+    id: 'fighter', name: '前衛', stats: { str: 16, dex: 12, int: 8, cha: 8, con: 16 },
+    maxHp: 40, hp: 40, defense: 12,
+    moves: withControl ? [strike, guardMove, stunBash] : [strike, guardMove], formationRow: 'front',
+  };
+}
+function mage(): PartyMember {
+  return {
+    id: 'mage', name: '法師', stats: { str: 8, dex: 13, int: 16, cha: 10, con: 10 },
+    maxHp: 30, hp: 30, defense: 11, moves: [fireball], formationRow: 'back',
+  };
+}
+function ranger(): PartyMember {
+  return {
+    id: 'ranger', name: '游俠', stats: { str: 10, dex: 16, int: 10, cha: 10, con: 12 },
+    maxHp: 34, hp: 34, defense: 12, moves: [shot], formationRow: 'back',
+  };
+}
+function cantor(): EnemyUnit {
+  return {
+    id: 'cantor', name: '儀式領唱者', stats: { str: 8, dex: 8, int: 16, cha: 12, con: 14 },
+    maxHp: 70, hp: 70, defense: 10, moves: [ritual],
+    weaknesses: ['blunt', 'fire'], maxPoise: 3,
+    intents: [{ weight: 1, moveId: ritual.id }],
+  };
+}
+
+function forceTurn(state: CombatState, id: string): void {
+  state.turnIndex = state.order.indexOf(id);
+}
+
+interface Probe {
+  bossHp: number;
+  frontHp: number;
+  mageHp: number;
+  mana: number;
+  interrupted: boolean;
+}
+
+type Policy = 'interrupt' | 'ward' | 'brace' | 'pressure';
+
+function probe(policy: Policy): Probe {
+  const front = fighter(true);
+  const caster = mage();
+  const boss = cantor();
+  const state = startCombat(scriptedRng([20, 19, 1]), [front, caster], [boss]);
+  caster.mystic!.current = 1; // simulate a real mid-expedition resource posture rather than a fresh duel
+
+  state.enemyIntents[boss.id] = ritual.id;
+  forceTurn(state, boss.id);
+  ritualEnemyAct(scriptedRng([10]), state, boss.id);
+  expect(ritualChargeFor(state, boss.id)).not.toBeNull();
+
+  if (policy === 'interrupt') {
+    forceTurn(state, front.id);
+    partyAct(scriptedRng([20, 1]), state, front.id, stunBash.id, boss.id);
+  } else if (policy === 'ward') {
+    forceTurn(state, caster.id);
+    partyAct(scriptedRng([10]), state, caster.id, 'arcane-focus', front.id);
+  } else if (policy === 'brace') {
+    forceTurn(state, front.id);
+    partyAct(scriptedRng([10]), state, front.id, guardMove.id, front.id);
+  } else {
+    forceTurn(state, caster.id);
+    partyAct(scriptedRng([20, 4]), state, caster.id, fireball.id, boss.id);
+  }
+
+  forceTurn(state, boss.id);
+  const result = ritualEnemyAct(scriptedRng([12, 6, 12, 6]), state, boss.id);
+  return {
+    bossHp: boss.hp,
+    frontHp: front.hp,
+    mageHp: caster.hp,
+    mana: caster.mystic?.current ?? 0,
+    interrupted: result.kind === 'interrupted',
+  };
+}
+
+describe('M45 player-perspective multidimensional ritual review', () => {
+  it('gives interrupt, ward, brace and pressure genuinely different advantages', () => {
+    const interrupt = probe('interrupt');
+    const ward = probe('ward');
+    const brace = probe('brace');
+    const pressure = probe('pressure');
+    console.log('[M45 RITUAL POLICIES]', { interrupt, ward, brace, pressure });
+
+    expect(interrupt.interrupted).toBe(true);
+    expect(interrupt.frontHp + interrupt.mageHp).toBeGreaterThan(pressure.frontHp + pressure.mageHp);
+
+    expect(ward.mana).toBeGreaterThan(interrupt.mana);
+    expect(ward.frontHp).toBeGreaterThan(pressure.frontHp);
+
+    expect(brace.frontHp).toBeGreaterThan(pressure.frontHp);
+    expect(brace.interrupted).toBe(false);
+
+    expect(pressure.bossHp).toBeLessThan(interrupt.bossHp);
+    expect(pressure.bossHp).toBeLessThan(ward.bossHp);
+  });
+
+  it('keeps a pure martial party alive without requiring a ritual interrupt tool', () => {
+    const front = fighter(false);
+    const back = ranger();
+    const boss = cantor();
+    const state = startCombat(scriptedRng([20, 19, 1]), [front, back], [boss]);
+
+    state.enemyIntents[boss.id] = ritual.id;
+    forceTurn(state, boss.id);
+    ritualEnemyAct(scriptedRng([10]), state, boss.id);
+
+    forceTurn(state, front.id);
+    partyAct(scriptedRng([10]), state, front.id, guardMove.id, front.id);
+    forceTurn(state, back.id);
+    partyAct(scriptedRng([20, 4]), state, back.id, shot.id, boss.id);
+
+    forceTurn(state, boss.id);
+    const result = ritualEnemyAct(scriptedRng([12, 6, 12, 6]), state, boss.id);
+
+    expect(result.kind).toBe('resolved');
+    expect(front.hp).toBeGreaterThan(0);
+    expect(back.hp).toBeGreaterThan(0);
+    expect(boss.hp).toBeLessThan(boss.maxHp);
+  });
+
+  it('does not permanently silence a ritual caster after one successful interrupt', () => {
+    const front = fighter(true);
+    const boss = cantor();
+    const state = startCombat(scriptedRng([20, 1]), [front], [boss]);
+
+    state.enemyIntents[boss.id] = ritual.id;
+    forceTurn(state, boss.id);
+    ritualEnemyAct(scriptedRng([10]), state, boss.id);
+    boss.statuses = [{ kind: 'stun', remaining: 1, potency: 0 }];
+    forceTurn(state, boss.id);
+    expect(ritualEnemyAct(scriptedRng([10]), state, boss.id).kind).toBe('interrupted');
+
+    // The only weighted intent is still the ritual; after recovering, it may begin another cast.
+    forceTurn(state, boss.id);
+    const retry = ritualEnemyAct(scriptedRng([10]), state, boss.id);
+    expect(retry.kind).toBe('prepared');
+    expect(ritualChargeFor(state, boss.id)).not.toBeNull();
+  });
+});

--- a/src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+++ b/src/scripts/games/caravan/data/rituals.balance.m45.test.ts
@@ -112,8 +112,9 @@ function probe(policy: Policy): Probe {
     forceTurn(state, front.id);
     partyAct(scriptedRng([10]), state, front.id, guardMove.id, front.id);
   } else {
-    forceTurn(state, caster.id);
-    partyAct(scriptedRng([20, 4]), state, caster.id, fireball.id, boss.id);
+    // Pressure remains available even when the mage is nearly dry: the martial front-liner can spend tempo on damage.
+    forceTurn(state, front.id);
+    partyAct(scriptedRng([20, 4]), state, front.id, strike.id, boss.id);
   }
 
   forceTurn(state, boss.id);

--- a/src/scripts/games/caravan/data/rituals.m45.test.ts
+++ b/src/scripts/games/caravan/data/rituals.m45.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  partyAct,
+  startCombat,
+  type CombatState,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+import {
+  ritualChargeFor,
+  ritualEnemyAct,
+  ritualIntentText,
+} from './rituals.m45';
+
+function scriptedRng(values: number[] = [10, 4, 10, 4]): Rng {
+  let index = 0;
+  const take = () => values[index++ % Math.max(1, values.length)] ?? 10;
+  return {
+    next: () => 0,
+    roll: take,
+    d20: take,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+const strike: Move = {
+  id: 'strike', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 1, bonusStat: 'str' },
+  narration: '{actor}揮擊{target}，造成 {amount} 點傷害！',
+};
+
+const stunBash: Move = {
+  id: 'test-stun-bash', name: '震地盾擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'blunt',
+  damage: { dice: 1, sides: 1 }, applyStatus: { kind: 'stun', duration: 1 },
+  narration: '{actor}以盾緣震擊{target}，造成 {amount} 點傷害！',
+};
+
+function fighter(id = 'fighter'): PartyMember {
+  return {
+    id, name: id, stats: { str: 16, dex: 12, int: 8, cha: 8, con: 16 },
+    maxHp: 40, hp: 40, defense: 12, moves: [strike, stunBash], formationRow: 'front',
+  };
+}
+
+function forceTurn(state: CombatState, id: string): void {
+  state.turnIndex = state.order.indexOf(id);
+}
+
+describe('M45 interruptible rituals', () => {
+  it('spends the first ritual turn on a visible preparation without damage or resource cost', () => {
+    const party = [fighter()];
+    const cantor = createReliquaryEncounter(2)[0];
+    const state = startCombat(scriptedRng([20, 1, 10, 4]), party, [cantor]);
+    state.enemyIntents[cantor.id] = 'reliquary-silent-chorus';
+    forceTurn(state, cantor.id);
+
+    const hpBefore = party[0].hp;
+    const manaBefore = cantor.mystic?.current;
+    const result = ritualEnemyAct(scriptedRng([10, 4]), state, cantor.id);
+
+    expect(result).toEqual({ kind: 'prepared', moveId: 'reliquary-silent-chorus' });
+    expect(party[0].hp).toBe(hpBefore);
+    expect(cantor.mystic?.current).toBe(manaBefore);
+    expect(ritualChargeFor(state, cantor.id)?.moveId).toBe('reliquary-silent-chorus');
+    expect(ritualIntentText(state, cantor)).toContain('即將完成');
+    expect(state.log.some((entry) => entry.text.includes('死寂'))).toBe(true);
+  });
+
+  it('lets stun or a poise-break stun cancel a prepared ritual before it resolves', () => {
+    const guard = fighter();
+    const cantor = createReliquaryEncounter(2)[0];
+    const state = startCombat(scriptedRng([20, 1, 10, 4]), [guard], [cantor]);
+    state.enemyIntents[cantor.id] = 'reliquary-silent-chorus';
+    forceTurn(state, cantor.id);
+    ritualEnemyAct(scriptedRng([10]), state, cantor.id);
+
+    forceTurn(state, guard.id);
+    partyAct(scriptedRng([20, 1]), state, guard.id, 'test-stun-bash', cantor.id);
+    expect(cantor.statuses?.some((status) => status.kind === 'stun')).toBe(true);
+
+    const hpBefore = guard.hp;
+    forceTurn(state, cantor.id);
+    const result = ritualEnemyAct(scriptedRng([10]), state, cantor.id);
+
+    expect(result.kind).toBe('interrupted');
+    expect(guard.hp).toBe(hpBefore);
+    expect(ritualChargeFor(state, cantor.id)).toBeNull();
+    expect(state.log.some((entry) => entry.text.includes('被打斷'))).toBe(true);
+  });
+
+  it('resolves normally on the second action and pays the original spell resource exactly once', () => {
+    const guard = fighter();
+    guard.maxHp = guard.hp = 80;
+    const cantor = createReliquaryEncounter(2)[0];
+    const state = startCombat(scriptedRng([20, 1, 10, 4]), [guard], [cantor]);
+    state.enemyIntents[cantor.id] = 'reliquary-silent-chorus';
+    const manaBefore = cantor.mystic?.current ?? 0;
+
+    forceTurn(state, cantor.id);
+    ritualEnemyAct(scriptedRng([10]), state, cantor.id);
+    expect(cantor.mystic?.current).toBe(manaBefore);
+
+    forceTurn(state, cantor.id);
+    const result = ritualEnemyAct(scriptedRng([20, 4]), state, cantor.id);
+
+    expect(result.kind).toBe('resolved');
+    expect(cantor.mystic?.current).toBe(manaBefore - 3);
+    expect(guard.hp).toBeLessThan(80);
+    expect(ritualChargeFor(state, cantor.id)).toBeNull();
+  });
+
+  it('keeps non-ritual enemy actions immediate', () => {
+    const guard = fighter();
+    const cantor = createReliquaryEncounter(2)[0];
+    const state = startCombat(scriptedRng([20, 1, 10, 4]), [guard], [cantor]);
+    state.enemyIntents[cantor.id] = 'reliquary-lament-touch';
+    forceTurn(state, cantor.id);
+    const hpBefore = guard.hp;
+
+    const result = ritualEnemyAct(scriptedRng([20, 4]), state, cantor.id);
+
+    expect(result.kind).toBe('normal');
+    expect(guard.hp).toBeLessThan(hpBefore);
+    expect(ritualChargeFor(state, cantor.id)).toBeNull();
+  });
+
+  it('uses the live dragon-heart breath as a costly, telegraphed pyromancy ritual', () => {
+    const guard = fighter();
+    guard.maxHp = guard.hp = 100;
+    const avatar = createReliquaryEncounter(3)[0];
+    const state = startCombat(scriptedRng([20, 1, 10, 4]), [guard], [avatar]);
+    const breath = avatar.moves.find((move) => move.id === 'reliquary-ember-breath');
+    expect(breath?.name).toContain('秘法 4');
+    expect(avatar.mystic?.kind).toBe('mana');
+    const manaBefore = avatar.mystic?.current ?? 0;
+
+    state.enemyIntents[avatar.id] = 'reliquary-ember-breath';
+    forceTurn(state, avatar.id);
+    const prepared = ritualEnemyAct(scriptedRng([10]), state, avatar.id);
+    expect(prepared.kind).toBe('prepared');
+    expect(guard.hp).toBe(100);
+    expect(avatar.mystic?.current).toBe(manaBefore);
+
+    forceTurn(state, avatar.id);
+    const resolved = ritualEnemyAct(scriptedRng([20, 5]), state, avatar.id);
+    expect(resolved.kind).toBe('resolved');
+    expect(avatar.mystic?.current).toBe(manaBefore - 4);
+    expect(guard.hp).toBeLessThan(100);
+  });
+});

--- a/src/scripts/games/caravan/data/rituals.m45.ts
+++ b/src/scripts/games/caravan/data/rituals.m45.ts
@@ -1,0 +1,187 @@
+import {
+  advanceTurn,
+  enemyAct,
+  type CombatState,
+  type EnemyUnit,
+  type Move,
+} from '../combat';
+import type { Rng } from '../rng';
+
+export interface RitualRule {
+  moveId: string;
+  label: string;
+  telegraph: string;
+  interruptHint: string;
+}
+
+export interface RitualCharge {
+  enemyId: string;
+  moveId: string;
+  startedRound: number;
+}
+
+export type RitualEnemyActionResult =
+  | { kind: 'normal'; moveId: string }
+  | { kind: 'prepared'; moveId: string }
+  | { kind: 'resolved'; moveId: string }
+  | { kind: 'interrupted'; moveId: string };
+
+/**
+ * M45 intentionally limits rituals to dangerous, readable encounter-defining moves.
+ * Ordinary attacks and minor spells still resolve immediately so combat does not become sluggish.
+ */
+export const RITUAL_RULES: Record<string, RitualRule> = {
+  'reliquary-silent-chorus': {
+    moveId: 'reliquary-silent-chorus',
+    label: '無聲聖歌儀式',
+    telegraph: '無舌領唱者仰起被縫死的臉，整座唱詩窟的死寂正向它胸腔聚攏。',
+    interruptHint: '在它下次行動前造成暈眩，或用弱點打空護勢使其破防。',
+  },
+  'reliquary-ember-breath': {
+    moveId: 'reliquary-ember-breath',
+    label: '心火吐息蓄勢',
+    telegraph: '龍燼化身收攏胸腔中的古龍心火，裂縫間的火光開始灼白。',
+    interruptHint: '在它下次行動前造成暈眩，或以冰／聖弱點擊破護勢。',
+  },
+};
+
+const charges = new WeakMap<CombatState, Map<string, RitualCharge>>();
+
+function chargeMap(state: CombatState): Map<string, RitualCharge> {
+  let map = charges.get(state);
+  if (!map) {
+    map = new Map<string, RitualCharge>();
+    charges.set(state, map);
+  }
+  return map;
+}
+
+export function ritualRuleForMove(moveId: string | undefined): RitualRule | null {
+  return moveId ? RITUAL_RULES[moveId] ?? null : null;
+}
+
+export function ritualChargeFor(state: CombatState, enemyId: string): RitualCharge | null {
+  return chargeMap(state).get(enemyId) ?? null;
+}
+
+export function clearRitualCharge(state: CombatState, enemyId: string): void {
+  chargeMap(state).delete(enemyId);
+}
+
+function hasStun(enemy: EnemyUnit): boolean {
+  return (enemy.statuses ?? []).some((status) => status.kind === 'stun' && status.remaining > 0);
+}
+
+function preparationMove(rule: RitualRule, source: Move): Move {
+  return {
+    id: `ritual-preparation:${source.id}`,
+    name: `準備・${rule.label}`,
+    kind: 'support',
+    target: 'self',
+    hitStat: source.hitStat,
+    narration: rule.telegraph,
+  };
+}
+
+/**
+ * UI-facing intent text. The first phase announces preparation; once charged, the player
+ * sees that the ritual will resolve on the caster's next action and how to interrupt it.
+ */
+export function ritualIntentText(state: CombatState, enemy: EnemyUnit): string {
+  const charged = ritualChargeFor(state, enemy.id);
+  if (charged) {
+    const move = enemy.moves.find((candidate) => candidate.id === charged.moveId);
+    const rule = ritualRuleForMove(charged.moveId)!;
+    return `即將完成：${move?.name ?? rule.label}｜可中斷：${rule.interruptHint}`;
+  }
+  const intended = state.enemyIntents[enemy.id];
+  const rule = ritualRuleForMove(intended);
+  if (!rule) {
+    const move = enemy.moves.find((candidate) => candidate.id === intended);
+    return move?.name ?? '未知意圖';
+  }
+  return `準備儀式：${rule.label}｜${rule.interruptHint}`;
+}
+
+/**
+ * M45 wrapper around the existing fair M44 enemy turn.
+ *
+ * - A ritual's first turn performs a harmless, visible preparation action.
+ * - The original move remains the public next intent.
+ * - Stun (including weakness/poise break) before the next turn cancels the charge.
+ * - If not interrupted, the ordinary M44 enemyAct executes the real move and pays its
+ *   normal mana/favor cost. No duplicate damage/resource implementation lives here.
+ */
+export function ritualEnemyAct(
+  rng: Rng,
+  state: CombatState,
+  enemyId: string,
+): RitualEnemyActionResult {
+  const enemy = state.enemies.find((candidate) => candidate.id === enemyId);
+  if (!enemy || state.outcome !== 'ongoing') return { kind: 'normal', moveId: '' };
+
+  const map = chargeMap(state);
+  const charged = map.get(enemyId);
+  if (charged) {
+    if (hasStun(enemy)) {
+      const rule = ritualRuleForMove(charged.moveId);
+      map.delete(enemyId);
+      state.log.push({
+        kind: 'info',
+        text: `${enemy.name}的${rule?.label ?? '儀式'}被打斷了！`,
+      });
+      enemyAct(rng, state, enemyId);
+      return { kind: 'interrupted', moveId: charged.moveId };
+    }
+
+    state.enemyIntents[enemyId] = charged.moveId;
+    enemyAct(rng, state, enemyId);
+    map.delete(enemyId);
+    return { kind: 'resolved', moveId: charged.moveId };
+  }
+
+  const intendedId = state.enemyIntents[enemyId] ?? enemy.moves[0]?.id ?? '';
+  const rule = ritualRuleForMove(intendedId);
+  if (!rule || hasStun(enemy)) {
+    enemyAct(rng, state, enemyId);
+    return { kind: 'normal', moveId: intendedId };
+  }
+
+  const source = enemy.moves.find((move) => move.id === intendedId);
+  if (!source) {
+    enemyAct(rng, state, enemyId);
+    return { kind: 'normal', moveId: intendedId };
+  }
+
+  const prep = preparationMove(rule, source);
+  enemy.moves.push(prep);
+  state.enemyIntents[enemyId] = prep.id;
+  enemyAct(rng, state, enemyId);
+  enemy.moves = enemy.moves.filter((move) => move.id !== prep.id);
+
+  // Poison or another start-of-turn effect may have killed the caster during preparation.
+  if (enemy.hp <= 0 || state.outcome !== 'ongoing') {
+    map.delete(enemyId);
+    return { kind: 'normal', moveId: intendedId };
+  }
+
+  map.set(enemyId, { enemyId, moveId: intendedId, startedRound: state.round });
+  state.enemyIntents[enemyId] = intendedId;
+  state.log.push({
+    kind: 'info',
+    text: `${rule.label}已經成形——${rule.interruptHint}`,
+  });
+  return { kind: 'prepared', moveId: intendedId };
+}
+
+/** Test helper: consume a preparation turn without needing UI or page logic. */
+export function forceRitualPreparation(
+  state: CombatState,
+  enemyId: string,
+  moveId: string,
+): void {
+  if (!RITUAL_RULES[moveId]) throw new Error(`未知儀式招式「${moveId}」`);
+  chargeMap(state).set(enemyId, { enemyId, moveId, startedRound: state.round });
+  state.enemyIntents[enemyId] = moveId;
+  advanceTurn(state);
+}


### PR DESCRIPTION
## Summary
- add a reusable interruptible ritual layer for encounter-defining fantasy abilities without slowing ordinary attacks and minor spells
- make Silent Chorus and Dragon-Heart Breath spend one visible preparation action before resolving
- allow stun and weakness-driven poise breaks to interrupt prepared rituals
- keep guard, magical warding, pressure, and accepting the hit as valid alternatives to interruption
- classify Dragon-Heart Breath as costly pyromancy so the boss follows the same mana fairness rules as other M44 casters
- surface ritual preparation, completion timing, interrupt instructions, enemy mystic resources, and armory access in the live Ashen Reliquary battle UI

## Player-facing design intent
M44 made hostile spellcasting readable and resource-limited. M45 adds a second layer of tactical readability to only the largest encounter-defining powers. Dangerous rituals are no longer instant surprises: the player gets one action window to decide whether to interrupt, defend, ward, race damage, or absorb the cost. Interruption is deliberately optional rather than a mandatory QTE.

## Multidimensional adversarial review
The M45 gates check:
- preparation deals no damage and spends no spell resource early
- resolution pays the original spell resource exactly once
- stun/poise-break interruption clears the current charge without permanently silencing the caster
- ordinary attacks and minor spells remain immediate
- live Tongueless Cantor and Dragon Ember Avatar integration
- interrupt, ward, brace, and pressure responses retain different advantages across party HP, boss HP, mana posture, and control tempo
- a pure martial party with no ritual-interrupt tool remains able to survive and progress through guarding and pressure
- core combat, M40 Reliquary combat, M41 magic, M42 composition/camp diversity, M43 armory, and M44 spellcraft remain regression gates

## Validation
`Caravan M45 Ritual CI` runs production build, ritual lifecycle/live encounter tests, multidimensional player-response probes, and the full M40–M44 gameplay regression set.