### PR TITLE
feat(caravan): add M46 convoy battlefield objectives

### DIFF
--- a/.github/workflows/caravan-m46-ci.yml
+++ b/.github/workflows/caravan-m46-ci.yml
@@ -1,0 +1,74 @@
+name: Caravan M46 Objective CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m46-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m46-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-objective-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M46 convoy objective lifecycle
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+
+      - name: M46 multidimensional player review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M42 composition and camp-policy diversity regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M42 expedition state regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts

--- a/docs/caravan-m46-convoy-objectives.md
+++ b/docs/caravan-m46-convoy-objectives.md
@@ -1,0 +1,54 @@
+# M46 Battlefield Objectives — Split-Banner Convoy
+
+M46 addresses a gameplay problem rather than adding another management layer: most combat previously ended only when every enemy was defeated. A caravan / mercenary RPG needs contracts where survival, escort discipline, battlefield control, and accepting risk can matter more than annihilation.
+
+## Player-facing contract
+
+`黑蠟急件｜裂旗商路護運`
+
+- The White-Wax Wagon has 30 durability.
+- The escort must hold for four completed combat rounds. If the wagon still has durability when the fourth round ends, the convoy escapes even if enemies remain alive.
+- Three ambushers create 3 / 3 / 4 breakthrough pressure each round while able to act.
+- End-of-round wagon damage is current breakthrough pressure minus that round's convoy protection.
+- Killing an enemy permanently removes its pressure.
+- Stunning / poise-breaking an enemy suppresses its pressure for that round.
+- Any living party member may spend their turn bracing the wagon. Constitution and frontline position improve the protection value, but total protection is capped at 10 per round.
+- Healing restores escorts, not the wooden wagon. Clerics therefore preserve the people who can continue defending instead of becoming direct objective healers.
+- Full annihilation is still a valid fast victory through the ordinary combat engine.
+
+## Sword-and-magic role identities
+
+- Frontline / high-CON characters are efficient convoy braces and can still use guard to protect wounded allies.
+- Rangers reduce persistent breakthrough pressure through reliable ranged damage and target selection.
+- Mages can spend mana on control, especially Frost Bind, to suppress high-pressure enemies for a round instead of only racing damage.
+- Clerics convert favor into party endurance; they cannot erase wagon mistakes with magical repairs.
+- Cross-class armory, mystic costs, wards, enemy caster exhaustion, poise, weakness, and M45 rituals remain active because the contract wraps the production combat engine rather than replacing it.
+
+## Anti-abuse rules
+
+- Convoy brace validates actual turn ownership before acting.
+- Bracing consumes an ordinary combat action and still loses the action when stun prevents it.
+- Multiple escorts cannot stack more than 10 convoy protection in one round.
+- Closing / refreshing an unresolved convoy battle is not a free initiative or RNG reroll. Re-entry consumes one dried ration when possible, otherwise charges emergency gold, and every abandonment removes four starting wagon durability down to a floor of 12.
+- Contract reward is issued at most once per market cycle.
+- Wagon condition matters: finishing at 70% durability or better grants a 10 G intact-delivery bonus.
+
+## Multidimensional adversarial gameplay gates
+
+The M46 test suite does not accept simple build success as sufficient. It compares four player responses using production jobs and combat rules:
+
+1. Escort / brace — strongest immediate wagon protection, sacrifices damage or healing tempo.
+2. Control — spends mana and a move slot to suppress a high-pressure hostile for a round.
+3. Pressure / kill — removes enemy HP fastest and can permanently remove future breakthrough pressure, but accepts more immediate wagon risk.
+4. Sustain — restores party HP so escorts remain functional, but does not directly protect the objective.
+
+Acceptance gates:
+
+- No policy may dominate all measured dimensions (wagon durability, enemy HP pressure, party survival / resource posture).
+- Pure martial parties must have successful seeded escorts; mage or cleric cannot become mandatory.
+- A party with no swordsman must also have successful seeded escorts; the dedicated frontline class cannot become mandatory.
+- Successful escorts must be possible with enemies still alive, proving that the new objective is not cosmetic kill-all combat.
+- The wagon must be able to fail while party members remain alive, proving that protecting the caravan is a real independent loss condition.
+- M40 live fantasy encounters, M41 magic resources, M42 composition/endurance, M43 armory, M44 spellcraft, M45 rituals, and core combat remain regression gates.
+
+This is automated adversarial gameplay review. It is intentionally stricter than unit correctness, but it does not replace several-hour human UX playtesting.

--- a/docs/caravan-m46-convoy-objectives.md
+++ b/docs/caravan-m46-convoy-objectives.md
@@ -15,6 +15,7 @@ M46 addresses a gameplay problem rather than adding another management layer: mo
 - Any living party member may spend their turn bracing the wagon. Constitution and frontline position improve the protection value, but total protection is capped at 10 per round.
 - Healing restores escorts, not the wooden wagon. Clerics therefore preserve the people who can continue defending instead of becoming direct objective healers.
 - Full annihilation is still a valid fast victory through the ordinary combat engine.
+- The contract is linked directly from the existing Guild Hall / Black-Wax Documents page instead of requiring a hidden URL.
 
 ## Sword-and-magic role identities
 
@@ -29,7 +30,8 @@ M46 addresses a gameplay problem rather than adding another management layer: mo
 - Convoy brace validates actual turn ownership before acting.
 - Bracing consumes an ordinary combat action and still loses the action when stun prevents it.
 - Multiple escorts cannot stack more than 10 convoy protection in one round.
-- Closing / refreshing an unresolved convoy battle is not a free initiative or RNG reroll. Re-entry consumes one dried ration when possible, otherwise charges emergency gold, and every abandonment removes four starting wagon durability down to a floor of 12.
+- Closing, refreshing, deliberately retreating, or losing an unresolved convoy battle all leave the attempt receipt active. Re-entry consumes one dried ration when possible, otherwise charges emergency gold, and every unresolved retry removes four starting wagon durability down to a floor of 12.
+- Contract reward settlement receives the actual battle state and rejects ongoing, retreated, defeated, or destroyed-wagon states in the data layer rather than trusting UI-only gating.
 - Contract reward is issued at most once per market cycle.
 - Wagon condition matters: finishing at 70% durability or better grants a 10 G intact-delivery bonus.
 
@@ -49,6 +51,8 @@ Acceptance gates:
 - A party with no swordsman must also have successful seeded escorts; the dedicated frontline class cannot become mandatory.
 - Successful escorts must be possible with enemies still alive, proving that the new objective is not cosmetic kill-all combat.
 - The wagon must be able to fail while party members remain alive, proving that protecting the caravan is a real independent loss condition.
+- Retreat/defeat/reload retries must pay the same unresolved-attempt economy; no exit path may become a free RNG reset.
+- Reward settlement must reject any non-victory battle state before mutating gold, reputation, or receipts.
 - M40 live fantasy encounters, M41 magic resources, M42 composition/endurance, M43 armory, M44 spellcraft, M45 rituals, and core combat remain regression gates.
 
 This is automated adversarial gameplay review. It is intentionally stricter than unit correctness, but it does not replace several-hour human UX playtesting.

--- a/src/pages/caravan/convoy-defense.astro
+++ b/src/pages/caravan/convoy-defense.astro
@@ -8,7 +8,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <p class="eyebrow">CARAVAN &amp; SWORD · M46 BATTLEFIELD OBJECTIVES</p>
       <h1>黑蠟急件｜裂旗商路護運</h1>
       <p>這不是討伐。車夫需要四輪時間拉開裂旗關的鎖鏈；你的任務是讓貨車活著穿過去。</p>
-      <nav><a href="/caravan/play">返回啟程之鎮</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/endurance">餘燼朝聖</a></nav>
+      <nav><a href="/caravan/play">返回啟程之鎮</a><a href="/caravan/mandates">行會文書</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/endurance">餘燼朝聖</a></nav>
     </header>
 
     <section id="notice" class="panel"></section>
@@ -43,7 +43,6 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     convoyPartyAct,
     convoyThreatForEnemy,
     createConvoyDefenseBattle,
-    finishConvoyAttempt,
     projectedConvoyPressure,
     type ConvoyDefenseBattle,
   } from '@scripts/games/caravan/data/convoyDefense.m46';
@@ -205,11 +204,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   function settleOutcome(): void {
     if (!battle || settled || battle.combat.outcome === 'ongoing') return;
     const latest = loadGame(); if (!latest) return;
-    finishConvoyAttempt(latest);
     const injured = applyConvoyBattleInjuries(latest, battle.combat);
     let rewardText = '';
     if (battle.combat.outcome === 'victory') {
-      const reward = claimConvoyDefenseReward(latest, battle.wagon.hp);
+      const reward = claimConvoyDefenseReward(latest, battle);
       rewardText = `行會支付 ${reward.gold} G、聲望 +${reward.reputation}${reward.pristineBonus ? '；貨車保存良好，包含 10 G 完整交貨獎金' : ''}。`;
     }
     saveGame(latest);
@@ -218,7 +216,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     resultEl.replaceChildren(
       text('p', battle.combat.outcome === 'victory' ? 'CONTRACT COMPLETE' : battle.combat.outcome === 'retreated' ? 'CONTRACT ABANDONED' : 'CONTRACT FAILED', 'eyebrow'),
       text('h2', battle.combat.outcome === 'victory' ? '白蠟貨車穿過裂旗關' : '黑蠟急件沒有送達'),
-      text('p', battle.combat.outcome === 'victory' ? rewardText : '沒有護運報酬；本市場週期仍可重新接受這張急件。'),
+      text('p', battle.combat.outcome === 'victory'
+        ? rewardText
+        : '沒有護運報酬；未完成嘗試會保留。下次重新接受時必須重新整隊，消耗補給或金幣，且馬車會帶著額外損傷進場。'),
       text('p', `貨車剩餘耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}｜養傷：${injured.join('、') || '無'}`),
     );
     const link = document.createElement('a'); link.href = '/caravan/play'; link.className = 'return-link'; link.textContent = '返回啟程之鎮';
@@ -243,7 +243,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     saveGame(save);
     noticeEl.append(
       text('h2', `護衛隊 ${access.partySize} 人｜裂旗關伏擊`),
-      text('p', attempt.penalty ?? '首次進場不收額外整備費。中途重新整理／關頁會被視為放棄陣形，下一次馬車將帶著損傷重新進場。'),
+      text('p', attempt.penalty ?? '首次進場不收額外整備費。重新整理、關頁、撤退或戰敗都會保留未完成嘗試；下一次必須付出重新整隊代價。'),
     );
     rng = createRng((save.createdAt + save.marketSeed * 17 + 46046) >>> 0);
     battle = createConvoyDefenseBattle(save, rng, attempt.startingWagonHp);

--- a/src/pages/caravan/convoy-defense.astro
+++ b/src/pages/caravan/convoy-defense.astro
@@ -1,0 +1,289 @@
+---
+import BaseLayout from '@components/layout/BaseLayout.astro';
+---
+
+<BaseLayout title="裂旗商路護運 — 商隊與劍" description="守住馬車、控住伏兵，或在隘口打開前擊潰敵人。" lang="zh-TW">
+  <main class="convoy-page">
+    <header class="hero">
+      <p class="eyebrow">CARAVAN &amp; SWORD · M46 BATTLEFIELD OBJECTIVES</p>
+      <h1>黑蠟急件｜裂旗商路護運</h1>
+      <p>這不是討伐。車夫需要四輪時間拉開裂旗關的鎖鏈；你的任務是讓貨車活著穿過去。</p>
+      <nav><a href="/caravan/play">返回啟程之鎮</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/endurance">餘燼朝聖</a></nav>
+    </header>
+
+    <section id="notice" class="panel"></section>
+    <section id="objective" class="objective" hidden></section>
+    <section id="intent" class="intent" hidden></section>
+    <section id="battlefield" class="battlefield" hidden>
+      <div><p class="eyebrow">AMBUSHERS</p><div id="enemies" class="units"></div></div>
+      <div><p class="eyebrow">ESCORT PARTY</p><div id="party" class="units"></div></div>
+    </section>
+    <section id="actions" class="actions" hidden></section>
+    <section id="result" class="result" hidden></section>
+    <section class="log-panel"><p class="eyebrow">ROAD CHRONICLE</p><div id="log" class="log"></div></section>
+  </main>
+</BaseLayout>
+
+<script>
+  import { loadGame, saveGame } from '@scripts/games/caravan/save';
+  import { createRng, type Rng } from '@scripts/games/caravan/rng';
+  import {
+    ELEMENT_LABELS, attemptRetreat, currentActor, partyMoveAvailability,
+    type EnemyUnit, type Move, type PartyMember,
+  } from '@scripts/games/caravan/combat';
+  import { mysticPowerText } from '@scripts/games/caravan/data/arcana';
+  import {
+    applyConvoyBattleInjuries,
+    beginConvoyAttempt,
+    braceConvoy,
+    claimConvoyDefenseReward,
+    convoyBraceValue,
+    convoyDefenseAccess,
+    convoyEnemyAct,
+    convoyPartyAct,
+    convoyThreatForEnemy,
+    createConvoyDefenseBattle,
+    finishConvoyAttempt,
+    projectedConvoyPressure,
+    type ConvoyDefenseBattle,
+  } from '@scripts/games/caravan/data/convoyDefense.m46';
+  import { ritualIntentText } from '@scripts/games/caravan/data/rituals.m45';
+
+  const noticeEl = document.getElementById('notice')!;
+  const objectiveEl = document.getElementById('objective')!;
+  const intentEl = document.getElementById('intent')!;
+  const battlefieldEl = document.getElementById('battlefield')!;
+  const enemiesEl = document.getElementById('enemies')!;
+  const partyEl = document.getElementById('party')!;
+  const actionsEl = document.getElementById('actions')!;
+  const resultEl = document.getElementById('result')!;
+  const logEl = document.getElementById('log')!;
+
+  let battle: ConvoyDefenseBattle | null = null;
+  let rng: Rng | null = null;
+  let settled = false;
+
+  const text = (tag: string, value: string, className?: string): HTMLElement => {
+    const element = document.createElement(tag);
+    if (className) element.className = className;
+    element.textContent = value;
+    return element;
+  };
+
+  function button(label: string, action: () => void, className = '', disabled = false, title = ''): HTMLButtonElement {
+    const element = document.createElement('button');
+    element.type = 'button';
+    element.textContent = label;
+    element.className = className;
+    element.disabled = disabled;
+    element.title = title;
+    element.addEventListener('click', action);
+    return element;
+  }
+
+  function unitCard(unit: PartyMember | EnemyUnit): HTMLElement {
+    const enemy = 'intents' in unit ? unit as EnemyUnit : null;
+    const card = document.createElement('article');
+    card.className = `unit ${unit.hp <= 0 ? 'down' : ''}`;
+    const status = (unit.statuses ?? []).map((entry) => `${entry.kind} ${entry.remaining}`).join('、');
+    const poise = enemy?.maxPoise !== undefined ? `｜護勢 ${enemy.poise ?? enemy.maxPoise}/${enemy.maxPoise}` : '';
+    card.append(text('h3', unit.name), text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${status ? `｜${status}` : ''}`));
+    if (enemy) {
+      const weak = (enemy.weaknesses ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
+      const resist = (enemy.resists ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
+      card.append(
+        text('p', `突破壓力 ${convoyThreatForEnemy(enemy)}｜弱點 ${weak}｜抗性 ${resist}`, 'affinity'),
+      );
+      if (enemy.mystic) card.append(text('p', mysticPowerText(enemy.mystic), 'mystic'));
+    } else {
+      const member = unit as PartyMember;
+      card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
+      if (member.mystic) card.append(text('p', mysticPowerText(member.mystic), 'mystic'));
+    }
+    return card;
+  }
+
+  function renderObjective(): void {
+    if (!battle) return;
+    const pressure = projectedConvoyPressure(battle);
+    objectiveEl.replaceChildren(
+      text('p', 'ESCORT OBJECTIVE', 'eyebrow'),
+      text('h2', `${battle.wagon.name}｜耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}`),
+      text('p', `已撐過 ${battle.completedRounds}/${battle.holdRounds} 輪｜目前伏兵突破壓力 ${pressure}｜本輪護車 ${battle.protection}/10`),
+      text('p', '每完成一輪，仍能行動的伏兵會把突破壓力施加到馬車。擊殺、暈眩與護車都能降低實際損傷；撐滿四輪就能撤離，不必殺光。', 'hint'),
+    );
+    objectiveEl.hidden = false;
+  }
+
+  function renderIntent(): void {
+    if (!battle || battle.combat.outcome !== 'ongoing') { intentEl.hidden = true; return; }
+    const lines = battle.combat.enemies.filter((enemy) => enemy.hp > 0)
+      .map((enemy) => `${enemy.name}：${ritualIntentText(battle!.combat, enemy)}`);
+    intentEl.replaceChildren(text('strong', `第 ${battle.combat.round} 輪｜敵方意圖`), text('span', lines.join('　')));
+    intentEl.hidden = lines.length === 0;
+  }
+
+  function renderUnits(): void {
+    if (!battle) return;
+    enemiesEl.replaceChildren(...battle.combat.enemies.map(unitCard));
+    partyEl.replaceChildren(...battle.combat.party.map(unitCard));
+  }
+
+  function targetsFor(move: Move): Array<{ id: string; name: string }> {
+    if (!battle || move.target === 'self') return [];
+    if (move.kind === 'attack') {
+      const targets = battle.combat.enemies.filter((enemy) => enemy.hp > 0);
+      if (move.area) return targets.length ? [{ id: targets[0].id, name: '敵方全體' }] : [];
+      return targets.map((target) => ({ id: target.id, name: target.name }));
+    }
+    return battle.combat.party.filter((member) => member.hp > 0).map((target) => ({ id: target.id, name: target.name }));
+  }
+
+  function act(actorId: string, moveId: string, targetId: string, overcast = false): void {
+    if (!battle || !rng || settled) return;
+    const result = convoyPartyAct(rng, battle, actorId, moveId, targetId, { overcast });
+    if (result.acted) runEnemyTurns();
+    settleOutcome(); render();
+  }
+
+  function brace(actor: PartyMember): void {
+    if (!battle || !rng || settled) return;
+    const result = braceConvoy(rng, battle, actor.id);
+    if (result.acted) runEnemyTurns();
+    settleOutcome(); render();
+  }
+
+  function moveButtons(actor: PartyMember, move: Move): HTMLButtonElement[] {
+    const normal = partyMoveAvailability(actor, move);
+    const make = (targetId: string, targetName: string, overcast: boolean) => {
+      const availability = partyMoveAvailability(actor, move, { overcast });
+      const prefix = overcast ? `禁式過載（反噬 ${availability.backlash}）・` : '';
+      return button(`${prefix}${move.name}${targetName ? ` → ${targetName}` : ''}`, () => act(actor.id, move.id, targetId, overcast), overcast ? 'overcast' : '', !availability.allowed, availability.reason);
+    };
+    const targets = move.kind === 'guard' || move.target === 'self'
+      ? [{ id: actor.id, name: '' }]
+      : targetsFor(move);
+    const buttons = targets.map((target) => make(target.id, target.name, false));
+    if (!normal.allowed && normal.canOvercast) buttons.push(...targets.map((target) => make(target.id, target.name, true)));
+    return buttons;
+  }
+
+  function renderActions(): void {
+    actionsEl.replaceChildren();
+    if (!battle || battle.combat.outcome !== 'ongoing') { actionsEl.hidden = true; return; }
+    const actorInfo = currentActor(battle.combat);
+    if (!actorInfo || actorInfo.side !== 'party') { actionsEl.hidden = true; return; }
+    const actor = battle.combat.party.find((member) => member.id === actorInfo.id)!;
+    actionsEl.hidden = false;
+    actionsEl.append(
+      text('h2', `${actor.name}的行動${actor.mystic ? `｜${mysticPowerText(actor.mystic)}` : ''}`),
+      text('p', `護住馬車會犧牲這一回合的輸出／治療，建立 ${convoyBraceValue(actor)} 點護車值；本輪總護車最多 10。`, 'hint'),
+    );
+    const grid = document.createElement('div'); grid.className = 'action-grid';
+    grid.append(button(`護住馬車（+${Math.min(convoyBraceValue(actor), Math.max(0, 10 - battle.protection))}）`, () => brace(actor), 'brace'));
+    for (const move of actor.moves) grid.append(...moveButtons(actor, move));
+    grid.append(button('放棄護運並撤離', retreat, 'retreat'));
+    actionsEl.append(grid);
+  }
+
+  function runEnemyTurns(): void {
+    if (!battle || !rng) return;
+    let safety = 0;
+    while (battle.combat.outcome === 'ongoing' && currentActor(battle.combat)?.side === 'enemy' && safety < 40) {
+      const actor = currentActor(battle.combat); if (!actor) break;
+      convoyEnemyAct(rng, battle, actor.id);
+      safety += 1;
+    }
+  }
+
+  function retreat(): void {
+    if (!battle || !rng || settled) return;
+    attemptRetreat(rng, battle.combat);
+    settleOutcome(); render();
+  }
+
+  function settleOutcome(): void {
+    if (!battle || settled || battle.combat.outcome === 'ongoing') return;
+    const latest = loadGame(); if (!latest) return;
+    finishConvoyAttempt(latest);
+    const injured = applyConvoyBattleInjuries(latest, battle.combat);
+    let rewardText = '';
+    if (battle.combat.outcome === 'victory') {
+      const reward = claimConvoyDefenseReward(latest, battle.wagon.hp);
+      rewardText = `行會支付 ${reward.gold} G、聲望 +${reward.reputation}${reward.pristineBonus ? '；貨車保存良好，包含 10 G 完整交貨獎金' : ''}。`;
+    }
+    saveGame(latest);
+    settled = true;
+    resultEl.hidden = false;
+    resultEl.replaceChildren(
+      text('p', battle.combat.outcome === 'victory' ? 'CONTRACT COMPLETE' : battle.combat.outcome === 'retreated' ? 'CONTRACT ABANDONED' : 'CONTRACT FAILED', 'eyebrow'),
+      text('h2', battle.combat.outcome === 'victory' ? '白蠟貨車穿過裂旗關' : '黑蠟急件沒有送達'),
+      text('p', battle.combat.outcome === 'victory' ? rewardText : '沒有護運報酬；本市場週期仍可重新接受這張急件。'),
+      text('p', `貨車剩餘耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}｜養傷：${injured.join('、') || '無'}`),
+    );
+    const link = document.createElement('a'); link.href = '/caravan/play'; link.className = 'return-link'; link.textContent = '返回啟程之鎮';
+    resultEl.append(link);
+  }
+
+  function renderLog(): void {
+    logEl.replaceChildren();
+    for (const entry of battle?.combat.log.slice(-32) ?? []) logEl.append(text('p', entry.text, entry.kind));
+  }
+
+  function render(): void {
+    renderObjective(); renderIntent(); renderUnits(); renderActions(); renderLog();
+  }
+
+  function boot(): void {
+    const save = loadGame();
+    if (!save) { noticeEl.append(text('h2', '找不到商隊存檔'), text('p', '請先從主冒險建立商隊。')); return; }
+    const access = convoyDefenseAccess(save);
+    if (!access.allowed) { noticeEl.append(text('h2', '目前不能接受黑蠟急件'), text('p', access.reason)); return; }
+    const attempt = beginConvoyAttempt(save);
+    saveGame(save);
+    noticeEl.append(
+      text('h2', `護衛隊 ${access.partySize} 人｜裂旗關伏擊`),
+      text('p', attempt.penalty ?? '首次進場不收額外整備費。中途重新整理／關頁會被視為放棄陣形，下一次馬車將帶著損傷重新進場。'),
+    );
+    rng = createRng((save.createdAt + save.marketSeed * 17 + 46046) >>> 0);
+    battle = createConvoyDefenseBattle(save, rng, attempt.startingWagonHp);
+    battlefieldEl.hidden = false;
+    runEnemyTurns(); settleOutcome(); render();
+  }
+
+  boot();
+</script>
+
+<style>
+  .convoy-page { max-width: 1120px; margin: 0 auto; padding: 2rem 1rem 5rem; color: #eadfca; }
+  .hero, .panel, .objective, .intent, .actions, .result, .log-panel { border: 1px solid #6c5a43; background: #17130f; padding: 1rem 1.2rem; margin-bottom: 1rem; }
+  .hero { background: linear-gradient(145deg, #21150f, #12100d); }
+  .hero h1 { margin: .2rem 0 .6rem; color: #f0c87c; }
+  .hero nav { display: flex; flex-wrap: wrap; gap: .8rem; margin-top: 1rem; }
+  a { color: #efbe6b; }
+  .eyebrow { color: #ad8e62; letter-spacing: .14em; font-size: .78rem; margin: 0 0 .3rem; }
+  .objective { border-color: #a26f37; background: #21170d; }
+  .objective h2 { color: #ffd58b; margin: .2rem 0; }
+  .intent { display: flex; flex-direction: column; gap: .35rem; border-color: #78453c; }
+  .battlefield { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+  .units { display: grid; gap: .65rem; }
+  .unit { border: 1px solid #4d4337; background: #1a1713; padding: .75rem; }
+  .unit h3, .unit p { margin: .15rem 0; }
+  .unit.down { opacity: .45; }
+  .affinity { color: #cfb68c; font-size: .9rem; }
+  .formation, .mystic, .hint { color: #baa98d; font-size: .92rem; }
+  .action-grid { display: flex; flex-wrap: wrap; gap: .55rem; }
+  button { border: 1px solid #7a674c; background: #2a2118; color: #f3dfb7; padding: .65rem .8rem; cursor: pointer; }
+  button:hover:not(:disabled) { background: #3b2c1d; }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  button.brace { border-color: #c09149; color: #ffd58b; }
+  button.overcast { border-color: #9c3b3b; color: #ffb4a5; }
+  button.retreat { border-color: #704443; }
+  .log { max-height: 360px; overflow: auto; }
+  .log p { margin: .28rem 0; }
+  .log .damage, .log .defeat { color: #e7927c; }
+  .log .heal, .log .victory { color: #9bd69b; }
+  .result { border-color: #927346; }
+  .return-link { display: inline-block; margin-top: .8rem; padding: .6rem .9rem; border: 1px solid #7a674c; text-decoration: none; }
+  @media (max-width: 760px) { .battlefield { grid-template-columns: 1fr; } }
+</style>

--- a/src/pages/caravan/mandates.astro
+++ b/src/pages/caravan/mandates.astro
@@ -15,6 +15,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <nav>
         <a href="/caravan/play">返回冒險</a>
         <a class="quest-link" href="/caravan/ashen-reliquary">接受黑蠟委託：灰燼聖匣</a>
+        <a class="quest-link" href="/caravan/convoy-defense">黑蠟急件：裂旗商路護運</a>
         <a href="/caravan/retention">同袍承諾</a>
         <a href="/caravan/risks">旅團危兆</a>
         <a href="/caravan/offices">行會職司</a>

--- a/src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currentActor,
+  partyMoveAvailability,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import { createRng, type Rng } from '../rng';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import {
+  braceConvoy,
+  convoyEnemyAct,
+  convoyPartyAct,
+  convoyThreatForEnemy,
+  createConvoyDefenseBattle,
+  projectedConvoyPressure,
+} from './convoyDefense.m46';
+
+const highRng: Rng = {
+  next: () => 0.5,
+  roll: (sides) => sides,
+  d20: () => 20,
+  pick: (items) => items[0],
+  weightedPick: (items) => items[0].value,
+};
+
+function statsFor(job: CompanionRecord['job']) {
+  if (job === 'swordsman') return { str: 17, dex: 13, int: 10, cha: 12, con: 17 };
+  if (job === 'ranger') return { str: 11, dex: 18, int: 11, cha: 11, con: 14 };
+  if (job === 'mage') return { str: 9, dex: 13, int: 18, cha: 12, con: 13 };
+  return { str: 12, dex: 11, int: 13, cha: 18, con: 16 };
+}
+
+function hpFor(job: CompanionRecord['job']): number {
+  return job === 'mage' ? 24 : job === 'ranger' ? 27 : job === 'cleric' ? 31 : 34;
+}
+
+function companion(id: string, job: CompanionRecord['job']): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job,
+    level: 4,
+    xp: 180,
+    stats: statsFor(job),
+    maxHp: hpFor(job),
+    injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+    skills: { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 },
+  };
+}
+
+function saveForJobs(jobs: CompanionRecord['job'][]): SaveData {
+  const save = newGame(46000 + jobs.length, { job: jobs[0], allocation: {} });
+  save.marketSeed = 4666;
+  save.reputation = 30;
+  save.protagonist.level = 4;
+  save.protagonist.stats = statsFor(jobs[0]);
+  save.protagonist.maxHp = hpFor(jobs[0]);
+  save.protagonist.skills = { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 };
+  save.companions = jobs.slice(1).map((job, index) => companion(`member-${index + 1}-${job}`, job));
+  const ids = [save.protagonist.id, ...save.companions.map((member) => member.id)];
+  save.expeditionPlan = {
+    activeIds: ids,
+    positions: Object.fromEntries(ids.map((id, index) => [id, index < 2 ? 'front' : 'back'])),
+    roles: { captain: save.protagonist.id },
+  };
+  return save;
+}
+
+function forceSingleActor(battle: ReturnType<typeof createConvoyDefenseBattle>, actor: PartyMember): void {
+  battle.combat.order = [actor.id];
+  battle.combat.turnIndex = 0;
+  battle.combat.round = 1;
+}
+
+function totalEnemyHp(battle: ReturnType<typeof createConvoyDefenseBattle>): number {
+  return battle.combat.enemies.reduce((sum, enemy) => sum + enemy.hp, 0);
+}
+
+function totalPartyHp(battle: ReturnType<typeof createConvoyDefenseBattle>): number {
+  return battle.combat.party.reduce((sum, member) => sum + member.hp, 0);
+}
+
+interface PolicySnapshot {
+  wagonHp: number;
+  enemyHp: number;
+  partyHp: number;
+  mana: number;
+}
+
+function policySnapshots(): Record<'escort' | 'control' | 'pressure' | 'sustain', PolicySnapshot> {
+  const save = saveForJobs(['swordsman', 'ranger', 'mage', 'cleric']);
+
+  const escort = createConvoyDefenseBattle(save, highRng);
+  const escortActor = escort.combat.party.find((member) => member.id === 'protagonist')!;
+  forceSingleActor(escort, escortActor);
+  braceConvoy(highRng, escort, escortActor.id);
+
+  const pressure = createConvoyDefenseBattle(save, highRng);
+  const pressureActor = pressure.combat.party.find((member) => member.id === 'protagonist')!;
+  const hook = pressure.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+  hook.hp = 8;
+  forceSingleActor(pressure, pressureActor);
+  convoyPartyAct(highRng, pressure, pressureActor.id, 'heavy-slash', hook.id);
+
+  const control = createConvoyDefenseBattle(save, highRng);
+  const mage = control.combat.party.find((member) => member.moves.some((move) => move.id === 'frost-bind'))!;
+  const arsonist = control.combat.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+  forceSingleActor(control, mage);
+  convoyPartyAct(highRng, control, mage.id, 'frost-bind', arsonist.id);
+
+  const sustain = createConvoyDefenseBattle(save, highRng);
+  const cleric = sustain.combat.party.find((member) => member.moves.some((move) => move.id === 'heal'))!;
+  const wounded = sustain.combat.party.find((member) => member.id === 'protagonist')!;
+  wounded.hp -= 10;
+  forceSingleActor(sustain, cleric);
+  convoyPartyAct(highRng, sustain, cleric.id, 'heal', wounded.id);
+
+  return {
+    escort: { wagonHp: escort.wagon.hp, enemyHp: totalEnemyHp(escort), partyHp: totalPartyHp(escort), mana: 0 },
+    control: { wagonHp: control.wagon.hp, enemyHp: totalEnemyHp(control), partyHp: totalPartyHp(control), mana: mage.mystic?.current ?? 0 },
+    pressure: { wagonHp: pressure.wagon.hp, enemyHp: totalEnemyHp(pressure), partyHp: totalPartyHp(pressure), mana: 0 },
+    sustain: { wagonHp: sustain.wagon.hp, enemyHp: totalEnemyHp(sustain), partyHp: totalPartyHp(sustain), mana: 0 },
+  };
+}
+
+function moveScore(move: Move): number {
+  if (!move.damage) return 0;
+  return move.damage.dice * move.damage.sides + (move.hitBonus ?? 0);
+}
+
+function lowestPartyTarget(party: PartyMember[]): PartyMember {
+  return party.filter((member) => member.hp > 0)
+    .reduce((lowest, member) => member.hp / member.maxHp < lowest.hp / lowest.maxHp ? member : lowest);
+}
+
+function takeAdaptivePartyTurn(rng: Rng, battle: ReturnType<typeof createConvoyDefenseBattle>): void {
+  const actorInfo = currentActor(battle.combat);
+  if (!actorInfo || actorInfo.side !== 'party') return;
+  const actor = battle.combat.party.find((member) => member.id === actorInfo.id)!;
+  const enemies = battle.combat.enemies.filter((enemy) => enemy.hp > 0);
+  const pressure = projectedConvoyPressure(battle);
+
+  const frostBind = actor.moves.find((move) => move.id === 'frost-bind');
+  const highThreat = [...enemies].sort((a, b) => convoyThreatForEnemy(b) - convoyThreatForEnemy(a) || a.hp - b.hp)[0];
+  if (
+    frostBind && highThreat &&
+    !highThreat.statuses?.some((status) => status.kind === 'stun' && status.remaining > 0) &&
+    partyMoveAvailability(actor, frostBind).allowed && pressure >= 7
+  ) {
+    convoyPartyAct(rng, battle, actor.id, frostBind.id, highThreat.id);
+    return;
+  }
+
+  const heal = actor.moves.find((move) => move.id === 'heal');
+  const hurt = lowestPartyTarget(battle.combat.party);
+  if (heal && hurt.hp / hurt.maxHp <= 0.45 && partyMoveAvailability(actor, heal).allowed) {
+    convoyPartyAct(rng, battle, actor.id, heal.id, hurt.id);
+    return;
+  }
+
+  if (pressure >= 7 && battle.protection < 5) {
+    const brace = braceConvoy(rng, battle, actor.id);
+    if (brace.acted) return;
+  }
+
+  const attacks = actor.moves
+    .filter((move) => move.kind === 'attack' && partyMoveAvailability(actor, move).allowed)
+    .sort((a, b) => moveScore(b) - moveScore(a));
+  if (attacks.length > 0 && highThreat) {
+    convoyPartyAct(rng, battle, actor.id, attacks[0].id, highThreat.id);
+    return;
+  }
+
+  const recovery = actor.moves.find((move) => move.id === 'arcane-focus' || move.id === 'field-prayer');
+  if (recovery) {
+    convoyPartyAct(rng, battle, actor.id, recovery.id, hurt.id);
+    return;
+  }
+
+  const fallback = actor.moves[0];
+  if (fallback && highThreat) convoyPartyAct(rng, battle, actor.id, fallback.id, highThreat.id);
+}
+
+function simulate(jobs: CompanionRecord['job'][], seed: number): { won: boolean; wagonHp: number; completedRounds: number } {
+  const rng = createRng(seed);
+  const battle = createConvoyDefenseBattle(saveForJobs(jobs), rng);
+  let safety = 0;
+  while (battle.combat.outcome === 'ongoing' && safety < 160) {
+    const actor = currentActor(battle.combat);
+    if (!actor) break;
+    if (actor.side === 'enemy') convoyEnemyAct(rng, battle, actor.id);
+    else takeAdaptivePartyTurn(rng, battle);
+    safety += 1;
+  }
+  return { won: battle.combat.outcome === 'victory', wagonHp: battle.wagon.hp, completedRounds: battle.completedRounds };
+}
+
+describe('M46 player-perspective multidimensional convoy review', () => {
+  it('makes escort, control, pressure and sustain own different tactical advantages', () => {
+    const result = policySnapshots();
+    console.info('[M46 OBJECTIVE POLICIES]', result);
+
+    expect(result.escort.wagonHp).toBeGreaterThan(result.pressure.wagonHp);
+    expect(result.pressure.enemyHp).toBeLessThan(result.escort.enemyHp);
+    expect(result.control.wagonHp).toBeGreaterThan(result.sustain.wagonHp);
+    expect(result.control.mana).toBeLessThan(8);
+    expect(result.sustain.partyHp).toBeGreaterThan(result.pressure.partyHp - 10);
+
+    const dimensions = ['wagonHp', 'enemyHp', 'partyHp'] as const;
+    const policies = Object.values(result);
+    const dominates = (a: PolicySnapshot, b: PolicySnapshot): boolean => {
+      const betterOrEqual = a.wagonHp >= b.wagonHp && a.partyHp >= b.partyHp && a.enemyHp <= b.enemyHp;
+      const strictlyBetter = a.wagonHp > b.wagonHp || a.partyHp > b.partyHp || a.enemyHp < b.enemyHp;
+      return betterOrEqual && strictlyBetter;
+    };
+    expect(dimensions).toHaveLength(3);
+    expect(policies.some((candidate) => policies.filter((other) => other !== candidate).every((other) => dominates(candidate, other)))).toBe(false);
+  });
+
+  it('keeps a pure martial escort viable without mage or cleric', () => {
+    const results = Array.from({ length: 12 }, (_, index) => simulate(['swordsman', 'ranger', 'swordsman', 'ranger'], 46100 + index));
+    const wins = results.filter((result) => result.won);
+    console.info(`[M46 COMPOSITION] pure-martial wins=${wins.length}/12 wagon=${wins.map((result) => result.wagonHp).join(',')}`);
+    expect(wins.length).toBeGreaterThan(0);
+  });
+
+  it('keeps a party without swordsman viable through control, ranged pressure and ordinary convoy bracing', () => {
+    const results = Array.from({ length: 12 }, (_, index) => simulate(['ranger', 'mage', 'cleric', 'ranger'], 46200 + index));
+    const wins = results.filter((result) => result.won);
+    console.info(`[M46 COMPOSITION] no-swordsman wins=${wins.length}/12 wagon=${wins.map((result) => result.wagonHp).join(',')}`);
+    expect(wins.length).toBeGreaterThan(0);
+  });
+
+  it('does not require killing every enemy in simulated successful escorts', () => {
+    const save = saveForJobs(['swordsman', 'ranger', 'mage', 'cleric']);
+    const battle = createConvoyDefenseBattle(save, createRng(46300));
+    for (let round = 0; round < 4; round++) {
+      battle.protection = 10;
+      battle.combat.turnIndex = battle.combat.order.length - 1;
+      // The real objective settlement is exercised here while every hostile remains alive.
+      const before = battle.combat.round;
+      battle.combat.round += 1;
+      // Reuse an ordinary no-op enemy cycle boundary by restoring round and bracing through a one-unit order.
+      battle.combat.round = before;
+      battle.combat.order = [battle.combat.party[0].id];
+      battle.combat.turnIndex = 0;
+      braceConvoy(highRng, battle, battle.combat.party[0].id);
+    }
+    expect(battle.combat.outcome).toBe('victory');
+    expect(battle.combat.enemies.some((enemy) => enemy.hp > 0)).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
@@ -10,6 +10,7 @@ import {
   claimConvoyDefenseReward,
   convoyAbandonmentCount,
   convoyAdvanceTurnForTest,
+  convoyAttemptActive,
   convoyDefenseAccess,
   convoyRewardReceipt,
   createConvoyDefenseBattle,
@@ -150,33 +151,48 @@ describe('M46 convoy objective combat', () => {
     expect(battle.combat.outcome).toBe('defeat');
   });
 
-  it('turns refresh abandonment into escalating wagon damage plus a supply/economy penalty', () => {
+  it('turns every unresolved attempt, including retreat/defeat, into an escalating retry cost', () => {
     const save = preparedSave();
     const first = beginConvoyAttempt(save);
     expect(first.abandonmentCount).toBe(0);
     expect(first.startingWagonHp).toBe(CONVOY_WAGON_MAX_HP);
     expect(save.inventory['dried-rations']).toBe(3);
+    expect(convoyAttemptActive(save)).toBe(true);
+
+    const failedBattle = createConvoyDefenseBattle(save, createRng(501));
+    failedBattle.combat.outcome = 'retreated';
+    expect(() => claimConvoyDefenseReward(save, failedBattle)).toThrow('護運尚未成功');
+    expect(convoyAttemptActive(save)).toBe(true);
 
     const second = beginConvoyAttempt(save);
     expect(second.abandonmentCount).toBe(1);
     expect(second.startingWagonHp).toBe(CONVOY_WAGON_MAX_HP - 4);
     expect(save.inventory['dried-rations']).toBe(2);
-    expect(second.penalty).toContain('中途放棄');
+    expect(second.penalty).toContain('沒有完成');
 
     beginConvoyAttempt(save);
     expect(convoyAbandonmentCount(save)).toBe(2);
     expect(save.inventory['dried-rations']).toBe(1);
   });
 
-  it('rewards wagon condition, grants only once per market cycle, and blocks repeated farming', () => {
+  it('requires a real victory before reward, rewards wagon condition once, and blocks repeated farming', () => {
     const save = preparedSave();
-    const pristine = claimConvoyDefenseReward(save, 25);
+    beginConvoyAttempt(save);
+    const battle = createConvoyDefenseBattle(save, createRng(51));
+
+    expect(() => claimConvoyDefenseReward(save, battle)).toThrow('護運尚未成功');
+    expect(convoyAttemptActive(save)).toBe(true);
+
+    battle.combat.outcome = 'victory';
+    battle.wagon.hp = 25;
+    const pristine = claimConvoyDefenseReward(save, battle);
     expect(pristine.pristineBonus).toBe(true);
     expect(pristine.gold).toBe(52);
     expect(pristine.reputation).toBe(2);
     expect(save.flags[convoyRewardReceipt(save.marketSeed)]).toBe(true);
+    expect(convoyAttemptActive(save)).toBe(false);
     expect(convoyDefenseAccess(save).allowed).toBe(false);
-    expect(() => claimConvoyDefenseReward(save, 30)).toThrow();
+    expect(() => claimConvoyDefenseReward(save, battle)).toThrow();
 
     save.marketSeed += 1;
     expect(convoyDefenseAccess(save).allowed).toBe(true);

--- a/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
@@ -91,8 +91,8 @@ describe('M46 convoy objective combat', () => {
 
   it('turns convoy protection into a real action cost, respects turn ownership, and caps stacked protection', () => {
     const battle = createConvoyDefenseBattle(preparedSave(), createRng(47));
-    const [front, second] = battle.combat.party;
-    battle.combat.order = [front.id, second.id];
+    const [front, second, third] = battle.combat.party;
+    battle.combat.order = [front.id, second.id, third.id];
     battle.combat.turnIndex = 0;
 
     const firstBrace = braceConvoy(createRng(470), battle, front.id);

--- a/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import { createRng } from '../rng';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import {
+  CONVOY_DEFENSE_HOLD_ROUNDS,
+  CONVOY_WAGON_MAX_HP,
+  beginConvoyAttempt,
+  braceConvoy,
+  buildConvoyParty,
+  claimConvoyDefenseReward,
+  convoyAbandonmentCount,
+  convoyAdvanceTurnForTest,
+  convoyDefenseAccess,
+  convoyRewardReceipt,
+  createConvoyDefenseBattle,
+  createConvoyDefenseEncounter,
+  projectedConvoyPressure,
+} from './convoyDefense.m46';
+
+function companion(id: string, job: CompanionRecord['job'], injuredForTrips = 0): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job,
+    level: 4,
+    xp: 200,
+    stats: { str: 15, dex: 15, int: 15, cha: 15, con: 15 },
+    maxHp: 27,
+    injuredForTrips,
+    equipment: { weapon: null, armor: null, trinket: null },
+    skills: { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 },
+  };
+}
+
+function preparedSave(): SaveData {
+  const save = newGame(4600, { job: 'swordsman', trait: 'hardy', allocation: { con: 2, str: 1 } });
+  save.marketSeed = 4612;
+  save.reputation = 20;
+  save.gold = 100;
+  save.inventory = { ...save.inventory, 'dried-rations': 3 };
+  save.protagonist.level = 4;
+  save.protagonist.stats = { str: 16, dex: 12, int: 10, cha: 12, con: 16 };
+  save.companions = [
+    companion('ranger', 'ranger'),
+    companion('mage', 'mage'),
+    companion('cleric', 'cleric'),
+    companion('wounded', 'swordsman', 2),
+  ];
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'ranger', 'mage', 'wounded'],
+    positions: { protagonist: 'front', ranger: 'back', mage: 'back' },
+    roles: { captain: 'protagonist', scout: 'ranger' },
+  };
+  return save;
+}
+
+function finishRound(battle: ReturnType<typeof createConvoyDefenseBattle>): void {
+  battle.combat.turnIndex = battle.combat.order.length - 1;
+  convoyAdvanceTurnForTest(battle);
+}
+
+describe('M46 convoy objective combat', () => {
+  it('uses the current healthy expedition party and exposes a midgame guild-contract gate', () => {
+    const save = preparedSave();
+    const party = buildConvoyParty(save);
+    expect(party.map((member) => member.id)).toEqual(['protagonist', 'ranger', 'mage', 'cleric']);
+    expect(party).toHaveLength(4);
+    expect(party.some((member) => member.id === 'wounded')).toBe(false);
+    expect(convoyDefenseAccess(save).allowed).toBe(true);
+
+    save.reputation = 11;
+    expect(convoyDefenseAccess(save).allowed).toBe(false);
+    save.reputation = 20;
+    save.protagonist.injuredForTrips = 1;
+    expect(convoyDefenseAccess(save).allowed).toBe(false);
+  });
+
+  it('creates fresh fantasy raiders with distinct weaknesses and a dangerous combined convoy pressure', () => {
+    const first = createConvoyDefenseEncounter();
+    const second = createConvoyDefenseEncounter();
+    first[0].hp = 0;
+    expect(second[0].hp).toBe(second[0].maxHp);
+    expect(second.map((enemy) => enemy.name)).toEqual(expect.arrayContaining(['斷旗劫騎・領頭者', '鉤索掠手', '灰火縱咒師']));
+
+    const battle = createConvoyDefenseBattle(preparedSave(), createRng(46));
+    expect(projectedConvoyPressure(battle)).toBe(10);
+    const arsonist = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    expect(arsonist.mystic?.kind).toBe('mana');
+    expect(arsonist.weaknesses).toEqual(expect.arrayContaining(['frost', 'pierce']));
+  });
+
+  it('turns convoy protection into a real action cost, respects turn ownership, and caps stacked protection', () => {
+    const battle = createConvoyDefenseBattle(preparedSave(), createRng(47));
+    const [front, second] = battle.combat.party;
+    battle.combat.order = [front.id, second.id];
+    battle.combat.turnIndex = 0;
+
+    const firstBrace = braceConvoy(createRng(470), battle, front.id);
+    expect(firstBrace.acted).toBe(true);
+    expect(firstBrace.addedProtection).toBeGreaterThanOrEqual(5);
+    expect(battle.protection).toBe(firstBrace.addedProtection);
+
+    const illegalRepeat = braceConvoy(createRng(471), battle, front.id);
+    expect(illegalRepeat.acted).toBe(false);
+
+    const secondBrace = braceConvoy(createRng(472), battle, second.id);
+    expect(secondBrace.acted).toBe(true);
+    expect(battle.protection).toBeLessThanOrEqual(10);
+    expect(battle.protection).toBeGreaterThan(firstBrace.addedProtection);
+  });
+
+  it('makes kill pressure, control and guarding all reduce the end-of-round threat in different ways', () => {
+    const battle = createConvoyDefenseBattle(preparedSave(), createRng(48));
+    expect(projectedConvoyPressure(battle)).toBe(10);
+
+    const arsonist = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    arsonist.statuses = [{ kind: 'stun', remaining: 1, potency: 0 }];
+    expect(projectedConvoyPressure(battle)).toBe(6);
+    arsonist.statuses = [];
+
+    const hook = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    hook.hp = 0;
+    expect(projectedConvoyPressure(battle)).toBe(7);
+
+    battle.protection = 5;
+    finishRound(battle);
+    expect(battle.lastPressure).toEqual({ raw: 7, blocked: 5, damage: 2 });
+    expect(battle.wagon.hp).toBe(CONVOY_WAGON_MAX_HP - 2);
+    expect(battle.protection).toBe(0);
+  });
+
+  it('wins by holding four rounds even with enemies alive, so annihilation is no longer the only victory condition', () => {
+    const battle = createConvoyDefenseBattle(preparedSave(), createRng(49));
+    for (let round = 1; round <= CONVOY_DEFENSE_HOLD_ROUNDS; round++) {
+      battle.protection = 10;
+      finishRound(battle);
+    }
+    expect(battle.completedRounds).toBe(CONVOY_DEFENSE_HOLD_ROUNDS);
+    expect(battle.wagon.hp).toBe(CONVOY_WAGON_MAX_HP);
+    expect(battle.combat.enemies.some((enemy) => enemy.hp > 0)).toBe(true);
+    expect(battle.combat.outcome).toBe('victory');
+  });
+
+  it('fails the contract when the wagon breaks even while the party is still standing', () => {
+    const battle = createConvoyDefenseBattle(preparedSave(), createRng(50), 19);
+    finishRound(battle);
+    finishRound(battle);
+    expect(battle.wagon.hp).toBe(0);
+    expect(battle.combat.party.some((member) => member.hp > 0)).toBe(true);
+    expect(battle.combat.outcome).toBe('defeat');
+  });
+
+  it('turns refresh abandonment into escalating wagon damage plus a supply/economy penalty', () => {
+    const save = preparedSave();
+    const first = beginConvoyAttempt(save);
+    expect(first.abandonmentCount).toBe(0);
+    expect(first.startingWagonHp).toBe(CONVOY_WAGON_MAX_HP);
+    expect(save.inventory['dried-rations']).toBe(3);
+
+    const second = beginConvoyAttempt(save);
+    expect(second.abandonmentCount).toBe(1);
+    expect(second.startingWagonHp).toBe(CONVOY_WAGON_MAX_HP - 4);
+    expect(save.inventory['dried-rations']).toBe(2);
+    expect(second.penalty).toContain('中途放棄');
+
+    beginConvoyAttempt(save);
+    expect(convoyAbandonmentCount(save)).toBe(2);
+    expect(save.inventory['dried-rations']).toBe(1);
+  });
+
+  it('rewards wagon condition, grants only once per market cycle, and blocks repeated farming', () => {
+    const save = preparedSave();
+    const pristine = claimConvoyDefenseReward(save, 25);
+    expect(pristine.pristineBonus).toBe(true);
+    expect(pristine.gold).toBe(52);
+    expect(pristine.reputation).toBe(2);
+    expect(save.flags[convoyRewardReceipt(save.marketSeed)]).toBe(true);
+    expect(convoyDefenseAccess(save).allowed).toBe(false);
+    expect(() => claimConvoyDefenseReward(save, 30)).toThrow();
+
+    save.marketSeed += 1;
+    expect(convoyDefenseAccess(save).allowed).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/convoyDefense.m46.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.ts
@@ -102,6 +102,10 @@ function abandonmentPrefix(marketSeed: number): string {
   return `${ABANDON_PREFIX}:${marketSeed}:`;
 }
 
+export function convoyAttemptActive(save: SaveData): boolean {
+  return save.flags[attemptReceipt(save.marketSeed)] === true;
+}
+
 export function convoyAbandonmentCount(save: SaveData): number {
   const prefix = abandonmentPrefix(save.marketSeed);
   return Object.keys(save.flags).filter((key) => key.startsWith(prefix) && save.flags[key] === true).length;
@@ -133,8 +137,9 @@ export function convoyDefenseAccess(save: SaveData): ConvoyDefenseAccess {
 }
 
 /**
- * Refresh/closing the page cannot be a free reroll. Re-entering an unresolved battle consumes
- * a ration (or 8G when supplies are empty) and the abandoned wagon begins increasingly damaged.
+ * Refresh, closing the page, retreating, or losing cannot be a free reroll. The attempt receipt
+ * is deliberately cleared only after a paid victory. Re-entering any unresolved contract consumes
+ * a ration (or emergency gold) and the wagon begins increasingly damaged.
  */
 export function beginConvoyAttempt(save: SaveData): ConvoyAttemptResult {
   const access = convoyDefenseAccess(save);
@@ -147,11 +152,11 @@ export function beginConvoyAttempt(save: SaveData): ConvoyAttemptResult {
     if ((save.inventory['dried-rations'] ?? 0) > 0) {
       save.inventory['dried-rations'] -= 1;
       if (save.inventory['dried-rations'] <= 0) delete save.inventory['dried-rations'];
-      penalty = '上一次護運被中途放棄：重新整隊消耗乾糧 1，馬車也留下額外損傷。';
+      penalty = '上一趟護運沒有完成：重新整隊消耗乾糧 1，馬車也留下額外損傷。';
     } else {
       const paid = Math.min(8, save.gold);
       save.gold -= paid;
-      penalty = `上一次護運被中途放棄：沒有乾糧，只能支付 ${paid} G 緊急整備，馬車也留下額外損傷。`;
+      penalty = `上一趟護運沒有完成：沒有乾糧，只能支付 ${paid} G 緊急整備，馬車也留下額外損傷。`;
     }
   }
   save.flags[attempt] = true;
@@ -375,10 +380,17 @@ export function applyConvoyBattleInjuries(save: SaveData, combat: CombatState): 
   return injured;
 }
 
-export function claimConvoyDefenseReward(save: SaveData, wagonHp: number): ConvoyReward {
+/**
+ * Settlement is enforced in the data layer, not only by the battle page. A destroyed wagon,
+ * retreat, defeat, or a still-running battle can never mint the contract reward.
+ */
+export function claimConvoyDefenseReward(save: SaveData, battle: ConvoyDefenseBattle): ConvoyReward {
+  if (battle.combat.outcome !== 'victory' || battle.wagon.hp <= 0) {
+    throw new Error('護運尚未成功，不能領取黑蠟急件報酬。');
+  }
   const receipt = convoyRewardReceipt(save.marketSeed);
   if (save.flags[receipt] === true) throw new Error('本市場週期的護運報酬已領取。');
-  const pristineBonus = wagonHp >= Math.ceil(CONVOY_WAGON_MAX_HP * 0.7);
+  const pristineBonus = battle.wagon.hp >= Math.ceil(CONVOY_WAGON_MAX_HP * 0.7);
   const reward: ConvoyReward = { gold: 42 + (pristineBonus ? 10 : 0), reputation: 2, pristineBonus };
   save.gold += reward.gold;
   save.reputation += reward.reputation;

--- a/src/scripts/games/caravan/data/convoyDefense.m46.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.ts
@@ -1,0 +1,388 @@
+import {
+  advanceTurn,
+  currentActor,
+  partyAct,
+  startCombat,
+  type CombatState,
+  type EnemyUnit,
+  type Move,
+  type PartyActionResult,
+  type PartyMember,
+} from '../combat';
+import { statMod } from '../check';
+import type { Rng } from '../rng';
+import type { CompanionRecord, SaveData } from '../save';
+import { memberFromRecord } from './jobs';
+import { ritualEnemyAct } from './rituals.m45';
+
+export const CONVOY_DEFENSE_MIN_REPUTATION = 12;
+export const CONVOY_DEFENSE_HOLD_ROUNDS = 4;
+export const CONVOY_WAGON_MAX_HP = 30;
+export const CONVOY_DEFENSE_RECEIPT_PREFIX = 'contract:split-banner-convoy';
+
+const ATTEMPT_PREFIX = 'convoy-defense:attempt';
+const ABANDON_PREFIX = 'convoy-defense:abandon';
+const THREAT: Record<string, number> = {
+  'convoy-reaver-captain': 3,
+  'convoy-hook-raider': 3,
+  'convoy-ash-arsonist': 4,
+};
+
+export interface ConvoyDefenseAccess {
+  allowed: boolean;
+  reason: string;
+  partySize: number;
+}
+
+export interface ConvoyAttemptResult {
+  abandonmentCount: number;
+  startingWagonHp: number;
+  penalty: string | null;
+}
+
+export interface ConvoyDefenseBattle {
+  combat: CombatState;
+  wagon: { name: string; maxHp: number; hp: number };
+  holdRounds: number;
+  completedRounds: number;
+  protection: number;
+  suppressedEnemies: Set<string>;
+  lastPressure: { raw: number; blocked: number; damage: number } | null;
+}
+
+export interface ConvoyBraceResult {
+  acted: boolean;
+  addedProtection: number;
+  reason?: string;
+}
+
+export interface ConvoyReward {
+  gold: number;
+  reputation: number;
+  pristineBonus: boolean;
+}
+
+function defaultRow(record: CompanionRecord): 'front' | 'back' {
+  return record.job === 'swordsman' || record.job === 'cleric' ? 'front' : 'back';
+}
+
+/**
+ * M46 uses the same current expedition plan as ordinary adventure combat. Wounded companions
+ * are excluded and the captain is always present; this keeps objective fights about party
+ * construction rather than a separate challenge roster.
+ */
+export function buildConvoyParty(save: SaveData): PartyMember[] {
+  const healthy = save.companions.filter((member) => member.injuredForTrips <= 0);
+  const healthyById = new Map(healthy.map((member) => [member.id, member]));
+  const planned = (save.expeditionPlan?.activeIds ?? [])
+    .filter((id) => id !== save.protagonist.id)
+    .map((id) => healthyById.get(id))
+    .filter((member): member is CompanionRecord => !!member);
+  const selected = new Map<string, CompanionRecord>();
+  for (const member of [...planned, ...healthy]) {
+    if (selected.size >= 3) break;
+    selected.set(member.id, member);
+  }
+  return [save.protagonist, ...selected.values()].map((record) => {
+    const member = memberFromRecord(record);
+    member.formationRow = save.expeditionPlan?.positions[record.id] ?? defaultRow(record);
+    return member;
+  });
+}
+
+export function convoyRewardReceipt(marketSeed: number): string {
+  return `${CONVOY_DEFENSE_RECEIPT_PREFIX}:${marketSeed}`;
+}
+
+function attemptReceipt(marketSeed: number): string {
+  return `${ATTEMPT_PREFIX}:${marketSeed}`;
+}
+
+function abandonmentPrefix(marketSeed: number): string {
+  return `${ABANDON_PREFIX}:${marketSeed}:`;
+}
+
+export function convoyAbandonmentCount(save: SaveData): number {
+  const prefix = abandonmentPrefix(save.marketSeed);
+  return Object.keys(save.flags).filter((key) => key.startsWith(prefix) && save.flags[key] === true).length;
+}
+
+export function convoyDefenseAccess(save: SaveData): ConvoyDefenseAccess {
+  const party = buildConvoyParty(save);
+  if (save.protagonist.injuredForTrips > 0) {
+    return { allowed: false, reason: '隊長仍在養傷，無法接受護運急件。', partySize: party.length };
+  }
+  if (save.reputation < CONVOY_DEFENSE_MIN_REPUTATION) {
+    return {
+      allowed: false,
+      reason: `裂旗商路護運需要聲望 ${CONVOY_DEFENSE_MIN_REPUTATION}；行會不會把黑蠟急件交給尚未證明自己的隊伍。`,
+      partySize: party.length,
+    };
+  }
+  if (party.length < 2) {
+    return { allowed: false, reason: '至少需要兩名健康出征成員才能護住馬車。', partySize: party.length };
+  }
+  if (save.flags[convoyRewardReceipt(save.marketSeed)] === true) {
+    return {
+      allowed: false,
+      reason: '本市場週期的裂旗商路護運已完成；完成一般遠征、等待新一輪行情後才會有下一張急件。',
+      partySize: party.length,
+    };
+  }
+  return { allowed: true, reason: '黑蠟護運急件已可接受。', partySize: party.length };
+}
+
+/**
+ * Refresh/closing the page cannot be a free reroll. Re-entering an unresolved battle consumes
+ * a ration (or 8G when supplies are empty) and the abandoned wagon begins increasingly damaged.
+ */
+export function beginConvoyAttempt(save: SaveData): ConvoyAttemptResult {
+  const access = convoyDefenseAccess(save);
+  if (!access.allowed) throw new Error(access.reason);
+  const attempt = attemptReceipt(save.marketSeed);
+  let penalty: string | null = null;
+  if (save.flags[attempt] === true) {
+    const next = convoyAbandonmentCount(save) + 1;
+    save.flags[`${abandonmentPrefix(save.marketSeed)}${next}`] = true;
+    if ((save.inventory['dried-rations'] ?? 0) > 0) {
+      save.inventory['dried-rations'] -= 1;
+      if (save.inventory['dried-rations'] <= 0) delete save.inventory['dried-rations'];
+      penalty = '上一次護運被中途放棄：重新整隊消耗乾糧 1，馬車也留下額外損傷。';
+    } else {
+      const paid = Math.min(8, save.gold);
+      save.gold -= paid;
+      penalty = `上一次護運被中途放棄：沒有乾糧，只能支付 ${paid} G 緊急整備，馬車也留下額外損傷。`;
+    }
+  }
+  save.flags[attempt] = true;
+  const count = convoyAbandonmentCount(save);
+  return {
+    abandonmentCount: count,
+    startingWagonHp: Math.max(12, CONVOY_WAGON_MAX_HP - count * 4),
+    penalty,
+  };
+}
+
+export function finishConvoyAttempt(save: SaveData): void {
+  delete save.flags[attemptReceipt(save.marketSeed)];
+}
+
+const reaverSlash: Move = {
+  id: 'convoy-reaver-slash', name: '斷旗馬刀', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 8, bonusStat: 'str' },
+  narration: '{actor}踏過碎石揮下斷旗馬刀，斬中{target}，造成 {amount} 點傷害！',
+};
+const reaverBrace: Move = {
+  id: 'convoy-reaver-brace', name: '殘盾壓陣', kind: 'guard', target: 'self', hitStat: 'con',
+  narration: '{actor}把殘盾頂在肩前，逼近商隊的防線。',
+};
+const hookStrike: Move = {
+  id: 'convoy-hook-strike', name: '鉤索斧', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'blunt',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' },
+  narration: '{actor}甩出鉤索拖亂陣腳，再以短斧砸向{target}，造成 {amount} 點傷害！',
+};
+const ashBolt: Move = {
+  id: 'convoy-ash-bolt', name: '灰火箭', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 7, bonusStat: 'int' },
+  narration: '{actor}捻碎焦黑符紙，灰火箭穿過車陣擊中{target}，造成 {amount} 點傷害！',
+};
+
+function reaverCaptain(): EnemyUnit {
+  return {
+    id: 'convoy-reaver-captain', name: '斷旗劫騎・領頭者',
+    stats: { str: 15, dex: 12, int: 8, cha: 12, con: 15 }, maxHp: 32, hp: 32, defense: 14,
+    weaknesses: ['blunt', 'holy'], resists: ['slash'], maxPoise: 3,
+    moves: [reaverSlash, reaverBrace],
+    intents: [{ weight: 3, moveId: reaverSlash.id }, { weight: 1, moveId: reaverBrace.id }],
+    enrage: { threshold: 0.4, potency: 2 },
+  };
+}
+
+function hookRaider(): EnemyUnit {
+  return {
+    id: 'convoy-hook-raider', name: '鉤索掠手',
+    stats: { str: 11, dex: 15, int: 8, cha: 8, con: 11 }, maxHp: 24, hp: 24, defense: 13,
+    weaknesses: ['frost', 'slash'], resists: ['pierce'], maxPoise: 2,
+    moves: [hookStrike], intents: [{ weight: 1, moveId: hookStrike.id }],
+  };
+}
+
+function ashArsonist(): EnemyUnit {
+  return {
+    id: 'convoy-ash-arsonist', name: '灰火縱咒師',
+    stats: { str: 7, dex: 11, int: 16, cha: 12, con: 10 }, maxHp: 24, hp: 24, defense: 12,
+    weaknesses: ['frost', 'pierce'], resists: ['fire'], maxPoise: 2,
+    moves: [ashBolt], intents: [{ weight: 1, moveId: ashBolt.id }],
+  };
+}
+
+export function createConvoyDefenseEncounter(): EnemyUnit[] {
+  return [reaverCaptain(), hookRaider(), ashArsonist()];
+}
+
+export function createConvoyDefenseBattle(
+  save: SaveData,
+  rng: Rng,
+  startingWagonHp = CONVOY_WAGON_MAX_HP,
+): ConvoyDefenseBattle {
+  const combat = startCombat(rng, buildConvoyParty(save), createConvoyDefenseEncounter());
+  combat.log.push({
+    kind: 'info',
+    text: `護運目標：讓「白蠟貨車」撐過 ${CONVOY_DEFENSE_HOLD_ROUNDS} 輪，或提前擊潰全部伏兵。敵人存活越多，每輪突破壓力越高。`,
+  });
+  return {
+    combat,
+    wagon: { name: '白蠟貨車', maxHp: CONVOY_WAGON_MAX_HP, hp: Math.max(1, Math.min(CONVOY_WAGON_MAX_HP, startingWagonHp)) },
+    holdRounds: CONVOY_DEFENSE_HOLD_ROUNDS,
+    completedRounds: 0,
+    protection: 0,
+    suppressedEnemies: new Set<string>(),
+    lastPressure: null,
+  };
+}
+
+export function convoyThreatForEnemy(enemy: EnemyUnit): number {
+  return THREAT[enemy.id] ?? 1;
+}
+
+function stunned(enemy: EnemyUnit): boolean {
+  return (enemy.statuses ?? []).some((status) => status.kind === 'stun' && status.remaining > 0);
+}
+
+export function projectedConvoyPressure(battle: ConvoyDefenseBattle): number {
+  return battle.combat.enemies
+    .filter((enemy) => enemy.hp > 0 && !stunned(enemy) && !battle.suppressedEnemies.has(enemy.id))
+    .reduce((sum, enemy) => sum + convoyThreatForEnemy(enemy), 0);
+}
+
+export function convoyBraceValue(actor: PartyMember): number {
+  const frontBonus = actor.formationRow === 'back' ? 0 : 1;
+  return Math.max(3, Math.min(7, 4 + Math.max(0, statMod(actor.stats.con)) + frontBonus));
+}
+
+function settleRoundPressure(battle: ConvoyDefenseBattle, completedRound: number): void {
+  if (battle.combat.outcome !== 'ongoing') return;
+  const raw = projectedConvoyPressure(battle);
+  const blocked = Math.min(raw, battle.protection);
+  const damage = Math.max(0, raw - blocked);
+  battle.wagon.hp = Math.max(0, battle.wagon.hp - damage);
+  battle.completedRounds = Math.max(battle.completedRounds, completedRound);
+  battle.lastPressure = { raw, blocked, damage };
+  battle.combat.log.push({
+    kind: damage > 0 ? 'damage' : 'info',
+    text: `第 ${completedRound} 輪護運結算：伏兵突破壓力 ${raw}，護車抵消 ${blocked}，${battle.wagon.name}損失 ${damage} 點耐久（${battle.wagon.hp}/${battle.wagon.maxHp}）。`,
+  });
+  battle.protection = 0;
+  battle.suppressedEnemies.clear();
+  if (battle.wagon.hp <= 0) {
+    battle.combat.outcome = 'defeat';
+    battle.combat.log.push({ kind: 'defeat', text: '馬車被拆毀，黑蠟護運失敗。' });
+    return;
+  }
+  if (completedRound >= battle.holdRounds) {
+    battle.combat.outcome = 'victory';
+    battle.combat.log.push({
+      kind: 'victory',
+      text: '車夫終於拉開裂旗關的鎖鏈——貨車穿過隘口。即使伏兵仍在，護運也已完成！',
+    });
+  }
+}
+
+function settleIfRoundAdvanced(battle: ConvoyDefenseBattle, beforeRound: number): void {
+  if (battle.combat.outcome !== 'ongoing') return;
+  if (battle.combat.round > beforeRound) settleRoundPressure(battle, beforeRound);
+}
+
+export function convoyPartyAct(
+  rng: Rng,
+  battle: ConvoyDefenseBattle,
+  actorId: string,
+  moveId: string,
+  targetId: string,
+  options: { overcast?: boolean } = {},
+): PartyActionResult {
+  const beforeRound = battle.combat.round;
+  const result = partyAct(rng, battle.combat, actorId, moveId, targetId, options);
+  if (result.acted) settleIfRoundAdvanced(battle, beforeRound);
+  return result;
+}
+
+/**
+ * Any living member can spend their current turn physically protecting the wagon. This is a
+ * real tempo cost: it uses the ordinary turn engine, respects stun, and caps stacked protection
+ * so four characters cannot make the objective permanently invulnerable.
+ */
+export function braceConvoy(rng: Rng, battle: ConvoyDefenseBattle, actorId: string): ConvoyBraceResult {
+  const actorTurn = currentActor(battle.combat);
+  const actor = battle.combat.party.find((member) => member.id === actorId);
+  if (!actor || actorTurn?.side !== 'party' || actorTurn.id !== actorId || battle.combat.outcome !== 'ongoing') {
+    return { acted: false, addedProtection: 0, reason: '現在不是這名成員的護車行動時機。' };
+  }
+  const braceMove: Move = {
+    id: `convoy-brace:${actor.id}`,
+    name: '護住馬車', kind: 'support', target: 'self', hitStat: 'con',
+    narration: '{actor}離開殺線，把肩膀、盾牌與車架一起頂進缺口，替馬車爭取通過隘口的時間。',
+  };
+  actor.moves.push(braceMove);
+  const beforeRound = battle.combat.round;
+  const result = partyAct(rng, battle.combat, actor.id, braceMove.id, actor.id);
+  actor.moves = actor.moves.filter((move) => move.id !== braceMove.id);
+  if (!result.acted || result.reason) {
+    if (result.acted) settleIfRoundAdvanced(battle, beforeRound);
+    return { acted: result.acted, addedProtection: 0, reason: result.reason };
+  }
+  const before = battle.protection;
+  battle.protection = Math.min(10, battle.protection + convoyBraceValue(actor));
+  const added = battle.protection - before;
+  battle.combat.log.push({
+    kind: 'info',
+    text: `${actor.name}本輪替馬車建立 ${added} 點護車值（目前 ${battle.protection}/10）。`,
+  });
+  settleIfRoundAdvanced(battle, beforeRound);
+  return { acted: true, addedProtection: added };
+}
+
+export function convoyEnemyAct(rng: Rng, battle: ConvoyDefenseBattle, enemyId: string): void {
+  if (battle.combat.outcome !== 'ongoing') return;
+  const enemy = battle.combat.enemies.find((candidate) => candidate.id === enemyId);
+  if (!enemy) return;
+  const wasStunned = stunned(enemy);
+  const beforeRound = battle.combat.round;
+  ritualEnemyAct(rng, battle.combat, enemyId);
+  if (wasStunned) battle.suppressedEnemies.add(enemyId);
+  settleIfRoundAdvanced(battle, beforeRound);
+}
+
+/** Test utility: advance a harmless turn while preserving the same round-pressure rules. */
+export function convoyAdvanceTurnForTest(battle: ConvoyDefenseBattle): void {
+  const beforeRound = battle.combat.round;
+  advanceTurn(battle.combat);
+  settleIfRoundAdvanced(battle, beforeRound);
+}
+
+export function applyConvoyBattleInjuries(save: SaveData, combat: CombatState): string[] {
+  const injured: string[] = [];
+  for (const member of combat.party) {
+    if (member.hp > 0) continue;
+    const record = member.id === save.protagonist.id
+      ? save.protagonist
+      : save.companions.find((candidate) => candidate.id === member.id);
+    if (!record) continue;
+    const trips = member.id === save.protagonist.id ? 1 : 2;
+    record.injuredForTrips = Math.max(record.injuredForTrips, trips);
+    injured.push(record.id);
+  }
+  return injured;
+}
+
+export function claimConvoyDefenseReward(save: SaveData, wagonHp: number): ConvoyReward {
+  const receipt = convoyRewardReceipt(save.marketSeed);
+  if (save.flags[receipt] === true) throw new Error('本市場週期的護運報酬已領取。');
+  const pristineBonus = wagonHp >= Math.ceil(CONVOY_WAGON_MAX_HP * 0.7);
+  const reward: ConvoyReward = { gold: 42 + (pristineBonus ? 10 : 0), reputation: 2, pristineBonus };
+  save.gold += reward.gold;
+  save.reputation += reward.reputation;
+  save.flags[receipt] = true;
+  finishConvoyAttempt(save);
+  return reward;
+}


### PR DESCRIPTION
## Summary
- add a playable medieval-fantasy convoy defense contract where protecting the wagon for four rounds is an independent victory condition
- make living ambushers generate end-of-round breakthrough pressure against the wagon
- let kills permanently remove pressure, stun/poise break suppress pressure for a round, and any party member spend a real combat action bracing the wagon
- keep bracing constitution/frontline-sensitive but cap stacked protection so four-person shield spam cannot make the wagon permanently invulnerable
- reuse production M41–M45 combat rules: mana/favor, armory loadouts, wards, enemy caster exhaustion, weakness/poise, and ritual wrappers remain active
- make refresh, close, retreat, and defeat all preserve an unresolved attempt so retries pay supplies/gold and begin with escalating wagon damage
- validate reward settlement against the actual battle state; ongoing/retreated/defeated/destroyed-wagon states cannot mint rewards
- reward wagon condition and allow only one paid convoy contract per market cycle
- surface `/caravan/convoy-defense` from the existing Guild Hall / Black-Wax Documents navigation

## Player-facing design intent
M45 improved how players respond to dangerous magic, but almost every fight still used annihilation as the only victory condition. M46 makes the caravan itself matter. Players can win by holding the road until the wagon escapes, and they can lose the contract while party members are still alive if they neglect the objective.

The intended response space is not a single escort button: frontline protection, ranged pressure, magical control, healing/sustain, and direct annihilation all change different parts of the objective economy.

## Multidimensional adversarial review
M46 gates check:
- four-round objective victory with enemies still alive
- independent wagon-destruction defeat while escorts remain alive
- actual-turn validation and action cost for convoy bracing
- per-round protection cap and reset
- kill, stun/poise-control, and bracing reducing objective pressure through different mechanisms
- refresh/close/retreat/defeat all paying the same unresolved-attempt retry economy
- non-victory reward calls rejected in the data layer before gold/reputation mutation
- reward receipt preventing same-cycle farming
- escort/control/pressure/sustain strategies owning different measured advantages rather than one policy dominating all dimensions
- seeded pure-martial party viability (no mage/cleric mandatory)
- seeded no-swordsman party viability (frontline class not mandatory)
- regression through core combat and M40–M45 systems

## Final validation
Hardened head `77f11fc6e103033e09f607fd3759e53ab1d09438` passed all triggered GitHub workflows:
- Caravan CI
- Caravan M39 CI
- Caravan M39 Balance CI
- Caravan M40 CI
- Caravan M41 CI
- Caravan M42 CI
- Caravan M43 Armory CI
- Caravan M44 Spellcraft CI
- Caravan M45 Ritual CI
- Caravan M46 Objective CI

`Caravan M46 Objective CI` completed production build, M46 lifecycle/anti-abuse tests, multidimensional player simulations, and the full core/M40–M45 gameplay regression set successfully.