### PR TITLE
feat(caravan): add M47 morale, rout and surrender

### DIFF
--- a/.github/workflows/caravan-m47-ci.yml
+++ b/.github/workflows/caravan-m47-ci.yml
@@ -1,0 +1,80 @@
+name: Caravan M47 Morale CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m47-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m47-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-morale-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M47 morale lifecycle, anti-abuse and settlement
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+
+      - name: M47 multidimensional player review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M46 convoy objective lifecycle and player review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M42 composition and camp-policy diversity regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M42 expedition state regression
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/endurance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts

--- a/docs/caravan-m47-morale-surrender.md
+++ b/docs/caravan-m47-morale-surrender.md
@@ -1,0 +1,65 @@
+# M47 Morale, Rout and Surrender
+
+M47 makes intelligent enemies behave like people with something to lose. It is deliberately scoped: only explicitly profiled human enemies receive morale. Undead, beasts, constructs, dragons and unknown future enemies remain unyielding until a designer opts them in.
+
+## Player-facing rules
+
+The Split-Banner convoy ambushers now have resolve:
+
+- Reaver Captain: 8 resolve and leader status.
+- Hook Raider: 6 resolve.
+- Ash Arsonist: 5 resolve.
+
+Resolve is not a second HP bar that must always be attacked. It is an alternate battlefield consequence layer:
+
+- An ordinary allied casualty shakes surviving intelligent enemies by 2 resolve.
+- Losing the leader shakes survivors by 4 resolve.
+- Crossing below half HP costs that enemy 1 resolve once.
+- Newly suffering stun / poise-break costs that enemy 1 resolve.
+- At 0 resolve, the enemy throws down arms and leaves the active battle without being counted as killed.
+
+## Battlefield command
+
+`戰場喝止` is a real action, not a free dialogue button.
+
+- It is unavailable against untouched full-resolve enemies. The party must first create battlefield leverage.
+- It uses Charisma and frontline presence, so a cleric is naturally good at it, but any profession can attempt it.
+- The DC rises with remaining resolve, leader status and previous failed attempts.
+- Natural 20 succeeds; natural 1 fails.
+- Failure raises the target's defiance by 1, adding +2 DC to later attempts. Repeating failed commands is therefore a tempo trap rather than a safe spam strategy.
+- Stun consumes the attempted command turn just like other actions.
+- A successful command deals resolve damage; it does not deal ordinary HP damage.
+
+Charisma therefore gains a combat identity without becoming a turn-one skip button.
+
+## Unyielding enemies
+
+The current M47 morale profile only contains the three Split-Banner human ambushers. The Tongueless Cantor, choir wraiths, Ashen Reliquary undead, Dragon Ember Avatar and other non-profiled enemies return no morale profile and cannot be intimidated through this system.
+
+## Post-rout treatment
+
+When a convoy victory contains explicitly routed enemies, reward settlement pauses for one consequence choice:
+
+1. Release them: +1 reputation, no extra gold or supply cost.
+2. Disarm and search them: +3 G per routed foe, no reputation bonus.
+3. Escort them for ransom: +8 G per routed foe, but consumes 1 dried ration and is unavailable without supplies.
+
+The base convoy contract reward is still paid exactly once. The aftermath receipt is also once per market cycle. Missing supplies or duplicate receipts are validated before mutation so no partial reward can be minted.
+
+## Multidimensional adversarial gameplay gates
+
+M47 acceptance is broader than unit correctness:
+
+- High Charisma cannot skip an untouched fight.
+- Failed commands consume tempo and make future attempts harder.
+- Leader loss has a larger morale effect than an ordinary casualty.
+- Stun and poise-break create leverage but are not mandatory; physical casualties can also break resolve.
+- A rout victory can occur while surrendered enemies still had HP, proving the system is genuinely non-lethal rather than renamed damage.
+- Live Reliquary undead and the Dragon Ember Avatar are explicitly checked as unyielding.
+- Cleric command success is better than a low-Charisma martial captain but remains probabilistic; the martial captain still has a viable chance after setup.
+- Brace, control, physical pressure and command retain different advantages across wagon protection, breakthrough pressure, HP damage, mana cost, setup cost and routed enemies.
+- Release, disarm and ransom remain Pareto alternatives across gold, reputation and supplies.
+- Ransom cannot create negative rations.
+- M46 objective lifecycle and balance are rerun in M47 CI, along with core combat and M40–M45 gameplay regressions.
+
+This is automated adversarial gameplay review. It does not replace multi-hour human UX playtesting, but it blocks obvious dominant strategies, free retries, charisma skips, non-human surrender bugs and reward duplication before merge.

--- a/src/pages/caravan/convoy-defense.astro
+++ b/src/pages/caravan/convoy-defense.astro
@@ -2,12 +2,12 @@
 import BaseLayout from '@components/layout/BaseLayout.astro';
 ---
 
-<BaseLayout title="裂旗商路護運 — 商隊與劍" description="守住馬車、控住伏兵，或在隘口打開前擊潰敵人。" lang="zh-TW">
+<BaseLayout title="裂旗商路護運 — 商隊與劍" description="守住馬車、擊潰戰意，或迫使伏兵棄械。" lang="zh-TW">
   <main class="convoy-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M46 BATTLEFIELD OBJECTIVES</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M46–M47 OBJECTIVES &amp; MORALE</p>
       <h1>黑蠟急件｜裂旗商路護運</h1>
-      <p>這不是討伐。車夫需要四輪時間拉開裂旗關的鎖鏈；你的任務是讓貨車活著穿過去。</p>
+      <p>這不是討伐。車夫需要四輪時間拉開裂旗關的鎖鏈；你可以護住貨車、擊潰伏兵，也可以先打碎他們的戰意再喝令棄械。</p>
       <nav><a href="/caravan/play">返回啟程之鎮</a><a href="/caravan/mandates">行會文書</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/endurance">餘燼朝聖</a></nav>
     </header>
 
@@ -36,16 +36,22 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     applyConvoyBattleInjuries,
     beginConvoyAttempt,
     braceConvoy,
-    claimConvoyDefenseReward,
     convoyBraceValue,
     convoyDefenseAccess,
     convoyEnemyAct,
-    convoyPartyAct,
     convoyThreatForEnemy,
-    createConvoyDefenseBattle,
     projectedConvoyPressure,
-    type ConvoyDefenseBattle,
   } from '@scripts/games/caravan/data/convoyDefense.m46';
+  import {
+    aftermathPreview,
+    claimMoraleConvoyReward,
+    commandAvailability,
+    commandMorale,
+    createMoraleConvoyDefenseBattle,
+    moraleConvoyPartyAct,
+    type MoraleConvoyBattle,
+    type MoraleDisposition,
+  } from '@scripts/games/caravan/data/convoyMorale.m47';
   import { ritualIntentText } from '@scripts/games/caravan/data/rituals.m45';
 
   const noticeEl = document.getElementById('notice')!;
@@ -58,9 +64,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   const resultEl = document.getElementById('result')!;
   const logEl = document.getElementById('log')!;
 
-  let battle: ConvoyDefenseBattle | null = null;
+  let battle: MoraleConvoyBattle | null = null;
   let rng: Rng | null = null;
   let settled = false;
+  let awaitingAftermath = false;
 
   const text = (tag: string, value: string, className?: string): HTMLElement => {
     const element = document.createElement(tag);
@@ -82,17 +89,21 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function unitCard(unit: PartyMember | EnemyUnit): HTMLElement {
     const enemy = 'intents' in unit ? unit as EnemyUnit : null;
+    const morale = enemy && battle ? battle.morale[enemy.id] : undefined;
     const card = document.createElement('article');
-    card.className = `unit ${unit.hp <= 0 ? 'down' : ''}`;
+    card.className = `unit ${unit.hp <= 0 ? 'down' : ''} ${morale?.routed ? 'routed' : ''}`;
     const status = (unit.statuses ?? []).map((entry) => `${entry.kind} ${entry.remaining}`).join('、');
     const poise = enemy?.maxPoise !== undefined ? `｜護勢 ${enemy.poise ?? enemy.maxPoise}/${enemy.maxPoise}` : '';
     card.append(text('h3', unit.name), text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${status ? `｜${status}` : ''}`));
     if (enemy) {
       const weak = (enemy.weaknesses ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
       const resist = (enemy.resists ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
-      card.append(
-        text('p', `突破壓力 ${convoyThreatForEnemy(enemy)}｜弱點 ${weak}｜抗性 ${resist}`, 'affinity'),
-      );
+      card.append(text('p', `突破壓力 ${convoyThreatForEnemy(enemy)}｜弱點 ${weak}｜抗性 ${resist}`, 'affinity'));
+      if (morale) {
+        card.append(text('p', morale.routed
+          ? '戰意 0｜已棄械退出戰列'
+          : `戰意 ${morale.current}/${morale.max}${morale.defiance ? `｜抗拒 ${morale.defiance}` : ''}${morale.leader ? '｜領頭者' : ''}`, morale.routed ? 'morale routed-label' : 'morale'));
+      }
       if (enemy.mystic) card.append(text('p', mysticPowerText(enemy.mystic), 'mystic'));
     } else {
       const member = unit as PartyMember;
@@ -108,8 +119,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     objectiveEl.replaceChildren(
       text('p', 'ESCORT OBJECTIVE', 'eyebrow'),
       text('h2', `${battle.wagon.name}｜耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}`),
-      text('p', `已撐過 ${battle.completedRounds}/${battle.holdRounds} 輪｜目前伏兵突破壓力 ${pressure}｜本輪護車 ${battle.protection}/10`),
-      text('p', '每完成一輪，仍能行動的伏兵會把突破壓力施加到馬車。擊殺、暈眩與護車都能降低實際損傷；撐滿四輪就能撤離，不必殺光。', 'hint'),
+      text('p', `已撐過 ${battle.completedRounds}/${battle.holdRounds} 輪｜目前突破壓力 ${pressure}｜本輪護車 ${battle.protection}/10｜已棄械 ${battle.routedEnemies.size} 人`),
+      text('p', '撐滿四輪即可撤離，不必殺光。人類伏兵的戰意會因傷亡、半血與破勢下降；但完整戰意時不能靠魅力直接跳過戰鬥。', 'hint'),
     );
     objectiveEl.hidden = false;
   }
@@ -139,15 +150,22 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   }
 
   function act(actorId: string, moveId: string, targetId: string, overcast = false): void {
-    if (!battle || !rng || settled) return;
-    const result = convoyPartyAct(rng, battle, actorId, moveId, targetId, { overcast });
+    if (!battle || !rng || settled || awaitingAftermath) return;
+    const result = moraleConvoyPartyAct(rng, battle, actorId, moveId, targetId, { overcast });
     if (result.acted) runEnemyTurns();
     settleOutcome(); render();
   }
 
   function brace(actor: PartyMember): void {
-    if (!battle || !rng || settled) return;
+    if (!battle || !rng || settled || awaitingAftermath) return;
     const result = braceConvoy(rng, battle, actor.id);
+    if (result.acted) runEnemyTurns();
+    settleOutcome(); render();
+  }
+
+  function command(actor: PartyMember, enemy: EnemyUnit): void {
+    if (!battle || !rng || settled || awaitingAftermath) return;
+    const result = commandMorale(rng, battle, actor.id, enemy.id);
     if (result.acted) runEnemyTurns();
     settleOutcome(); render();
   }
@@ -169,17 +187,27 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function renderActions(): void {
     actionsEl.replaceChildren();
-    if (!battle || battle.combat.outcome !== 'ongoing') { actionsEl.hidden = true; return; }
+    if (!battle || battle.combat.outcome !== 'ongoing' || awaitingAftermath) { actionsEl.hidden = true; return; }
     const actorInfo = currentActor(battle.combat);
     if (!actorInfo || actorInfo.side !== 'party') { actionsEl.hidden = true; return; }
     const actor = battle.combat.party.find((member) => member.id === actorInfo.id)!;
     actionsEl.hidden = false;
     actionsEl.append(
       text('h2', `${actor.name}的行動${actor.mystic ? `｜${mysticPowerText(actor.mystic)}` : ''}`),
-      text('p', `護住馬車會犧牲這一回合的輸出／治療，建立 ${convoyBraceValue(actor)} 點護車值；本輪總護車最多 10。`, 'hint'),
+      text('p', `護車建立 ${convoyBraceValue(actor)} 點防護；喝止則用魅力嘗試壓垮已動搖的敵人，但會消耗完整一回合，失敗還會提高對方抗拒。`, 'hint'),
     );
     const grid = document.createElement('div'); grid.className = 'action-grid';
     grid.append(button(`護住馬車（+${Math.min(convoyBraceValue(actor), Math.max(0, 10 - battle.protection))}）`, () => brace(actor), 'brace'));
+    for (const enemy of battle.combat.enemies.filter((candidate) => candidate.hp > 0 && battle!.morale[candidate.id])) {
+      const availability = commandAvailability(battle, actor, enemy);
+      grid.append(button(
+        availability.allowed ? `喝止 ${enemy.name}（DC ${availability.dc}）` : `喝止 ${enemy.name}（尚未動搖）`,
+        () => command(actor, enemy),
+        'command',
+        !availability.allowed,
+        availability.reason,
+      ));
+    }
     for (const move of actor.moves) grid.append(...moveButtons(actor, move));
     grid.append(button('放棄護運並撤離', retreat, 'retreat'));
     actionsEl.append(grid);
@@ -196,38 +224,93 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   }
 
   function retreat(): void {
-    if (!battle || !rng || settled) return;
+    if (!battle || !rng || settled || awaitingAftermath) return;
     attemptRetreat(rng, battle.combat);
     settleOutcome(); render();
   }
 
-  function settleOutcome(): void {
-    if (!battle || settled || battle.combat.outcome === 'ongoing') return;
-    const latest = loadGame(); if (!latest) return;
-    const injured = applyConvoyBattleInjuries(latest, battle.combat);
-    let rewardText = '';
-    if (battle.combat.outcome === 'victory') {
-      const reward = claimConvoyDefenseReward(latest, battle);
-      rewardText = `行會支付 ${reward.gold} G、聲望 +${reward.reputation}${reward.pristineBonus ? '；貨車保存良好，包含 10 G 完整交貨獎金' : ''}。`;
-    }
-    saveGame(latest);
-    settled = true;
+  function renderFinalResult(title: string, body: string, injuries: string[]): void {
+    if (!battle) return;
     resultEl.hidden = false;
     resultEl.replaceChildren(
       text('p', battle.combat.outcome === 'victory' ? 'CONTRACT COMPLETE' : battle.combat.outcome === 'retreated' ? 'CONTRACT ABANDONED' : 'CONTRACT FAILED', 'eyebrow'),
-      text('h2', battle.combat.outcome === 'victory' ? '白蠟貨車穿過裂旗關' : '黑蠟急件沒有送達'),
-      text('p', battle.combat.outcome === 'victory'
-        ? rewardText
-        : '沒有護運報酬；未完成嘗試會保留。下次重新接受時必須重新整隊，消耗補給或金幣，且馬車會帶著額外損傷進場。'),
-      text('p', `貨車剩餘耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}｜養傷：${injured.join('、') || '無'}`),
+      text('h2', title),
+      text('p', body),
+      text('p', `貨車剩餘耐久 ${battle.wagon.hp}/${battle.wagon.maxHp}｜養傷：${injuries.join('、') || '無'}`),
     );
     const link = document.createElement('a'); link.href = '/caravan/play'; link.className = 'return-link'; link.textContent = '返回啟程之鎮';
     resultEl.append(link);
   }
 
+  function finalizeVictory(disposition?: MoraleDisposition): void {
+    if (!battle || settled) return;
+    const latest = loadGame(); if (!latest) return;
+    try {
+      const injuries = applyConvoyBattleInjuries(latest, battle.combat);
+      const reward = claimMoraleConvoyReward(latest, battle, disposition);
+      saveGame(latest);
+      settled = true;
+      awaitingAftermath = false;
+      const after = reward.aftermath;
+      const aftermathText = after.disposition === 'release'
+        ? `你放走 ${after.routedCount} 名棄械伏兵；聲望 +${after.reputation}。`
+        : after.disposition === 'disarm'
+          ? `你收繳 ${after.routedCount} 名伏兵的武器與贓物，追加 ${after.gold} G。`
+          : after.disposition === 'ransom'
+            ? `你押送 ${after.routedCount} 名俘虜換取贖金，追加 ${after.gold} G、乾糧 -1。`
+            : '沒有留下需要處置的俘虜。';
+      renderFinalResult(
+        '白蠟貨車穿過裂旗關',
+        `行會支付 ${reward.base.gold} G、聲望 +${reward.base.reputation}${reward.base.pristineBonus ? '；貨車保存良好，包含 10 G 完整交貨獎金' : ''}。${aftermathText}`,
+        injuries,
+      );
+    } catch (error) {
+      resultEl.hidden = false;
+      resultEl.replaceChildren(text('p', error instanceof Error ? error.message : '護運結算失敗。'));
+    }
+  }
+
+  function showAftermath(): void {
+    if (!battle || awaitingAftermath || settled) return;
+    const latest = loadGame(); if (!latest) return;
+    awaitingAftermath = true;
+    actionsEl.hidden = true;
+    const release = aftermathPreview(latest, battle, 'release');
+    const disarm = aftermathPreview(latest, battle, 'disarm');
+    const ransom = aftermathPreview(latest, battle, 'ransom');
+    const hasRation = (latest.inventory['dried-rations'] ?? 0) > 0;
+    resultEl.hidden = false;
+    resultEl.replaceChildren(
+      text('p', 'SURRENDER AFTERMATH', 'eyebrow'),
+      text('h2', `${battle.routedEnemies.size} 名伏兵已棄械`),
+      text('p', '戰鬥已經贏了；現在決定商隊如何對待活下來的人。三種選擇交換聲望、金錢與補給，不存在無代價的最佳答案。'),
+      button(`放行｜聲望 +${release.reputation}`, () => finalizeVictory('release'), 'aftermath'),
+      button(`繳械搜身｜追加 ${disarm.gold} G`, () => finalizeVictory('disarm'), 'aftermath'),
+      button(`押送贖金｜追加 ${ransom.gold} G、乾糧 -1`, () => finalizeVictory('ransom'), 'aftermath', !hasRation, hasRation ? '' : '沒有乾糧，不能押送俘虜。'),
+    );
+  }
+
+  function settleOutcome(): void {
+    if (!battle || settled || battle.combat.outcome === 'ongoing') return;
+    if (battle.combat.outcome === 'victory') {
+      if (battle.routedEnemies.size > 0) showAftermath();
+      else finalizeVictory();
+      return;
+    }
+    const latest = loadGame(); if (!latest) return;
+    const injuries = applyConvoyBattleInjuries(latest, battle.combat);
+    saveGame(latest);
+    settled = true;
+    renderFinalResult(
+      '黑蠟急件沒有送達',
+      '沒有護運報酬；未完成嘗試會保留。下次重新接受時必須消耗補給或金幣，而且馬車會帶著額外損傷進場。',
+      injuries,
+    );
+  }
+
   function renderLog(): void {
     logEl.replaceChildren();
-    for (const entry of battle?.combat.log.slice(-32) ?? []) logEl.append(text('p', entry.text, entry.kind));
+    for (const entry of battle?.combat.log.slice(-36) ?? []) logEl.append(text('p', entry.text, entry.kind));
   }
 
   function render(): void {
@@ -244,9 +327,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     noticeEl.append(
       text('h2', `護衛隊 ${access.partySize} 人｜裂旗關伏擊`),
       text('p', attempt.penalty ?? '首次進場不收額外整備費。重新整理、關頁、撤退或戰敗都會保留未完成嘗試；下一次必須付出重新整隊代價。'),
+      text('p', '戰意規則只套用在會怕死、能溝通的人類伏兵；亡靈、魔物與龍燼不會因一句喝止就退場。', 'hint'),
     );
-    rng = createRng((save.createdAt + save.marketSeed * 17 + 46046) >>> 0);
-    battle = createConvoyDefenseBattle(save, rng, attempt.startingWagonHp);
+    rng = createRng((save.createdAt + save.marketSeed * 17 + 47047) >>> 0);
+    battle = createMoraleConvoyDefenseBattle(save, rng, attempt.startingWagonHp);
     battlefieldEl.hidden = false;
     runEnemyTurns(); settleOutcome(); render();
   }
@@ -269,17 +353,22 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .units { display: grid; gap: .65rem; }
   .unit { border: 1px solid #4d4337; background: #1a1713; padding: .75rem; }
   .unit h3, .unit p { margin: .15rem 0; }
-  .unit.down { opacity: .45; }
+  .unit.down { opacity: .55; }
+  .unit.routed { border-style: dashed; border-color: #77705f; }
   .affinity { color: #cfb68c; font-size: .9rem; }
   .formation, .mystic, .hint { color: #baa98d; font-size: .92rem; }
+  .morale { color: #e0b978; font-size: .92rem; }
+  .routed-label { color: #a7b29a; }
   .action-grid { display: flex; flex-wrap: wrap; gap: .55rem; }
   button { border: 1px solid #7a674c; background: #2a2118; color: #f3dfb7; padding: .65rem .8rem; cursor: pointer; }
   button:hover:not(:disabled) { background: #3b2c1d; }
   button:disabled { opacity: .45; cursor: not-allowed; }
   button.brace { border-color: #c09149; color: #ffd58b; }
+  button.command { border-color: #8d7041; color: #ffe1a1; }
   button.overcast { border-color: #9c3b3b; color: #ffb4a5; }
   button.retreat { border-color: #704443; }
-  .log { max-height: 360px; overflow: auto; }
+  button.aftermath { margin: .5rem .45rem .2rem 0; border-color: #9b7d4e; }
+  .log { max-height: 390px; overflow: auto; }
   .log p { margin: .28rem 0; }
   .log .damage, .log .defeat { color: #e7927c; }
   .log .heal, .log .victory { color: #9bd69b; }

--- a/src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+++ b/src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import type { Rng } from '../rng';
+import { createRng } from '../rng';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import { braceConvoy, projectedConvoyPressure } from './convoyDefense.m46';
+import {
+  aftermathPreview,
+  commandMorale,
+  createMoraleConvoyDefenseBattle,
+  moraleConvoyPartyAct,
+} from './convoyMorale.m47';
+
+function fixedRng(d20 = 20, rollValue = 4): Rng {
+  return {
+    next: () => 0.5,
+    roll: (sides) => Math.max(1, Math.min(sides, rollValue)),
+    d20: () => d20,
+    pick: (arr) => arr[0],
+    weightedPick: (items) => items[0].value,
+  };
+}
+
+function companion(id: string, job: CompanionRecord['job'], stats: CompanionRecord['stats']): CompanionRecord {
+  return {
+    id, name: id, job, level: 4, xp: 200, stats, maxHp: 28, injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+    skills: { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 },
+  };
+}
+
+function save(): SaveData {
+  const data = newGame(4747, { job: 'swordsman', trait: 'hardy', allocation: { con: 2, str: 1 } });
+  data.marketSeed = 4799;
+  data.reputation = 20;
+  data.inventory = { ...data.inventory, 'dried-rations': 3 };
+  data.protagonist.level = 4;
+  data.protagonist.stats = { str: 16, dex: 12, int: 10, cha: 12, con: 16 };
+  data.companions = [
+    companion('ranger', 'ranger', { str: 10, dex: 18, int: 10, cha: 10, con: 11 }),
+    companion('mage', 'mage', { str: 8, dex: 12, int: 18, cha: 10, con: 10 }),
+    companion('cleric', 'cleric', { str: 10, dex: 9, int: 12, cha: 18, con: 13 }),
+  ];
+  data.expeditionPlan = {
+    activeIds: ['protagonist', 'ranger', 'mage', 'cleric'],
+    positions: { protagonist: 'front', ranger: 'back', mage: 'back', cleric: 'front' },
+    roles: { captain: 'protagonist', scout: 'ranger' },
+  };
+  return data;
+}
+
+function actorFirst(battle: ReturnType<typeof createMoraleConvoyDefenseBattle>, actorId: string): void {
+  battle.combat.order = [actorId, ...battle.combat.order.filter((id) => id !== actorId)];
+  battle.combat.turnIndex = 0;
+}
+
+function target(battle: ReturnType<typeof createMoraleConvoyDefenseBattle>) {
+  return battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+}
+
+describe('M47 player-perspective multidimensional morale review', () => {
+  it('keeps brace, control, physical pressure and morale command as materially different answers', () => {
+    const braceBattle = createMoraleConvoyDefenseBattle(save(), createRng(1));
+    const front = braceBattle.combat.party.find((member) => member.id === 'protagonist')!;
+    actorFirst(braceBattle, front.id);
+    braceConvoy(fixedRng(), braceBattle, front.id);
+    const brace = {
+      protection: braceBattle.protection,
+      pressure: projectedConvoyPressure(braceBattle),
+      targetHp: target(braceBattle).hp,
+      manaSpent: 0,
+      setup: 0,
+      routed: 0,
+    };
+
+    const controlBattle = createMoraleConvoyDefenseBattle(save(), createRng(2));
+    const mage = controlBattle.combat.party.find((member) => member.id === 'mage')!;
+    actorFirst(controlBattle, mage.id);
+    const manaBefore = mage.mystic?.current ?? 0;
+    moraleConvoyPartyAct(fixedRng(20, 4), controlBattle, mage.id, 'frost-bind', target(controlBattle).id);
+    const control = {
+      protection: controlBattle.protection,
+      pressure: projectedConvoyPressure(controlBattle),
+      targetHp: target(controlBattle).hp,
+      manaSpent: manaBefore - (mage.mystic?.current ?? 0),
+      setup: 0,
+      routed: controlBattle.routedEnemies.size,
+    };
+
+    const pressureBattle = createMoraleConvoyDefenseBattle(save(), createRng(3));
+    const ranger = pressureBattle.combat.party.find((member) => member.id === 'ranger')!;
+    actorFirst(pressureBattle, ranger.id);
+    moraleConvoyPartyAct(fixedRng(20, 8), pressureBattle, ranger.id, 'quick-shot', target(pressureBattle).id);
+    const pressure = {
+      protection: pressureBattle.protection,
+      pressure: projectedConvoyPressure(pressureBattle),
+      targetHp: target(pressureBattle).hp,
+      manaSpent: 0,
+      setup: 0,
+      routed: pressureBattle.routedEnemies.size,
+    };
+
+    const commandBattle = createMoraleConvoyDefenseBattle(save(), createRng(4));
+    const cleric = commandBattle.combat.party.find((member) => member.id === 'cleric')!;
+    const commandTarget = target(commandBattle);
+    commandBattle.morale[commandTarget.id].current = 4; // represents prior battlefield pressure; command cannot create this state itself.
+    actorFirst(commandBattle, cleric.id);
+    const commandResult = commandMorale(fixedRng(20), commandBattle, cleric.id, commandTarget.id);
+    const command = {
+      protection: commandBattle.protection,
+      pressure: projectedConvoyPressure(commandBattle),
+      targetHp: commandTarget.hp,
+      manaSpent: 0,
+      setup: 1,
+      routed: commandBattle.routedEnemies.size,
+    };
+
+    console.log('[M47 MORALE POLICIES]', { brace, control, pressure, command });
+    expect(brace.protection).toBeGreaterThan(Math.max(control.protection, pressure.protection, command.protection));
+    expect(control.pressure).toBeLessThan(brace.pressure);
+    expect(control.manaSpent).toBeGreaterThan(0);
+    expect(pressure.targetHp).toBeLessThan(brace.targetHp);
+    expect(pressure.setup).toBe(0);
+    expect(commandResult.success).toBe(true);
+    expect(command.routed).toBe(1);
+    expect(command.pressure).toBeLessThan(brace.pressure);
+    expect(command.setup).toBe(1);
+  });
+
+  it('makes charisma useful but probabilistic after setup, including for a non-cleric martial captain', () => {
+    let clericWins = 0;
+    let martialWins = 0;
+    const trials = 60;
+    for (let seed = 1; seed <= trials; seed++) {
+      const clericBattle = createMoraleConvoyDefenseBattle(save(), createRng(seed + 100));
+      const cleric = clericBattle.combat.party.find((member) => member.id === 'cleric')!;
+      const clericTarget = target(clericBattle);
+      clericBattle.morale[clericTarget.id].current = 4;
+      actorFirst(clericBattle, cleric.id);
+      if (commandMorale(createRng(seed * 7919), clericBattle, cleric.id, clericTarget.id).success) clericWins += 1;
+
+      const martialBattle = createMoraleConvoyDefenseBattle(save(), createRng(seed + 300));
+      const martial = martialBattle.combat.party.find((member) => member.id === 'protagonist')!;
+      const martialTarget = target(martialBattle);
+      martialBattle.morale[martialTarget.id].current = 4;
+      actorFirst(martialBattle, martial.id);
+      if (commandMorale(createRng(seed * 3571), martialBattle, martial.id, martialTarget.id).success) martialWins += 1;
+    }
+    console.log(`[M47 COMMAND RATE] cleric=${clericWins}/${trials} martial=${martialWins}/${trials}`);
+    expect(clericWins).toBeGreaterThan(martialWins);
+    expect(clericWins).toBeGreaterThan(30);
+    expect(clericWins).toBeLessThan(trials);
+    expect(martialWins).toBeGreaterThan(15);
+    expect(martialWins).toBeLessThan(trials - 5);
+  });
+
+  it('keeps release, disarm and ransom on a Pareto frontier across money, reputation and supplies', () => {
+    const data = save();
+    const battle = createMoraleConvoyDefenseBattle(data, createRng(88));
+    battle.routedEnemies.add('convoy-hook-raider');
+    battle.routedEnemies.add('convoy-ash-arsonist');
+    const startingRations = data.inventory['dried-rations'] ?? 0;
+    const vectors = ['release', 'disarm', 'ransom'].map((choice) => {
+      const preview = aftermathPreview(data, battle, choice as 'release' | 'disarm' | 'ransom');
+      return {
+        choice,
+        gold: preview.gold,
+        reputation: preview.reputation,
+        rationsRemaining: startingRations + preview.rations,
+      };
+    });
+    const dominates = (a: (typeof vectors)[number], b: (typeof vectors)[number]) =>
+      a.gold >= b.gold && a.reputation >= b.reputation && a.rationsRemaining >= b.rationsRemaining &&
+      (a.gold > b.gold || a.reputation > b.reputation || a.rationsRemaining > b.rationsRemaining);
+    console.log('[M47 AFTERMATH FRONTIER]', vectors);
+    for (const vector of vectors) {
+      expect(vectors.some((other) => other.choice !== vector.choice && dominates(other, vector))).toBe(false);
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+++ b/src/scripts/games/caravan/data/convoyMorale.m47.test.ts
@@ -152,9 +152,10 @@ describe('M47 morale, rout and surrender', () => {
     expect(battle.combat.log.some((entry) => entry.text.includes('棄械'))).toBe(true);
   });
 
-  it('keeps undead and the Dragon Ember Avatar unyielding', () => {
-    const cantor = createReliquaryEncounter(2).find((enemy) => enemy.id === 'reliquary-cantor')!;
+  it('keeps live Reliquary undead and the Dragon Ember Avatar unyielding', () => {
+    const cantor = createReliquaryEncounter(2).find((enemy) => enemy.id === 'reliquary-tongueless-cantor')!;
     const avatar = createReliquaryEncounter(3).find((enemy) => enemy.id === 'reliquary-ember-avatar')!;
+    expect(cantor.name).toBe('無舌領唱者');
     expect(moraleProfileForEnemy(cantor)).toBeNull();
     expect(moraleProfileForEnemy(avatar)).toBeNull();
   });

--- a/src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+++ b/src/scripts/games/caravan/data/convoyMorale.m47.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import type { Rng } from '../rng';
+import { createRng } from '../rng';
+import { newGame, type CompanionRecord, type SaveData } from '../save';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+import {
+  aftermathPreview,
+  applyMoraleFromBattlefield,
+  claimMoraleConvoyReward,
+  commandAvailability,
+  commandMorale,
+  createMoraleConvoyDefenseBattle,
+  moraleAftermathReceipt,
+  moraleProfileForEnemy,
+} from './convoyMorale.m47';
+import { convoyRewardReceipt } from './convoyDefense.m46';
+
+function fixedRng(d20 = 20, rollValue = 4): Rng {
+  return {
+    next: () => 0.5,
+    roll: (sides) => Math.max(1, Math.min(sides, rollValue)),
+    d20: () => d20,
+    pick: (arr) => arr[0],
+    weightedPick: (items) => items[0].value,
+  };
+}
+
+function companion(id: string, job: CompanionRecord['job'], stats = { str: 14, dex: 14, int: 14, cha: 14, con: 14 }): CompanionRecord {
+  return {
+    id, name: id, job, level: 4, xp: 200, stats, maxHp: 28, injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+    skills: { martial: 3, scouting: 3, lore: 3, negotiation: 3, survival: 3 },
+  };
+}
+
+function preparedSave(): SaveData {
+  const save = newGame(4700, { job: 'swordsman', trait: 'hardy', allocation: { con: 2, str: 1 } });
+  save.marketSeed = 4712;
+  save.reputation = 20;
+  save.gold = 100;
+  save.inventory = { ...save.inventory, 'dried-rations': 3 };
+  save.protagonist.level = 4;
+  save.protagonist.stats = { str: 16, dex: 12, int: 10, cha: 12, con: 16 };
+  save.companions = [
+    companion('ranger', 'ranger', { str: 10, dex: 18, int: 10, cha: 10, con: 11 }),
+    companion('mage', 'mage', { str: 8, dex: 12, int: 18, cha: 10, con: 10 }),
+    companion('cleric', 'cleric', { str: 10, dex: 9, int: 12, cha: 18, con: 13 }),
+  ];
+  save.expeditionPlan = {
+    activeIds: ['protagonist', 'ranger', 'mage', 'cleric'],
+    positions: { protagonist: 'front', ranger: 'back', mage: 'back', cleric: 'front' },
+    roles: { captain: 'protagonist', scout: 'ranger' },
+  };
+  return save;
+}
+
+function putActorFirst(battle: ReturnType<typeof createMoraleConvoyDefenseBattle>, actorId: string): void {
+  const rest = battle.combat.order.filter((id) => id !== actorId);
+  battle.combat.order = [actorId, ...rest];
+  battle.combat.turnIndex = 0;
+}
+
+describe('M47 morale, rout and surrender', () => {
+  it('keeps turn-one charisma from skipping an untouched battle', () => {
+    const battle = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4701));
+    const actor = battle.combat.party.find((member) => member.id === 'cleric')!;
+    const target = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    putActorFirst(battle, actor.id);
+
+    const availability = commandAvailability(battle, actor, target);
+    expect(availability.allowed).toBe(false);
+    expect(availability.reason).toContain('先造成傷亡');
+    const result = commandMorale(fixedRng(20), battle, actor.id, target.id);
+    expect(result.acted).toBe(false);
+    expect(target.hp).toBe(target.maxHp);
+    expect(battle.morale[target.id].current).toBe(battle.morale[target.id].max);
+  });
+
+  it('makes leader loss a larger morale shock than an ordinary casualty', () => {
+    const ordinary = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4702));
+    const ordinaryBefore = Object.fromEntries(ordinary.combat.enemies.map((enemy) => [enemy.id, {
+      hp: enemy.hp, poise: enemy.poise, stunned: false,
+    }]));
+    ordinary.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!.hp = 0;
+    applyMoraleFromBattlefield(ordinary, ordinaryBefore);
+    const afterOrdinary = ordinary.morale['convoy-ash-arsonist'].current;
+
+    const leader = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4703));
+    const leaderBefore = Object.fromEntries(leader.combat.enemies.map((enemy) => [enemy.id, {
+      hp: enemy.hp, poise: enemy.poise, stunned: false,
+    }]));
+    leader.combat.enemies.find((enemy) => enemy.id === 'convoy-reaver-captain')!.hp = 0;
+    applyMoraleFromBattlefield(leader, leaderBefore);
+    const afterLeader = leader.morale['convoy-ash-arsonist'].current;
+
+    expect(afterOrdinary).toBe(3);
+    expect(afterLeader).toBe(1);
+    expect(afterLeader).toBeLessThan(afterOrdinary);
+  });
+
+  it('makes failed commands spend a real action and escalate defiance instead of inviting spam', () => {
+    const battle = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4704));
+    const actor = battle.combat.party.find((member) => member.id === 'cleric')!;
+    const target = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    battle.morale[target.id].current = 4;
+    putActorFirst(battle, actor.id);
+    const firstDc = commandAvailability(battle, actor, target).dc;
+
+    const result = commandMorale(fixedRng(1), battle, actor.id, target.id);
+    expect(result.acted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(battle.morale[target.id].defiance).toBe(1);
+    expect(battle.combat.turnIndex).not.toBe(0);
+
+    putActorFirst(battle, actor.id);
+    expect(commandAvailability(battle, actor, target).dc).toBe(firstDc + 2);
+  });
+
+  it('lets stun consume the attempted command turn without rolling or damaging morale', () => {
+    const battle = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4705));
+    const actor = battle.combat.party.find((member) => member.id === 'cleric')!;
+    const target = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    battle.morale[target.id].current = 4;
+    actor.statuses = [{ kind: 'stun', remaining: 1, potency: 0 }];
+    putActorFirst(battle, actor.id);
+    const before = battle.morale[target.id].current;
+
+    const result = commandMorale(fixedRng(20), battle, actor.id, target.id);
+    expect(result.acted).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.roll).toBe(0);
+    expect(battle.morale[target.id].current).toBe(before);
+    expect(actor.statuses?.some((status) => status.kind === 'stun')).toBe(false);
+  });
+
+  it('can end an intelligent-human fight through rout while the surrendered foes still had HP', () => {
+    const battle = createMoraleConvoyDefenseBattle(preparedSave(), createRng(4706));
+    const actor = battle.combat.party.find((member) => member.id === 'cleric')!;
+    const remainingHp = new Map(battle.combat.enemies.map((enemy) => [enemy.id, enemy.hp]));
+
+    for (const enemy of battle.combat.enemies) {
+      battle.morale[enemy.id].current = 1;
+      putActorFirst(battle, actor.id);
+      const result = commandMorale(fixedRng(20), battle, actor.id, enemy.id);
+      expect(result.success).toBe(true);
+      expect(result.routed).toBe(true);
+      expect(remainingHp.get(enemy.id)).toBeGreaterThan(0);
+    }
+
+    expect(battle.routedEnemies.size).toBe(3);
+    expect(battle.combat.outcome).toBe('victory');
+    expect(battle.combat.log.some((entry) => entry.text.includes('棄械'))).toBe(true);
+  });
+
+  it('keeps undead and the Dragon Ember Avatar unyielding', () => {
+    const cantor = createReliquaryEncounter(2).find((enemy) => enemy.id === 'reliquary-cantor')!;
+    const avatar = createReliquaryEncounter(3).find((enemy) => enemy.id === 'reliquary-ember-avatar')!;
+    expect(moraleProfileForEnemy(cantor)).toBeNull();
+    expect(moraleProfileForEnemy(avatar)).toBeNull();
+  });
+
+  it('gives post-rout choices different gold, reputation and supply costs', () => {
+    const save = preparedSave();
+    const battle = createMoraleConvoyDefenseBattle(save, createRng(4707));
+    battle.routedEnemies.add('convoy-hook-raider');
+    battle.routedEnemies.add('convoy-ash-arsonist');
+
+    const release = aftermathPreview(save, battle, 'release');
+    const disarm = aftermathPreview(save, battle, 'disarm');
+    const ransom = aftermathPreview(save, battle, 'ransom');
+    expect(release).toMatchObject({ gold: 0, reputation: 1, rations: 0 });
+    expect(disarm).toMatchObject({ gold: 6, reputation: 0, rations: 0 });
+    expect(ransom).toMatchObject({ gold: 16, reputation: 0, rations: -1 });
+    expect(ransom.gold).toBeGreaterThan(disarm.gold);
+    expect(release.reputation).toBeGreaterThan(disarm.reputation);
+  });
+
+  it('settles base reward plus chosen aftermath once and never creates negative ration', () => {
+    const save = preparedSave();
+    const battle = createMoraleConvoyDefenseBattle(save, createRng(4708));
+    const target = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    target.hp = 0;
+    battle.morale[target.id].routed = true;
+    battle.morale[target.id].current = 0;
+    battle.routedEnemies.add(target.id);
+    battle.combat.outcome = 'victory';
+    battle.wagon.hp = 25;
+    const goldBefore = save.gold;
+    const repBefore = save.reputation;
+    const rationBefore = save.inventory['dried-rations'];
+
+    const reward = claimMoraleConvoyReward(save, battle, 'ransom');
+    expect(reward.base.gold).toBe(52);
+    expect(reward.aftermath.gold).toBe(8);
+    expect(save.gold).toBe(goldBefore + 60);
+    expect(save.reputation).toBe(repBefore + 2);
+    expect(save.inventory['dried-rations']).toBe(rationBefore - 1);
+    expect(save.flags[convoyRewardReceipt(save.marketSeed)]).toBe(true);
+    expect(save.flags[moraleAftermathReceipt(save.marketSeed)]).toBe(true);
+    expect(() => claimMoraleConvoyReward(save, battle, 'release')).toThrow();
+  });
+
+  it('rejects ransom without supplies before mutating any reward state', () => {
+    const save = preparedSave();
+    delete save.inventory['dried-rations'];
+    const battle = createMoraleConvoyDefenseBattle(save, createRng(4709));
+    const target = battle.combat.enemies.find((enemy) => enemy.id === 'convoy-hook-raider')!;
+    target.hp = 0;
+    battle.morale[target.id].routed = true;
+    battle.routedEnemies.add(target.id);
+    battle.combat.outcome = 'victory';
+    const before = { gold: save.gold, reputation: save.reputation, flags: { ...save.flags } };
+
+    expect(() => claimMoraleConvoyReward(save, battle, 'ransom')).toThrow('乾糧 1');
+    expect(save.gold).toBe(before.gold);
+    expect(save.reputation).toBe(before.reputation);
+    expect(save.flags).toEqual(before.flags);
+  });
+});

--- a/src/scripts/games/caravan/data/convoyMorale.m47.ts
+++ b/src/scripts/games/caravan/data/convoyMorale.m47.ts
@@ -1,0 +1,352 @@
+import { currentActor, type EnemyUnit, type Move, type PartyActionResult, type PartyMember } from '../combat';
+import { statMod } from '../check';
+import type { Rng } from '../rng';
+import type { SaveData } from '../save';
+import {
+  claimConvoyDefenseReward,
+  convoyPartyAct,
+  createConvoyDefenseBattle,
+  convoyRewardReceipt,
+  type ConvoyDefenseBattle,
+  type ConvoyReward,
+} from './convoyDefense.m46';
+
+export type MoraleDisposition = 'release' | 'disarm' | 'ransom';
+
+export interface MoraleProfile {
+  maxResolve: number;
+  leader?: boolean;
+}
+
+export interface EnemyMorale {
+  max: number;
+  current: number;
+  defiance: number;
+  leader: boolean;
+  routed: boolean;
+}
+
+export interface MoraleConvoyBattle extends ConvoyDefenseBattle {
+  morale: Record<string, EnemyMorale>;
+  routedEnemies: Set<string>;
+}
+
+export interface CommandAvailability {
+  allowed: boolean;
+  dc: number;
+  reason: string;
+}
+
+export interface CommandResult {
+  acted: boolean;
+  success: boolean;
+  roll: number;
+  total: number;
+  dc: number;
+  moraleDamage: number;
+  routed: boolean;
+  reason?: string;
+}
+
+export interface MoraleAftermathReward {
+  disposition: MoraleDisposition | null;
+  routedCount: number;
+  gold: number;
+  reputation: number;
+  rations: number;
+}
+
+export interface MoraleConvoyReward {
+  base: ConvoyReward;
+  aftermath: MoraleAftermathReward;
+}
+
+const MORALE_PROFILES: Record<string, MoraleProfile> = {
+  'convoy-reaver-captain': { maxResolve: 8, leader: true },
+  'convoy-hook-raider': { maxResolve: 6 },
+  'convoy-ash-arsonist': { maxResolve: 5 },
+};
+
+const AFTERMATH_PREFIX = 'convoy-morale:aftermath';
+
+/**
+ * M47 is opt-in per enemy identity. Unknown foes are deliberately unyielding: undead, beasts,
+ * constructs, dragons and future bosses do not accidentally become vulnerable to charisma.
+ */
+export function moraleProfileForEnemy(enemy: EnemyUnit): MoraleProfile | null {
+  return MORALE_PROFILES[enemy.id] ?? null;
+}
+
+export function createMoraleConvoyDefenseBattle(
+  save: SaveData,
+  rng: Rng,
+  startingWagonHp?: number,
+): MoraleConvoyBattle {
+  const base = createConvoyDefenseBattle(save, rng, startingWagonHp);
+  const morale: Record<string, EnemyMorale> = {};
+  for (const enemy of base.combat.enemies) {
+    const profile = moraleProfileForEnemy(enemy);
+    if (!profile) continue;
+    morale[enemy.id] = {
+      max: profile.maxResolve,
+      current: profile.maxResolve,
+      defiance: 0,
+      leader: profile.leader === true,
+      routed: false,
+    };
+  }
+  base.combat.log.push({
+    kind: 'info',
+    text: '這批伏兵不是亡靈。傷亡、破勢與首領倒下會削弱戰意；先讓他們動搖，才可能以喝止迫使棄械。',
+  });
+  return { ...base, morale, routedEnemies: new Set<string>() };
+}
+
+function enemyStunned(enemy: EnemyUnit): boolean {
+  return (enemy.statuses ?? []).some((status) => status.kind === 'stun' && status.remaining > 0);
+}
+
+function routeEnemy(battle: MoraleConvoyBattle, enemy: EnemyUnit, reason: string): boolean {
+  const morale = battle.morale[enemy.id];
+  if (!morale || morale.routed || enemy.hp <= 0) return false;
+  morale.current = 0;
+  morale.routed = true;
+  battle.routedEnemies.add(enemy.id);
+  enemy.hp = 0;
+  battle.combat.log.push({
+    kind: 'info',
+    text: `${enemy.name}的戰意徹底崩潰，丟下武器退出戰列！${reason}`,
+  });
+  if (battle.combat.enemies.every((foe) => foe.hp <= 0)) {
+    battle.combat.outcome = 'victory';
+    battle.combat.log.push({ kind: 'victory', text: '仍活著的伏兵已棄械潰散——護衛隊控制了商路！' });
+  }
+  return true;
+}
+
+function damageResolve(
+  battle: MoraleConvoyBattle,
+  enemy: EnemyUnit,
+  amount: number,
+  reason: string,
+): void {
+  const morale = battle.morale[enemy.id];
+  if (!morale || morale.routed || enemy.hp <= 0 || amount <= 0) return;
+  const before = morale.current;
+  morale.current = Math.max(0, morale.current - amount);
+  if (morale.current !== before) {
+    battle.combat.log.push({
+      kind: 'info',
+      text: `${enemy.name}戰意 ${before} → ${morale.current}/${morale.max}：${reason}`,
+    });
+  }
+  if (morale.current <= 0) routeEnemy(battle, enemy, '他們寧願活著回去，也不願替一張斷旗送命。');
+}
+
+interface EnemySnapshot {
+  hp: number;
+  poise?: number;
+  stunned: boolean;
+}
+
+function snapshots(battle: MoraleConvoyBattle): Record<string, EnemySnapshot> {
+  return Object.fromEntries(battle.combat.enemies.map((enemy) => [enemy.id, {
+    hp: enemy.hp,
+    poise: enemy.poise,
+    stunned: enemyStunned(enemy),
+  }]));
+}
+
+/**
+ * Translate visible battlefield events into morale pressure after a normal player action.
+ * The event is observed after M46 has settled any round boundary, so a last-moment rout does not
+ * retroactively erase breakthrough damage that already landed on the wagon that round.
+ */
+export function applyMoraleFromBattlefield(
+  battle: MoraleConvoyBattle,
+  before: Record<string, EnemySnapshot>,
+): void {
+  const newlyDown = battle.combat.enemies.filter((enemy) => (before[enemy.id]?.hp ?? 0) > 0 && enemy.hp <= 0 && !battle.morale[enemy.id]?.routed);
+  for (const fallen of newlyDown) {
+    const profile = battle.morale[fallen.id];
+    const shock = profile?.leader ? 4 : 2;
+    for (const witness of battle.combat.enemies.filter((enemy) => enemy.hp > 0 && battle.morale[enemy.id])) {
+      damageResolve(
+        battle,
+        witness,
+        shock,
+        profile?.leader ? '領頭者倒下，斷旗底下再沒有人能保證他們活著撤走。' : '同伴倒下，伏擊已經不再像一場輕鬆搶掠。',
+      );
+    }
+  }
+
+  for (const enemy of battle.combat.enemies) {
+    const prior = before[enemy.id];
+    const morale = battle.morale[enemy.id];
+    if (!prior || !morale || morale.routed || enemy.hp <= 0) continue;
+    if (prior.hp > enemy.maxHp * 0.5 && enemy.hp <= enemy.maxHp * 0.5) {
+      damageResolve(battle, enemy, 1, '傷勢過半，求財的念頭開始讓位給求生。');
+    }
+    const nowStunned = enemyStunned(enemy);
+    if (!prior.stunned && nowStunned) {
+      damageResolve(battle, enemy, 1, '陣腳被打散，連下一步該往哪裡站都失去把握。');
+    }
+  }
+}
+
+export function moraleConvoyPartyAct(
+  rng: Rng,
+  battle: MoraleConvoyBattle,
+  actorId: string,
+  moveId: string,
+  targetId: string,
+  options: { overcast?: boolean } = {},
+): PartyActionResult {
+  const before = snapshots(battle);
+  const result = convoyPartyAct(rng, battle, actorId, moveId, targetId, options);
+  if (result.acted) applyMoraleFromBattlefield(battle, before);
+  return result;
+}
+
+function shaken(battle: MoraleConvoyBattle, target: EnemyUnit): boolean {
+  const morale = battle.morale[target.id];
+  if (!morale) return false;
+  return morale.current < morale.max || target.hp <= target.maxHp * 0.5 || enemyStunned(target);
+}
+
+export function commandAvailability(
+  battle: MoraleConvoyBattle,
+  actor: PartyMember,
+  target: EnemyUnit,
+): CommandAvailability {
+  const morale = battle.morale[target.id];
+  if (!morale || morale.routed) return { allowed: false, dc: 0, reason: '這個敵人不接受戰場喝止。' };
+  if (target.hp <= 0 || battle.combat.outcome !== 'ongoing') return { allowed: false, dc: 0, reason: '現在沒有可迫降的目標。' };
+  if (!shaken(battle, target)) {
+    return { allowed: false, dc: 0, reason: '敵軍戰意尚未動搖；先造成傷亡、重傷、暈眩或破勢。' };
+  }
+  const leaderPenalty = morale.leader ? 2 : 0;
+  const dc = 9 + Math.ceil(morale.current / 2) + leaderPenalty + morale.defiance * 2;
+  return { allowed: true, dc, reason: `喝止 DC ${dc}；失敗會讓對方更難再次威嚇。` };
+}
+
+export function commandMorale(
+  rng: Rng,
+  battle: MoraleConvoyBattle,
+  actorId: string,
+  targetId: string,
+): CommandResult {
+  const actorTurn = currentActor(battle.combat);
+  const actor = battle.combat.party.find((member) => member.id === actorId);
+  const target = battle.combat.enemies.find((enemy) => enemy.id === targetId);
+  if (!actor || !target || actorTurn?.side !== 'party' || actorTurn.id !== actor.id || battle.combat.outcome !== 'ongoing') {
+    return { acted: false, success: false, roll: 0, total: 0, dc: 0, moraleDamage: 0, routed: false, reason: '現在不是這名成員喝止敵軍的時機。' };
+  }
+  const availability = commandAvailability(battle, actor, target);
+  if (!availability.allowed) {
+    return { acted: false, success: false, roll: 0, total: 0, dc: availability.dc, moraleDamage: 0, routed: false, reason: availability.reason };
+  }
+
+  const commandMove: Move = {
+    id: `morale-command:${actor.id}`,
+    name: '戰場喝止',
+    kind: 'support',
+    target: 'self',
+    hitStat: 'cha',
+    narration: '{actor}踏前一步喝令伏兵棄械，讓每個人都聽見繼續送命與活著離開之間的差別。',
+  };
+  actor.moves.push(commandMove);
+  const result = convoyPartyAct(rng, battle, actor.id, commandMove.id, actor.id);
+  actor.moves = actor.moves.filter((move) => move.id !== commandMove.id);
+  if (!result.acted || result.reason || battle.combat.outcome !== 'ongoing') {
+    return {
+      acted: result.acted,
+      success: false,
+      roll: 0,
+      total: 0,
+      dc: availability.dc,
+      moraleDamage: 0,
+      routed: false,
+      reason: result.reason ?? (battle.combat.outcome !== 'ongoing' ? '護運目標已在喝止前完成。' : '喝止沒有完成。'),
+    };
+  }
+
+  const roll = rng.d20();
+  const presence = statMod(actor.stats.cha) + (actor.formationRow === 'back' ? 0 : 1);
+  const total = roll + presence;
+  const success = roll === 20 || (roll !== 1 && total >= availability.dc);
+  if (!success) {
+    battle.morale[target.id].defiance = Math.min(3, battle.morale[target.id].defiance + 1);
+    battle.combat.log.push({
+      kind: 'info',
+      text: `${actor.name}喝令${target.name}棄械，但對方咬牙撐住（${roll}+${presence}=${total}，DC ${availability.dc}）。下一次喝止會更難。`,
+    });
+    return { acted: true, success: false, roll, total, dc: availability.dc, moraleDamage: 0, routed: false };
+  }
+
+  const moraleDamage = Math.min(6, 2 + Math.max(0, statMod(actor.stats.cha)) + (actor.formationRow === 'back' ? 0 : 1));
+  const beforeMorale = battle.morale[target.id].current;
+  damageResolve(battle, target, moraleDamage, `${actor.name}抓住了他們真正害怕的不是失去戰利品，而是死在裂旗關。`);
+  const routed = battle.morale[target.id].routed;
+  battle.combat.log.push({
+    kind: 'info',
+    text: `${actor.name}的喝止奏效（${roll}+${presence}=${total}，DC ${availability.dc}），削去 ${Math.min(moraleDamage, beforeMorale)} 點戰意。`,
+  });
+  return { acted: true, success: true, roll, total, dc: availability.dc, moraleDamage, routed };
+}
+
+export function routedEnemies(battle: MoraleConvoyBattle): EnemyUnit[] {
+  return battle.combat.enemies.filter((enemy) => battle.routedEnemies.has(enemy.id));
+}
+
+export function moraleAftermathReceipt(marketSeed: number): string {
+  return `${AFTERMATH_PREFIX}:${marketSeed}`;
+}
+
+export function aftermathPreview(
+  save: SaveData,
+  battle: MoraleConvoyBattle,
+  disposition: MoraleDisposition,
+): MoraleAftermathReward {
+  const count = battle.routedEnemies.size;
+  if (count <= 0) return { disposition: null, routedCount: 0, gold: 0, reputation: 0, rations: 0 };
+  if (disposition === 'release') return { disposition, routedCount: count, gold: 0, reputation: 1, rations: 0 };
+  if (disposition === 'disarm') return { disposition, routedCount: count, gold: count * 3, reputation: 0, rations: 0 };
+  const available = save.inventory['dried-rations'] ?? 0;
+  return { disposition, routedCount: count, gold: count * 8, reputation: 0, rations: available > 0 ? -1 : 0 };
+}
+
+/**
+ * One atomic settlement entry point for the M47 page. Base convoy reward and post-rout treatment
+ * are validated before any mutation so a missing ration or duplicate receipt cannot mint partial rewards.
+ */
+export function claimMoraleConvoyReward(
+  save: SaveData,
+  battle: MoraleConvoyBattle,
+  disposition?: MoraleDisposition,
+): MoraleConvoyReward {
+  if (battle.combat.outcome !== 'victory' || battle.wagon.hp <= 0) {
+    throw new Error('護運尚未成功，不能處理伏兵或領取報酬。');
+  }
+  if (save.flags[convoyRewardReceipt(save.marketSeed)] === true) throw new Error('本市場週期的護運報酬已領取。');
+  const routedCount = battle.routedEnemies.size;
+  const aftermathReceipt = moraleAftermathReceipt(save.marketSeed);
+  if (save.flags[aftermathReceipt] === true) throw new Error('本市場週期的伏兵處置已完成。');
+  if (routedCount > 0 && !disposition) throw new Error('仍有棄械伏兵，必須先決定如何處置。');
+  if (disposition === 'ransom' && (save.inventory['dried-rations'] ?? 0) <= 0) {
+    throw new Error('押送俘虜至少需要乾糧 1；不能讓俘虜在路上餓死。');
+  }
+
+  const aftermath = routedCount > 0
+    ? aftermathPreview(save, battle, disposition!)
+    : { disposition: null, routedCount: 0, gold: 0, reputation: 0, rations: 0 } satisfies MoraleAftermathReward;
+  const base = claimConvoyDefenseReward(save, battle);
+  if (aftermath.gold > 0) save.gold += aftermath.gold;
+  if (aftermath.reputation > 0) save.reputation += aftermath.reputation;
+  if (aftermath.rations < 0) {
+    save.inventory['dried-rations'] = (save.inventory['dried-rations'] ?? 0) + aftermath.rations;
+    if (save.inventory['dried-rations'] <= 0) delete save.inventory['dried-rations'];
+  }
+  save.flags[aftermathReceipt] = true;
+  return { base, aftermath };
+}


### PR DESCRIPTION
## Summary
- give the three intelligent Split-Banner human ambushers explicit resolve while leaving unknown enemies, undead and the Dragon Ember Avatar unyielding by default
- reduce resolve from casualties, leader loss, half-HP pressure and fresh stun / poise-break control
- add a real-action Charisma command that only unlocks after enemies are shaken; failure raises defiance and future DC so it cannot be spammed safely
- allow routed humans to leave combat alive and finish the fight without converting surrender into ordinary HP damage
- surface resolve, defiance, command DCs and lock reasons in the live convoy-defense page
- pause victory settlement when enemies surrendered and require a release / disarm / ransom consequence choice
- make release trade for reputation, disarm for modest gold, and ransom for higher gold at a dried-ration cost
- validate base reward + aftermath atomically and once per market cycle

## Sword-and-magic gameplay intent
M46 made the caravan itself a battlefield objective. M47 makes intelligent human enemies behave differently from undead, beasts and magical horrors. Charisma gains a battlefield identity, but only after steel, arrows, control or casualties have created leverage. The system is therefore an alternate consequence path rather than a turn-one dialogue skip.

## Multidimensional adversarial review
The M47 gates check:
- untouched enemies cannot be talked out of combat
- command consumes a real turn; stun can waste it; failed commands increase future DC
- leader loss shocks morale more than an ordinary casualty
- rout victory can happen while surrendered enemies still had HP
- live Tongueless Cantor and Dragon Ember Avatar remain unyielding
- cleric Charisma is better but still probabilistic, while a martial captain retains a viable command chance after setup
- brace, control, physical pressure and command retain different advantages across wagon protection, breakthrough pressure, HP damage, mana cost, setup cost and routed enemies
- release, disarm and ransom remain Pareto alternatives across gold, reputation and supplies
- ransom cannot mint negative rations or partial rewards
- M46 convoy objective lifecycle + multidimensional balance are rerun, together with core combat and M40–M45 regressions

## Validation
`Caravan M47 Morale CI` runs production build, M47 lifecycle/settlement tests, M47 player-perspective balance probes, M46 objective/balance tests, and core/M40–M45 gameplay regressions.