### PR TITLE
feat(caravan): add M48 armor profiles and armor-piercing

### DIFF
--- a/.github/workflows/caravan-m48-ci.yml
+++ b/.github/workflows/caravan-m48-ci.yml
@@ -1,0 +1,82 @@
+name: Caravan M48 Armor CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m48-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m48-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-armor-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M48 armor lifecycle and combat integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+
+      - name: M48 multidimensional player review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts

--- a/docs/caravan-m48-armor-profiles.md
+++ b/docs/caravan-m48-armor-profiles.md
@@ -1,0 +1,69 @@
+# Caravan M48 — Armor Profiles & Armor-Piercing
+
+## Why this milestone exists
+
+M43 made armor affect defense, burden, class fit, travel fatigue and mystical capacity, but incoming slash / pierce / blunt attacks still treated every player armor as the same generic defense number. In a medieval sword-and-magic game that made mail, leather and robes feel too abstract at the moment steel actually landed.
+
+M48 adds a small, readable material layer instead of a simulation-heavy armor model.
+
+## Material profiles
+
+| Armor | Mundane physical protection | Magical protection | Existing tradeoff retained |
+| --- | --- | --- | --- |
+| Light armor | Slash -1 | — | low burden, better mobility |
+| Mail | Slash -2, Pierce -1 | — | high burden, DEX / casting interference |
+| Arcane robe | — | Fire -1, Frost -1 | mana capacity |
+| Sacred vestment | — | Holy -2 | favor capacity |
+
+Reductions are flat and visible in the combat log. They are applied after enemy weakness / resistance scaling and before M44 one-charge wards. Material reduction cannot reduce an otherwise successful hit below 1 damage; a magical ward may still absorb the remaining magical damage completely.
+
+## Physical versus magical damage
+
+M48 does not infer physicality from the element label alone. `mysticRuleForMove(move)` decides whether the move is a real spell.
+
+That means a magical `blunt` spell such as Gravity Crush is still magical and is not stopped by mail simply because its element is blunt. Likewise, mundane fire-like fiction would need an explicit future damage model rather than being silently treated as a sword cut.
+
+This keeps the existing M41/M44 magic rules authoritative.
+
+## Armor-piercing
+
+`Move.armorPiercing` bypasses only mundane physical material reduction. It never bypasses robe / vestment magical protection or M44 ward charges.
+
+The ranger's existing `piercing-arrow` now receives `armorPiercing: 2` through the armory move preparation layer. Against current mail (-1 pierce) it ignores the full material reduction, but it does not improve accuracy, raw dice, magical damage or weakness multipliers.
+
+## Live encounter integration
+
+M48 is not test-only:
+
+- Split-Banner Reaver Captain: mail
+- Split-Banner Hook Raider: light armor
+- Split-Banner Ash Arsonist: arcane robe
+- Ashen Reliquary Ash Knight: mail
+- Ashen Reliquary Cinder Squire: light armor
+
+This gives real value to blunt pressure, ordinary arrows versus light targets, armor-piercing arrows versus mail, and magic against physical protection.
+
+## Player-perspective adversarial gates
+
+M48 must demonstrate all of the following before merge:
+
+1. Mail is meaningfully better against mundane slash / pierce but does not reduce blunt attacks.
+2. Armor-piercing bypasses physical material reduction but cannot bypass magical cloth protection.
+3. Arcane robe and sacred vestment defenses only trigger on actual magic.
+4. Passive magical cloth protection and M44 one-charge wards compose in a deterministic order instead of replacing each other.
+5. Ranger light armor versus mail stays a protection / mobility tradeoff.
+6. Mage robe versus mail stays an arcane-capacity / magical-defense versus steel-defense tradeoff.
+7. Cleric vestment versus mail stays a favor / holy-defense versus steel-defense tradeoff.
+8. Swordsman mail is strong without making light armor strictly useless because burden and DEX still matter.
+9. Live convoy and Reliquary encounters carry the same profiles used by the rules tests.
+10. Core combat, M40, M41, M42, M43, M44, M45, M46 and M47 regressions remain green.
+
+## Deliberate non-goals
+
+- no armor durability or repair tax
+- no hit-location simulation
+- no percentage stacking table
+- no save migration requirement
+- no automatic split between the physical blade and magical flame of a single hybrid attack
+
+The goal is player-readable tactical identity, not armor simulation for its own sake.

--- a/src/pages/caravan/armory.astro
+++ b/src/pages/caravan/armory.astro
@@ -4,14 +4,14 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="武裝整備所 — 商隊與劍"
-  description="依照中世紀劍與魔法世界的武器熟練、護甲重量、施法媒介與負重整備遠征隊。"
+  description="依照中世紀劍與魔法世界的武器熟練、護甲材質、施法媒介與負重整備遠征隊。"
   lang="zh-TW"
 >
   <main class="armory-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M43 ARMORY DOCTRINES</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M48 ARMOR PROFILES</p>
       <h1>武裝整備所</h1>
-      <p>鋼鐵會保命，也會拖慢腳步；法杖、法袍與聖衣能擴張施法容量，但無法提供鎖甲的可靠防護。跨職裝備不被禁止，代價會清楚列在整備報告中。</p>
+      <p>鋼鐵不再只是一個防禦數字。鎖甲擅長吃下刀斬與部分箭刺，輕甲提供有限斬擊保護；法袍與聖衣則把重量換成秘法、神恩與對應魔法防護。跨職裝備仍不禁止，但每個代價都必須能被玩家看見。</p>
       <nav>
         <a href="/caravan/play">返回主冒險</a>
         <a href="/caravan/endurance">前往餘燼朝聖</a>
@@ -22,7 +22,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <h2>整備原則</h2>
       <div class="doctrine-grid">
         <article><strong>武器熟練</strong><span>熟練流派命中 +1；勉強運用命中 -2、傷害 -1，仍保留跨職構築。</span></article>
-        <article><strong>護甲重量</strong><span>鎖甲防護最高，但降低敏捷並干擾秘法手勢；超過個人負重容量會再扣敏捷與生命。</span></article>
+        <article><strong>護甲材質</strong><span>鎖甲抗斬、略抗刺，但不會神奇吸收鈍擊；穿甲箭可削掉物理護甲減傷。</span></article>
+        <article><strong>秘法織物</strong><span>法袍能削減少量火／霜魔法；聖衣對神聖衝擊最可靠。這些防護不會替代一次性護法。</span></article>
+        <article><strong>護甲重量</strong><span>鎖甲防護最穩，但降低敏捷並干擾秘法手勢；超過個人負重容量會再扣敏捷與生命。</span></article>
         <article><strong>施法媒介</strong><span>法杖與法袍提高秘法上限；錘杖、聖衣與王室聖印提高神恩上限。</span></article>
         <article><strong>遠征負重</strong><span>負重會進入朝聖整備快照，影響紮營效率與強行軍疲勞。</span></article>
       </div>
@@ -38,6 +40,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   import { loadGame, saveGame, type CompanionRecord, type SaveData } from '@scripts/games/caravan/save';
   import { ITEMS } from '@scripts/games/caravan/data/items';
   import { memberFromRecord } from '@scripts/games/caravan/data/jobs';
+  import { armorProtectionText } from '@scripts/games/caravan/data/armorProfiles.m48';
   import {
     ARMOR_DISCIPLINE_LABELS,
     GEAR_FIT_LABELS,
@@ -135,6 +138,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       text('p', `Lv${record.level}｜防禦 ${member.defense}｜生命 ${member.maxHp}｜敏捷 ${member.stats.dex}`, 'summary'),
       text('p', `個人負重 ${profile.burden}/${profile.capacity}${profile.overload ? `｜超載 ${profile.overload}` : ''}`, 'load'),
       text('p', fitText(record, profile), 'fit'),
+      text('p', `材質防護：${armorProtectionText(profile.armorProtection)}`, 'protection'),
       text('p', `秘法上限修正 ${profile.mysticCapacity.mana >= 0 ? '+' : ''}${profile.mysticCapacity.mana}｜神恩上限修正 ${profile.mysticCapacity.favor >= 0 ? '+' : ''}${profile.mysticCapacity.favor}`, 'mystic'),
     );
 
@@ -188,7 +192,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     loadEl.replaceChildren(
       text('h2', '目前出征隊負重'),
       text('p', `${partyLoad.burden}/${partyLoad.capacity}${partyLoad.overload ? `｜超載 ${partyLoad.overload}` : '｜整隊可負荷'}`),
-      text('p', '負重不只是介面資訊：武裝已立即影響戰鬥面板、武器命中與秘法／神恩容量；餘燼朝聖會把整備快照鎖入行程。'),
+      text('p', '護甲材質、武器熟練與負重都已進入實際戰鬥：鎖甲會削斬／刺傷害、法袍與聖衣會處理特定魔法，穿甲技則能削弱物理減傷；餘燼朝聖仍會把整備快照鎖入行程。'),
     );
     const members = [save.protagonist, ...save.companions];
     rosterEl.replaceChildren(...members.map(memberCard));
@@ -198,7 +202,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   if (!save) {
     noticeEl.replaceChildren(text('h2', '尚未建立商隊'), text('p', '請先返回主冒險建立角色與存檔。'));
   } else {
-    noticeEl.textContent = '武裝報告會即時計算，不會隱藏跨職裝備的代價。';
+    noticeEl.textContent = '武裝報告會即時計算，不會隱藏跨職裝備、負重或材質防護的代價。';
     render();
   }
 </script>
@@ -219,7 +223,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .member-card { padding: 1.25rem; border: 1px solid #5e503d; background: #1b1713; }
   .member-card.overloaded { border-color: #a54b3b; box-shadow: inset 4px 0 #a54b3b; }
   .member-card h2 { margin: .2rem 0 .5rem; font-size: 1.8rem; }
-  .summary, .load, .fit, .mystic { color: #d7c7aa; }
+  .summary, .load, .fit, .protection, .mystic { color: #d7c7aa; }
+  .protection { color: #e1c98f; }
   .equipment { display: grid; gap: .45rem; margin: 1rem 0; }
   .equipment-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .6rem .75rem; background: #282117; }
   .warnings { margin: 1rem 0; padding-left: 1.3rem; line-height: 1.6; color: #e4c68d; }

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -8,6 +8,10 @@ import {
   mysticRuleForMove,
   prepareMysticPartyMember,
 } from './data/arcana';
+import {
+  resolveArmorMitigation,
+  type ArmorProtection,
+} from './data/armorProfiles.m48';
 
 export interface Move {
   id: string; name: string;
@@ -18,6 +22,8 @@ export interface Move {
   area?: boolean;
   /** M16 隊伍戰術：命中檢定的固定加值 */
   hitBonus?: number;
+  /** M48：只削減物理護甲的平坦減傷，不影響命中，也不穿透魔法防護。 */
+  armorPiercing?: number;
   damage?: { dice: number; sides: number; bonusStat?: Stat };
   heal?: { dice: number; sides: number; bonusStat?: Stat };
   /** M44：ward 為一次性魔法護法；remaining 代表可抵擋的命中次數。 */
@@ -52,6 +58,8 @@ export interface CombatantBase {
   maxHp: number; hp: number; defense: number; moves: Move[];
   /** M14 鐵匠強化：武器 +N 固定傷害加值 */
   damageBonus?: number;
+  /** M48：裝備或敵人本身的材質防護。 */
+  armorProtection?: ArmorProtection;
   /** 進行中狀態效果（M7/M44，戰鬥 runtime） */
   statuses?: StatusEffect[];
   /** M41 戰鬥中的秘法／神恩，不寫回角色存檔。M44 起敵方施法者也遵守同規則。 */
@@ -307,9 +315,26 @@ function performMove(
     }
   }
 
+  const spellRule = mysticRuleForMove(move);
+  const armor = resolveArmorMitigation(target.armorProtection, move, !!spellRule);
+  if (armor.baseReduction > 0) {
+    if (armor.reduction > 0) {
+      amount = Math.max(1, amount - armor.reduction);
+      state.log.push({
+        kind: 'info',
+        text: `${target.name}的${armor.label}削去了 ${armor.reduction} 點${armor.magical ? '魔法' : '物理'}傷害。`,
+      });
+    }
+    if (armor.bypassed > 0) {
+      state.log.push({
+        kind: 'info',
+        text: `${actor.name}的${move.name}穿透了 ${armor.bypassed} 點護甲減傷！`,
+      });
+    }
+  }
+
   // M44：護法只反制真正的魔法招式，不會把劍、箭、毒牙等物理威脅也一併作廢。
   let wardAbsorbed = 0;
-  const spellRule = mysticRuleForMove(move);
   if (spellRule) {
     const ward = target.statuses?.find((status) => status.kind === 'ward' && status.remaining > 0);
     if (ward) {

--- a/src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { Element, Move } from '../combat';
+import { createProtagonist, type CompanionRecord } from '../save';
+import { armoryProfile } from './armory';
+import { armorProtectionForDiscipline, resolveArmorMitigation, type ArmorProfileId } from './armorProfiles.m48';
+import { memberFromRecord } from './jobs';
+
+const DAMAGE = 10;
+
+function mundane(element: Element, armorPiercing = 0): Move {
+  return {
+    id: `mundane-${element}-${armorPiercing}`,
+    name: '威脅', kind: 'attack', target: 'enemy', hitStat: 'str', element, armorPiercing,
+    damage: { dice: 1, sides: DAMAGE }, narration: '',
+  };
+}
+
+function magical(element: Element): Move {
+  return {
+    id: element === 'holy' ? 'holy-strike' : element === 'fire' ? 'fireball' : 'ice-spike',
+    name: '魔法威脅', kind: 'attack', target: 'enemy', hitStat: element === 'holy' ? 'cha' : 'int', element,
+    damage: { dice: 1, sides: DAMAGE }, narration: '',
+  };
+}
+
+function damageAfter(profile: ArmorProfileId, move: Move, isMagical: boolean): number {
+  const mitigation = resolveArmorMitigation(armorProtectionForDiscipline(profile), move, isMagical);
+  return Math.max(1, DAMAGE - mitigation.reduction);
+}
+
+function threatVector(profile: ArmorProfileId) {
+  return {
+    steel: damageAfter(profile, mundane('slash'), false) + damageAfter(profile, mundane('pierce'), false),
+    blunt: damageAfter(profile, mundane('blunt'), false),
+    arcane: damageAfter(profile, magical('fire'), true) + damageAfter(profile, magical('frost'), true),
+    divine: damageAfter(profile, magical('holy'), true),
+    piercing: damageAfter(profile, mundane('pierce', 2), false),
+  };
+}
+
+function record(job: CompanionRecord['job'], armor: string): CompanionRecord {
+  const member = createProtagonist({ job });
+  member.id = `${job}-${armor}`;
+  member.name = member.id;
+  member.level = 4;
+  member.equipment.armor = armor;
+  return member;
+}
+
+function tradeoff(job: CompanionRecord['job'], lightArmor: string, heavyArmor: string) {
+  const lightRecord = record(job, lightArmor);
+  const heavyRecord = record(job, heavyArmor);
+  const lightProfile = armoryProfile(lightRecord);
+  const heavyProfile = armoryProfile(heavyRecord);
+  const lightMember = memberFromRecord(lightRecord);
+  const heavyMember = memberFromRecord(heavyRecord);
+  return { lightRecord, heavyRecord, lightProfile, heavyProfile, lightMember, heavyMember };
+}
+
+describe('M48 player-perspective multidimensional armor review', () => {
+  it('makes material matchups readable without one armor winning every incoming threat', () => {
+    const vectors = {
+      light: threatVector('light'),
+      mail: threatVector('mail'),
+      robe: threatVector('robe'),
+      vestment: threatVector('vestment'),
+    };
+    console.log('[M48 ARMOR THREATS]', vectors);
+
+    expect(vectors.mail.steel).toBeLessThan(vectors.light.steel);
+    expect(vectors.mail.blunt).toBe(vectors.light.blunt);
+    expect(vectors.robe.arcane).toBeLessThan(vectors.mail.arcane);
+    expect(vectors.vestment.divine).toBeLessThan(vectors.mail.divine);
+    expect(vectors.mail.piercing).toBe(DAMAGE);
+  });
+
+  it('keeps ranger light armor and mail on a real protection-versus-mobility frontier', () => {
+    const { lightProfile, heavyProfile, lightMember, heavyMember } = tradeoff('ranger', 'ridgeleather-vest', 'saltforged-mail');
+    const lightSteel = threatVector('light').steel;
+    const mailSteel = threatVector('mail').steel;
+    console.log(`[M48 RANGER] light steel=${lightSteel} burden=${lightProfile.burden} dex=${lightMember.stats.dex}; mail steel=${mailSteel} burden=${heavyProfile.burden} dex=${heavyMember.stats.dex}`);
+    expect(mailSteel).toBeLessThan(lightSteel);
+    expect(lightProfile.burden).toBeLessThan(heavyProfile.burden);
+    expect(lightMember.stats.dex).toBeGreaterThan(heavyMember.stats.dex);
+  });
+
+  it('keeps mage robe and mail on a survival-versus-spell-capacity frontier', () => {
+    const { lightProfile: robe, heavyProfile: mail, lightMember: robeMage, heavyMember: mailMage } = tradeoff('mage', 'ashveil-robe', 'saltforged-mail');
+    console.log(`[M48 MAGE] robe arcane=${threatVector('robe').arcane} manaBonus=${robe.mysticCapacity.mana} burden=${robe.burden}; mail steel=${threatVector('mail').steel} manaBonus=${mail.mysticCapacity.mana} burden=${mail.burden}`);
+    expect(threatVector('mail').steel).toBeLessThan(threatVector('robe').steel);
+    expect(threatVector('robe').arcane).toBeLessThan(threatVector('mail').arcane);
+    expect(robe.mysticCapacity.mana).toBeGreaterThan(mail.mysticCapacity.mana);
+    expect(robeMage.stats.dex).toBeGreaterThan(mailMage.stats.dex);
+  });
+
+  it('keeps cleric vestment and mail on a divine-capacity-versus-steel frontier', () => {
+    const { lightProfile: vestment, heavyProfile: mail } = tradeoff('cleric', 'brinewarded-vestment', 'saltforged-mail');
+    console.log(`[M48 CLERIC] vestment holy=${threatVector('vestment').divine} favorBonus=${vestment.mysticCapacity.favor}; mail steel=${threatVector('mail').steel} favorBonus=${mail.mysticCapacity.favor}`);
+    expect(threatVector('mail').steel).toBeLessThan(threatVector('vestment').steel);
+    expect(threatVector('vestment').divine).toBeLessThan(threatVector('mail').divine);
+    expect(vestment.mysticCapacity.favor).toBeGreaterThan(mail.mysticCapacity.favor);
+  });
+
+  it('keeps swordsman mail meaningful without making light armor a trap', () => {
+    const { lightProfile, heavyProfile, lightMember, heavyMember } = tradeoff('swordsman', 'ridgeleather-vest', 'saltforged-mail');
+    console.log(`[M48 SWORDSMAN] light burden=${lightProfile.burden} dex=${lightMember.stats.dex}; mail burden=${heavyProfile.burden} dex=${heavyMember.stats.dex}`);
+    expect(threatVector('mail').steel).toBeLessThan(threatVector('light').steel);
+    expect(lightProfile.burden).toBeLessThan(heavyProfile.burden);
+    expect(lightMember.stats.dex).toBeGreaterThan(heavyMember.stats.dex);
+  });
+});

--- a/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
@@ -153,7 +153,7 @@ describe('M48 armor material profiles', () => {
     state.enemyIntents[mage.id] = 'fireball';
     const before = target.hp;
     enemyAct(fixedRng, state, mage.id);
-    expect(before - target.hp).toBe(5); // 6 + INT mod 3 - robe 1 - ward 3
+    expect(before - target.hp).toBe(2); // 1d6 max 6 - robe 1 - ward 3
     expect(target.statuses?.some((status) => status.kind === 'ward')).toBe(false);
     expect(state.log.some((entry) => entry.text.includes('法袍削去了 1 點魔法傷害'))).toBe(true);
     expect(state.log.some((entry) => entry.text.includes('護法削去了 3 點魔法傷害'))).toBe(true);

--- a/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { partyAct, startCombat, type EnemyUnit, type Move, type PartyMember } from '../combat';
+import type { Rng } from '../rng';
+import { createProtagonist, type CompanionRecord } from '../save';
+import { armoryProfile } from './armory';
+import {
+  armorProtectionForDiscipline,
+  armorProtectionText,
+  resolveArmorMitigation,
+} from './armorProfiles.m48';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+import { createConvoyDefenseEncounter } from './convoyDefense.m46';
+import { memberFromRecord } from './jobs';
+
+const fixedRng: Rng = {
+  next: () => 0.5,
+  roll: (sides) => sides,
+  d20: () => 20,
+  pick: (items) => items[0],
+  weightedPick: (items) => items[0].value,
+};
+
+function record(job: CompanionRecord['job'], armor: string | null): CompanionRecord {
+  const member = createProtagonist({ job });
+  member.id = `${job}-${armor ?? 'none'}`;
+  member.name = member.id;
+  member.level = 4;
+  member.equipment.armor = armor;
+  return member;
+}
+
+function attacker(move: Move): PartyMember {
+  return {
+    id: 'attacker', name: '測試攻擊者',
+    stats: { str: 10, dex: 10, int: 16, cha: 16, con: 10 },
+    maxHp: 40, hp: 40, defense: 10,
+    moves: [move],
+  };
+}
+
+function armoredEnemy(profile: 'light' | 'mail' | 'robe' | 'vestment'): EnemyUnit {
+  return {
+    id: 'armored-target', name: '護甲標靶',
+    stats: { str: 10, dex: 10, int: 10, cha: 10, con: 10 },
+    maxHp: 40, hp: 40, defense: 1,
+    armorProtection: armorProtectionForDiscipline(profile),
+    moves: [{
+      id: 'tap', name: '輕敲', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 2 }, narration: '{actor}敲擊{target}，造成 {amount} 點傷害。',
+    }],
+    intents: [{ weight: 1, moveId: 'tap' }],
+  };
+}
+
+function hit(move: Move, profile: 'light' | 'mail' | 'robe' | 'vestment'): { damage: number; log: string } {
+  const target = armoredEnemy(profile);
+  const state = startCombat(fixedRng, [attacker(move)], [target]);
+  state.order = ['attacker', target.id];
+  state.turnIndex = 0;
+  const before = target.hp;
+  partyAct(fixedRng, state, 'attacker', move.id, target.id);
+  return { damage: before - target.hp, log: state.log.map((entry) => entry.text).join('\n') };
+}
+
+describe('M48 armor material profiles', () => {
+  it('maps live armory disciplines to readable material protection', () => {
+    const light = armoryProfile(record('ranger', 'ridgeleather-vest'));
+    const mail = armoryProfile(record('swordsman', 'saltforged-mail'));
+    const robe = armoryProfile(record('mage', 'ashveil-robe'));
+    const vestment = armoryProfile(record('cleric', 'brinewarded-vestment'));
+    expect(armorProtectionText(light.armorProtection)).toContain('斬 -1');
+    expect(armorProtectionText(mail.armorProtection)).toContain('斬 -2');
+    expect(armorProtectionText(mail.armorProtection)).toContain('刺 -1');
+    expect(armorProtectionText(robe.armorProtection)).toContain('火 -1');
+    expect(armorProtectionText(robe.armorProtection)).toContain('霜 -1');
+    expect(armorProtectionText(vestment.armorProtection)).toContain('聖 -2');
+  });
+
+  it('makes mail strongly answer cuts, partly answer ordinary arrows, and never invent blunt reduction', () => {
+    const mail = armorProtectionForDiscipline('mail');
+    const slash: Move = { id: 'slash', name: '刀斬', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash', damage: { dice: 1, sides: 8 }, narration: '' };
+    const pierce: Move = { ...slash, id: 'pierce', name: '箭刺', element: 'pierce' };
+    const blunt: Move = { ...slash, id: 'blunt', name: '錘擊', element: 'blunt' };
+    expect(resolveArmorMitigation(mail, slash, false).reduction).toBe(2);
+    expect(resolveArmorMitigation(mail, pierce, false).reduction).toBe(1);
+    expect(resolveArmorMitigation(mail, blunt, false).reduction).toBe(0);
+  });
+
+  it('lets armor-piercing remove physical reduction without piercing magical cloth wards', () => {
+    const mail = armorProtectionForDiscipline('mail');
+    const robe = armorProtectionForDiscipline('robe');
+    const arrow: Move = {
+      id: 'piercing-arrow', name: '穿甲箭', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce',
+      armorPiercing: 2, damage: { dice: 1, sides: 10 }, narration: '',
+    };
+    const fire: Move = {
+      id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+      armorPiercing: 99, damage: { dice: 1, sides: 10 }, narration: '',
+    };
+    expect(resolveArmorMitigation(mail, arrow, false)).toMatchObject({ baseReduction: 1, reduction: 0, bypassed: 1 });
+    expect(resolveArmorMitigation(robe, fire, true)).toMatchObject({ baseReduction: 1, reduction: 1, bypassed: 0 });
+  });
+
+  it('integrates flat armor reduction into real combat damage and logs the material response', () => {
+    const slash: Move = {
+      id: 'test-slash', name: '測試斬擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+      damage: { dice: 1, sides: 10 }, narration: '{actor}斬中{target}，造成 {amount} 點傷害。',
+    };
+    const regularPierce: Move = { ...slash, id: 'test-pierce', name: '普通箭', element: 'pierce' };
+    const piercing: Move = { ...regularPierce, id: 'test-piercing', name: '穿甲測試箭', armorPiercing: 2 };
+    expect(hit(slash, 'mail').damage).toBe(8);
+    expect(hit(slash, 'light').damage).toBe(9);
+    expect(hit(regularPierce, 'mail').damage).toBe(9);
+    const pierced = hit(piercing, 'mail');
+    expect(pierced.damage).toBe(10);
+    expect(pierced.log).toContain('穿透了 1 點護甲減傷');
+  });
+
+  it('treats robe and vestment protection as magical rather than mundane physical armor', () => {
+    const fireball: Move = {
+      id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+      damage: { dice: 1, sides: 6 }, narration: '{actor}以火球擊中{target}，造成 {amount} 點傷害。',
+    };
+    const holy: Move = {
+      id: 'holy-strike', name: '聖擊', kind: 'attack', target: 'enemy', hitStat: 'cha', element: 'holy',
+      damage: { dice: 1, sides: 6 }, narration: '{actor}以聖光擊中{target}，造成 {amount} 點傷害。',
+    };
+    expect(hit(fireball, 'robe').damage).toBeLessThan(hit(fireball, 'mail').damage);
+    expect(hit(holy, 'vestment').damage).toBeLessThan(hit(holy, 'light').damage);
+  });
+
+  it('turns the ranger piercing-arrow name into a real armor-piercing combat property', () => {
+    const ranger = record('ranger', 'ridgeleather-vest');
+    const move = memberFromRecord(ranger).moves.find((candidate) => candidate.id === 'piercing-arrow');
+    expect(move?.armorPiercing).toBe(2);
+  });
+
+  it('wires armor into live convoy raiders and the Reliquary knight instead of test-only fixtures', () => {
+    const [captain, hook, arsonist] = createConvoyDefenseEncounter();
+    expect(captain.armorProtection?.id).toBe('mail');
+    expect(hook.armorProtection?.id).toBe('light');
+    expect(arsonist.armorProtection?.id).toBe('robe');
+    const [knight, squire] = createReliquaryEncounter(1);
+    expect(knight.armorProtection?.id).toBe('mail');
+    expect(squire.armorProtection?.id).toBe('light');
+  });
+});

--- a/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.m48.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { partyAct, startCombat, type EnemyUnit, type Move, type PartyMember } from '../combat';
+import { enemyAct, partyAct, startCombat, type EnemyUnit, type Move, type PartyMember } from '../combat';
 import type { Rng } from '../rng';
 import { createProtagonist, type CompanionRecord } from '../save';
 import { armoryProfile } from './armory';
@@ -127,6 +127,36 @@ describe('M48 armor material profiles', () => {
     };
     expect(hit(fireball, 'robe').damage).toBeLessThan(hit(fireball, 'mail').damage);
     expect(hit(holy, 'vestment').damage).toBeLessThan(hit(holy, 'light').damage);
+  });
+
+  it('stacks passive robe protection before the one-charge M44 ward instead of replacing either layer', () => {
+    const target: PartyMember = {
+      id: 'robe-mage', name: '法袍法師',
+      stats: { str: 8, dex: 10, int: 16, cha: 10, con: 10 },
+      maxHp: 30, hp: 30, defense: 1,
+      armorProtection: armorProtectionForDiscipline('robe'),
+      statuses: [{ kind: 'ward', remaining: 1, potency: 3 }],
+      moves: [{ id: 'strike', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'blunt', damage: { dice: 1, sides: 2 }, narration: '' }],
+    };
+    const fireball: Move = {
+      id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+      damage: { dice: 1, sides: 6 }, narration: '{actor}以火球擊中{target}，造成 {amount} 點傷害。',
+    };
+    const mage: EnemyUnit = {
+      id: 'hostile-mage', name: '敵方法師',
+      stats: { str: 8, dex: 10, int: 16, cha: 10, con: 10 },
+      maxHp: 20, hp: 20, defense: 1, moves: [fireball], intents: [{ weight: 1, moveId: 'fireball' }],
+    };
+    const state = startCombat(fixedRng, [target], [mage]);
+    state.order = [mage.id, target.id];
+    state.turnIndex = 0;
+    state.enemyIntents[mage.id] = 'fireball';
+    const before = target.hp;
+    enemyAct(fixedRng, state, mage.id);
+    expect(before - target.hp).toBe(5); // 6 + INT mod 3 - robe 1 - ward 3
+    expect(target.statuses?.some((status) => status.kind === 'ward')).toBe(false);
+    expect(state.log.some((entry) => entry.text.includes('法袍削去了 1 點魔法傷害'))).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('護法削去了 3 點魔法傷害'))).toBe(true);
   });
 
   it('turns the ranger piercing-arrow name into a real armor-piercing combat property', () => {

--- a/src/scripts/games/caravan/data/armorProfiles.m48.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.m48.ts
@@ -1,0 +1,102 @@
+import type { Element, Move } from '../combat';
+
+export type ArmorProfileId = 'light' | 'mail' | 'robe' | 'vestment';
+
+export interface ArmorProtection {
+  id: ArmorProfileId;
+  label: string;
+  physical: Partial<Record<Element, number>>;
+  magical: Partial<Record<Element, number>>;
+}
+
+export interface ArmorMitigation {
+  baseReduction: number;
+  reduction: number;
+  bypassed: number;
+  magical: boolean;
+  label: string;
+}
+
+const PROFILES: Record<ArmorProfileId, ArmorProtection> = {
+  light: {
+    id: 'light',
+    label: '輕甲',
+    physical: { slash: 1 },
+    magical: {},
+  },
+  mail: {
+    id: 'mail',
+    label: '鎖甲',
+    physical: { slash: 2, pierce: 1 },
+    magical: {},
+  },
+  robe: {
+    id: 'robe',
+    label: '法袍',
+    physical: {},
+    magical: { fire: 1, frost: 1 },
+  },
+  vestment: {
+    id: 'vestment',
+    label: '聖衣',
+    physical: {},
+    magical: { holy: 2 },
+  },
+};
+
+const PHYSICAL_ELEMENTS = new Set<Element>(['slash', 'pierce', 'blunt']);
+
+export function armorProtectionForDiscipline(
+  discipline: ArmorProfileId | null | undefined,
+): ArmorProtection | undefined {
+  if (!discipline) return undefined;
+  const profile = PROFILES[discipline];
+  return {
+    ...profile,
+    physical: { ...profile.physical },
+    magical: { ...profile.magical },
+  };
+}
+
+export function armorProtectionText(protection: ArmorProtection | undefined): string {
+  if (!protection) return '無材質減傷';
+  const physical = (['slash', 'pierce', 'blunt'] as Element[])
+    .map((element) => [element, protection.physical[element] ?? 0] as const)
+    .filter(([, value]) => value > 0)
+    .map(([element, value]) => `${element === 'slash' ? '斬' : element === 'pierce' ? '刺' : '鈍'} -${value}`);
+  const magical = (['fire', 'frost', 'holy'] as Element[])
+    .map((element) => [element, protection.magical[element] ?? 0] as const)
+    .filter(([, value]) => value > 0)
+    .map(([element, value]) => `${element === 'fire' ? '火' : element === 'frost' ? '霜' : '聖'} -${value}`);
+  return [...physical, ...magical].join('｜') || '無材質減傷';
+}
+
+/**
+ * M48 armor is deliberately flat and readable. Physical armor only answers mundane slash/pierce/blunt;
+ * a spell that happens to use the blunt element (for example Gravity Crush) is still magical and therefore
+ * cannot be trivialized by mail. Armor-piercing applies only to physical protection.
+ */
+export function resolveArmorMitigation(
+  protection: ArmorProtection | undefined,
+  move: Move,
+  magical: boolean,
+): ArmorMitigation {
+  const element = move.element;
+  if (!protection || !element) {
+    return { baseReduction: 0, reduction: 0, bypassed: 0, magical, label: protection?.label ?? '' };
+  }
+  const baseReduction = magical
+    ? protection.magical[element] ?? 0
+    : PHYSICAL_ELEMENTS.has(element)
+      ? protection.physical[element] ?? 0
+      : 0;
+  const penetration = magical ? 0 : Math.max(0, move.armorPiercing ?? 0);
+  const reduction = Math.max(0, baseReduction - penetration);
+  return {
+    baseReduction,
+    reduction,
+    bypassed: baseReduction - reduction,
+    magical,
+    label: protection.label,
+  };
+}

--- a/src/scripts/games/caravan/data/armory.ts
+++ b/src/scripts/games/caravan/data/armory.ts
@@ -2,6 +2,10 @@ import type { Move } from '../combat';
 import type { CompanionRecord, SaveData } from '../save';
 import type { StatBlock } from '../types';
 import { ITEMS, type ItemDef } from './items';
+import {
+  armorProtectionForDiscipline,
+  type ArmorProtection,
+} from './armorProfiles.m48';
 
 export type WeaponDiscipline = 'blade' | 'bow' | 'staff' | 'mace';
 export type ArmorDiscipline = 'light' | 'mail' | 'robe' | 'vestment';
@@ -28,6 +32,7 @@ export interface ArmoryProfile {
   maxHpAdjustment: number;
   statAdjustments: Partial<StatBlock>;
   mysticCapacity: { mana: number; favor: number };
+  armorProtection?: ArmorProtection;
   warnings: string[];
 }
 
@@ -200,6 +205,7 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
     maxHpAdjustment,
     statAdjustments,
     mysticCapacity: { mana, favor },
+    armorProtection: armorProtectionForDiscipline(armorRule?.armor),
     warnings,
   };
 }
@@ -207,11 +213,15 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
 export function adjustMovesForArmory(record: CompanionRecord, moves: Move[]): Move[] {
   const weaponId = record.equipment.weapon;
   const weaponMoveId = weaponId ? ITEMS[weaponId]?.equip?.move?.id : null;
-  if (!weaponMoveId) return moves.map((move) => ({ ...move }));
   const profile = armoryProfile(record);
-  return moves.map((move) => move.id === weaponMoveId
-    ? { ...move, hitBonus: (move.hitBonus ?? 0) + profile.weaponHitBonus }
-    : { ...move });
+  return moves.map((move) => {
+    const adjusted: Move = { ...move };
+    if (move.id === 'piercing-arrow') adjusted.armorPiercing = Math.max(adjusted.armorPiercing ?? 0, 2);
+    if (weaponMoveId && move.id === weaponMoveId) {
+      adjusted.hitBonus = (move.hitBonus ?? 0) + profile.weaponHitBonus;
+    }
+    return adjusted;
+  });
 }
 
 export function partyArmoryLoad(save: SaveData, memberIds?: string[]): PartyArmoryLoad {

--- a/src/scripts/games/caravan/data/ashenReliquaryCombat.ts
+++ b/src/scripts/games/caravan/data/ashenReliquaryCombat.ts
@@ -1,5 +1,6 @@
 import type { CombatState, EnemyUnit, Move, PartyMember } from '../combat';
 import type { CompanionRecord, SaveData } from '../save';
+import { armorProtectionForDiscipline } from './armorProfiles.m48';
 import { memberFromRecord } from './jobs';
 
 export type ReliquaryBattleStage = 1 | 2 | 3;
@@ -103,6 +104,7 @@ function ashKnight(): EnemyUnit {
     id: 'reliquary-ash-knight', name: '灰燼騎士・守橋者',
     stats: { str: 16, dex: 10, int: 10, cha: 8, con: 16 }, maxHp: 28, hp: 28, defense: 15,
     weaknesses: ['holy', 'blunt'], resists: ['fire', 'slash'], maxPoise: 4,
+    armorProtection: armorProtectionForDiscipline('mail'),
     moves: [ashCleave, ashWard], intents: [
       { weight: 3, moveId: ashCleave.id }, { weight: 1, moveId: ashWard.id },
     ],
@@ -114,6 +116,7 @@ function cinderSquire(): EnemyUnit {
     id: 'reliquary-cinder-squire', name: '燼甲侍從',
     stats: { str: 11, dex: 15, int: 8, cha: 7, con: 11 }, maxHp: 14, hp: 14, defense: 12,
     weaknesses: ['frost', 'blunt'], resists: ['fire'], maxPoise: 2,
+    armorProtection: armorProtectionForDiscipline('light'),
     moves: [cinderSpear], intents: [{ weight: 1, moveId: cinderSpear.id }],
   };
 }

--- a/src/scripts/games/caravan/data/convoyDefense.m46.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.ts
@@ -12,6 +12,7 @@ import {
 import { statMod } from '../check';
 import type { Rng } from '../rng';
 import type { CompanionRecord, SaveData } from '../save';
+import { armorProtectionForDiscipline } from './armorProfiles.m48';
 import { memberFromRecord } from './jobs';
 import { ritualEnemyAct } from './rituals.m45';
 
@@ -197,6 +198,7 @@ function reaverCaptain(): EnemyUnit {
     id: 'convoy-reaver-captain', name: '斷旗劫騎・領頭者',
     stats: { str: 15, dex: 12, int: 8, cha: 12, con: 15 }, maxHp: 32, hp: 32, defense: 14,
     weaknesses: ['blunt', 'holy'], resists: ['slash'], maxPoise: 3,
+    armorProtection: armorProtectionForDiscipline('mail'),
     moves: [reaverSlash, reaverBrace],
     intents: [{ weight: 3, moveId: reaverSlash.id }, { weight: 1, moveId: reaverBrace.id }],
     enrage: { threshold: 0.4, potency: 2 },
@@ -208,6 +210,7 @@ function hookRaider(): EnemyUnit {
     id: 'convoy-hook-raider', name: '鉤索掠手',
     stats: { str: 11, dex: 15, int: 8, cha: 8, con: 11 }, maxHp: 24, hp: 24, defense: 13,
     weaknesses: ['frost', 'slash'], resists: ['pierce'], maxPoise: 2,
+    armorProtection: armorProtectionForDiscipline('light'),
     moves: [hookStrike], intents: [{ weight: 1, moveId: hookStrike.id }],
   };
 }
@@ -217,6 +220,7 @@ function ashArsonist(): EnemyUnit {
     id: 'convoy-ash-arsonist', name: '灰火縱咒師',
     stats: { str: 7, dex: 11, int: 16, cha: 12, con: 10 }, maxHp: 24, hp: 24, defense: 12,
     weaknesses: ['frost', 'pierce'], resists: ['fire'], maxPoise: 2,
+    armorProtection: armorProtectionForDiscipline('robe'),
     moves: [ashBolt], intents: [{ weight: 1, moveId: ashBolt.id }],
   };
 }

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -33,6 +33,8 @@ export interface ArmoryPartyMemberRuntime {
   armoryOverload?: number;
   armoryWarnings?: string[];
   armoryProfile?: ArmoryProfile;
+  /** M48：實際受擊時使用的護甲材質輪廓。 */
+  armorProtection?: ArmoryProfile['armorProtection'];
 }
 
 /** M18：每名角色最多攜帶四招，讓升級後的技能選擇形成構築取捨。 */
@@ -229,6 +231,7 @@ export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): st
 /**
  * 將角色成長、裝備、特質、專精、武裝熟練與戰技配置整合成實際戰鬥成員。
  * M43 不禁止跨職裝備，而是把不合訓練的代價公開轉成命中、屬性、負重與施法上限。
+ * M48 再把護甲材質輪廓帶入戰鬥，使斬、刺、鈍與真正魔法在受擊端產生可讀差異。
  */
 export function memberFromRecord(record: CompanionRecord): PartyMember {
   const job = JOBS[record.job];
@@ -260,6 +263,7 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     armoryOverload: armory.overload,
     armoryWarnings: [...armory.warnings],
     armoryProfile: armory,
+    armorProtection: armory.armorProtection,
   };
   return member;
 }


### PR DESCRIPTION
## Summary
- give light armor, mail, arcane robes and sacred vestments readable material protection instead of relying only on generic DEF
- distinguish actual spell damage from mundane slash / pierce / blunt so Gravity Crush does not become ordinary hammer damage just because its element is blunt
- add physical-only armor penetration and make the existing ranger Piercing Arrow actually bypass material protection
- carry armor profiles from M43 armory records into live combatants
- equip live Split-Banner raiders and Ashen Reliquary armored enemies with the same protection profiles
- surface exact material protection in the armory UI

## Sword-and-magic gameplay intent
M43 made armor affect burden, fit and spell capacity, but being struck by steel still barely cared whether a character wore mail, leather or a robe. M48 gives armor a small material identity at the moment of impact without turning combat into a durability or hit-location simulator.

Current profiles:
- light: mundane slash -1
- mail: mundane slash -2, pierce -1
- arcane robe: magical fire -1, frost -1
- sacred vestment: magical holy -2

Material reduction resolves after enemy weakness/resistance and before the M44 one-charge ward. Mundane armor reduction leaves at least 1 damage on a successful hit. Armor-piercing bypasses only mundane protection and cannot pierce magical cloth protection or wards.

## Multidimensional player-perspective adversarial review
M48 gates require:
- mail is strongest against ordinary steel but does not invent blunt resistance
- piercing attacks can counter mail without increasing all damage or bypassing magical defenses
- robe / vestment defense only works on actual magic
- passive cloth protection and M44 ward compose in a deterministic order
- ranger light vs mail remains protection versus mobility
- mage robe vs mail remains arcane capacity / magical defense versus steel defense
- cleric vestment vs mail remains favor / holy defense versus steel defense
- swordsman mail remains strong without making light armor strictly useless due to burden and DEX
- live convoy / Reliquary armored enemies use the same rules
- core combat and M40–M47 regressions remain green

## Validation
`Caravan M48 Armor CI` runs production build, M48 lifecycle/integration tests, M48 multidimensional player review, and core/M40–M47 gameplay regressions.