### PR TITLE
chore(caravan): validate M48 armor gameplay gates

### DIFF
--- a/src/scripts/games/caravan/data/armorProfiles.m48.ts
+++ b/src/scripts/games/caravan/data/armorProfiles.m48.ts
@@ -100,3 +100,5 @@ export function resolveArmorMitigation(
     label: protection.label,
   };
 }
+
+// M48 validation trigger: keep gameplay gates running against the current master implementation.


### PR DESCRIPTION
## Purpose
M48 armor profiles and armor-piercing are already present on `master` as commit `2ce237600a50e56453e8a7933225658a65e3772f`, but that direct commit did not leave PR-triggered GitHub Actions records through the connector. This PR changes no gameplay behavior; it adds a source comment solely to trigger the full Caravan gameplay validation suite against the exact M48 implementation now on master.

## M48 gameplay being validated
- mail reduces mundane slash / pierce but not blunt
- light armor preserves a mobility / burden tradeoff
- arcane robes reduce fire / frost magic while retaining mana-capacity identity
- sacred vestments reduce holy magic while retaining favor-capacity identity
- armor-piercing bypasses only physical material reduction
- magical blunt effects such as Gravity Crush do not get incorrectly absorbed by mail
- passive magical cloth protection composes with M44 one-charge wards in deterministic order
- real Split-Banner and Ashen Reliquary enemies carry live armor profiles
- ranger, mage, cleric and swordsman armor choices remain multidimensional tradeoffs rather than a single dominant armor

## Validation scope
The M48 workflow reruns production build, M48 lifecycle + player-perspective balance tests, core combat, M40–M47 regressions, M42 composition diversity and M43 armory/endurance gates.