### PR TITLE
Transform hidden family missions into a pixel adventure

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,7 +45,10 @@ export default defineConfig({
   },
 
   // 整合
-  integrations: [sitemap()],
+  integrations: [sitemap({
+    // 家庭任務是知道網址才可進入的隱藏頁，不列入公開網站地圖。
+    filter: (page) => !new URL(page).pathname.startsWith('/family-missions'),
+  })],
 
   // 建構輸出
   build: {

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -13,6 +13,7 @@ interface Props {
   type?: 'website' | 'article';
   publishedTime?: string;
   author?: string;
+  indexable?: boolean;
 }
 
 const {
@@ -23,6 +24,7 @@ const {
   type = 'website',
   publishedTime,
   author = 'Galen',
+  indexable = true,
 } = Astro.props;
 
 // 網站基本資訊
@@ -90,6 +92,7 @@ const jsonLd = type === 'article' ? {
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <meta name="author" content={author} />
+    {!indexable && <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />}
 
     <!-- Canonical URL -->
     <link rel="canonical" href={canonicalUrl} />
@@ -119,8 +122,8 @@ const jsonLd = type === 'article' ? {
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
 
-    <!-- JSON-LD Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    <!-- 隱藏頁不輸出結構化資料，避免被搜尋引擎當成公開內容探索 -->
+    {indexable && <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />}
 
     <!-- Font Awesome (非同步載入) -->
     <link
@@ -145,13 +148,17 @@ const jsonLd = type === 'article' ? {
     <!-- 動畫庫（gsap 已移除：第一方程式碼無使用；guild 成員頁自行載入） -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js" defer></script>
 
-    <!-- Alternate language links -->
-    <link rel="alternate" hreflang="zh-TW" href={`${siteUrl}/zh-TW${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
-    <link rel="alternate" hreflang="zh-CN" href={`${siteUrl}/zh-CN${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
-    <link rel="alternate" hreflang="en" href={`${siteUrl}/en${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
-    <link rel="alternate" hreflang="ja" href={`${siteUrl}/ja${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
-    <link rel="alternate" hreflang="ko" href={`${siteUrl}/ko${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
-    <link rel="alternate" hreflang="x-default" href={`${siteUrl}/zh-TW${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+    <!-- 隱藏頁不建立多語系探索路徑 -->
+    {indexable && (
+      <>
+        <link rel="alternate" hreflang="zh-TW" href={`${siteUrl}/zh-TW${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+        <link rel="alternate" hreflang="zh-CN" href={`${siteUrl}/zh-CN${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+        <link rel="alternate" hreflang="en" href={`${siteUrl}/en${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+        <link rel="alternate" hreflang="ja" href={`${siteUrl}/ja${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+        <link rel="alternate" hreflang="ko" href={`${siteUrl}/ko${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+        <link rel="alternate" hreflang="x-default" href={`${siteUrl}/zh-TW${Astro.url.pathname.replace(/^\/(zh-TW|zh-CN|en|ja|ko)/, '')}`} />
+      </>
+    )}
 
     <title>{title}</title>
 

--- a/src/data/family-missions.test.ts
+++ b/src/data/family-missions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { abilityCatalog, rankSteps, scoutProfiles } from './family-missions';
+import { abilityCatalog, abilityGrades, rankChapters, rankSteps, scoutProfiles } from './family-missions';
 
 describe('雙羽任務靜態資料', () => {
   it('每位偵查員都有五個可部署任務，且任務 id 不重複', () => {
@@ -11,24 +11,41 @@ describe('雙羽任務靜態資料', () => {
     expect(new Set(allIds).size).toBe(allIds.length);
   });
 
-  it('所有任務都指向六項核心能力之一', () => {
+  it('所有任務都有一項或多項核心能力，完成時固定得到一顆任務星', () => {
     const abilityIds = new Set(Object.keys(abilityCatalog));
 
     for (const profile of Object.values(scoutProfiles)) {
       for (const task of profile.tasks) {
-        expect(abilityIds.has(task.abilityId)).toBe(true);
-        expect(task.rewardStars).toBeGreaterThan(0);
-        expect(task.abilityXp).toBeGreaterThan(0);
+        expect(task.abilityIds.length).toBeGreaterThan(0);
+        expect(task.steps).toHaveLength(3);
+        task.steps.forEach((step) => expect(step.length).toBeGreaterThan(0));
+        expect(new Set(task.abilityIds).size).toBe(task.abilityIds.length);
+        task.abilityIds.forEach((abilityId) => expect(abilityIds.has(abilityId)).toBe(true));
       }
     }
   });
 
-  it('保留 Apple 與 Amy 的既定起始軍階', () => {
-    const rankAt = (stars: number) => rankSteps.filter((rank) => stars >= rank.stars).at(-1)?.name;
+  it('以每十星一階組成 50 階、500 星成長路徑', () => {
+    expect(rankChapters).toHaveLength(10);
+    expect(rankSteps).toHaveLength(50);
+    expect(rankSteps.map((rank) => rank.level)).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+    expect(rankSteps.map((rank) => rank.stars)).toEqual(Array.from({ length: 50 }, (_, index) => (index + 1) * 10));
+    expect(rankSteps.at(-1)?.name).toBe('雙羽星光總隊長');
+    expect(rankSteps.at(-1)?.stars).toBe(500);
+  });
 
-    expect(scoutProfiles.apple.startingStars).toBe(80);
+  it('能力從 F- 到 S+ 共 21 段，每段對應一顆能力星', () => {
+    expect(abilityGrades).toHaveLength(21);
+    expect(abilityGrades.slice(0, 3)).toEqual(['F-', 'F', 'F+']);
+    expect(abilityGrades.slice(-3)).toEqual(['S-', 'S', 'S+']);
+  });
+
+  it('保留 Apple 與 Amy 的目前星星進度', () => {
+    const rankAt = (stars: number) => rankSteps.filter((rank) => stars >= rank.stars).at(-1)?.name ?? '見習小兵';
+
+    expect(scoutProfiles.apple.startingStars).toBe(39);
     expect(rankAt(scoutProfiles.apple.startingStars)).toBe('初級偵查兵');
-    expect(scoutProfiles.amy.startingStars).toBe(0);
+    expect(scoutProfiles.amy.startingStars).toBe(11);
     expect(rankAt(scoutProfiles.amy.startingStars)).toBe('小兵');
   });
 });

--- a/src/data/family-missions.test.ts
+++ b/src/data/family-missions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { abilityCatalog, abilityGrades, rankChapters, rankSteps, scoutProfiles } from './family-missions';
+import { abilityCatalog, abilityGrades, abilityStages, rankChapters, rankSteps, scoutProfiles } from './family-missions';
 
 describe('雙羽任務靜態資料', () => {
   it('每位偵查員都有五個可部署任務，且任務 id 不重複', () => {
@@ -11,10 +11,12 @@ describe('雙羽任務靜態資料', () => {
     expect(new Set(allIds).size).toBe(allIds.length);
   });
 
-  it('所有任務都有一項或多項核心能力，完成時固定得到一顆任務星', () => {
+  it('所有任務都有核心能力，且每位孩子每天有三個主線與兩個自由挑戰', () => {
     const abilityIds = new Set(Object.keys(abilityCatalog));
 
     for (const profile of Object.values(scoutProfiles)) {
+      expect(profile.tasks.filter((task) => task.kind === 'main')).toHaveLength(3);
+      expect(profile.tasks.filter((task) => task.kind === 'free')).toHaveLength(2);
       for (const task of profile.tasks) {
         expect(task.abilityIds.length).toBeGreaterThan(0);
         expect(task.steps).toHaveLength(3);
@@ -34,10 +36,11 @@ describe('雙羽任務靜態資料', () => {
     expect(rankSteps.at(-1)?.stars).toBe(500);
   });
 
-  it('能力從 F- 到 S+ 共 21 段，每段對應一顆能力星', () => {
+  it('能力使用七個兒童可理解的階段，共 21 個成長小步', () => {
+    expect(abilityStages).toEqual(['萌芽', '練習', '熟悉', '穩定', '熟練', '自主', '閃耀']);
     expect(abilityGrades).toHaveLength(21);
-    expect(abilityGrades.slice(0, 3)).toEqual(['F-', 'F', 'F+']);
-    expect(abilityGrades.slice(-3)).toEqual(['S-', 'S', 'S+']);
+    expect(abilityGrades.slice(0, 3)).toEqual(['萌芽 1', '萌芽 2', '萌芽 3']);
+    expect(abilityGrades.slice(-3)).toEqual(['閃耀 1', '閃耀 2', '閃耀 3']);
   });
 
   it('保留 Apple 與 Amy 的目前星星進度', () => {

--- a/src/data/family-missions.ts
+++ b/src/data/family-missions.ts
@@ -3,7 +3,7 @@
  *
  * 新增任務時：
  * 1. 在對應孩子的 tasks 陣列複製一個任務物件。
- * 2. 換成全站不重複的 id，並填入文案、主能力與獎勵。
+ * 2. 換成全站不重複的 id，填入文案、三步任務口訣與一項或多項能力。
  * 3. 重新執行靜態部署，頁面就會出現新任務。
  *
  * id 一旦上線請不要修改，否則裝置上既有的完成紀錄會認成新任務。
@@ -18,9 +18,10 @@ export interface MissionTask {
   title: string;
   story: string;
   description: string;
-  abilityId: AbilityId;
-  rewardStars: number;
-  abilityXp: number;
+  /** 給孩子看的三步任務口訣；維持短句，方便在任務卡上逐步揭曉。 */
+  steps: readonly [string, string, string];
+  /** 任務可以同時鍛鍊一項或多項能力；完成後每項能力各加一顆能力星。 */
+  abilityIds: AbilityId[];
   estimatedMinutes: string;
   difficulty: '輕鬆' | '小挑戰' | '大挑戰';
   skillTag: string;
@@ -38,7 +39,8 @@ export interface ScoutProfile {
   startingStars: number;
   greeting: string;
   story: string;
-  baseAbilityXp: Record<AbilityId, number>;
+  /** 1 顆為 F-，每顆能力星前進一小段，21 顆為 S+。 */
+  baseAbilityStars: Record<AbilityId, number>;
   tasks: MissionTask[];
 }
 
@@ -99,20 +101,150 @@ export const abilityCatalog = {
   },
 } as const;
 
-export const rankSteps = [
-  { stars: 0, name: '小兵', symbol: '🌱', gift: '領取第一本任務手冊' },
-  { stars: 30, name: '大兵', symbol: '🎒', gift: '解鎖自己的探險背包' },
-  { stars: 80, name: '初級偵查兵', symbol: '🔎', gift: '解鎖星光放大鏡' },
-  { stars: 150, name: '中級偵查兵', symbol: '🗺️', gift: '可以規劃一個家庭任務' },
-  { stars: 240, name: '高級偵查兵', symbol: '🪶', gift: '獲得金色羽毛徽章' },
-  { stars: 360, name: '星光領航員', symbol: '🌟', gift: '帶領一次家庭小冒險' },
+/**
+ * 能力階級共有 7 個字母階級，每階 3 段：F-、F、F+ …… S-、S、S+。
+ * 每完成一項涉及該能力的任務，就增加 1 顆能力星並前進一段。
+ */
+export const abilityGrades = ['F-', 'F', 'F+', 'E-', 'E', 'E+', 'D-', 'D', 'D+', 'C-', 'C', 'C+', 'B-', 'B', 'B+', 'A-', 'A', 'A+', 'S-', 'S', 'S+'] as const;
+
+type RankSeed = readonly [name: string, gift: string];
+
+const rankChapterSeeds: ReadonlyArray<{
+  id: string;
+  name: string;
+  subtitle: string;
+  symbol: string;
+  ranks: readonly RankSeed[];
+}> = [
+  {
+    id: 'rookie-camp', name: '新兵啟程', subtitle: '先學會照顧自己，也勇敢接受小任務', symbol: '🌱',
+    ranks: [
+      ['小兵', '領取自己的任務手冊'],
+      ['大兵', '解鎖個人任務徽章'],
+      ['初級偵查兵', '可以自己選一項每日任務'],
+      ['中級偵查兵', '能準備自己的小裝備'],
+      ['高級偵查兵', '能規劃一件家庭小任務'],
+    ],
+  },
+  {
+    id: 'forest-path', name: '森林探路', subtitle: '觀察環境、找到方法，再把事情做完', symbol: '🧭',
+    ranks: [
+      ['初級探路兵', '練習發現生活裡的小線索'],
+      ['中級探路兵', '能照步驟完成兩件小事'],
+      ['高級探路兵', '出發前會自己檢查物品'],
+      ['菁英探路兵', '遇到問題會換一個方法'],
+      ['森林探路隊長', '能帶家人完成一次尋寶任務'],
+    ],
+  },
+  {
+    id: 'puzzle-library', name: '知識解謎', subtitle: '用閱讀、數字和語言解開生活謎題', symbol: '📚',
+    ranks: [
+      ['初級解謎兵', '願意開口問一個好問題'],
+      ['中級解謎兵', '能說出自己找到的答案'],
+      ['高級解謎兵', '會把大問題分成小步驟'],
+      ['菁英解謎兵', '能比較兩種不同的方法'],
+      ['星光解謎隊長', '可以設計一道題目給家人'],
+    ],
+  },
+  {
+    id: 'kindness-garden', name: '溫暖守護', subtitle: '懂得禮貌、分享，也看見別人的感受', symbol: '💛',
+    ranks: [
+      ['初級守護兵', '記得使用請、謝謝與對不起'],
+      ['中級守護兵', '願意輪流、分享與等待'],
+      ['高級守護兵', '能好好說出自己的感受'],
+      ['菁英守護兵', '主動發現別人需要幫忙'],
+      ['暖心守護隊長', '能化解一次小小的爭執'],
+    ],
+  },
+  {
+    id: 'brave-expedition', name: '勇氣遠征', subtitle: '面對新挑戰，試著多走勇敢的一步', symbol: '🦋',
+    ranks: [
+      ['初級遠征兵', '願意試一次不熟悉的小事'],
+      ['中級遠征兵', '做錯時願意再試一次'],
+      ['高級遠征兵', '能完成需要耐心的挑戰'],
+      ['菁英遠征兵', '遇到害怕會說出需要什麼'],
+      ['勇氣遠征隊長', '能鼓勵家人一起挑戰'],
+    ],
+  },
+  {
+    id: 'independent-base', name: '自主管理', subtitle: '安排自己的事情，對約定負責', symbol: '🎒',
+    ranks: [
+      ['初級自主兵', '能自己完成固定的生活工作'],
+      ['中級自主兵', '會記得今天答應的事情'],
+      ['高級自主兵', '能先做完再安心玩耍'],
+      ['菁英自主兵', '會自己檢查任務是否完成'],
+      ['自主行動隊長', '能安排一段自己的任務時間'],
+    ],
+  },
+  {
+    id: 'star-map', name: '星圖規劃', subtitle: '學著判斷先後順序，為目標做準備', symbol: '🗺️',
+    ranks: [
+      ['初級星圖兵', '能說出任務的第一步'],
+      ['中級星圖兵', '能排出三件事的先後順序'],
+      ['高級星圖兵', '會先準備需要的工具'],
+      ['菁英星圖兵', '知道何時需要請人幫忙'],
+      ['星圖規劃隊長', '能規劃半天的家庭小行程'],
+    ],
+  },
+  {
+    id: 'team-camp', name: '團隊協作', subtitle: '一起討論、分工，也完成共同目標', symbol: '🤝',
+    ranks: [
+      ['初級協作兵', '能聽完別人的想法'],
+      ['中級協作兵', '願意接受公平的分工'],
+      ['高級協作兵', '完成自己負責的部分'],
+      ['菁英協作兵', '夥伴卡住時願意幫忙'],
+      ['星光協作隊長', '能帶領一次家庭合作任務'],
+    ],
+  },
+  {
+    id: 'dawn-guide', name: '晨光領航', subtitle: '不只照顧自己，也能帶給身邊的人力量', symbol: '🌤️',
+    ranks: [
+      ['初級領航員', '能示範一件自己擅長的事'],
+      ['中級領航員', '會用溫柔方式提醒別人'],
+      ['高級領航員', '能照顧比自己小的夥伴'],
+      ['菁英領航員', '遇到變化也能重新安排'],
+      ['晨光領航隊長', '能帶大家完成一日小目標'],
+    ],
+  },
+  {
+    id: 'twinwing-legend', name: '雙羽傳奇', subtitle: '把成熟、知識與溫暖變成真正的影響力', symbol: '🌟',
+    ranks: [
+      ['初級星光領航員', '建立自己的長期成長目標'],
+      ['中級星光領航員', '能主動追蹤目標進度'],
+      ['高級星光領航員', '遇到困難會調整而不放棄'],
+      ['榮耀星光領航員', '完成一項值得紀念的大挑戰'],
+      ['雙羽星光總隊長', '完成 500 星成長路徑'],
+    ],
+  },
 ] as const;
 
+export const rankChapters = rankChapterSeeds.map((chapter, chapterIndex) => ({
+  ...chapter,
+  startStars: chapterIndex * 50 + 10,
+  endStars: (chapterIndex + 1) * 50,
+  ranks: chapter.ranks.map(([name, gift], rankIndex) => ({
+    level: chapterIndex * 5 + rankIndex + 1,
+    stars: (chapterIndex * 5 + rankIndex + 1) * 10,
+    name,
+    gift,
+    symbol: chapter.symbol,
+    chapterId: chapter.id,
+  })),
+}));
+
+export const rankSteps = rankChapters.flatMap((chapter) => chapter.ranks);
+
 export const growthBadges = [
-  { id: 'self-care', name: '自理小達人', icon: '🧺', unlockStars: 20, description: '會照顧自己的物品與日常需要' },
-  { id: 'helper', name: '溫柔小幫手', icon: '🤲', unlockStars: 60, description: '看見別人需要時願意伸出手' },
-  { id: 'reader', name: '故事探險家', icon: '📖', unlockStars: 100, description: '能讀完故事並分享自己的發現' },
-  { id: 'brave-heart', name: '勇氣發光者', icon: '🦋', unlockStars: 180, description: '遇到新挑戰也願意試一小步' },
+  { id: 'self-care', name: '自理小達人', icon: '🧺', unlockStars: 50, description: '完成新兵啟程，會照顧自己的物品與日常需要' },
+  { id: 'pathfinder', name: '森林探路家', icon: '🧭', unlockStars: 100, description: '完成森林探路，懂得觀察、準備與找方法' },
+  { id: 'puzzle', name: '故事解謎家', icon: '📖', unlockStars: 150, description: '完成知識解謎，能用學到的事解決問題' },
+  { id: 'helper', name: '溫柔守護者', icon: '🤲', unlockStars: 200, description: '完成溫暖守護，願意分享並關心別人的感受' },
+  { id: 'brave-heart', name: '勇氣發光者', icon: '🦋', unlockStars: 250, description: '完成勇氣遠征，遇到新挑戰也願意試一小步' },
+  { id: 'independent', name: '自主行動家', icon: '🎒', unlockStars: 300, description: '完成自主管理，能安排事情並對約定負責' },
+  { id: 'planner', name: '星圖規劃家', icon: '🗺️', unlockStars: 350, description: '完成星圖規劃，能替目標準備與安排步驟' },
+  { id: 'teammate', name: '最佳小隊友', icon: '🤝', unlockStars: 400, description: '完成團隊協作，懂得討論、分工與互相幫忙' },
+  { id: 'guide', name: '晨光領航員', icon: '🌤️', unlockStars: 450, description: '完成晨光領航，能照顧夥伴並帶來好影響' },
+  { id: 'legend', name: '雙羽星光傳奇', icon: '🌟', unlockStars: 500, description: '走完全程 500 星，成為雙羽星光總隊長' },
 ] as const;
 
 export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
@@ -125,16 +257,16 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
     portrait: '/assets/img/family-missions/apple-scout.webp',
     portraitAlt: 'Apple 星圖偵查員的童書插畫',
     theme: 'apple',
-    startingStars: 80,
+    startingStars: 39,
     greeting: '今天也來完成一件厲害的小事吧！',
     story: 'Apple 擅長看懂線索，也開始學著照顧身邊的人。今天，她要替星光營地找回五顆散落在生活裡的任務星。',
-    baseAbilityXp: {
-      language: 36,
-      math: 32,
-      english: 25,
-      manners: 31,
-      kindness: 39,
-      responsibility: 38,
+    baseAbilityStars: {
+      language: 8,
+      math: 7,
+      english: 5,
+      manners: 7,
+      kindness: 8,
+      responsibility: 8,
     },
     tasks: [
       {
@@ -143,9 +275,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '整理自己的物品',
         story: '迷路的物品想回家',
         description: '把今天用過的書、玩具或衣物放回固定的位置。',
-        abilityId: 'responsibility',
-        rewardStars: 2,
-        abilityXp: 6,
+        steps: ['先找出三樣沒回家的物品', '一樣一樣放回固定位置', '回頭檢查桌面和地板'],
+        abilityIds: ['responsibility'],
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '自理',
@@ -156,9 +287,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '小小閱讀偵探',
         story: '故事書裡藏著一條線索',
         description: '自己讀一小段故事，再說出最喜歡的角色或情節。',
-        abilityId: 'language',
-        rewardStars: 2,
-        abilityXp: 6,
+        steps: ['挑一本今天想探索的書', '慢慢讀完一小段', '說出最喜歡的角色和原因'],
+        abilityIds: ['language', 'responsibility'],
         estimatedMinutes: '10 分鐘',
         difficulty: '小挑戰',
         skillTag: '表達',
@@ -169,9 +299,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '英文尋寶任務',
         story: '找出藏在家裡的英文密碼',
         description: '找出三個看得到的英文單字，試著讀出來並說出意思。',
-        abilityId: 'english',
-        rewardStars: 2,
-        abilityXp: 6,
+        steps: ['張大眼睛找英文字樣', '選三個單字讀出來', '猜猜看它們代表什麼'],
+        abilityIds: ['english', 'responsibility'],
         estimatedMinutes: '8 分鐘',
         difficulty: '小挑戰',
         skillTag: '觀察',
@@ -182,9 +311,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '家庭暖心小幫手',
         story: '營地需要一雙主動的手',
         description: '不用提醒，主動幫家人或妹妹完成一件小事。',
-        abilityId: 'kindness',
-        rewardStars: 3,
-        abilityXp: 8,
+        steps: ['先觀察誰正需要幫忙', '問一句「我可以幫什麼？」', '完成後送上一個笑容'],
+        abilityIds: ['kindness', 'responsibility'],
         estimatedMinutes: '隨時',
         difficulty: '大挑戰',
         skillTag: '主動',
@@ -195,9 +323,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '好好說出我的感受',
         story: '把心裡的雲變成一句話',
         description: '遇到開心或不開心的事，用完整的一句話告訴家人。',
-        abilityId: 'manners',
-        rewardStars: 2,
-        abilityXp: 6,
+        steps: ['先停一下感覺心裡的天氣', '用「我覺得……」開頭', '再說「我希望……」'],
+        abilityIds: ['language', 'manners', 'kindness'],
         estimatedMinutes: '3 分鐘',
         difficulty: '小挑戰',
         skillTag: '溝通',
@@ -213,16 +340,16 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
     portrait: '/assets/img/family-missions/amy-scout.webp',
     portraitAlt: 'Amy 花園偵查員的童書插畫',
     theme: 'amy',
-    startingStars: 0,
+    startingStars: 11,
     greeting: '選一個任務，完成後回來蓋章！',
     story: 'Amy 帶著放大鏡尋找生活裡的小驚喜。每完成一件自己做得到的事，就會有一朵新的能力花慢慢長大。',
-    baseAbilityXp: {
-      language: 14,
-      math: 17,
-      english: 10,
-      manners: 20,
-      kindness: 22,
-      responsibility: 16,
+    baseAbilityStars: {
+      language: 4,
+      math: 5,
+      english: 3,
+      manners: 4,
+      kindness: 5,
+      responsibility: 4,
     },
     tasks: [
       {
@@ -231,9 +358,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '玩具回家任務',
         story: '每個玩具都在找自己的家',
         description: '玩完以後，把玩具一個一個送回固定的位置。',
-        abilityId: 'responsibility',
-        rewardStars: 2,
-        abilityXp: 7,
+        steps: ['先找到玩具的家', '一次拿一個慢慢收', '最後數三下完成檢查'],
+        abilityIds: ['responsibility'],
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '自理',
@@ -244,9 +370,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '尋找數字小隊',
         story: '放大鏡發現了一群數字',
         description: '找一種喜歡的東西，指著它們慢慢數到十。',
-        abilityId: 'math',
-        rewardStars: 2,
-        abilityXp: 7,
+        steps: ['挑一種想數的東西', '手指一個就數一個', '數完再說一次總數'],
+        abilityIds: ['math', 'responsibility'],
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '數數',
@@ -257,9 +382,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '英文小耳朵',
         story: '聽見一個來自遠方的聲音',
         description: '聽一首英文歌，跟著說出或唱出一個聽見的單字。',
-        abilityId: 'english',
-        rewardStars: 2,
-        abilityXp: 7,
+        steps: ['挑一首喜歡的英文歌', '聽到熟悉的聲音就指出來', '跟著唱出一個單字'],
+        abilityIds: ['english', 'language'],
         estimatedMinutes: '5 分鐘',
         difficulty: '小挑戰',
         skillTag: '聆聽',
@@ -270,9 +394,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '魔法禮貌語',
         story: '有三句話能打開禮貌之門',
         description: '今天主動說一次「請、謝謝或對不起」。',
-        abilityId: 'manners',
-        rewardStars: 2,
-        abilityXp: 7,
+        steps: ['看見需要幫忙時說「請」', '收到幫忙後說「謝謝」', '不小心時勇敢說「對不起」'],
+        abilityIds: ['manners', 'kindness'],
         estimatedMinutes: '隨時',
         difficulty: '輕鬆',
         skillTag: '禮貌',
@@ -283,9 +406,8 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         title: '分享一點點',
         story: '兩個人一起玩，快樂會變大',
         description: '和姊姊或家人分享一樣東西，或輪流玩一次。',
-        abilityId: 'kindness',
-        rewardStars: 3,
-        abilityXp: 8,
+        steps: ['挑一樣願意分享的東西', '問對方想不想一起玩', '輪流時等對方完成再接手'],
+        abilityIds: ['kindness', 'manners'],
         estimatedMinutes: '隨時',
         difficulty: '大挑戰',
         skillTag: '分享',
@@ -293,4 +415,3 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
     ],
   },
 };
-

--- a/src/data/family-missions.ts
+++ b/src/data/family-missions.ts
@@ -25,6 +25,8 @@ export interface MissionTask {
   estimatedMinutes: string;
   difficulty: '輕鬆' | '小挑戰' | '大挑戰';
   skillTag: string;
+  /** 主線影響每日榮譽星；自由挑戰只給收藏與能力成長。 */
+  kind: 'main' | 'free';
 }
 
 export interface ScoutProfile {
@@ -39,7 +41,7 @@ export interface ScoutProfile {
   startingStars: number;
   greeting: string;
   story: string;
-  /** 1 顆為 F-，每顆能力星前進一小段，21 顆為 S+。 */
+  /** 每顆能力星前進一小步，21 顆走完「萌芽」到「閃耀」七階段。 */
   baseAbilityStars: Record<AbilityId, number>;
   tasks: MissionTask[];
 }
@@ -102,10 +104,15 @@ export const abilityCatalog = {
 } as const;
 
 /**
- * 能力階級共有 7 個字母階級，每階 3 段：F-、F、F+ …… S-、S、S+。
+ * 能力階級共有 7 個兒童可理解的階段，每階 3 個小步。
  * 每完成一項涉及該能力的任務，就增加 1 顆能力星並前進一段。
  */
-export const abilityGrades = ['F-', 'F', 'F+', 'E-', 'E', 'E+', 'D-', 'D', 'D+', 'C-', 'C', 'C+', 'B-', 'B', 'B+', 'A-', 'A', 'A+', 'S-', 'S', 'S+'] as const;
+export const abilityStages = ['萌芽', '練習', '熟悉', '穩定', '熟練', '自主', '閃耀'] as const;
+export const abilityGrades = abilityStages.flatMap((stage) => [
+  `${stage} 1`,
+  `${stage} 2`,
+  `${stage} 3`,
+]) as readonly string[];
 
 type RankSeed = readonly [name: string, gift: string];
 
@@ -280,6 +287,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '自理',
+        kind: 'main',
       },
       {
         id: 'apple-reading',
@@ -292,6 +300,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '10 分鐘',
         difficulty: '小挑戰',
         skillTag: '表達',
+        kind: 'main',
       },
       {
         id: 'apple-english-hunt',
@@ -304,6 +313,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '8 分鐘',
         difficulty: '小挑戰',
         skillTag: '觀察',
+        kind: 'main',
       },
       {
         id: 'apple-kindness',
@@ -316,6 +326,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '隨時',
         difficulty: '大挑戰',
         skillTag: '主動',
+        kind: 'free',
       },
       {
         id: 'apple-feelings',
@@ -328,6 +339,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '3 分鐘',
         difficulty: '小挑戰',
         skillTag: '溝通',
+        kind: 'free',
       },
     ],
   },
@@ -363,6 +375,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '自理',
+        kind: 'main',
       },
       {
         id: 'amy-counting',
@@ -375,6 +388,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '5 分鐘',
         difficulty: '輕鬆',
         skillTag: '數數',
+        kind: 'main',
       },
       {
         id: 'amy-english-ears',
@@ -387,6 +401,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '5 分鐘',
         difficulty: '小挑戰',
         skillTag: '聆聽',
+        kind: 'main',
       },
       {
         id: 'amy-manners',
@@ -399,6 +414,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '隨時',
         difficulty: '輕鬆',
         skillTag: '禮貌',
+        kind: 'free',
       },
       {
         id: 'amy-sharing',
@@ -411,6 +427,7 @@ export const scoutProfiles: Record<ScoutId, ScoutProfile> = {
         estimatedMinutes: '隨時',
         difficulty: '大挑戰',
         skillTag: '分享',
+        kind: 'free',
       },
     ],
   },

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -63,10 +63,6 @@ const attributes = [
             <i class="fas fa-gamepad"></i> <span>遊戲室</span>
           </a>
 
-          <a href="/family-missions" class="arcade-nav-link family-mission-nav-link" title="進入 Apple 與 Amy 的生活任務所">
-            <i class="fas fa-star"></i> <span>雙羽任務</span>
-          </a>
-
           <!-- 連接錢包按鈕 (未連接時顯示) -->
           <button class="connect-wallet-btn-header" id="connect-wallet-header" style="display: none;">
             <span class="wallet-icon"><i class="fab fa-ethereum"></i></span>
@@ -119,10 +115,6 @@ const attributes = [
           <!-- 遊戲室入口 -->
           <a href="/games" class="arcade-nav-link arcade-nav-link--mobile" title="進入遊戲室 — Dungeon Arcade">
             <i class="fas fa-gamepad"></i> <span>遊戲室 ARCADE</span>
-          </a>
-
-          <a href="/family-missions" class="arcade-nav-link arcade-nav-link--mobile family-mission-nav-link" title="進入 Apple 與 Amy 的生活任務所">
-            <i class="fas fa-star"></i> <span>雙羽任務 FAMILY QUEST</span>
           </a>
 
           <!-- 連接錢包按鈕 (未連接時顯示) -->

--- a/src/pages/family-missions.astro
+++ b/src/pages/family-missions.astro
@@ -4,6 +4,7 @@ import { defaultLang, type Language } from '@i18n/index';
 import {
   abilityCatalog,
   abilityGrades,
+  abilityStages,
   growthBadges,
   rankChapters,
   rankSteps,
@@ -85,6 +86,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <span class="sound-toggle__on" aria-hidden="true">🔔</span>
         <span class="sound-toggle__off" aria-hidden="true">🔕</span>
         <small>任務音效</small>
+      </button>
+      <button class="parent-base-toggle" id="parent-base-toggle" type="button">
+        <span aria-hidden="true">🔐</span><small>家長基地</small><b id="parent-pending-count" hidden>0</b>
       </button>
       <div class="quest-hero__copy">
         <p class="eyebrow">SUPERGALEN FAMILY QUEST · 16-BIT EDITION</p>
@@ -193,7 +197,13 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         </div>
       </section>
 
-      <section class="mission-board" aria-labelledby="mission-board-title">
+      <nav class="game-mode-tabs" aria-label="任務所功能" role="tablist">
+        <button class="is-active" type="button" role="tab" aria-selected="true" data-game-tab="missions"><span aria-hidden="true">🗺️</span>今日任務</button>
+        <button type="button" role="tab" aria-selected="false" data-game-tab="growth"><span aria-hidden="true">🌱</span>成長手冊</button>
+        <button type="button" role="tab" aria-selected="false" data-game-tab="map"><span aria-hidden="true">🏕️</span>收藏地圖</button>
+      </nav>
+
+      <section class="mission-board" aria-labelledby="mission-board-title" data-game-panel="missions">
         <div class="section-heading mission-board__heading">
           <span class="section-heading__icon" aria-hidden="true">🗺️</span>
           <div>
@@ -212,10 +222,10 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
             const taskAbilities = task.abilityIds.map((abilityId) => abilityCatalog[abilityId]);
             const primaryAbility = taskAbilities[0];
             return (
-              <article class={`mission-card mission-card--${primaryAbility.id}`} data-task-id={task.id}>
+              <article class={`mission-card mission-card--${primaryAbility.id} is-available`} data-task-id={task.id}>
                 <div class="mission-card__topline">
-                  <span class="mission-card__number">任務 {String(index + 1).padStart(2, '0')}</span>
-                  <span class="difficulty-tag">{task.difficulty}</span>
+                  <span class="mission-card__number">{task.kind === 'main' ? '主線' : '自由挑戰'} {String(index + 1).padStart(2, '0')}</span>
+                  <span class="mission-status-tag">可以接取</span>
                 </div>
                 <div class="mission-card__illustration" aria-hidden="true">
                   <span>{task.icon}</span>
@@ -234,21 +244,20 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
                   <span>⏱ {task.estimatedMinutes}</span>
                   <span>🏷 {task.skillTag}</span>
                 </div>
-                <div class="mission-card__reward" aria-label={`獎勵：1 顆任務星；${taskAbilities.map((ability) => ability.name).join('、')}各加 1 顆能力星`}>
+                <div class="mission-card__reward" aria-label={`家長確認後培養${taskAbilities.map((ability) => ability.name).join('、')}；${task.kind === 'main' ? '主線里程碑可獲榮譽星' : '自由挑戰增加基地收藏'}`}>
                   <span class="ability-reward-list">
                     {taskAbilities.map((ability) => <i>{ability.icon} {ability.name} ＋1</i>)}
                   </span>
-                  <strong>★ ＋1</strong>
+                  <strong>{task.kind === 'main' ? '★ 每日榮譽' : '◆ 基地收藏'}</strong>
                 </div>
                 <button
                   class="mission-complete"
                   type="button"
-                  aria-label={`完成：${task.title}`}
+                  aria-label={`接下這個任務：${task.title}`}
                   data-task-id={task.id}
-                  data-reward-preview={`${taskAbilities.map((ability) => `${ability.name} +1`).join('、')}、任務星 +1`}
+                  data-action="start"
                 >
-                  <span class="mission-complete__ready">我完成了，蓋章！</span>
-                  <span class="mission-complete__done">已回報</span>
+                  <span class="mission-complete__ready">接下這個任務</span>
                 </button>
               </article>
             );
@@ -256,25 +265,25 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         </div>
       </section>
 
-      <section class="ability-garden" role="region" aria-label="能力花園">
+      <section class="ability-garden" role="region" aria-label="能力花園" data-game-panel="growth" hidden>
         <div class="section-heading">
           <span class="section-heading__icon" aria-hidden="true">🌷</span>
           <div>
             <p>MY GROWING GARDEN</p>
             <h2>我的能力花園</h2>
-            <span>每個任務可培養一項或多項能力；涉及的能力各長出一顆星。</span>
+            <span>家長確認後，今天第一次使用到的能力會長出一顆星。</span>
           </div>
         </div>
 
         <div class="ability-scale" aria-label="能力階級說明">
           <div>
             <strong>能力階級</strong>
-            <span>從 F 慢慢成長到 S</span>
+            <span>從萌芽慢慢走向閃耀</span>
           </div>
           <ol>
-            {['F', 'E', 'D', 'C', 'B', 'A', 'S'].map((letter) => <li>{letter}<small>−　　＋</small></li>)}
+            {abilityStages.map((stage) => <li>{stage}<small>1　2　3</small></li>)}
           </ol>
-          <p><span aria-hidden="true">★</span> 一顆能力星前進一段：F− → F → F＋ → E− …… → S＋</p>
+          <p><span aria-hidden="true">★</span> 每個階段有三小步：萌芽 1 → 萌芽 2 → 萌芽 3 → 練習 1……</p>
         </div>
 
         <div class="ability-grid" id="ability-grid">
@@ -295,9 +304,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
                   <progress class="ability-card__meter" max="100" value={growth.progress} aria-label={`${ability.name}成長進度`}>
                     {growth.progress}%
                   </progress>
-                  <small>{growth.stars} / 21 顆能力星 · {growth.nextGrade ? `下一顆升到 ${growth.nextGrade}` : '已達 S＋'}</small>
+                  <small>{growth.stars} / 21 格成長 · {growth.nextGrade ? `下一格是 ${growth.nextGrade}` : '已達閃耀 3'}</small>
                   <button class="ability-inspect" type="button" aria-expanded="false" data-action="toggle-ability">
-                    展開 F−～S＋成長軌道 <span aria-hidden="true">⌄</span>
+                    展開完整成長軌道 <span aria-hidden="true">⌄</span>
                   </button>
                   <div class="ability-ladder" aria-hidden="true">
                     {abilityGrades.map((grade, gradeIndex) => (
@@ -314,7 +323,31 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         </div>
       </section>
 
-      <section class="badge-shelf" role="region" aria-label="成長徽章">
+      <section class="base-building" role="region" aria-label="星光基地" data-game-panel="map" hidden>
+        <div class="section-heading">
+          <span class="section-heading__icon" aria-hidden="true">🏕️</span>
+          <div>
+            <p>STARLIGHT BASE</p>
+            <h2>我的星光基地</h2>
+            <span>主線會點亮今天的營火；自由挑戰會留下永久基地收藏。</span>
+          </div>
+          <div class="base-collection-counter"><strong id="base-collection-count">0</strong><span>份收藏</span></div>
+        </div>
+        <div class="base-scene" id="base-scene" aria-label="星光基地建設進度">
+          <div class="base-campfire" aria-hidden="true">🔥<span><i data-main-light="1">★</i><i data-main-light="2">★</i><i data-main-light="3">★</i></span></div>
+          <ol class="base-collection-grid">
+            <li data-base-piece="1"><span>🌷</span><strong>花園旗幟</strong></li>
+            <li data-base-piece="2"><span>📚</span><strong>故事書架</strong></li>
+            <li data-base-piece="3"><span>🧭</span><strong>探路指標</strong></li>
+            <li data-base-piece="4"><span>🦋</span><strong>勇氣風鈴</strong></li>
+            <li data-base-piece="5"><span>🤝</span><strong>姊妹小橋</strong></li>
+            <li data-base-piece="6"><span>🌟</span><strong>星光塔燈</strong></li>
+          </ol>
+          <p id="base-next-piece">完成一個自由挑戰，就能放進第一件基地收藏。</p>
+        </div>
+      </section>
+
+      <section class="badge-shelf" role="region" aria-label="成長徽章" data-game-panel="map" hidden>
         <div class="section-heading">
           <span class="section-heading__icon" aria-hidden="true">🏕️</span>
           <div>
@@ -340,13 +373,13 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         </div>
       </section>
 
-      <section class="rank-journey" role="region" aria-label="升階旅程">
+      <section class="rank-journey" role="region" aria-label="升階旅程" data-game-panel="map" hidden>
         <div class="section-heading">
           <span class="section-heading__icon" aria-hidden="true">✨</span>
           <div>
             <p>STARLIGHT JOURNEY</p>
             <h2>500 星・50 階成長地圖</h2>
-            <span>每完成一個任務得到 1 顆星，每 10 顆星升 1 階；全程分成 10 個冒險章節。</span>
+            <span>每天最多獲得 2 顆榮譽星，每 10 顆星升 1 階；自由挑戰會留下收藏紀錄。</span>
           </div>
         </div>
         <div class="rank-map" id="rank-trail">
@@ -400,16 +433,15 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     </div>
 
     <div class="mission-toast" id="mission-toast" role="status" aria-live="polite"></div>
-    <div class="pixel-combo" id="pixel-combo" aria-hidden="true"><small>DAILY COMBO</small><strong>×1</strong></div>
-    <aside class="quest-chain-hud" id="quest-chain-hud" aria-label="今日任務連擊進度">
+    <aside class="quest-chain-hud" id="quest-chain-hud" aria-label="今日任務確認進度">
       <div class="quest-chain-hud__title">
-        <span>QUEST CHAIN</span>
+        <span>TODAY'S QUESTS</span>
         <strong id="quest-chain-count">0 / 5</strong>
       </div>
       <div class="quest-chain-track" id="quest-chain-track" aria-hidden="true">
         {initialProfile.tasks.map((_, index) => <i data-chain-step={index + 1}>★</i>)}
       </div>
-      <small id="quest-chain-message">完成第一個任務，點亮連擊！</small>
+      <small id="quest-chain-message">選一個主線任務，開始今天的冒險。</small>
     </aside>
     <div class="ability-level-up" id="ability-level-up" aria-hidden="true">
       <small>ABILITY UP!</small>
@@ -424,17 +456,58 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <small>MISSION COMPLETE!</small>
         <span class="mission-win__icon" id="mission-win-icon" aria-hidden="true">★</span>
         <strong id="mission-win-title">任務完成</strong>
+        <p class="mission-win__praise" id="mission-win-praise">家長看見你的努力了！</p>
         <div id="mission-win-rewards"></div>
-        <div class="mission-win__counter" aria-label="任務星增加一顆">
+        <div class="mission-win__counter" aria-label="榮譽星變化">
           <span id="mission-win-stars-before">39</span><i aria-hidden="true">▶</i><strong id="mission-win-stars-after">40 ★</strong>
         </div>
-        <p><b>★ ＋1</b> 任務星已收進星星袋</p>
+        <p><b id="mission-win-star-note">★ 榮譽星已收進星星袋</b></p>
       </div>
     </div>
     <div class="reward-flight-layer" id="reward-flight-layer" aria-hidden="true"></div>
     <div class="celebration" aria-hidden="true">
       <span>★</span><span>●</span><span>✦</span><span>●</span><span>★</span><span>✦</span>
       <span>◆</span><span>★</span><span>●</span><span>✦</span><span>★</span><span>◆</span>
+    </div>
+
+    <div class="mission-report-overlay" id="mission-report-overlay" role="dialog" aria-modal="true" aria-labelledby="mission-report-title" hidden>
+      <div class="mission-report-card">
+        <button class="overlay-close" id="mission-report-close" type="button" aria-label="關閉任務回報">×</button>
+        <p class="report-eyebrow">MISSION REPORT</p>
+        <span class="report-mission-icon" id="mission-report-icon" aria-hidden="true">🎒</span>
+        <h2 id="mission-report-title">任務回報</h2>
+        <p id="mission-report-copy">你是怎麼完成的呢？</p>
+        <div class="effort-choices" role="radiogroup" aria-label="選擇這次的完成方式">
+          <button type="button" role="radio" aria-checked="false" data-effort="solo"><span>🙂</span><strong>我自己完成</strong></button>
+          <button type="button" role="radio" aria-checked="false" data-effort="help"><span>🤝</span><strong>有人幫我</strong></button>
+          <button type="button" role="radio" aria-checked="false" data-effort="tried"><span>💪</span><strong>有點難，我有試</strong></button>
+        </div>
+        <button class="send-report" id="send-report" type="button" disabled><span aria-hidden="true">✉️</span>投入星光信箱</button>
+        <small>送出後會等待家長看見你的努力，不會立刻加星。</small>
+      </div>
+    </div>
+
+    <div class="parent-base-overlay" id="parent-base-overlay" role="dialog" aria-modal="true" aria-labelledby="parent-base-title" hidden>
+      <div class="parent-base-card">
+        <button class="overlay-close" id="parent-base-close" type="button" aria-label="關閉家長基地">×</button>
+        <p class="report-eyebrow">PARENT BASE</p>
+        <h2 id="parent-base-title">家長確認基地</h2>
+        <section class="parent-pin-panel" id="parent-pin-panel">
+          <p id="parent-pin-instruction">第一次使用請設定 4 位數家長密碼。</p>
+          <label for="parent-pin-input">家長密碼</label>
+          <input id="parent-pin-input" type="password" inputmode="numeric" pattern="[0-9]*" maxlength="4" autocomplete="off" aria-describedby="parent-pin-error" />
+          <p class="parent-pin-error" id="parent-pin-error" role="alert"></p>
+          <button id="parent-pin-submit" type="button">進入家長基地</button>
+        </section>
+        <section class="parent-queue" id="parent-queue" hidden>
+          <div class="parent-queue__heading">
+            <div><strong>等待確認的任務</strong><span>先說出孩子做到的具體行為，再選擇回應。</span></div>
+            <button id="parent-lock" type="button">鎖定</button>
+          </div>
+          <div id="parent-queue-list"></div>
+          <p class="parent-empty" id="parent-empty">目前沒有等待確認的任務。</p>
+        </section>
+      </div>
     </div>
 
     <div class="rank-up-overlay" id="rank-up-overlay" role="dialog" aria-modal="true" aria-label="升階成功" hidden>
@@ -452,23 +525,24 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <button id="rank-up-close" type="button" aria-label="收下新軍階">收下新軍階，繼續出發！</button>
       </div>
     </div>
-    <div class="daily-clear-overlay" id="daily-clear-overlay" role="dialog" aria-modal="true" aria-label="今日任務全破" hidden>
+    <div class="daily-clear-overlay" id="daily-clear-overlay" role="dialog" aria-modal="true" aria-label="今日主線完成" hidden>
       <div class="daily-clear-rays" aria-hidden="true"></div>
       <div class="daily-clear-card">
-        <p>ALL QUESTS CLEAR!</p>
+        <p>MAIN QUESTS CLEAR!</p>
         <div class="daily-clear-chest" aria-hidden="true"><span>★</span></div>
-        <strong id="daily-clear-name">Apple 今日全破！</strong>
-        <div class="daily-clear-stars" aria-hidden="true"><i>★</i><i>★</i><i>★</i><i>★</i><i>★</i></div>
-        <span>五個生活任務全部完成<br />今天的努力已經收進冒險紀錄！</span>
+        <strong id="daily-clear-name">Apple 主線完成！</strong>
+        <div class="daily-clear-stars" aria-hidden="true"><i>★</i><i>★</i><i>★</i></div>
+        <span>三個主線任務都獲得家長確認<br />自由挑戰想做再做，今天已經很棒！</span>
         <button id="daily-clear-close" type="button">查看今天成長的能力</button>
       </div>
     </div>
   </main>
 </BaseLayout>
 
-<script define:vars={{ profiles, abilities: abilityCatalog, grades: abilityGrades, ranks: rankSteps, badges: growthBadges }}>
-  const STORAGE_KEY = 'supergalen-family-missions-v3';
-  const LEGACY_STORAGE_KEYS = ['supergalen-family-missions-v2', 'supergalen-family-missions-v1'];
+<script define:vars={{ profiles, abilities: abilityCatalog, grades: abilityGrades, stages: abilityStages, ranks: rankSteps, badges: growthBadges }}>
+  const STORAGE_KEY = 'supergalen-family-missions-v4';
+  const LEGACY_STORAGE_KEYS = ['supergalen-family-missions-v3', 'supergalen-family-missions-v2', 'supergalen-family-missions-v1'];
+  const PARENT_PIN_KEY = 'supergalen-family-parent-pin';
   const LEGACY_STARTING_STARS = { apple: 80, amy: 0 };
   const todayKey = new Date().toLocaleDateString('en-CA');
   let activeProfileId = 'apple';
@@ -481,6 +555,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   let pendingDailyClearProfileId = null;
   let effectsSoundOn = localStorage.getItem('supergalen-family-sound') !== 'off';
   let audioContext;
+  let reportTaskId = null;
+  let reportEffort = null;
+  let parentUnlocked = false;
 
   const page = document.querySelector('.family-missions');
   const missionList = document.querySelector('#mission-list');
@@ -488,7 +565,15 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
   function blankProfileState() {
-    return { earnedStars: 0, abilityBonusStars: {}, dailyDate: todayKey, completed: [] };
+    return {
+      earnedStars: 0,
+      abilityBonusStars: {},
+      dailyDate: todayKey,
+      taskStates: {},
+      abilityGrownToday: [],
+      honorMilestones: [],
+      collections: 0,
+    };
   }
 
   function loadState() {
@@ -496,16 +581,17 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
 
     try {
       const current = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
-      const legacy = LEGACY_STORAGE_KEYS
+      const previous = JSON.parse(localStorage.getItem('supergalen-family-missions-v3') || 'null');
+      const legacy = LEGACY_STORAGE_KEYS.slice(1)
         .map((key) => JSON.parse(localStorage.getItem(key) || 'null'))
         .find(Boolean);
-      const saved = current || legacy;
+      const saved = current || previous || legacy;
       if (!saved?.profiles) return fallback;
 
       for (const profileId of Object.keys(fallback)) {
         const profileState = saved.profiles[profileId] || blankProfileState();
         const isToday = profileState.dailyDate === todayKey;
-        const isLegacy = !current;
+        const isLegacy = !current && !previous;
         const legacyTotal = (LEGACY_STARTING_STARS[profileId] || 0) + (Number(profileState.bonusStars) || 0);
         const earnedStars = isLegacy
           ? Math.max(0, legacyTotal - profiles[profileId].startingStars)
@@ -516,11 +602,17 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
           const rawValue = Math.max(0, Number(rawAbilityBonus[abilityId]) || 0);
           abilityBonusStars[abilityId] = isLegacy ? Math.round(rawValue / 7) : rawValue;
         }
+        const oldCompleted = isToday && Array.isArray(profileState.completed) ? profileState.completed : [];
         fallback[profileId] = {
           earnedStars,
           abilityBonusStars,
           dailyDate: todayKey,
-          completed: isToday && Array.isArray(profileState.completed) ? profileState.completed : [],
+          taskStates: isToday && profileState.taskStates
+            ? profileState.taskStates
+            : Object.fromEntries(oldCompleted.map((taskId) => [taskId, { status: 'confirmed', effort: 'solo' }])),
+          abilityGrownToday: isToday && Array.isArray(profileState.abilityGrownToday) ? profileState.abilityGrownToday : [],
+          honorMilestones: isToday && Array.isArray(profileState.honorMilestones) ? profileState.honorMilestones : [],
+          collections: Math.max(0, Number(profileState.collections) || 0),
         };
       }
       return fallback;
@@ -535,6 +627,20 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
 
   function totalStars(profile) {
     return Math.min(500, profile.startingStars + state[profile.id].earnedStars);
+  }
+
+  function getTaskState(profileId, taskId) {
+    return state[profileId].taskStates[taskId] || { status: 'available' };
+  }
+
+  function confirmedTasks(profile) {
+    return profile.tasks.filter((task) => getTaskState(profile.id, task.id).status === 'confirmed');
+  }
+
+  function pendingTasks() {
+    return Object.values(profiles).flatMap((profile) => profile.tasks
+      .filter((task) => getTaskState(profile.id, task.id).status === 'pending')
+      .map((task) => ({ profile, task, report: getTaskState(profile.id, task.id) })));
   }
 
   function rankInfo(stars) {
@@ -625,21 +731,22 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   }
 
   function updateQuestChain(profile) {
-    const completed = state[profile.id].completed;
+    const completed = confirmedTasks(profile);
+    const mainCompleted = completed.filter((task) => task.kind === 'main').length;
     const hud = document.querySelector('#quest-chain-hud');
     const count = completed.length;
     document.querySelector('#quest-chain-count').textContent = `${count} / ${profile.tasks.length}`;
-    document.querySelector('#quest-chain-message').textContent = count === profile.tasks.length
-      ? 'PERFECT！今天的任務全部完成！'
-      : count === 0
-        ? '完成第一個任務，點亮連擊！'
-        : `連擊中！再完成 ${profile.tasks.length - count} 個任務就全破`;
+    document.querySelector('#quest-chain-message').textContent = mainCompleted === 3
+      ? '三個主線完成！自由挑戰想做再做。'
+      : mainCompleted === 0
+        ? '選一個主線任務，開始今天的冒險。'
+        : `主線進行中：再完成 ${3 - mainCompleted} 個就能點亮基地`;
     document.querySelectorAll('[data-chain-step]').forEach((step, index) => {
       step.classList.toggle('is-lit', index < count);
       step.classList.toggle('is-current', index === count && count < profile.tasks.length);
     });
-    hud.classList.toggle('is-perfect', count === profile.tasks.length);
-    hud.setAttribute('aria-label', `今日任務已完成 ${count} / ${profile.tasks.length}`);
+    hud.classList.toggle('is-perfect', mainCompleted === 3);
+    hud.setAttribute('aria-label', `今日已有 ${count} 個任務獲得家長確認`);
   }
 
   function showAbilityLevelUp(abilityId, beforeGrade, afterGrade, delay = 0) {
@@ -660,14 +767,14 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
 
   function showDailyClear(profile) {
     const overlay = document.querySelector('#daily-clear-overlay');
-    document.querySelector('#daily-clear-name').textContent = `${profile.shortName} 今日全破！`;
+    document.querySelector('#daily-clear-name').textContent = `${profile.shortName} 主線完成！`;
     overlay.hidden = false;
     requestAnimationFrame(() => {
       overlay.classList.add('is-visible');
       document.querySelector('#daily-clear-close').focus({ preventScroll: true });
     });
     replayClass(document.querySelector('.scout-story-card'), 'is-cheering', 1800);
-    showScoutReaction('五個任務都完成了！今天是完美冒險日！', 'perfect', 4800);
+    showScoutReaction('三個主線都被看見了！自由挑戰想做再做，今天已經很棒。', 'perfect', 4800);
     playSound('clear');
   }
 
@@ -676,6 +783,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     overlay.classList.remove('is-visible');
     window.setTimeout(() => {
       overlay.hidden = true;
+      document.querySelector('[data-game-tab="growth"]')?.click();
       document.querySelector('.ability-garden')?.scrollIntoView({ behavior: reducedMotion.matches ? 'auto' : 'smooth', block: 'start' });
     }, reducedMotion.matches ? 0 : 260);
   }
@@ -711,20 +819,36 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     else portrait.addEventListener('load', () => drawPixelArt(portrait, canvas), { once: true });
   }
 
-  function createMissionCard(task, index, completed) {
+  function createMissionCard(task, index, taskState) {
     const taskAbilities = task.abilityIds.map((abilityId) => abilities[abilityId]);
     const primaryAbility = taskAbilities[0];
     const abilityRewardHtml = taskAbilities
       .map((ability) => `<i>${ability.icon} ${ability.name} ＋1</i>`)
       .join('');
     const abilityNames = taskAbilities.map((ability) => ability.name).join('、');
+    const status = taskState.status || 'available';
+    const action = status === 'available' ? 'start' : status === 'in-progress' ? 'report' : status;
+    const buttonCopy = status === 'available'
+      ? '接下這個任務'
+      : status === 'in-progress'
+        ? '我回來了，準備回報'
+        : status === 'pending'
+          ? '報告已送到家長基地'
+          : '家長已看見我的努力';
+    const statusCopy = status === 'available'
+      ? '可以接取'
+      : status === 'in-progress'
+        ? '任務進行中'
+        : status === 'pending'
+          ? '等待家長確認'
+          : '已獲得確認';
     const card = document.createElement('article');
-    card.className = `mission-card mission-card--${primaryAbility.id} mission-card--order-${index + 1}${completed ? ' is-completed' : ''}`;
+    card.className = `mission-card mission-card--${primaryAbility.id} mission-card--order-${index + 1} is-${status}${status === 'confirmed' ? ' is-completed' : ''}`;
     card.dataset.taskId = task.id;
     card.innerHTML = `
       <div class="mission-card__topline">
-        <span class="mission-card__number">任務 ${String(index + 1).padStart(2, '0')}</span>
-        <span class="difficulty-tag">${task.difficulty}</span>
+        <span class="mission-card__number">${task.kind === 'main' ? '主線' : '自由挑戰'} ${String(index + 1).padStart(2, '0')}</span>
+        <span class="mission-status-tag">${statusCopy}</span>
       </div>
       <div class="mission-card__illustration" aria-hidden="true">
         <span>${task.icon}</span><i></i><i></i><i></i>
@@ -736,21 +860,21 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <span aria-hidden="true">🧭</span> 偷看三步任務口訣 <i aria-hidden="true">＋</i>
       </button>
       <ol class="mission-guide" aria-hidden="true">${task.steps.map((step, stepIndex) => `<li><span>${stepIndex + 1}</span></li>`).join('')}</ol>
+      ${taskState.note ? `<p class="mission-next-step"><span>🧭</span><strong>最後一條線索：</strong></p>` : ''}
       <div class="mission-card__details"><span>⏱ ${task.estimatedMinutes}</span><span>🏷 ${task.skillTag}</span></div>
-      <div class="mission-card__reward"><span class="ability-reward-list">${abilityRewardHtml}</span><strong>★ ＋1</strong></div>
-      <button class="mission-complete" type="button" data-task-id="${task.id}" data-reward-preview="${taskAbilities.map((ability) => `${ability.name} +1`).join('、')}、任務星 +1">
-        <span class="mission-complete__ready">我完成了，蓋章！</span>
-        <span class="mission-complete__done">已回報</span>
+      <div class="mission-card__reward"><span class="ability-reward-list">${abilityRewardHtml}</span><strong>${task.kind === 'main' ? '★ 每日榮譽' : '◆ 基地收藏'}</strong></div>
+      <button class="mission-complete" type="button" data-action="${action}" data-task-id="${task.id}" ${status === 'pending' || status === 'confirmed' ? 'disabled' : ''}>
+        <span class="mission-complete__ready">${buttonCopy}</span>
       </button>
     `;
     card.querySelector('.mission-card__story').textContent = task.story;
     card.querySelector('h3').textContent = task.title;
     card.querySelector('.mission-card__description').textContent = task.description;
     card.querySelectorAll('.mission-guide li').forEach((item, stepIndex) => item.append(task.steps[stepIndex]));
+    if (taskState.note) card.querySelector('.mission-next-step').append(taskState.note);
     const button = card.querySelector('.mission-complete');
-    button.setAttribute('aria-label', completed ? `已回報：${task.title}` : `完成：${task.title}`);
-    button.disabled = completed;
-    card.querySelector('.mission-card__reward').setAttribute('aria-label', `獎勵：1 顆任務星；${abilityNames}各加 1 顆能力星`);
+    button.setAttribute('aria-label', `${buttonCopy}：${task.title}`);
+    card.querySelector('.mission-card__reward').setAttribute('aria-label', `家長確認後：${abilityNames}能力今天尚未成長時各加一格；${task.kind === 'main' ? '主線里程碑可獲榮譽星' : '自由挑戰增加基地收藏'}`);
     return card;
   }
 
@@ -773,9 +897,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
           <p>${ability.description}</p>
           <div class="ability-stage-stars" aria-label="${growth.grade}，本階段 ${growth.stageStars} 顆星">${stagePips}</div>
           <progress class="ability-card__meter" max="100" value="${growth.progress}" aria-label="${ability.name}成長進度">${growth.progress}%</progress>
-          <small>${growth.stars} / 21 顆能力星 · ${growth.nextGrade ? `下一顆升到 ${growth.nextGrade}` : '已達 S＋'}</small>
+          <small>${growth.stars} / 21 格成長 · ${growth.nextGrade ? `下一格是 ${growth.nextGrade}` : '已達閃耀 3'}</small>
           <button class="ability-inspect" type="button" aria-expanded="false" data-action="toggle-ability">
-            展開 F−～S＋成長軌道 <span aria-hidden="true">⌄</span>
+            展開完整成長軌道 <span aria-hidden="true">⌄</span>
           </button>
           <div class="ability-ladder" aria-hidden="true">${abilityLadderHtml(growth.stars)}</div>
         </div>
@@ -800,6 +924,26 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       return card;
     });
     grid.replaceChildren(...cards);
+  }
+
+  function renderBase(profile) {
+    const profileState = state[profile.id];
+    const collectionCount = profileState.collections;
+    const mainCount = confirmedTasks(profile).filter((task) => task.kind === 'main').length;
+    document.querySelector('#base-collection-count').textContent = String(collectionCount);
+    document.querySelectorAll('[data-main-light]').forEach((star, index) => {
+      star.classList.toggle('is-lit', index < mainCount);
+    });
+    document.querySelectorAll('[data-base-piece]').forEach((piece, index) => {
+      piece.classList.toggle('is-built', index < collectionCount);
+    });
+    const nextPiece = document.querySelector('#base-next-piece');
+    nextPiece.textContent = collectionCount >= 6
+      ? '六件基地收藏都已到位！之後的自由挑戰仍會記在收藏總數裡。'
+      : collectionCount === 0
+        ? '完成一個自由挑戰，就能放進第一件基地收藏。'
+        : `再完成一個自由挑戰，解鎖第 ${collectionCount + 1} 件基地收藏。`;
+    document.querySelector('#base-scene').setAttribute('aria-label', `今天點亮 ${mainCount} / 3 顆營火星，累積 ${collectionCount} 份基地收藏`);
   }
 
   function renderRankTrail(stars) {
@@ -831,22 +975,37 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     });
   }
 
-  function showMissionWin(task, starsBefore, starsAfter) {
+  function showMissionWin(task, starsBefore, starsAfter, grownAbilityIds, starAwarded, praise) {
     const panel = document.querySelector('#mission-win');
     document.querySelector('#mission-win-icon').textContent = task.icon;
     document.querySelector('#mission-win-title').textContent = task.title;
     const rewards = document.querySelector('#mission-win-rewards');
-    rewards.replaceChildren(...task.abilityIds.map((abilityId) => {
+    rewards.replaceChildren(...rewardAbilityIds(grownAbilityIds, task).map((abilityId) => {
       const chip = document.createElement('span');
-      chip.textContent = `${abilities[abilityId].icon} ${abilities[abilityId].name} ＋1`;
+      chip.textContent = grownAbilityIds.includes(abilityId)
+        ? `${abilities[abilityId].icon} ${abilities[abilityId].name}成長 1 格`
+        : `${abilities[abilityId].icon} ${abilities[abilityId].name}今天已成長`;
       return chip;
     }));
     document.querySelector('#mission-win-stars-before').textContent = String(starsBefore);
     document.querySelector('#mission-win-stars-after').textContent = `${starsAfter} ★`;
+    const counter = document.querySelector('.mission-win__counter');
+    counter.hidden = starAwarded === 0;
+    counter.setAttribute('aria-label', starAwarded ? `榮譽星增加 ${starAwarded} 顆` : '這次沒有增加榮譽星');
+    document.querySelector('#mission-win-praise').textContent = praise;
+    document.querySelector('#mission-win-star-note').textContent = starAwarded
+      ? `★ ＋${starAwarded} 榮譽星已收進星星袋`
+      : task.kind === 'free'
+        ? '◆ 自由挑戰已變成基地收藏'
+        : '今天的能力成長已留下紀錄';
     window.clearTimeout(missionWinTimer);
     panel.classList.remove('is-visible');
     requestAnimationFrame(() => panel.classList.add('is-visible'));
     missionWinTimer = window.setTimeout(() => panel.classList.remove('is-visible'), reducedMotion.matches ? 900 : 2200);
+  }
+
+  function rewardAbilityIds(grownAbilityIds, task) {
+    return [...new Set([...grownAbilityIds, ...task.abilityIds])];
   }
 
   function replayClass(element, className, duration = 900) {
@@ -917,6 +1076,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     const previousThreshold = rank.current.stars;
     const nextThreshold = rank.next?.stars ?? previousThreshold;
     const progress = rank.next ? ((stars - previousThreshold) / (nextThreshold - previousThreshold)) * 100 : 100;
+    const confirmed = confirmedTasks(profile);
 
     const profileChanged = profileId !== activeProfileId;
     activeProfileId = profileId;
@@ -938,14 +1098,14 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     document.querySelector('#hud-player').textContent = profile.shortName.toUpperCase();
     document.querySelector('#hud-level').textContent = String(rank.current.level).padStart(2, '0');
     document.querySelector('#hud-stars').textContent = String(stars).padStart(3, '0');
-    document.querySelector('#hud-quests').textContent = `${profileState.completed.length}/${profile.tasks.length}`;
+    document.querySelector('#hud-quests').textContent = `${confirmed.length}/${profile.tasks.length}`;
     document.querySelector('#next-rank').textContent = rank.next ? `下一站：${rank.next.name}` : '最高階達成！';
     document.querySelector('#next-rank-note').textContent = rank.next
       ? `再收集 ${rank.next.stars - stars} 顆星星`
       : '繼續收集生活裡的美好成就';
     document.querySelector('#rank-progress-bar').value = Math.max(0, Math.min(100, progress));
-    renderMiniStarTrail(stars, Boolean(options.justCompletedTaskId));
-    document.querySelector('#completed-count').textContent = String(profileState.completed.length);
+    renderMiniStarTrail(stars, Boolean(options.starAwarded));
+    document.querySelector('#completed-count').textContent = String(confirmed.length);
     document.querySelector('.mission-count > span').textContent = ` / ${profile.tasks.length}`;
     updateQuestChain(profile);
 
@@ -956,15 +1116,17 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     });
 
     missionList.replaceChildren(...profile.tasks.map((task, index) => (
-      createMissionCard(task, index, profileState.completed.includes(task.id))
+      createMissionCard(task, index, getTaskState(profile.id, task.id))
     )));
     missionList.querySelectorAll('.mission-card').forEach((card, index) => {
       card.classList.add('is-entering');
       window.setTimeout(() => card.classList.remove('is-entering'), 760 + index * 80);
     });
     renderAbilityGarden(profile);
+    renderBase(profile);
     renderBadges(stars);
     renderRankTrail(stars);
+    updateParentPendingCount();
 
     if (options.justCompletedTaskId) {
       const completedCard = missionList.querySelector(`[data-task-id="${options.justCompletedTaskId}"]`);
@@ -978,84 +1140,239 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     }
   }
 
-  function completeMission(taskId, sourceButton) {
+  function openOverlay(selector, focusSelector) {
+    const overlay = document.querySelector(selector);
+    overlay.hidden = false;
+    requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+      overlay.querySelector(focusSelector)?.focus({ preventScroll: true });
+    });
+  }
+
+  function closeOverlay(selector) {
+    const overlay = document.querySelector(selector);
+    overlay.classList.remove('is-visible');
+    window.setTimeout(() => { overlay.hidden = true; }, reducedMotion.matches ? 0 : 220);
+  }
+
+  function updateParentPendingCount() {
+    const count = pendingTasks().length;
+    const badge = document.querySelector('#parent-pending-count');
+    badge.textContent = String(count);
+    badge.hidden = count === 0;
+    document.querySelector('#parent-base-toggle').classList.toggle('has-pending', count > 0);
+  }
+
+  function renderParentQueue() {
+    const queue = document.querySelector('#parent-queue-list');
+    const items = pendingTasks();
+    const effortLabels = { solo: '孩子回報：自己完成', help: '孩子回報：有人幫忙', tried: '孩子回報：有點難，但有嘗試' };
+    const cards = items.map(({ profile, task, report }) => {
+      const card = document.createElement('article');
+      card.className = 'parent-review-card';
+      card.dataset.profileId = profile.id;
+      card.dataset.taskId = task.id;
+      card.innerHTML = `
+        <header><span aria-hidden="true">${task.icon}</span><div><small>${profile.shortName} · ${task.kind === 'main' ? '主線任務' : '自由挑戰'}</small><h3></h3></div></header>
+        <p class="parent-effort"></p>
+        <p class="parent-praise-preview"><strong>可以這樣說：</strong>「${profile.shortName} ${task.description.replace(/。$/, '')}，我有看見！」</p>
+        <div class="parent-review-actions">
+          <button type="button" data-parent-action="confirm">✓ 確認完成</button>
+          <button type="button" data-parent-action="together">🤝 這次一起完成</button>
+          <button type="button" data-parent-action="step">🧭 還差一小步</button>
+        </div>
+      `;
+      card.querySelector('h3').textContent = task.title;
+      card.querySelector('.parent-effort').textContent = effortLabels[report.effort] || '孩子已送出任務回報';
+      return card;
+    });
+    queue.replaceChildren(...cards);
+    document.querySelector('#parent-empty').hidden = items.length > 0;
+  }
+
+  function openParentBase() {
+    parentUnlocked = false;
+    document.querySelector('#parent-pin-panel').hidden = false;
+    document.querySelector('#parent-queue').hidden = true;
+    document.querySelector('#parent-pin-input').value = '';
+    document.querySelector('#parent-pin-error').textContent = '';
+    document.querySelector('#parent-pin-instruction').textContent = localStorage.getItem(PARENT_PIN_KEY)
+      ? '請輸入 4 位數家長密碼。'
+      : '第一次使用，請設定 4 位數家長密碼。之後只有家長能確認獎勵。';
+    openOverlay('#parent-base-overlay', '#parent-pin-input');
+  }
+
+  function submitParentPin() {
+    const input = document.querySelector('#parent-pin-input');
+    const value = input.value.trim();
+    const savedPin = localStorage.getItem(PARENT_PIN_KEY);
+    if (!/^\d{4}$/.test(value)) {
+      document.querySelector('#parent-pin-error').textContent = '請輸入完整 4 位數字。';
+      input.focus();
+      return;
+    }
+    if (savedPin && value !== savedPin) {
+      document.querySelector('#parent-pin-error').textContent = '密碼不正確，請再試一次。';
+      input.select();
+      return;
+    }
+    if (!savedPin) localStorage.setItem(PARENT_PIN_KEY, value);
+    parentUnlocked = true;
+    document.querySelector('#parent-pin-panel').hidden = true;
+    document.querySelector('#parent-queue').hidden = false;
+    renderParentQueue();
+    document.querySelector('#parent-lock').focus({ preventScroll: true });
+  }
+
+  function startMission(taskId) {
     const profile = profiles[activeProfileId];
-    const profileState = state[activeProfileId];
-    if (profileState.completed.includes(taskId)) return;
     const task = profile.tasks.find((item) => item.id === taskId);
+    if (!task || getTaskState(profile.id, taskId).status !== 'available') return;
+    state[profile.id].taskStates[taskId] = { status: 'in-progress' };
+    saveState();
+    renderProfile(profile.id);
+    showScoutReaction(`「${task.title}」已放進背包！完成後回來按「我回來了」。`, 'ready', 3600);
+    playSound('start');
+  }
+
+  function openMissionReport(taskId) {
+    const profile = profiles[activeProfileId];
+    const task = profile.tasks.find((item) => item.id === taskId);
+    if (!task || getTaskState(profile.id, taskId).status !== 'in-progress') return;
+    reportTaskId = taskId;
+    reportEffort = null;
+    document.querySelector('#mission-report-icon').textContent = task.icon;
+    document.querySelector('#mission-report-title').textContent = `回報：${task.title}`;
+    document.querySelector('#mission-report-copy').textContent = `${profile.shortName}，你是怎麼完成這次任務的呢？`;
+    document.querySelectorAll('[data-effort]').forEach((button) => {
+      button.classList.remove('is-selected');
+      button.setAttribute('aria-checked', 'false');
+    });
+    document.querySelector('#send-report').disabled = true;
+    openOverlay('#mission-report-overlay', '[data-effort]');
+  }
+
+  function sendMissionReport() {
+    if (!reportTaskId || !reportEffort) return;
+    const profile = profiles[activeProfileId];
+    const task = profile.tasks.find((item) => item.id === reportTaskId);
     if (!task) return;
+    state[profile.id].taskStates[task.id] = { status: 'pending', effort: reportEffort };
+    saveState();
+    closeOverlay('#mission-report-overlay');
+    renderProfile(profile.id);
+    showScoutReaction('任務報告飛到家長基地了！你的努力已經被保存。', 'happy', 4200);
+    const toast = document.querySelector('#mission-toast');
+    toast.textContent = '✉️ 報告送達！等待家長看見後，才會揭曉成長獎勵。';
+    toast.classList.add('is-visible');
+    window.clearTimeout(toastTimer);
+    toastTimer = window.setTimeout(() => toast.classList.remove('is-visible'), 3600);
+    playSound('open');
+    reportTaskId = null;
+    reportEffort = null;
+  }
+
+  function confirmMission(profileId, taskId, response, sourceButton) {
+    const profile = profiles[profileId];
+    const profileState = state[profileId];
+    const task = profile.tasks.find((item) => item.id === taskId);
+    const report = getTaskState(profileId, taskId);
+    if (!task || report.status !== 'pending') return;
 
     const previousStars = totalStars(profile);
     const previousRank = rankInfo(previousStars).current;
     const previousAbilityGrades = Object.fromEntries(task.abilityIds.map((abilityId) => {
-      const stars = profile.baseAbilityStars[abilityId] + (Number(profileState.abilityBonusStars[abilityId]) || 0);
-      return [abilityId, abilityGrowth(abilities[abilityId], stars).grade];
+      const starsValue = profile.baseAbilityStars[abilityId] + (Number(profileState.abilityBonusStars[abilityId]) || 0);
+      return [abilityId, abilityGrowth(abilities[abilityId], starsValue).grade];
     }));
     const sourceRect = sourceButton?.getBoundingClientRect();
-    const rewardOrigin = sourceRect ? {
-      x: sourceRect.left + sourceRect.width / 2,
-      y: sourceRect.top + sourceRect.height / 2,
-    } : null;
+    const rewardOrigin = sourceRect ? { x: sourceRect.left + sourceRect.width / 2, y: sourceRect.top + sourceRect.height / 2 } : null;
 
-    profileState.completed.push(taskId);
-    profileState.earnedStars += 1;
-    for (const abilityId of task.abilityIds) {
+    profileState.taskStates[taskId] = { ...report, status: 'confirmed', response };
+    const grownAbilityIds = task.abilityIds.filter((abilityId) => !profileState.abilityGrownToday.includes(abilityId));
+    for (const abilityId of grownAbilityIds) {
       profileState.abilityBonusStars[abilityId] = (Number(profileState.abilityBonusStars[abilityId]) || 0) + 1;
+      profileState.abilityGrownToday.push(abilityId);
+    }
+
+    let starAwarded = 0;
+    if (task.kind === 'main') {
+      const mainCount = confirmedTasks(profile).filter((item) => item.kind === 'main').length;
+      if (mainCount >= 1 && !profileState.honorMilestones.includes('first-main')) {
+        profileState.honorMilestones.push('first-main');
+        starAwarded += 1;
+      }
+      if (mainCount === 3 && !profileState.honorMilestones.includes('all-main')) {
+        profileState.honorMilestones.push('all-main');
+        starAwarded += 1;
+      }
+      profileState.earnedStars += starAwarded;
+    } else {
+      profileState.collections += 1;
     }
     saveState();
+    parentUnlocked = false;
+    closeOverlay('#parent-base-overlay');
+    activeProfileId = profileId;
+    renderProfile(profileId, { justCompletedTaskId: taskId, grownAbilityIds, starAwarded });
+
+    const newStars = totalStars(profile);
+    const newRank = rankInfo(newStars).current;
+    const effortText = report.effort === 'solo' ? '自己完成了' : report.effort === 'help' ? '願意接受幫忙完成' : '覺得困難仍然試了一步';
+    const praise = `${profile.shortName} ${effortText}「${task.title}」！`;
     page.classList.remove('is-pixel-hit');
     void page.offsetWidth;
     page.classList.add('is-pixel-hit');
     window.setTimeout(() => page.classList.remove('is-pixel-hit'), reducedMotion.matches ? 0 : 520);
-    renderProfile(activeProfileId, {
-      justCompletedTaskId: taskId,
-      grownAbilityIds: task.abilityIds,
-    });
-
-    const newRank = rankInfo(totalStars(profile)).current;
-    const newStars = totalStars(profile);
     const starWallet = document.querySelector('.star-wallet');
-    flyReward(rewardOrigin, starWallet, '★', 'reward-particle--star');
-    task.abilityIds.forEach((abilityId, index) => {
+    if (starAwarded) flyReward(rewardOrigin, starWallet, '★', 'reward-particle--star');
+    grownAbilityIds.forEach((abilityId, index) => {
       const target = document.querySelector(`[data-testid="ability-${abilityId}"] .ability-card__icon`);
       flyReward(rewardOrigin, target, abilities[abilityId].icon, 'reward-particle--ability', 110 + index * 140);
       window.setTimeout(() => replayClass(target, 'is-sparkling', 780), 760 + index * 130);
     });
-    window.setTimeout(() => replayClass(starWallet, 'is-rewarded', 1050), 680);
+    if (starAwarded) window.setTimeout(() => replayClass(starWallet, 'is-rewarded', 1050), 680);
     replayClass(document.querySelector('.mission-count'), 'is-rewarded', 850);
-    showMissionWin(task, previousStars, newStars);
-    const combo = document.querySelector('#pixel-combo');
-    combo.querySelector('strong').textContent = `×${profileState.completed.length}`;
-    replayClass(combo, 'is-visible', 1500);
     replayClass(document.querySelector('#quest-chain-hud'), 'is-pulsing', 1000);
     replayClass(document.querySelector('.scout-story-card'), 'is-cheering', 1500);
-    showScoutReaction(`太棒了！「${task.title}」完成，星星和能力都變強了！`, 'cheer', 4200);
-    task.abilityIds.forEach((abilityId, index) => {
+    showMissionWin(task, previousStars, newStars, grownAbilityIds, starAwarded, praise);
+    showScoutReaction(`${praise} 家長看見你的努力了。`, 'cheer', 4400);
+    grownAbilityIds.forEach((abilityId, index) => {
       const abilityStars = profile.baseAbilityStars[abilityId] + (Number(profileState.abilityBonusStars[abilityId]) || 0);
-      const nextGrade = abilityGrowth(abilities[abilityId], abilityStars).grade;
-      showAbilityLevelUp(abilityId, previousAbilityGrades[abilityId], nextGrade, 900 + index * 1250);
+      showAbilityLevelUp(abilityId, previousAbilityGrades[abilityId], abilityGrowth(abilities[abilityId], abilityStars).grade, 900 + index * 1250);
     });
     playSound(newRank.level > previousRank.level ? 'rank' : 'complete');
     if (typeof navigator.vibrate === 'function') navigator.vibrate(newRank.level > previousRank.level ? [35, 45, 80] : 35);
-
-    const toast = document.querySelector('#mission-toast');
-    const abilityNames = task.abilityIds.map((abilityId) => abilities[abilityId].name).join('、');
-    toast.textContent = `任務完成回報！${profile.shortName} 得到 1 顆任務星，${abilityNames}各得到 1 顆能力星！`;
-    toast.classList.add('is-visible');
     page.classList.remove('is-celebrating');
     requestAnimationFrame(() => page.classList.add('is-celebrating'));
-    window.clearTimeout(toastTimer);
     window.clearTimeout(celebrationTimer);
-    toastTimer = window.setTimeout(() => toast.classList.remove('is-visible'), 3600);
     celebrationTimer = window.setTimeout(() => page.classList.remove('is-celebrating'), 1500);
 
     if (newRank.level > previousRank.level) {
       window.setTimeout(() => showRankUp(profile, newRank), reducedMotion.matches ? 0 : 900);
     }
-    if (profileState.completed.length === profile.tasks.length) {
+    const mainCount = confirmedTasks(profile).filter((item) => item.kind === 'main').length;
+    if (mainCount === 3 && starAwarded > 0) {
       if (newRank.level > previousRank.level) pendingDailyClearProfileId = profile.id;
       else window.setTimeout(() => showDailyClear(profile), reducedMotion.matches ? 100 : 2400);
     }
+  }
+
+  function returnForOneStep(profileId, taskId) {
+    const profile = profiles[profileId];
+    const task = profile.tasks.find((item) => item.id === taskId);
+    const report = getTaskState(profileId, taskId);
+    if (!task || report.status !== 'pending') return;
+    state[profileId].taskStates[taskId] = {
+      status: 'in-progress',
+      effort: report.effort,
+      note: `再完成這一步：${task.steps[2]}`,
+    };
+    saveState();
+    parentUnlocked = false;
+    closeOverlay('#parent-base-overlay');
+    renderProfile(profileId);
+    showScoutReaction('家長找到最後一條線索了！完成這一小步，就可以再送一次報告。', 'hint', 4600);
   }
 
   tabs.forEach((tab) => tab.addEventListener('click', () => {
@@ -1073,6 +1390,19 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     }, reducedMotion.matches ? 0 : 360);
     window.setTimeout(() => warp.classList.remove('is-visible'), reducedMotion.matches ? 150 : 920);
   });
+  document.querySelectorAll('[data-game-tab]').forEach((tab) => tab.addEventListener('click', () => {
+    const target = tab.dataset.gameTab;
+    document.querySelectorAll('[data-game-tab]').forEach((item) => {
+      const selected = item === tab;
+      item.classList.toggle('is-active', selected);
+      item.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+    document.querySelectorAll('[data-game-panel]').forEach((panel) => {
+      panel.hidden = panel.dataset.gamePanel !== target;
+    });
+    playSound('switch');
+    showScoutReaction(target === 'missions' ? '今天想先接哪個任務？' : target === 'growth' ? '這裡記錄每一次真正的成長。' : '每個確認過的行動，都會讓基地慢慢改變。', 'hint');
+  }));
   missionList.addEventListener('click', (event) => {
     const guideButton = event.target.closest('[data-action="toggle-guide"]');
     if (guideButton) {
@@ -1087,7 +1417,47 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       return;
     }
     const button = event.target.closest('.mission-complete');
-    if (button?.dataset.taskId) completeMission(button.dataset.taskId, button);
+    if (!button?.dataset.taskId) return;
+    if (button.dataset.action === 'start') startMission(button.dataset.taskId);
+    if (button.dataset.action === 'report') openMissionReport(button.dataset.taskId);
+  });
+
+  document.querySelectorAll('[data-effort]').forEach((button) => button.addEventListener('click', () => {
+    reportEffort = button.dataset.effort;
+    document.querySelectorAll('[data-effort]').forEach((item) => {
+      const selected = item === button;
+      item.classList.toggle('is-selected', selected);
+      item.setAttribute('aria-checked', selected ? 'true' : 'false');
+    });
+    document.querySelector('#send-report').disabled = false;
+    playSound('switch');
+  }));
+  document.querySelector('#send-report').addEventListener('click', sendMissionReport);
+  document.querySelector('#mission-report-close').addEventListener('click', () => closeOverlay('#mission-report-overlay'));
+  document.querySelector('#mission-report-overlay').addEventListener('click', (event) => {
+    if (event.target.id === 'mission-report-overlay') closeOverlay('#mission-report-overlay');
+  });
+
+  document.querySelector('#parent-base-toggle').addEventListener('click', openParentBase);
+  document.querySelector('#parent-base-close').addEventListener('click', () => closeOverlay('#parent-base-overlay'));
+  document.querySelector('#parent-base-overlay').addEventListener('click', (event) => {
+    if (event.target.id === 'parent-base-overlay') closeOverlay('#parent-base-overlay');
+  });
+  document.querySelector('#parent-pin-submit').addEventListener('click', submitParentPin);
+  document.querySelector('#parent-pin-input').addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') submitParentPin();
+  });
+  document.querySelector('#parent-lock').addEventListener('click', () => {
+    parentUnlocked = false;
+    closeOverlay('#parent-base-overlay');
+  });
+  document.querySelector('#parent-queue-list').addEventListener('click', (event) => {
+    if (!parentUnlocked) return;
+    const button = event.target.closest('[data-parent-action]');
+    const card = button?.closest('.parent-review-card');
+    if (!button || !card) return;
+    if (button.dataset.parentAction === 'step') returnForOneStep(card.dataset.profileId, card.dataset.taskId);
+    else confirmMission(card.dataset.profileId, card.dataset.taskId, button.dataset.parentAction, button);
   });
 
   document.querySelector('#ability-grid').addEventListener('click', (event) => {
@@ -1097,7 +1467,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     const expanded = !card.classList.contains('is-expanded');
     card.classList.toggle('is-expanded', expanded);
     button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-    button.firstChild.textContent = expanded ? '收起成長軌道 ' : '展開 F−～S＋成長軌道 ';
+    button.firstChild.textContent = expanded ? '收起成長軌道 ' : '展開完整成長軌道 ';
     card.querySelector('.ability-ladder').setAttribute('aria-hidden', expanded ? 'false' : 'true');
     playSound('open');
     if (expanded) showScoutReaction(`${card.querySelector('h3').textContent}的成長軌道打開了！下一顆星就在前面。`, 'hint');
@@ -1164,7 +1534,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   });
   document.addEventListener('keydown', (event) => {
     if (event.key !== 'Escape') return;
-    if (!document.querySelector('#daily-clear-overlay').hidden) hideDailyClear();
+    if (!document.querySelector('#mission-report-overlay').hidden) closeOverlay('#mission-report-overlay');
+    else if (!document.querySelector('#parent-base-overlay').hidden) closeOverlay('#parent-base-overlay');
+    else if (!document.querySelector('#daily-clear-overlay').hidden) hideDailyClear();
     else if (!document.querySelector('#rank-up-overlay').hidden) hideRankUp();
   });
   document.querySelector('#daily-clear-close').addEventListener('click', hideDailyClear);

--- a/src/pages/family-missions.astro
+++ b/src/pages/family-missions.astro
@@ -61,6 +61,8 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   indexable={false}
 >
   <main class="family-missions" data-theme={initialProfile.theme} data-motion-ready="false">
+    <div class="pixel-scroll-meter" aria-hidden="true"><span id="pixel-scroll-meter"></span></div>
+    <div class="pixel-screen-grid" aria-hidden="true"></div>
     <div class="floating-sparkles" aria-hidden="true">
       <span>✦</span><span>●</span><span>✦</span><span>●</span><span>✦</span>
     </div>
@@ -84,14 +86,24 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <small>任務音效</small>
       </button>
       <div class="quest-hero__copy">
-        <p class="eyebrow">SUPERGALEN FAMILY QUEST</p>
+        <p class="eyebrow">SUPERGALEN FAMILY QUEST · 16-BIT EDITION</p>
         <h1>雙羽星光<br />任務所</h1>
         <p>任務不在螢幕裡，真正的冒險就在每天的生活裡。</p>
         <span class="date-sticker" id="today-label">今天的任務</span>
+        <div class="hero-command">
+          <button id="quest-start" type="button"><span aria-hidden="true">▶</span> 進入今日任務</button>
+          <small><i aria-hidden="true"></i> 5 QUESTS READY</small>
+        </div>
       </div>
       <div class="quest-hero__seal" aria-hidden="true">
-        <span>★</span>
-        <small>生活冒險<br />出發！</small>
+        <span>▶</span>
+        <small>PRESS<br />START</small>
+      </div>
+      <div class="pixel-hero-hud" aria-label="目前遊戲狀態">
+        <span>PLAYER <b id="hud-player">APPLE</b></span>
+        <span>LV <b id="hud-level">03</b></span>
+        <span>STAR <b id="hud-stars">039</b></span>
+        <span>QUEST <b id="hud-quests">0/5</b></span>
       </div>
     </header>
 
@@ -382,6 +394,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     </div>
 
     <div class="mission-toast" id="mission-toast" role="status" aria-live="polite"></div>
+    <div class="pixel-combo" id="pixel-combo" aria-hidden="true"><small>DAILY COMBO</small><strong>×1</strong></div>
+    <div class="pixel-hit-layer" id="pixel-hit-layer" aria-hidden="true"></div>
+    <div class="quest-warp" id="quest-warp" aria-hidden="true"><span>QUEST START!</span><small>今天也升級一小步</small></div>
     <div class="mission-win" id="mission-win" aria-hidden="true">
       <div class="mission-win__burst" aria-hidden="true"><span></span><span></span><span></span></div>
       <div class="mission-win__card">
@@ -526,6 +541,8 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       const now = audioContext.currentTime;
       const notes = kind === 'rank'
         ? [[523.25, 0], [659.25, 0.12], [783.99, 0.24], [1046.5, 0.4]]
+        : kind === 'start'
+          ? [[261.63, 0], [392, 0.08], [523.25, 0.18]]
         : kind === 'switch'
           ? [[392, 0], [523.25, 0.08]]
           : [[659.25, 0], [783.99, 0.1], [987.77, 0.22]];
@@ -769,6 +786,10 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     document.querySelector('#rank-level-label').textContent = `第 ${rank.current.level} / 50 階`;
     document.querySelector('#scout-rank').textContent = rank.current.name;
     document.querySelector('#star-count').textContent = String(stars);
+    document.querySelector('#hud-player').textContent = profile.shortName.toUpperCase();
+    document.querySelector('#hud-level').textContent = String(rank.current.level).padStart(2, '0');
+    document.querySelector('#hud-stars').textContent = String(stars).padStart(3, '0');
+    document.querySelector('#hud-quests').textContent = `${profileState.completed.length}/${profile.tasks.length}`;
     document.querySelector('#next-rank').textContent = rank.next ? `下一站：${rank.next.name}` : '最高階達成！';
     document.querySelector('#next-rank-note').textContent = rank.next
       ? `再收集 ${rank.next.stars - stars} 顆星星`
@@ -827,6 +848,10 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       profileState.abilityBonusStars[abilityId] = (Number(profileState.abilityBonusStars[abilityId]) || 0) + 1;
     }
     saveState();
+    page.classList.remove('is-pixel-hit');
+    void page.offsetWidth;
+    page.classList.add('is-pixel-hit');
+    window.setTimeout(() => page.classList.remove('is-pixel-hit'), reducedMotion.matches ? 0 : 520);
     renderProfile(activeProfileId, {
       justCompletedTaskId: taskId,
       grownAbilityIds: task.abilityIds,
@@ -843,6 +868,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     window.setTimeout(() => replayClass(starWallet, 'is-rewarded', 1050), 680);
     replayClass(document.querySelector('.mission-count'), 'is-rewarded', 850);
     showMissionWin(task);
+    const combo = document.querySelector('#pixel-combo');
+    combo.querySelector('strong').textContent = `×${profileState.completed.length}`;
+    replayClass(combo, 'is-visible', 1500);
     playSound(newRank.level > previousRank.level ? 'rank' : 'complete');
     if (typeof navigator.vibrate === 'function') navigator.vibrate(newRank.level > previousRank.level ? [35, 45, 80] : 35);
 
@@ -866,6 +894,16 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     renderProfile(tab.dataset.profile);
     playSound('switch');
   }));
+
+  document.querySelector('#quest-start').addEventListener('click', () => {
+    const warp = document.querySelector('#quest-warp');
+    playSound('start');
+    warp.classList.add('is-visible');
+    window.setTimeout(() => {
+      document.querySelector('.mission-board').scrollIntoView({ behavior: reducedMotion.matches ? 'auto' : 'smooth', block: 'start' });
+    }, reducedMotion.matches ? 0 : 360);
+    window.setTimeout(() => warp.classList.remove('is-visible'), reducedMotion.matches ? 150 : 920);
+  });
   missionList.addEventListener('click', (event) => {
     const guideButton = event.target.closest('[data-action="toggle-guide"]');
     if (guideButton) {
@@ -924,6 +962,28 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     }
   });
 
+  document.addEventListener('pointerdown', (event) => {
+    if (reducedMotion.matches || event.pointerType === 'touch' && event.isPrimary === false) return;
+    const layer = document.querySelector('#pixel-hit-layer');
+    const colors = ['#ffe45e', '#ff7897', '#6ee7b7', '#78b7ff'];
+    for (let index = 0; index < 6; index += 1) {
+      const pixel = document.createElement('i');
+      pixel.style.setProperty('--hit-x', `${event.clientX}px`);
+      pixel.style.setProperty('--hit-y', `${event.clientY}px`);
+      pixel.style.setProperty('--hit-dx', `${(index - 2.5) * 13}px`);
+      pixel.style.setProperty('--hit-dy', `${-18 - (index % 3) * 10}px`);
+      pixel.style.setProperty('--hit-color', colors[index % colors.length]);
+      layer.append(pixel);
+      pixel.addEventListener('animationend', () => pixel.remove(), { once: true });
+    }
+  });
+
+  function updateScrollMeter() {
+    const maxScroll = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+    document.querySelector('#pixel-scroll-meter').style.width = `${Math.min(100, (window.scrollY / maxScroll) * 100)}%`;
+  }
+  window.addEventListener('scroll', updateScrollMeter, { passive: true });
+
   document.querySelector('#rank-up-close').addEventListener('click', hideRankUp);
   document.querySelector('#rank-up-overlay').addEventListener('click', (event) => {
     if (event.target.id === 'rank-up-overlay') hideRankUp();
@@ -940,6 +1000,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
 
   page.dataset.motionReady = 'true';
   updateSoundButton();
+  updateScrollMeter();
   requestAnimationFrame(() => page.classList.add('is-ready'));
   renderProfile(activeProfileId);
 </script>

--- a/src/pages/family-missions.astro
+++ b/src/pages/family-missions.astro
@@ -76,6 +76,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         height="878"
         fetchpriority="high"
       />
+      <canvas class="quest-hero__pixel-art" id="hero-pixel-art" width="240" height="132" aria-hidden="true"></canvas>
       <div class="quest-hero__shade" aria-hidden="true"></div>
       <a class="home-link" href="/" aria-label="回到 SuperGalen's Dungeon 首頁">
         <span aria-hidden="true">←</span> 回到主站
@@ -148,6 +149,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
               width="900"
               height="900"
             />
+            <canvas class="scout-portrait-pixel" id="scout-portrait-pixel" width="112" height="112" aria-hidden="true"></canvas>
           </div>
           <span class="portrait-pin portrait-pin--top" aria-hidden="true">{initialProfile.symbol}</span>
           <span class="portrait-pin portrait-pin--bottom" aria-hidden="true">★</span>
@@ -570,6 +572,37 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     button.classList.toggle('is-muted', !effectsSoundOn);
   }
 
+  function drawPixelArt(image, canvas) {
+    if (!image?.complete || !image.naturalWidth || !canvas) return;
+    const context = canvas.getContext('2d');
+    if (!context) return;
+    const sourceRatio = image.naturalWidth / image.naturalHeight;
+    const targetRatio = canvas.width / canvas.height;
+    let sourceWidth = image.naturalWidth;
+    let sourceHeight = image.naturalHeight;
+    let sourceX = 0;
+    let sourceY = 0;
+    if (sourceRatio > targetRatio) {
+      sourceWidth = image.naturalHeight * targetRatio;
+      sourceX = (image.naturalWidth - sourceWidth) / 2;
+    } else {
+      sourceHeight = image.naturalWidth / targetRatio;
+      sourceY = (image.naturalHeight - sourceHeight) / 2;
+    }
+    context.imageSmoothingEnabled = false;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(image, sourceX, sourceY, sourceWidth, sourceHeight, 0, 0, canvas.width, canvas.height);
+    canvas.classList.add('is-rendered');
+  }
+
+  function refreshPortraitPixels() {
+    const portrait = document.querySelector('#scout-portrait');
+    const canvas = document.querySelector('#scout-portrait-pixel');
+    canvas.classList.remove('is-rendered');
+    if (portrait.complete) drawPixelArt(portrait, canvas);
+    else portrait.addEventListener('load', () => drawPixelArt(portrait, canvas), { once: true });
+  }
+
   function createMissionCard(task, index, completed) {
     const taskAbilities = task.abilityIds.map((abilityId) => abilities[abilityId]);
     const primaryAbility = taskAbilities[0];
@@ -777,6 +810,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     const portrait = document.querySelector('#scout-portrait');
     portrait.src = profile.portrait;
     portrait.alt = profile.portraitAlt;
+    refreshPortraitPixels();
     document.querySelector('.portrait-pin--top').textContent = profile.symbol;
     document.querySelector('#scout-name').textContent = profile.name;
     document.querySelector('#scout-call-sign').textContent = profile.callSign;
@@ -997,6 +1031,11 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     day: 'numeric',
     weekday: 'long',
   }).format(new Date());
+
+  const heroArt = document.querySelector('.quest-hero__art');
+  const heroCanvas = document.querySelector('#hero-pixel-art');
+  if (heroArt.complete) drawPixelArt(heroArt, heroCanvas);
+  else heroArt.addEventListener('load', () => drawPixelArt(heroArt, heroCanvas), { once: true });
 
   page.dataset.motionReady = 'true';
   updateSoundButton();

--- a/src/pages/family-missions.astro
+++ b/src/pages/family-missions.astro
@@ -153,6 +153,10 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
           </div>
           <span class="portrait-pin portrait-pin--top" aria-hidden="true">{initialProfile.symbol}</span>
           <span class="portrait-pin portrait-pin--bottom" aria-hidden="true">★</span>
+          <div class="scout-reaction is-visible" id="scout-reaction" role="status" aria-live="polite">
+            <span id="scout-reaction-text">Apple 已經準備好出發了！</span>
+            <i aria-hidden="true"></i>
+          </div>
         </div>
 
         <div class="scout-story-card__copy">
@@ -397,6 +401,21 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
 
     <div class="mission-toast" id="mission-toast" role="status" aria-live="polite"></div>
     <div class="pixel-combo" id="pixel-combo" aria-hidden="true"><small>DAILY COMBO</small><strong>×1</strong></div>
+    <aside class="quest-chain-hud" id="quest-chain-hud" aria-label="今日任務連擊進度">
+      <div class="quest-chain-hud__title">
+        <span>QUEST CHAIN</span>
+        <strong id="quest-chain-count">0 / 5</strong>
+      </div>
+      <div class="quest-chain-track" id="quest-chain-track" aria-hidden="true">
+        {initialProfile.tasks.map((_, index) => <i data-chain-step={index + 1}>★</i>)}
+      </div>
+      <small id="quest-chain-message">完成第一個任務，點亮連擊！</small>
+    </aside>
+    <div class="ability-level-up" id="ability-level-up" aria-hidden="true">
+      <small>ABILITY UP!</small>
+      <span id="ability-level-up-icon">🎒</span>
+      <div><strong id="ability-level-up-name">責任成長</strong><b id="ability-level-up-grade">F → F＋</b></div>
+    </div>
     <div class="pixel-hit-layer" id="pixel-hit-layer" aria-hidden="true"></div>
     <div class="quest-warp" id="quest-warp" aria-hidden="true"><span>QUEST START!</span><small>今天也升級一小步</small></div>
     <div class="mission-win" id="mission-win" aria-hidden="true">
@@ -406,6 +425,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <span class="mission-win__icon" id="mission-win-icon" aria-hidden="true">★</span>
         <strong id="mission-win-title">任務完成</strong>
         <div id="mission-win-rewards"></div>
+        <div class="mission-win__counter" aria-label="任務星增加一顆">
+          <span id="mission-win-stars-before">39</span><i aria-hidden="true">▶</i><strong id="mission-win-stars-after">40 ★</strong>
+        </div>
         <p><b>★ ＋1</b> 任務星已收進星星袋</p>
       </div>
     </div>
@@ -430,6 +452,17 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
         <button id="rank-up-close" type="button" aria-label="收下新軍階">收下新軍階，繼續出發！</button>
       </div>
     </div>
+    <div class="daily-clear-overlay" id="daily-clear-overlay" role="dialog" aria-modal="true" aria-label="今日任務全破" hidden>
+      <div class="daily-clear-rays" aria-hidden="true"></div>
+      <div class="daily-clear-card">
+        <p>ALL QUESTS CLEAR!</p>
+        <div class="daily-clear-chest" aria-hidden="true"><span>★</span></div>
+        <strong id="daily-clear-name">Apple 今日全破！</strong>
+        <div class="daily-clear-stars" aria-hidden="true"><i>★</i><i>★</i><i>★</i><i>★</i><i>★</i></div>
+        <span>五個生活任務全部完成<br />今天的努力已經收進冒險紀錄！</span>
+        <button id="daily-clear-close" type="button">查看今天成長的能力</button>
+      </div>
+    </div>
   </main>
 </BaseLayout>
 
@@ -443,6 +476,9 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
   let toastTimer;
   let celebrationTimer;
   let missionWinTimer;
+  let reactionTimer;
+  let abilityLevelTimer;
+  let pendingDailyClearProfileId = null;
   let effectsSoundOn = localStorage.getItem('supergalen-family-sound') !== 'off';
   let audioContext;
 
@@ -541,17 +577,21 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     try {
       audioContext ||= new (window.AudioContext || window.webkitAudioContext)();
       const now = audioContext.currentTime;
-      const notes = kind === 'rank'
-        ? [[523.25, 0], [659.25, 0.12], [783.99, 0.24], [1046.5, 0.4]]
+      const notes = kind === 'clear'
+        ? [[392, 0], [523.25, 0.1], [659.25, 0.2], [783.99, 0.31], [1046.5, 0.48]]
+        : kind === 'rank'
+          ? [[523.25, 0], [659.25, 0.12], [783.99, 0.24], [1046.5, 0.4]]
         : kind === 'start'
           ? [[261.63, 0], [392, 0.08], [523.25, 0.18]]
+        : kind === 'open'
+          ? [[330, 0], [440, 0.07]]
         : kind === 'switch'
           ? [[392, 0], [523.25, 0.08]]
           : [[659.25, 0], [783.99, 0.1], [987.77, 0.22]];
       notes.forEach(([frequency, delay], index) => {
         const oscillator = audioContext.createOscillator();
         const gain = audioContext.createGain();
-        oscillator.type = kind === 'rank' ? 'triangle' : 'sine';
+        oscillator.type = kind === 'rank' || kind === 'clear' ? 'triangle' : kind === 'open' ? 'square' : 'sine';
         oscillator.frequency.setValueAtTime(frequency, now + delay);
         gain.gain.setValueAtTime(0.0001, now + delay);
         gain.gain.exponentialRampToValueAtTime(index === notes.length - 1 ? 0.11 : 0.075, now + delay + 0.025);
@@ -570,6 +610,74 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     button.setAttribute('aria-pressed', effectsSoundOn ? 'true' : 'false');
     button.setAttribute('aria-label', effectsSoundOn ? '關閉任務音效' : '開啟任務音效');
     button.classList.toggle('is-muted', !effectsSoundOn);
+  }
+
+  function showScoutReaction(message, mood = 'happy', duration = 2800) {
+    const reaction = document.querySelector('#scout-reaction');
+    const text = document.querySelector('#scout-reaction-text');
+    window.clearTimeout(reactionTimer);
+    text.textContent = message;
+    reaction.dataset.mood = mood;
+    reaction.classList.remove('is-visible');
+    void reaction.offsetWidth;
+    reaction.classList.add('is-visible');
+    reactionTimer = window.setTimeout(() => reaction.classList.remove('is-visible'), reducedMotion.matches ? 1400 : duration);
+  }
+
+  function updateQuestChain(profile) {
+    const completed = state[profile.id].completed;
+    const hud = document.querySelector('#quest-chain-hud');
+    const count = completed.length;
+    document.querySelector('#quest-chain-count').textContent = `${count} / ${profile.tasks.length}`;
+    document.querySelector('#quest-chain-message').textContent = count === profile.tasks.length
+      ? 'PERFECT！今天的任務全部完成！'
+      : count === 0
+        ? '完成第一個任務，點亮連擊！'
+        : `連擊中！再完成 ${profile.tasks.length - count} 個任務就全破`;
+    document.querySelectorAll('[data-chain-step]').forEach((step, index) => {
+      step.classList.toggle('is-lit', index < count);
+      step.classList.toggle('is-current', index === count && count < profile.tasks.length);
+    });
+    hud.classList.toggle('is-perfect', count === profile.tasks.length);
+    hud.setAttribute('aria-label', `今日任務已完成 ${count} / ${profile.tasks.length}`);
+  }
+
+  function showAbilityLevelUp(abilityId, beforeGrade, afterGrade, delay = 0) {
+    if (beforeGrade === afterGrade || afterGrade === '尚未啟程') return;
+    window.setTimeout(() => {
+      const banner = document.querySelector('#ability-level-up');
+      const ability = abilities[abilityId];
+      window.clearTimeout(abilityLevelTimer);
+      document.querySelector('#ability-level-up-icon').textContent = ability.icon;
+      document.querySelector('#ability-level-up-name').textContent = `${ability.name}能力成長！`;
+      document.querySelector('#ability-level-up-grade').textContent = `${beforeGrade} ▶ ${afterGrade}`;
+      banner.classList.remove('is-visible');
+      void banner.offsetWidth;
+      banner.classList.add('is-visible');
+      abilityLevelTimer = window.setTimeout(() => banner.classList.remove('is-visible'), reducedMotion.matches ? 1100 : 2100);
+    }, delay);
+  }
+
+  function showDailyClear(profile) {
+    const overlay = document.querySelector('#daily-clear-overlay');
+    document.querySelector('#daily-clear-name').textContent = `${profile.shortName} 今日全破！`;
+    overlay.hidden = false;
+    requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+      document.querySelector('#daily-clear-close').focus({ preventScroll: true });
+    });
+    replayClass(document.querySelector('.scout-story-card'), 'is-cheering', 1800);
+    showScoutReaction('五個任務都完成了！今天是完美冒險日！', 'perfect', 4800);
+    playSound('clear');
+  }
+
+  function hideDailyClear() {
+    const overlay = document.querySelector('#daily-clear-overlay');
+    overlay.classList.remove('is-visible');
+    window.setTimeout(() => {
+      overlay.hidden = true;
+      document.querySelector('.ability-garden')?.scrollIntoView({ behavior: reducedMotion.matches ? 'auto' : 'smooth', block: 'start' });
+    }, reducedMotion.matches ? 0 : 260);
   }
 
   function drawPixelArt(image, canvas) {
@@ -723,7 +831,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     });
   }
 
-  function showMissionWin(task) {
+  function showMissionWin(task, starsBefore, starsAfter) {
     const panel = document.querySelector('#mission-win');
     document.querySelector('#mission-win-icon').textContent = task.icon;
     document.querySelector('#mission-win-title').textContent = task.title;
@@ -733,6 +841,8 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       chip.textContent = `${abilities[abilityId].icon} ${abilities[abilityId].name} ＋1`;
       return chip;
     }));
+    document.querySelector('#mission-win-stars-before').textContent = String(starsBefore);
+    document.querySelector('#mission-win-stars-after').textContent = `${starsAfter} ★`;
     window.clearTimeout(missionWinTimer);
     panel.classList.remove('is-visible');
     requestAnimationFrame(() => panel.classList.add('is-visible'));
@@ -791,6 +901,11 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       overlay.hidden = true;
       const activeTab = tabs.find((tab) => tab.dataset.profile === activeProfileId);
       activeTab?.focus({ preventScroll: true });
+      if (pendingDailyClearProfileId) {
+        const clearProfile = profiles[pendingDailyClearProfileId];
+        pendingDailyClearProfileId = null;
+        window.setTimeout(() => showDailyClear(clearProfile), 220);
+      }
     }, reducedMotion.matches ? 0 : 260);
   }
 
@@ -832,6 +947,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     renderMiniStarTrail(stars, Boolean(options.justCompletedTaskId));
     document.querySelector('#completed-count').textContent = String(profileState.completed.length);
     document.querySelector('.mission-count > span').textContent = ` / ${profile.tasks.length}`;
+    updateQuestChain(profile);
 
     tabs.forEach((tab) => {
       const selected = tab.dataset.profile === profileId;
@@ -869,7 +985,12 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     const task = profile.tasks.find((item) => item.id === taskId);
     if (!task) return;
 
-    const previousRank = rankInfo(totalStars(profile)).current;
+    const previousStars = totalStars(profile);
+    const previousRank = rankInfo(previousStars).current;
+    const previousAbilityGrades = Object.fromEntries(task.abilityIds.map((abilityId) => {
+      const stars = profile.baseAbilityStars[abilityId] + (Number(profileState.abilityBonusStars[abilityId]) || 0);
+      return [abilityId, abilityGrowth(abilities[abilityId], stars).grade];
+    }));
     const sourceRect = sourceButton?.getBoundingClientRect();
     const rewardOrigin = sourceRect ? {
       x: sourceRect.left + sourceRect.width / 2,
@@ -892,6 +1013,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     });
 
     const newRank = rankInfo(totalStars(profile)).current;
+    const newStars = totalStars(profile);
     const starWallet = document.querySelector('.star-wallet');
     flyReward(rewardOrigin, starWallet, '★', 'reward-particle--star');
     task.abilityIds.forEach((abilityId, index) => {
@@ -901,10 +1023,18 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     });
     window.setTimeout(() => replayClass(starWallet, 'is-rewarded', 1050), 680);
     replayClass(document.querySelector('.mission-count'), 'is-rewarded', 850);
-    showMissionWin(task);
+    showMissionWin(task, previousStars, newStars);
     const combo = document.querySelector('#pixel-combo');
     combo.querySelector('strong').textContent = `×${profileState.completed.length}`;
     replayClass(combo, 'is-visible', 1500);
+    replayClass(document.querySelector('#quest-chain-hud'), 'is-pulsing', 1000);
+    replayClass(document.querySelector('.scout-story-card'), 'is-cheering', 1500);
+    showScoutReaction(`太棒了！「${task.title}」完成，星星和能力都變強了！`, 'cheer', 4200);
+    task.abilityIds.forEach((abilityId, index) => {
+      const abilityStars = profile.baseAbilityStars[abilityId] + (Number(profileState.abilityBonusStars[abilityId]) || 0);
+      const nextGrade = abilityGrowth(abilities[abilityId], abilityStars).grade;
+      showAbilityLevelUp(abilityId, previousAbilityGrades[abilityId], nextGrade, 900 + index * 1250);
+    });
     playSound(newRank.level > previousRank.level ? 'rank' : 'complete');
     if (typeof navigator.vibrate === 'function') navigator.vibrate(newRank.level > previousRank.level ? [35, 45, 80] : 35);
 
@@ -922,11 +1052,16 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     if (newRank.level > previousRank.level) {
       window.setTimeout(() => showRankUp(profile, newRank), reducedMotion.matches ? 0 : 900);
     }
+    if (profileState.completed.length === profile.tasks.length) {
+      if (newRank.level > previousRank.level) pendingDailyClearProfileId = profile.id;
+      else window.setTimeout(() => showDailyClear(profile), reducedMotion.matches ? 100 : 2400);
+    }
   }
 
   tabs.forEach((tab) => tab.addEventListener('click', () => {
     renderProfile(tab.dataset.profile);
     playSound('switch');
+    showScoutReaction(`${profiles[tab.dataset.profile].shortName} 出發！今天想先挑哪一張任務卡？`, 'ready');
   }));
 
   document.querySelector('#quest-start').addEventListener('click', () => {
@@ -947,6 +1082,8 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
       guideButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
       card.querySelector('.mission-guide').setAttribute('aria-hidden', expanded ? 'false' : 'true');
       guideButton.querySelector('i').textContent = expanded ? '−' : '＋';
+      playSound('open');
+      if (expanded) showScoutReaction(`發現任務提示！照著 1、2、3 慢慢完成就可以了。`, 'hint');
       return;
     }
     const button = event.target.closest('.mission-complete');
@@ -962,6 +1099,8 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     button.firstChild.textContent = expanded ? '收起成長軌道 ' : '展開 F−～S＋成長軌道 ';
     card.querySelector('.ability-ladder').setAttribute('aria-hidden', expanded ? 'false' : 'true');
+    playSound('open');
+    if (expanded) showScoutReaction(`${card.querySelector('h3').textContent}的成長軌道打開了！下一顆星就在前面。`, 'hint');
   });
 
   document.querySelector('#rank-trail').addEventListener('click', (event) => {
@@ -972,6 +1111,7 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     chapter.classList.toggle('is-open', expanded);
     button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     button.firstChild.textContent = expanded ? '收起地圖 ' : '展開地圖 ';
+    playSound('open');
   });
 
   document.querySelector('#sound-toggle').addEventListener('click', () => {
@@ -1023,7 +1163,13 @@ const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.c
     if (event.target.id === 'rank-up-overlay') hideRankUp();
   });
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && !document.querySelector('#rank-up-overlay').hidden) hideRankUp();
+    if (event.key !== 'Escape') return;
+    if (!document.querySelector('#daily-clear-overlay').hidden) hideDailyClear();
+    else if (!document.querySelector('#rank-up-overlay').hidden) hideRankUp();
+  });
+  document.querySelector('#daily-clear-close').addEventListener('click', hideDailyClear);
+  document.querySelector('#daily-clear-overlay').addEventListener('click', (event) => {
+    if (event.target.id === 'daily-clear-overlay') hideDailyClear();
   });
 
   document.querySelector('#today-label').textContent = new Intl.DateTimeFormat('zh-TW', {

--- a/src/pages/family-missions.astro
+++ b/src/pages/family-missions.astro
@@ -3,7 +3,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 import { defaultLang, type Language } from '@i18n/index';
 import {
   abilityCatalog,
+  abilityGrades,
   growthBadges,
+  rankChapters,
   rankSteps,
   scoutProfiles,
   type AbilityId,
@@ -14,16 +16,41 @@ const initialProfile = profiles.apple;
 const initialStars = initialProfile.startingStars;
 const abilityEntries = Object.values(abilityCatalog);
 
-function getAbilityGrowth(abilityId: AbilityId, xp: number) {
+function getRankInfo(stars: number) {
+  const reached = rankSteps.filter((rank) => stars >= rank.stars);
+  const current = reached.at(-1) ?? {
+    level: 0,
+    stars: 0,
+    name: '見習小兵',
+    symbol: '🪶',
+    gift: '再收集幾顆星，就能正式加入偵查隊',
+    chapterId: 'rookie-camp',
+  };
+  const next = rankSteps.find((rank) => stars < rank.stars) ?? null;
+  return { current, next };
+}
+
+function getAbilityGrowth(abilityId: AbilityId, abilityStars: number) {
   const ability = abilityCatalog[abilityId];
-  const level = Math.min(10, Math.floor(xp / 10) + 1);
-  const stageIndex = Math.min(ability.growthNames.length - 1, Math.floor((level - 1) / 3));
+  const stars = Math.max(0, Math.min(abilityGrades.length, abilityStars));
+  const grade = stars === 0 ? '尚未啟程' : abilityGrades[stars - 1];
+  const stageStars = stars === 0 ? 0 : ((stars - 1) % 3) + 1;
+  const growthIndex = Math.min(ability.growthNames.length - 1, Math.floor(stars / 6));
   return {
-    level,
-    progress: level === 10 ? 100 : (xp % 10) * 10,
-    growthName: ability.growthNames[stageIndex],
+    stars,
+    grade,
+    stageStars,
+    progress: Math.round((stars / abilityGrades.length) * 100),
+    nextGrade: stars >= abilityGrades.length ? null : abilityGrades[stars],
+    growthName: ability.growthNames[growthIndex],
   };
 }
+
+const initialRank = getRankInfo(initialStars);
+const initialRankProgress = initialRank.next
+  ? ((initialStars - initialRank.current.stars) / (initialRank.next.stars - initialRank.current.stars)) * 100
+  : 100;
+const initialStepStars = initialStars >= 500 ? 10 : initialStars - initialRank.current.stars;
 ---
 
 <BaseLayout
@@ -31,8 +58,9 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
   description="Apple 與 Amy 的圖文生活任務、能力花園與星光升階旅程"
   image="/assets/img/family-missions/family-missions-hero.webp"
   lang={lang}
+  indexable={false}
 >
-  <main class="family-missions" data-theme={initialProfile.theme}>
+  <main class="family-missions" data-theme={initialProfile.theme} data-motion-ready="false">
     <div class="floating-sparkles" aria-hidden="true">
       <span>✦</span><span>●</span><span>✦</span><span>●</span><span>✦</span>
     </div>
@@ -50,6 +78,11 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
       <a class="home-link" href="/" aria-label="回到 SuperGalen's Dungeon 首頁">
         <span aria-hidden="true">←</span> 回到主站
       </a>
+      <button class="sound-toggle" id="sound-toggle" type="button" aria-pressed="true" aria-label="關閉任務音效">
+        <span class="sound-toggle__on" aria-hidden="true">🔔</span>
+        <span class="sound-toggle__off" aria-hidden="true">🔕</span>
+        <small>任務音效</small>
+      </button>
       <div class="quest-hero__copy">
         <p class="eyebrow">SUPERGALEN FAMILY QUEST</p>
         <h1>雙羽星光<br />任務所</h1>
@@ -92,7 +125,7 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
         </nav>
       </section>
 
-      <section class="scout-story-card" aria-labelledby="scout-name">
+      <section class="scout-story-card" aria-labelledby="scout-name" aria-live="polite">
         <div class="scout-portrait-wrap">
           <div class="scout-portrait-frame">
             <img
@@ -115,10 +148,10 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
           <p class="scout-story" id="scout-story">{initialProfile.story}</p>
 
           <div class="rank-overview">
-            <div class="rank-medal" aria-hidden="true">🔎</div>
+            <div class="rank-medal" id="rank-medal" aria-hidden="true">{initialRank.current.symbol}</div>
             <div>
-              <span>目前軍階</span>
-              <strong id="scout-rank" data-testid="scout-rank">初級偵查兵</strong>
+              <span id="rank-level-label">第 {initialRank.current.level} / 50 階</span>
+              <strong id="scout-rank" data-testid="scout-rank">{initialRank.current.name}</strong>
             </div>
             <div class="star-wallet">
               <span aria-hidden="true">★</span>
@@ -129,10 +162,15 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
 
           <div class="rank-progress" aria-label="前往下一個軍階的進度">
             <div class="rank-progress__labels">
-              <strong id="next-rank">下一站：中級偵查兵</strong>
-              <span id="next-rank-note">再收集 70 顆星星</span>
+              <strong id="next-rank">下一站：{initialRank.next?.name}</strong>
+              <span id="next-rank-note">再收集 {(initialRank.next?.stars ?? 500) - initialStars} 顆星星</span>
             </div>
-            <progress class="rank-progress__track" id="rank-progress-bar" max="100" value="0">0%</progress>
+            <progress class="rank-progress__track" id="rank-progress-bar" max="100" value={initialRankProgress}>{initialRankProgress}%</progress>
+            <div class="mini-star-trail" id="mini-star-trail" aria-label={`本階已收集 ${initialStepStars} / 10 顆星`}>
+              {Array.from({ length: 10 }, (_, index) => (
+                <span class={index < initialStepStars ? 'is-lit' : ''} data-star-step={index + 1}>★</span>
+              ))}
+            </div>
           </div>
         </div>
       </section>
@@ -153,9 +191,10 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
 
         <div class="mission-list" id="mission-list">
           {initialProfile.tasks.map((task, index) => {
-            const ability = abilityCatalog[task.abilityId];
+            const taskAbilities = task.abilityIds.map((abilityId) => abilityCatalog[abilityId]);
+            const primaryAbility = taskAbilities[0];
             return (
-              <article class={`mission-card mission-card--${task.abilityId}`} data-task-id={task.id}>
+              <article class={`mission-card mission-card--${primaryAbility.id}`} data-task-id={task.id}>
                 <div class="mission-card__topline">
                   <span class="mission-card__number">任務 {String(index + 1).padStart(2, '0')}</span>
                   <span class="difficulty-tag">{task.difficulty}</span>
@@ -167,15 +206,29 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
                 <p class="mission-card__story">{task.story}</p>
                 <h3>{task.title}</h3>
                 <p class="mission-card__description">{task.description}</p>
+                <button class="mission-guide-toggle" type="button" aria-expanded="false" data-action="toggle-guide">
+                  <span aria-hidden="true">🧭</span> 偷看三步任務口訣 <i aria-hidden="true">＋</i>
+                </button>
+                <ol class="mission-guide" aria-hidden="true">
+                  {task.steps.map((step, stepIndex) => <li><span>{stepIndex + 1}</span>{step}</li>)}
+                </ol>
                 <div class="mission-card__details">
                   <span>⏱ {task.estimatedMinutes}</span>
                   <span>🏷 {task.skillTag}</span>
                 </div>
-                <div class="mission-card__reward" aria-label={`獎勵：${ability.name}能力與 ${task.rewardStars} 顆星星`}>
-                  <span>{ability.icon} {ability.name} ＋{task.abilityXp}</span>
-                  <strong>★ ＋{task.rewardStars}</strong>
+                <div class="mission-card__reward" aria-label={`獎勵：1 顆任務星；${taskAbilities.map((ability) => ability.name).join('、')}各加 1 顆能力星`}>
+                  <span class="ability-reward-list">
+                    {taskAbilities.map((ability) => <i>{ability.icon} {ability.name} ＋1</i>)}
+                  </span>
+                  <strong>★ ＋1</strong>
                 </div>
-                <button class="mission-complete" type="button" aria-label={`完成：${task.title}`} data-task-id={task.id}>
+                <button
+                  class="mission-complete"
+                  type="button"
+                  aria-label={`完成：${task.title}`}
+                  data-task-id={task.id}
+                  data-reward-preview={`${taskAbilities.map((ability) => `${ability.name} +1`).join('、')}、任務星 +1`}
+                >
                   <span class="mission-complete__ready">我完成了，蓋章！</span>
                   <span class="mission-complete__done">已回報</span>
                 </button>
@@ -191,27 +244,51 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
           <div>
             <p>MY GROWING GARDEN</p>
             <h2>我的能力花園</h2>
-            <span>不是分數，是每一次練習後長出來的小小力量。</span>
+            <span>每個任務可培養一項或多項能力；涉及的能力各長出一顆星。</span>
           </div>
+        </div>
+
+        <div class="ability-scale" aria-label="能力階級說明">
+          <div>
+            <strong>能力階級</strong>
+            <span>從 F 慢慢成長到 S</span>
+          </div>
+          <ol>
+            {['F', 'E', 'D', 'C', 'B', 'A', 'S'].map((letter) => <li>{letter}<small>−　　＋</small></li>)}
+          </ol>
+          <p><span aria-hidden="true">★</span> 一顆能力星前進一段：F− → F → F＋ → E− …… → S＋</p>
         </div>
 
         <div class="ability-grid" id="ability-grid">
           {abilityEntries.map((ability) => {
-            const xp = initialProfile.baseAbilityXp[ability.id];
-            const growth = getAbilityGrowth(ability.id, xp);
+            const growth = getAbilityGrowth(ability.id, initialProfile.baseAbilityStars[ability.id]);
             return (
               <article class={`ability-card ability-card--${ability.id}`} data-testid={`ability-${ability.id}`}>
                 <div class="ability-card__icon" aria-hidden="true">{ability.icon}</div>
                 <div class="ability-card__copy">
                   <div class="ability-card__title">
                     <h3>{ability.name}</h3>
-                    <span>Lv.{growth.level}</span>
+                    <span class="ability-grade">{growth.grade}</span>
                   </div>
                   <p>{ability.description}</p>
+                  <div class="ability-stage-stars" aria-label={`${growth.grade}，本階段 ${growth.stageStars} 顆星`}>
+                    {[1, 2, 3].map((star) => <span class={star <= growth.stageStars ? 'is-filled' : ''}>★</span>)}
+                  </div>
                   <progress class="ability-card__meter" max="100" value={growth.progress} aria-label={`${ability.name}成長進度`}>
                     {growth.progress}%
                   </progress>
-                  <small>現在是：{growth.growthName}</small>
+                  <small>{growth.stars} / 21 顆能力星 · {growth.nextGrade ? `下一顆升到 ${growth.nextGrade}` : '已達 S＋'}</small>
+                  <button class="ability-inspect" type="button" aria-expanded="false" data-action="toggle-ability">
+                    展開 F−～S＋成長軌道 <span aria-hidden="true">⌄</span>
+                  </button>
+                  <div class="ability-ladder" aria-hidden="true">
+                    {abilityGrades.map((grade, gradeIndex) => (
+                      <span
+                        class={`${gradeIndex < growth.stars ? 'is-earned' : ''}${gradeIndex === growth.stars - 1 ? ' is-current' : ''}`}
+                        title={`${grade}：第 ${gradeIndex + 1} 顆能力星`}
+                      >{grade}</span>
+                    ))}
+                  </div>
                 </div>
               </article>
             );
@@ -250,22 +327,52 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
           <span class="section-heading__icon" aria-hidden="true">✨</span>
           <div>
             <p>STARLIGHT JOURNEY</p>
-            <h2>星光升階旅程</h2>
-            <span>星星只會累積、不會扣除；每一階都代表多了一點獨立與成熟。</span>
+            <h2>500 星・50 階成長地圖</h2>
+            <span>每完成一個任務得到 1 顆星，每 10 顆星升 1 階；全程分成 10 個冒險章節。</span>
           </div>
         </div>
-        <ol class="rank-trail" id="rank-trail">
-          {rankSteps.map((rank) => (
-            <li class={initialStars >= rank.stars ? 'is-reached' : ''} data-rank-stars={rank.stars}>
-              <span class="rank-trail__symbol" aria-hidden="true">{rank.symbol}</span>
-              <div>
-                <small>{rank.stars} 星</small>
-                <h3>{rank.name}</h3>
-                <p>{rank.gift}</p>
-              </div>
-            </li>
-          ))}
-        </ol>
+        <div class="rank-map" id="rank-trail">
+          {rankChapters.map((chapter, chapterIndex) => {
+            const isCurrent = initialStars >= chapterIndex * 50
+              && (initialStars < chapter.endStars || (chapter.endStars === 500 && initialStars === 500));
+            return (
+              <article
+                class={`rank-chapter${isCurrent ? ' is-current is-open' : ''}${initialStars >= chapter.endStars ? ' is-complete' : ''}`}
+                data-rank-chapter={chapter.id}
+                data-start-stars={chapterIndex * 50}
+                data-end-stars={chapter.endStars}
+              >
+                <header class="rank-chapter__header">
+                  <span class="rank-chapter__number">冒險 {String(chapterIndex + 1).padStart(2, '0')}</span>
+                  <span class="rank-chapter__symbol" aria-hidden="true">{chapter.symbol}</span>
+                  <div>
+                    <h3>{chapter.name}</h3>
+                    <p>{chapter.subtitle}</p>
+                  </div>
+                  <strong>{chapter.startStars}–{chapter.endStars} ★</strong>
+                  <button
+                    class="rank-chapter__toggle"
+                    type="button"
+                    aria-expanded={isCurrent ? 'true' : 'false'}
+                    aria-label={`${isCurrent ? '收起' : '展開'}${chapter.name}的五個軍階`}
+                  >{isCurrent ? '收起地圖' : '展開地圖'} <span aria-hidden="true">⌄</span></button>
+                </header>
+                <ol class="rank-chapter__steps">
+                  {chapter.ranks.map((rank) => (
+                    <li class={initialStars >= rank.stars ? 'is-reached' : ''} data-rank-stars={rank.stars}>
+                      <span class="rank-step__dot">{rank.level}</span>
+                      <div>
+                        <small>{rank.stars} 星</small>
+                        <h4>{rank.name}</h4>
+                        <p>{rank.gift}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </article>
+            );
+          })}
+        </div>
       </section>
 
       <aside class="family-rule">
@@ -275,25 +382,60 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     </div>
 
     <div class="mission-toast" id="mission-toast" role="status" aria-live="polite"></div>
+    <div class="mission-win" id="mission-win" aria-hidden="true">
+      <div class="mission-win__burst" aria-hidden="true"><span></span><span></span><span></span></div>
+      <div class="mission-win__card">
+        <small>MISSION COMPLETE!</small>
+        <span class="mission-win__icon" id="mission-win-icon" aria-hidden="true">★</span>
+        <strong id="mission-win-title">任務完成</strong>
+        <div id="mission-win-rewards"></div>
+        <p><b>★ ＋1</b> 任務星已收進星星袋</p>
+      </div>
+    </div>
+    <div class="reward-flight-layer" id="reward-flight-layer" aria-hidden="true"></div>
     <div class="celebration" aria-hidden="true">
       <span>★</span><span>●</span><span>✦</span><span>●</span><span>★</span><span>✦</span>
+      <span>◆</span><span>★</span><span>●</span><span>✦</span><span>★</span><span>◆</span>
+    </div>
+
+    <div class="rank-up-overlay" id="rank-up-overlay" role="dialog" aria-modal="true" aria-label="升階成功" hidden>
+      <div class="rank-up-sky" aria-hidden="true"><span>☁</span><span>✦</span><span>☁</span></div>
+      <div class="rank-up-card">
+        <p class="rank-up-eyebrow">RANK UP!</p>
+        <span class="rank-up-level" id="rank-up-level">第 4 階</span>
+        <div class="rank-up-medal" id="rank-up-medal" aria-hidden="true">🌱</div>
+        <p class="rank-up-name" id="rank-up-scout-name">Apple</p>
+        <h2 id="rank-up-title">中級偵查兵</h2>
+        <div class="rank-up-unlock">
+          <span aria-hidden="true">🔓</span>
+          <div><small>新的獨立能力</small><strong id="rank-up-gift">能準備自己的小裝備</strong></div>
+        </div>
+        <button id="rank-up-close" type="button" aria-label="收下新軍階">收下新軍階，繼續出發！</button>
+      </div>
     </div>
   </main>
 </BaseLayout>
 
-<script define:vars={{ profiles, abilities: abilityCatalog, ranks: rankSteps, badges: growthBadges }}>
-  const STORAGE_KEY = 'supergalen-family-missions-v2';
-  const LEGACY_STORAGE_KEY = 'supergalen-family-missions-v1';
+<script define:vars={{ profiles, abilities: abilityCatalog, grades: abilityGrades, ranks: rankSteps, badges: growthBadges }}>
+  const STORAGE_KEY = 'supergalen-family-missions-v3';
+  const LEGACY_STORAGE_KEYS = ['supergalen-family-missions-v2', 'supergalen-family-missions-v1'];
+  const LEGACY_STARTING_STARS = { apple: 80, amy: 0 };
   const todayKey = new Date().toLocaleDateString('en-CA');
   let activeProfileId = 'apple';
   let state = loadState();
+  let toastTimer;
+  let celebrationTimer;
+  let missionWinTimer;
+  let effectsSoundOn = localStorage.getItem('supergalen-family-sound') !== 'off';
+  let audioContext;
 
   const page = document.querySelector('.family-missions');
   const missionList = document.querySelector('#mission-list');
   const tabs = Array.from(document.querySelectorAll('[data-profile]'));
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
   function blankProfileState() {
-    return { bonusStars: 0, abilityBonus: {}, dailyDate: todayKey, completed: [] };
+    return { earnedStars: 0, abilityBonusStars: {}, dailyDate: todayKey, completed: [] };
   }
 
   function loadState() {
@@ -301,16 +443,29 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
 
     try {
       const current = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
-      const legacy = JSON.parse(localStorage.getItem(LEGACY_STORAGE_KEY) || 'null');
+      const legacy = LEGACY_STORAGE_KEYS
+        .map((key) => JSON.parse(localStorage.getItem(key) || 'null'))
+        .find(Boolean);
       const saved = current || legacy;
       if (!saved?.profiles) return fallback;
 
       for (const profileId of Object.keys(fallback)) {
         const profileState = saved.profiles[profileId] || blankProfileState();
         const isToday = profileState.dailyDate === todayKey;
+        const isLegacy = !current;
+        const legacyTotal = (LEGACY_STARTING_STARS[profileId] || 0) + (Number(profileState.bonusStars) || 0);
+        const earnedStars = isLegacy
+          ? Math.max(0, legacyTotal - profiles[profileId].startingStars)
+          : Math.max(0, Number(profileState.earnedStars) || 0);
+        const rawAbilityBonus = isLegacy ? (profileState.abilityBonus || {}) : (profileState.abilityBonusStars || {});
+        const abilityBonusStars = {};
+        for (const abilityId of Object.keys(abilities)) {
+          const rawValue = Math.max(0, Number(rawAbilityBonus[abilityId]) || 0);
+          abilityBonusStars[abilityId] = isLegacy ? Math.round(rawValue / 7) : rawValue;
+        }
         fallback[profileId] = {
-          bonusStars: Number(profileState.bonusStars) || 0,
-          abilityBonus: profileState.abilityBonus || {},
+          earnedStars,
+          abilityBonusStars,
           dailyDate: todayKey,
           completed: isToday && Array.isArray(profileState.completed) ? profileState.completed : [],
         };
@@ -326,36 +481,87 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
   }
 
   function totalStars(profile) {
-    return profile.startingStars + state[profile.id].bonusStars;
+    return Math.min(500, profile.startingStars + state[profile.id].earnedStars);
   }
 
   function rankInfo(stars) {
-    let current = ranks[0];
-    let next = null;
+    let current = {
+      level: 0,
+      stars: 0,
+      name: '見習小兵',
+      symbol: '🪶',
+      gift: '再收集幾顆星，就能正式加入偵查隊',
+      chapterId: 'rookie-camp',
+    };
     for (const step of ranks) {
       if (stars >= step.stars) current = step;
-      else {
-        next = step;
-        break;
-      }
     }
+    const next = ranks.find((step) => stars < step.stars) || null;
     return { current, next };
   }
 
-  function abilityGrowth(ability, xp) {
-    const level = Math.min(10, Math.floor(xp / 10) + 1);
-    const stageIndex = Math.min(ability.growthNames.length - 1, Math.floor((level - 1) / 3));
+  function abilityGrowth(ability, abilityStars) {
+    const stars = Math.max(0, Math.min(grades.length, abilityStars));
+    const grade = stars === 0 ? '尚未啟程' : grades[stars - 1];
     return {
-      level,
-      progress: level === 10 ? 100 : (xp % 10) * 10,
-      growthName: ability.growthNames[stageIndex],
+      stars,
+      grade,
+      stageStars: stars === 0 ? 0 : ((stars - 1) % 3) + 1,
+      progress: Math.round((stars / grades.length) * 100),
+      nextGrade: stars >= grades.length ? null : grades[stars],
     };
   }
 
+  function abilityLadderHtml(stars) {
+    return grades.map((grade, index) => {
+      const classes = `${index < stars ? 'is-earned' : ''}${index === stars - 1 ? ' is-current' : ''}`;
+      return `<span class="${classes}" title="${grade}：第 ${index + 1} 顆能力星">${grade}</span>`;
+    }).join('');
+  }
+
+  function playSound(kind = 'complete') {
+    if (!effectsSoundOn) return;
+    try {
+      audioContext ||= new (window.AudioContext || window.webkitAudioContext)();
+      const now = audioContext.currentTime;
+      const notes = kind === 'rank'
+        ? [[523.25, 0], [659.25, 0.12], [783.99, 0.24], [1046.5, 0.4]]
+        : kind === 'switch'
+          ? [[392, 0], [523.25, 0.08]]
+          : [[659.25, 0], [783.99, 0.1], [987.77, 0.22]];
+      notes.forEach(([frequency, delay], index) => {
+        const oscillator = audioContext.createOscillator();
+        const gain = audioContext.createGain();
+        oscillator.type = kind === 'rank' ? 'triangle' : 'sine';
+        oscillator.frequency.setValueAtTime(frequency, now + delay);
+        gain.gain.setValueAtTime(0.0001, now + delay);
+        gain.gain.exponentialRampToValueAtTime(index === notes.length - 1 ? 0.11 : 0.075, now + delay + 0.025);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + delay + 0.22);
+        oscillator.connect(gain).connect(audioContext.destination);
+        oscillator.start(now + delay);
+        oscillator.stop(now + delay + 0.24);
+      });
+    } catch {
+      // Web Audio 不可用時仍保留所有視覺回饋。
+    }
+  }
+
+  function updateSoundButton() {
+    const button = document.querySelector('#sound-toggle');
+    button.setAttribute('aria-pressed', effectsSoundOn ? 'true' : 'false');
+    button.setAttribute('aria-label', effectsSoundOn ? '關閉任務音效' : '開啟任務音效');
+    button.classList.toggle('is-muted', !effectsSoundOn);
+  }
+
   function createMissionCard(task, index, completed) {
-    const ability = abilities[task.abilityId];
+    const taskAbilities = task.abilityIds.map((abilityId) => abilities[abilityId]);
+    const primaryAbility = taskAbilities[0];
+    const abilityRewardHtml = taskAbilities
+      .map((ability) => `<i>${ability.icon} ${ability.name} ＋1</i>`)
+      .join('');
+    const abilityNames = taskAbilities.map((ability) => ability.name).join('、');
     const card = document.createElement('article');
-    card.className = `mission-card mission-card--${task.abilityId}${completed ? ' is-completed' : ''}`;
+    card.className = `mission-card mission-card--${primaryAbility.id} mission-card--order-${index + 1}${completed ? ' is-completed' : ''}`;
     card.dataset.taskId = task.id;
     card.innerHTML = `
       <div class="mission-card__topline">
@@ -368,9 +574,13 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
       <p class="mission-card__story"></p>
       <h3></h3>
       <p class="mission-card__description"></p>
+      <button class="mission-guide-toggle" type="button" aria-expanded="false" data-action="toggle-guide">
+        <span aria-hidden="true">🧭</span> 偷看三步任務口訣 <i aria-hidden="true">＋</i>
+      </button>
+      <ol class="mission-guide" aria-hidden="true">${task.steps.map((step, stepIndex) => `<li><span>${stepIndex + 1}</span></li>`).join('')}</ol>
       <div class="mission-card__details"><span>⏱ ${task.estimatedMinutes}</span><span>🏷 ${task.skillTag}</span></div>
-      <div class="mission-card__reward"><span>${ability.icon} ${ability.name} ＋${task.abilityXp}</span><strong>★ ＋${task.rewardStars}</strong></div>
-      <button class="mission-complete" type="button" data-task-id="${task.id}">
+      <div class="mission-card__reward"><span class="ability-reward-list">${abilityRewardHtml}</span><strong>★ ＋1</strong></div>
+      <button class="mission-complete" type="button" data-task-id="${task.id}" data-reward-preview="${taskAbilities.map((ability) => `${ability.name} +1`).join('、')}、任務星 +1">
         <span class="mission-complete__ready">我完成了，蓋章！</span>
         <span class="mission-complete__done">已回報</span>
       </button>
@@ -378,10 +588,11 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     card.querySelector('.mission-card__story').textContent = task.story;
     card.querySelector('h3').textContent = task.title;
     card.querySelector('.mission-card__description').textContent = task.description;
+    card.querySelectorAll('.mission-guide li').forEach((item, stepIndex) => item.append(task.steps[stepIndex]));
     const button = card.querySelector('.mission-complete');
     button.setAttribute('aria-label', completed ? `已回報：${task.title}` : `完成：${task.title}`);
     button.disabled = completed;
-    card.querySelector('.mission-card__reward').setAttribute('aria-label', `獎勵：${ability.name}能力與 ${task.rewardStars} 顆星星`);
+    card.querySelector('.mission-card__reward').setAttribute('aria-label', `獎勵：1 顆任務星；${abilityNames}各加 1 顆能力星`);
     return card;
   }
 
@@ -389,18 +600,26 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     const grid = document.querySelector('#ability-grid');
     const profileState = state[profile.id];
     const cards = Object.values(abilities).map((ability) => {
-      const xp = profile.baseAbilityXp[ability.id] + (Number(profileState.abilityBonus[ability.id]) || 0);
-      const growth = abilityGrowth(ability, xp);
+      const abilityStars = profile.baseAbilityStars[ability.id] + (Number(profileState.abilityBonusStars[ability.id]) || 0);
+      const growth = abilityGrowth(ability, abilityStars);
+      const stagePips = [1, 2, 3]
+        .map((star) => `<span class="${star <= growth.stageStars ? 'is-filled' : ''}">★</span>`)
+        .join('');
       const card = document.createElement('article');
       card.className = `ability-card ability-card--${ability.id}`;
       card.dataset.testid = `ability-${ability.id}`;
       card.innerHTML = `
         <div class="ability-card__icon" aria-hidden="true">${ability.icon}</div>
         <div class="ability-card__copy">
-          <div class="ability-card__title"><h3>${ability.name}</h3><span>Lv.${growth.level}</span></div>
+          <div class="ability-card__title"><h3>${ability.name}</h3><span class="ability-grade">${growth.grade}</span></div>
           <p>${ability.description}</p>
+          <div class="ability-stage-stars" aria-label="${growth.grade}，本階段 ${growth.stageStars} 顆星">${stagePips}</div>
           <progress class="ability-card__meter" max="100" value="${growth.progress}" aria-label="${ability.name}成長進度">${growth.progress}%</progress>
-          <small>現在是：${growth.growthName}</small>
+          <small>${growth.stars} / 21 顆能力星 · ${growth.nextGrade ? `下一顆升到 ${growth.nextGrade}` : '已達 S＋'}</small>
+          <button class="ability-inspect" type="button" aria-expanded="false" data-action="toggle-ability">
+            展開 F−～S＋成長軌道 <span aria-hidden="true">⌄</span>
+          </button>
+          <div class="ability-ladder" aria-hidden="true">${abilityLadderHtml(growth.stars)}</div>
         </div>
       `;
       return card;
@@ -429,9 +648,103 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     document.querySelectorAll('[data-rank-stars]').forEach((item) => {
       item.classList.toggle('is-reached', stars >= Number(item.dataset.rankStars));
     });
+    document.querySelectorAll('[data-rank-chapter]').forEach((chapter) => {
+      const start = Number(chapter.dataset.startStars);
+      const end = Number(chapter.dataset.endStars);
+      const isCurrent = stars >= start && (stars < end || (end === 500 && stars === 500));
+      chapter.classList.toggle('is-current', isCurrent);
+      chapter.classList.toggle('is-complete', stars >= end);
+      chapter.classList.toggle('is-open', isCurrent);
+      const toggle = chapter.querySelector('.rank-chapter__toggle');
+      toggle.setAttribute('aria-expanded', isCurrent ? 'true' : 'false');
+      toggle.firstChild.textContent = isCurrent ? '收起地圖 ' : '展開地圖 ';
+    });
   }
 
-  function renderProfile(profileId) {
+  function renderMiniStarTrail(stars, animateLast = false) {
+    const currentRank = rankInfo(stars).current;
+    const stepStars = stars >= 500 ? 10 : Math.max(0, stars - currentRank.stars);
+    const trail = document.querySelector('#mini-star-trail');
+    trail.setAttribute('aria-label', `本階已收集 ${stepStars} / 10 顆星`);
+    trail.querySelectorAll('[data-star-step]').forEach((star, index) => {
+      const lit = index < stepStars;
+      star.classList.toggle('is-lit', lit);
+      star.classList.toggle('is-new', animateLast && lit && index === stepStars - 1);
+    });
+  }
+
+  function showMissionWin(task) {
+    const panel = document.querySelector('#mission-win');
+    document.querySelector('#mission-win-icon').textContent = task.icon;
+    document.querySelector('#mission-win-title').textContent = task.title;
+    const rewards = document.querySelector('#mission-win-rewards');
+    rewards.replaceChildren(...task.abilityIds.map((abilityId) => {
+      const chip = document.createElement('span');
+      chip.textContent = `${abilities[abilityId].icon} ${abilities[abilityId].name} ＋1`;
+      return chip;
+    }));
+    window.clearTimeout(missionWinTimer);
+    panel.classList.remove('is-visible');
+    requestAnimationFrame(() => panel.classList.add('is-visible'));
+    missionWinTimer = window.setTimeout(() => panel.classList.remove('is-visible'), reducedMotion.matches ? 900 : 2200);
+  }
+
+  function replayClass(element, className, duration = 900) {
+    if (!element) return;
+    element.classList.remove(className);
+    void element.offsetWidth;
+    element.classList.add(className);
+    window.setTimeout(() => element.classList.remove(className), duration);
+  }
+
+  function flyReward(origin, target, symbol, className, delay = 0) {
+    if (!origin || !target || reducedMotion.matches || typeof target.animate !== 'function') return;
+    const targetRect = target.getBoundingClientRect();
+    const endX = targetRect.left + targetRect.width / 2;
+    const endY = targetRect.top + targetRect.height / 2;
+    const particle = document.createElement('span');
+    particle.className = `reward-particle ${className}`;
+    particle.textContent = symbol;
+    document.querySelector('#reward-flight-layer').append(particle);
+    const animation = particle.animate([
+      { transform: `translate(${origin.x}px, ${origin.y}px) scale(.45) rotate(-20deg)`, opacity: 0 },
+      { transform: `translate(${origin.x}px, ${origin.y - 36}px) scale(1.35) rotate(8deg)`, opacity: 1, offset: 0.22 },
+      { transform: `translate(${endX}px, ${endY - 12}px) scale(.78) rotate(180deg)`, opacity: 1, offset: 0.82 },
+      { transform: `translate(${endX}px, ${endY}px) scale(.25) rotate(240deg)`, opacity: 0 },
+    ], {
+      duration: 980,
+      delay,
+      easing: 'cubic-bezier(.2,.82,.22,1)',
+      fill: 'forwards',
+    });
+    animation.finished.finally(() => particle.remove());
+  }
+
+  function showRankUp(profile, rank) {
+    const overlay = document.querySelector('#rank-up-overlay');
+    document.querySelector('#rank-up-level').textContent = `第 ${rank.level} 階`;
+    document.querySelector('#rank-up-medal').textContent = rank.symbol;
+    document.querySelector('#rank-up-scout-name').textContent = `${profile.shortName} 升階成功`;
+    document.querySelector('#rank-up-title').textContent = rank.name;
+    document.querySelector('#rank-up-gift').textContent = rank.gift;
+    overlay.hidden = false;
+    requestAnimationFrame(() => {
+      overlay.classList.add('is-visible');
+      document.querySelector('#rank-up-close').focus({ preventScroll: true });
+    });
+  }
+
+  function hideRankUp() {
+    const overlay = document.querySelector('#rank-up-overlay');
+    overlay.classList.remove('is-visible');
+    window.setTimeout(() => {
+      overlay.hidden = true;
+      const activeTab = tabs.find((tab) => tab.dataset.profile === activeProfileId);
+      activeTab?.focus({ preventScroll: true });
+    }, reducedMotion.matches ? 0 : 260);
+  }
+
+  function renderProfile(profileId, options = {}) {
     const profile = profiles[profileId];
     const profileState = state[profileId];
     const stars = totalStars(profile);
@@ -440,8 +753,10 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     const nextThreshold = rank.next?.stars ?? previousThreshold;
     const progress = rank.next ? ((stars - previousThreshold) / (nextThreshold - previousThreshold)) * 100 : 100;
 
+    const profileChanged = profileId !== activeProfileId;
     activeProfileId = profileId;
     page.dataset.theme = profile.theme;
+    if (profileChanged) replayClass(document.querySelector('.scout-story-card'), 'is-switching', 680);
     const portrait = document.querySelector('#scout-portrait');
     portrait.src = profile.portrait;
     portrait.alt = profile.portraitAlt;
@@ -450,6 +765,8 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     document.querySelector('#scout-call-sign').textContent = profile.callSign;
     document.querySelector('#scout-greeting').textContent = profile.greeting;
     document.querySelector('#scout-story').textContent = profile.story;
+    document.querySelector('#rank-medal').textContent = rank.current.symbol;
+    document.querySelector('#rank-level-label').textContent = `第 ${rank.current.level} / 50 階`;
     document.querySelector('#scout-rank').textContent = rank.current.name;
     document.querySelector('#star-count').textContent = String(stars);
     document.querySelector('#next-rank').textContent = rank.next ? `下一站：${rank.next.name}` : '最高階達成！';
@@ -457,6 +774,7 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
       ? `再收集 ${rank.next.stars - stars} 顆星星`
       : '繼續收集生活裡的美好成就';
     document.querySelector('#rank-progress-bar').value = Math.max(0, Math.min(100, progress));
+    renderMiniStarTrail(stars, Boolean(options.justCompletedTaskId));
     document.querySelector('#completed-count').textContent = String(profileState.completed.length);
     document.querySelector('.mission-count > span').textContent = ` / ${profile.tasks.length}`;
 
@@ -469,37 +787,149 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     missionList.replaceChildren(...profile.tasks.map((task, index) => (
       createMissionCard(task, index, profileState.completed.includes(task.id))
     )));
+    missionList.querySelectorAll('.mission-card').forEach((card, index) => {
+      card.classList.add('is-entering');
+      window.setTimeout(() => card.classList.remove('is-entering'), 760 + index * 80);
+    });
     renderAbilityGarden(profile);
     renderBadges(stars);
     renderRankTrail(stars);
+
+    if (options.justCompletedTaskId) {
+      const completedCard = missionList.querySelector(`[data-task-id="${options.justCompletedTaskId}"]`);
+      replayClass(completedCard, 'is-just-completed', 1150);
+    }
+    if (Array.isArray(options.grownAbilityIds)) {
+      options.grownAbilityIds.forEach((abilityId, index) => {
+        const abilityCard = document.querySelector(`[data-testid="ability-${abilityId}"]`);
+        window.setTimeout(() => abilityCard?.classList.add('is-just-grown'), 250 + index * 130);
+      });
+    }
   }
 
-  function completeMission(taskId) {
+  function completeMission(taskId, sourceButton) {
     const profile = profiles[activeProfileId];
     const profileState = state[activeProfileId];
     if (profileState.completed.includes(taskId)) return;
     const task = profile.tasks.find((item) => item.id === taskId);
     if (!task) return;
 
+    const previousRank = rankInfo(totalStars(profile)).current;
+    const sourceRect = sourceButton?.getBoundingClientRect();
+    const rewardOrigin = sourceRect ? {
+      x: sourceRect.left + sourceRect.width / 2,
+      y: sourceRect.top + sourceRect.height / 2,
+    } : null;
+
     profileState.completed.push(taskId);
-    profileState.bonusStars += task.rewardStars;
-    profileState.abilityBonus[task.abilityId] = (Number(profileState.abilityBonus[task.abilityId]) || 0) + task.abilityXp;
+    profileState.earnedStars += 1;
+    for (const abilityId of task.abilityIds) {
+      profileState.abilityBonusStars[abilityId] = (Number(profileState.abilityBonusStars[abilityId]) || 0) + 1;
+    }
     saveState();
-    renderProfile(activeProfileId);
+    renderProfile(activeProfileId, {
+      justCompletedTaskId: taskId,
+      grownAbilityIds: task.abilityIds,
+    });
+
+    const newRank = rankInfo(totalStars(profile)).current;
+    const starWallet = document.querySelector('.star-wallet');
+    flyReward(rewardOrigin, starWallet, '★', 'reward-particle--star');
+    task.abilityIds.forEach((abilityId, index) => {
+      const target = document.querySelector(`[data-testid="ability-${abilityId}"] .ability-card__icon`);
+      flyReward(rewardOrigin, target, abilities[abilityId].icon, 'reward-particle--ability', 110 + index * 140);
+      window.setTimeout(() => replayClass(target, 'is-sparkling', 780), 760 + index * 130);
+    });
+    window.setTimeout(() => replayClass(starWallet, 'is-rewarded', 1050), 680);
+    replayClass(document.querySelector('.mission-count'), 'is-rewarded', 850);
+    showMissionWin(task);
+    playSound(newRank.level > previousRank.level ? 'rank' : 'complete');
+    if (typeof navigator.vibrate === 'function') navigator.vibrate(newRank.level > previousRank.level ? [35, 45, 80] : 35);
 
     const toast = document.querySelector('#mission-toast');
-    toast.textContent = `任務完成回報！${profile.shortName} 得到 ${task.rewardStars} 顆星星，${abilities[task.abilityId].name}也長大了！`;
+    const abilityNames = task.abilityIds.map((abilityId) => abilities[abilityId].name).join('、');
+    toast.textContent = `任務完成回報！${profile.shortName} 得到 1 顆任務星，${abilityNames}各得到 1 顆能力星！`;
     toast.classList.add('is-visible');
     page.classList.remove('is-celebrating');
     requestAnimationFrame(() => page.classList.add('is-celebrating'));
-    window.setTimeout(() => toast.classList.remove('is-visible'), 3200);
-    window.setTimeout(() => page.classList.remove('is-celebrating'), 1200);
+    window.clearTimeout(toastTimer);
+    window.clearTimeout(celebrationTimer);
+    toastTimer = window.setTimeout(() => toast.classList.remove('is-visible'), 3600);
+    celebrationTimer = window.setTimeout(() => page.classList.remove('is-celebrating'), 1500);
+
+    if (newRank.level > previousRank.level) {
+      window.setTimeout(() => showRankUp(profile, newRank), reducedMotion.matches ? 0 : 900);
+    }
   }
 
-  tabs.forEach((tab) => tab.addEventListener('click', () => renderProfile(tab.dataset.profile)));
+  tabs.forEach((tab) => tab.addEventListener('click', () => {
+    renderProfile(tab.dataset.profile);
+    playSound('switch');
+  }));
   missionList.addEventListener('click', (event) => {
+    const guideButton = event.target.closest('[data-action="toggle-guide"]');
+    if (guideButton) {
+      const card = guideButton.closest('.mission-card');
+      const expanded = !card.classList.contains('is-guide-open');
+      card.classList.toggle('is-guide-open', expanded);
+      guideButton.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      card.querySelector('.mission-guide').setAttribute('aria-hidden', expanded ? 'false' : 'true');
+      guideButton.querySelector('i').textContent = expanded ? '−' : '＋';
+      return;
+    }
     const button = event.target.closest('.mission-complete');
-    if (button?.dataset.taskId) completeMission(button.dataset.taskId);
+    if (button?.dataset.taskId) completeMission(button.dataset.taskId, button);
+  });
+
+  document.querySelector('#ability-grid').addEventListener('click', (event) => {
+    const button = event.target.closest('[data-action="toggle-ability"]');
+    if (!button) return;
+    const card = button.closest('.ability-card');
+    const expanded = !card.classList.contains('is-expanded');
+    card.classList.toggle('is-expanded', expanded);
+    button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    button.firstChild.textContent = expanded ? '收起成長軌道 ' : '展開 F−～S＋成長軌道 ';
+    card.querySelector('.ability-ladder').setAttribute('aria-hidden', expanded ? 'false' : 'true');
+  });
+
+  document.querySelector('#rank-trail').addEventListener('click', (event) => {
+    const button = event.target.closest('.rank-chapter__toggle');
+    if (!button) return;
+    const chapter = button.closest('.rank-chapter');
+    const expanded = !chapter.classList.contains('is-open');
+    chapter.classList.toggle('is-open', expanded);
+    button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    button.firstChild.textContent = expanded ? '收起地圖 ' : '展開地圖 ';
+  });
+
+  document.querySelector('#sound-toggle').addEventListener('click', () => {
+    effectsSoundOn = !effectsSoundOn;
+    localStorage.setItem('supergalen-family-sound', effectsSoundOn ? 'on' : 'off');
+    updateSoundButton();
+    if (effectsSoundOn) playSound('switch');
+  });
+
+  missionList.addEventListener('pointermove', (event) => {
+    const card = event.target.closest('.mission-card');
+    if (!card || event.pointerType === 'touch' || reducedMotion.matches) return;
+    const rect = card.getBoundingClientRect();
+    card.style.setProperty('--tilt-x', `${((event.clientY - rect.top) / rect.height - 0.5) * -4}deg`);
+    card.style.setProperty('--tilt-y', `${((event.clientX - rect.left) / rect.width - 0.5) * 5}deg`);
+  });
+  missionList.addEventListener('pointerout', (event) => {
+    const card = event.target.closest('.mission-card');
+    if (card && !card.contains(event.relatedTarget)) {
+      card.style.removeProperty('--tilt-x');
+      card.style.removeProperty('--tilt-y');
+    }
+  });
+
+  document.querySelector('#rank-up-close').addEventListener('click', hideRankUp);
+  document.querySelector('#rank-up-overlay').addEventListener('click', (event) => {
+    if (event.target.id === 'rank-up-overlay') hideRankUp();
+  });
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !document.querySelector('#rank-up-overlay').hidden) hideRankUp();
   });
 
   document.querySelector('#today-label').textContent = new Intl.DateTimeFormat('zh-TW', {
@@ -508,5 +938,8 @@ function getAbilityGrowth(abilityId: AbilityId, xp: number) {
     weekday: 'long',
   }).format(new Date());
 
+  page.dataset.motionReady = 'true';
+  updateSoundButton();
+  requestAnimationFrame(() => page.classList.add('is-ready'));
   renderProfile(activeProfileId);
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,10 +45,6 @@ const pageDescription = trans.site?.description || 'RPG 風格技術部落格';
                   <i class="fas fa-gamepad"></i> <span>遊戲室</span>
               </a>
 
-              <a href="/family-missions" class="arcade-nav-link family-mission-nav-link" title="進入 Apple 與 Amy 的生活任務所">
-                  <i class="fas fa-star"></i> <span>雙羽任務</span>
-              </a>
-
               <!-- 連接錢包按鈕 (未連接時顯示) -->
               <button class="connect-wallet-btn-header" id="connect-wallet-header" style="display: none;">
                   <span class="wallet-icon"><i class="fab fa-ethereum"></i></span>
@@ -95,10 +91,6 @@ const pageDescription = trans.site?.description || 'RPG 風格技術部落格';
               <!-- 遊戲室入口 -->
               <a href="/games" class="arcade-nav-link arcade-nav-link--mobile" title="進入遊戲室 — Dungeon Arcade">
                   <i class="fas fa-gamepad"></i> <span>遊戲室 ARCADE</span>
-              </a>
-
-              <a href="/family-missions" class="arcade-nav-link arcade-nav-link--mobile family-mission-nav-link" title="進入 Apple 與 Amy 的生活任務所">
-                  <i class="fas fa-star"></i> <span>雙羽任務 FAMILY QUEST</span>
               </a>
 
               <button class="connect-wallet-btn-mobile" id="connect-wallet-mobile" style="display: none;">

--- a/src/styles/_family-missions-pixel.scss
+++ b/src/styles/_family-missions-pixel.scss
@@ -101,6 +101,22 @@ body:has(.family-missions) {
   transform: scale(1.05);
 }
 
+.quest-hero__pixel-art {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  image-rendering: pixelated;
+  filter: saturate(1.28) contrast(1.12) brightness(0.94);
+  transform: scale(1.012);
+  transition: opacity 180ms steps(2, end);
+}
+
+.quest-hero__pixel-art.is-rendered {
+  opacity: 1;
+}
+
 .family-missions.is-ready .quest-hero__art {
   animation: pixel-hero-pan 12s steps(12, end) infinite alternate;
 }
@@ -379,6 +395,19 @@ body:has(.family-missions) {
   image-rendering: pixelated;
   filter: saturate(1.34) contrast(1.12);
 }
+
+.scout-portrait-pixel {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  image-rendering: pixelated;
+  filter: saturate(1.32) contrast(1.12);
+  transition: opacity 120ms steps(2, end);
+}
+
+.scout-portrait-pixel.is-rendered { opacity: 1; }
 
 .portrait-pin {
   border: 3px solid var(--pixel-ink);

--- a/src/styles/_family-missions-pixel.scss
+++ b/src/styles/_family-missions-pixel.scss
@@ -1473,3 +1473,243 @@ a:focus-visible {
   .ability-level-up.is-visible { opacity: 1; transform: translateX(-50%); }
   .daily-clear-overlay.is-visible .daily-clear-card { transform: none; }
 }
+
+/* 行為回饋循環：接取、回報、家長確認、成長。 */
+.family-missions [hidden] { display: none !important; }
+
+.parent-base-toggle {
+  position: absolute;
+  z-index: 8;
+  top: 26px;
+  right: 104px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 46px;
+  padding: 7px 12px;
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  color: var(--pixel-ink);
+  background: #fff3b8;
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+  font: 800 .72rem/1 'Courier New', 'Noto Sans TC', monospace;
+  cursor: pointer;
+}
+
+.parent-base-toggle.has-pending { background: var(--pixel-gold); animation: pixel-button-pulse 1.4s steps(2, end) infinite; }
+.parent-base-toggle b { min-width: 20px; padding: 4px; color: #fff; background: #d83b58; }
+
+.game-mode-tabs {
+  position: sticky;
+  z-index: 15;
+  top: 12px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin: 20px 0 14px;
+  padding: 8px;
+  border: 4px solid var(--pixel-ink);
+  background: #30264d;
+  box-shadow: 6px 6px 0 var(--pixel-shadow);
+}
+
+.game-mode-tabs button {
+  min-height: 54px;
+  border: 3px solid #161225;
+  color: #fff9df;
+  background: #554a76;
+  box-shadow: inset -3px -3px 0 #30264d;
+  font: 900 clamp(.72rem, 2vw, .92rem)/1.2 'Courier New', 'Noto Sans TC', monospace;
+  cursor: pointer;
+}
+
+.game-mode-tabs button.is-active {
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: inset -3px -3px 0 #d79824, 0 0 0 2px #fff3a2;
+  transform: translateY(2px);
+}
+
+.mission-status-tag {
+  padding: 5px 7px;
+  border: 2px solid var(--pixel-ink);
+  color: #fff;
+  background: #71678d;
+  font-size: .67rem;
+  font-weight: 900;
+}
+
+.mission-card.is-in-progress { outline: 4px solid var(--pixel-gold); outline-offset: -8px; }
+.mission-card.is-in-progress .mission-status-tag { color: var(--pixel-ink); background: var(--pixel-gold); }
+.mission-card.is-pending { filter: saturate(.82); }
+.mission-card.is-pending .mission-status-tag { color: var(--pixel-ink); background: #9de8ff; }
+.mission-card.is-confirmed .mission-status-tag { background: #3e9b66; }
+.mission-card.is-confirmed::after { content: '家長已看見'; }
+
+.mission-next-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  margin: 10px 0;
+  padding: 9px;
+  border: 3px dashed #b36d20;
+  color: #593912;
+  background: #fff0b8;
+  font-size: .76rem;
+  line-height: 1.45;
+}
+
+.base-building {
+  margin: 24px 0;
+  padding: clamp(18px, 4vw, 34px);
+  border: 4px solid var(--pixel-ink);
+  background: var(--pixel-panel);
+  box-shadow: inset 0 0 0 3px #fff9e2, 8px 8px 0 var(--pixel-shadow);
+}
+.base-collection-counter { display: grid; min-width: 86px; padding: 8px; border: 3px solid var(--pixel-ink); background: #fff; text-align: center; }
+.base-collection-counter strong { color: var(--accent-dark); font-size: 1.65rem; }
+.base-collection-counter span { font-size: .65rem; font-weight: 900; }
+.base-scene { margin-top: 20px; padding: 20px; border: 4px solid var(--pixel-ink); background: linear-gradient(#74bce7 0 42%, #78c67f 42% 68%, #d8a95d 68%); }
+.base-campfire { display: flex; align-items: center; justify-content: center; gap: 14px; min-height: 88px; font-size: 3.2rem; }
+.base-campfire span { display: flex; gap: 6px; }
+.base-campfire i { color: #5c5670; opacity: .42; font-style: normal; font-size: 1.2rem; filter: grayscale(1); }
+.base-campfire i.is-lit { color: #fff17a; opacity: 1; filter: none; text-shadow: 3px 3px 0 #b85c24; }
+.base-collection-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; padding: 0; list-style: none; }
+.base-collection-grid li { display: grid; place-items: center; min-height: 100px; padding: 10px 5px; border: 3px dashed rgba(36,27,53,.7); color: #393049; background: rgba(255,255,255,.52); filter: grayscale(1); opacity: .52; text-align: center; }
+.base-collection-grid li span { font-size: 2rem; }
+.base-collection-grid li strong { margin-top: 5px; font-size: .68rem; }
+.base-collection-grid li.is-built { border-style: solid; background: #fff1a8; filter: none; opacity: 1; box-shadow: 4px 4px 0 #5d5932; animation: base-piece-arrive 420ms steps(4, end); }
+.base-scene > p { margin: 14px 0 0; padding: 9px; border: 3px solid var(--pixel-ink); background: #fff8d8; font-size: .74rem; font-weight: 900; text-align: center; }
+
+@keyframes base-piece-arrive { from { transform: translateY(-12px) scale(.8); opacity: 0; } to { transform: none; opacity: 1; } }
+
+.mission-complete:disabled { cursor: default; filter: none; opacity: .86; }
+
+.mission-report-overlay,
+.parent-base-overlay {
+  position: fixed;
+  z-index: 520;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  overflow-y: auto;
+  opacity: 0;
+  background: rgba(20, 15, 38, .86);
+  transition: opacity 180ms steps(2, end);
+}
+
+.mission-report-overlay.is-visible,
+.parent-base-overlay.is-visible { opacity: 1; }
+
+.mission-report-card,
+.parent-base-card {
+  position: relative;
+  width: min(620px, 100%);
+  padding: 28px;
+  border: 5px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background: var(--pixel-panel-light);
+  box-shadow: 0 0 0 5px var(--pixel-gold), 12px 12px 0 var(--pixel-shadow);
+  text-align: center;
+  transform: translateY(18px) scale(.96);
+  transition: transform 180ms steps(3, end);
+}
+
+.parent-base-card { width: min(760px, 100%); text-align: left; }
+.is-visible > .mission-report-card,
+.is-visible > .parent-base-card { transform: none; }
+
+.overlay-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 38px;
+  height: 38px;
+  border: 3px solid var(--pixel-ink);
+  color: #fff;
+  background: #d84f62;
+  font: 900 1.25rem/1 monospace;
+  cursor: pointer;
+}
+
+.report-eyebrow { margin: 0 0 10px; color: var(--accent-dark); font-weight: 900; letter-spacing: .16em; }
+.report-mission-icon { display: block; margin: 4px 0; font-size: 3.8rem; image-rendering: pixelated; }
+.mission-report-card h2,
+.parent-base-card h2 { margin: 0 42px 10px; font-size: clamp(1.35rem, 5vw, 2rem); }
+
+.effort-choices { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin: 22px 0; }
+.effort-choices button {
+  min-height: 112px;
+  padding: 12px 8px;
+  border: 4px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background: #fff;
+  box-shadow: 5px 5px 0 #b6a77b;
+  cursor: pointer;
+}
+.effort-choices button span { display: block; margin-bottom: 8px; font-size: 2rem; }
+.effort-choices button strong { font-size: .82rem; }
+.effort-choices button.is-selected { background: #fff0a1; box-shadow: inset -4px -4px 0 #e0b438; transform: translate(3px, 3px); }
+
+.send-report,
+#parent-pin-submit {
+  min-height: 52px;
+  padding: 10px 18px;
+  border: 4px solid var(--pixel-ink);
+  color: #fff;
+  background: var(--accent-dark);
+  box-shadow: 5px 5px 0 var(--pixel-shadow);
+  font: 900 .9rem/1.2 'Courier New', 'Noto Sans TC', monospace;
+  cursor: pointer;
+}
+.send-report:disabled { opacity: .42; cursor: not-allowed; }
+.mission-report-card > small { display: block; margin-top: 15px; line-height: 1.5; }
+
+.parent-pin-panel { max-width: 440px; margin: 22px auto 0; padding: 20px; border: 3px solid var(--pixel-ink); background: #fff4c9; }
+.parent-pin-panel label { display: block; margin: 14px 0 6px; font-weight: 900; }
+.parent-pin-panel input { width: 100%; height: 54px; border: 4px solid var(--pixel-ink); background: #fff; font: 900 1.5rem/1 monospace; text-align: center; letter-spacing: .5em; }
+.parent-pin-error { min-height: 1.4em; color: #b8243e; font-weight: 800; }
+
+.parent-queue__heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin: 20px 0 14px; }
+.parent-queue__heading div { display: grid; gap: 5px; }
+.parent-queue__heading span { font-size: .78rem; line-height: 1.5; }
+.parent-queue__heading button { border: 3px solid var(--pixel-ink); padding: 7px 10px; background: #e7e1ef; font-weight: 900; cursor: pointer; }
+.parent-review-card { margin: 12px 0; padding: 16px; border: 4px solid var(--pixel-ink); background: #fff; box-shadow: 5px 5px 0 #b8aa83; }
+.parent-review-card header { display: flex; align-items: center; gap: 12px; }
+.parent-review-card header > span { font-size: 2rem; }
+.parent-review-card h3 { margin: 2px 0; }
+.parent-effort { font-weight: 800; }
+.parent-praise-preview { padding: 10px; border-left: 5px solid var(--pixel-green); background: #eaf9e9; line-height: 1.6; }
+.parent-review-actions { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+.parent-review-actions button { min-height: 48px; border: 3px solid var(--pixel-ink); background: #f2ecdc; font-weight: 900; cursor: pointer; }
+.parent-review-actions button:first-child { background: #bff2c8; }
+.parent-review-actions button:nth-child(2) { background: #ccecff; }
+.parent-review-actions button:last-child { background: #fff0a7; }
+.parent-empty { padding: 24px; border: 3px dashed #8e84a2; text-align: center; }
+.mission-win__praise { max-width: 410px; margin: 5px auto 10px; font-weight: 900; line-height: 1.45; }
+
+@media (max-width: 700px) {
+  .parent-base-toggle { top: 82px; right: 12px; padding: 6px 8px; }
+  .parent-base-toggle small { display: none; }
+  .game-mode-tabs { top: 8px; gap: 4px; padding: 5px; }
+  .game-mode-tabs button { min-height: 48px; padding: 6px 3px; font-size: .66rem; }
+  .game-mode-tabs button span { display: block; margin-bottom: 3px; }
+  .effort-choices { grid-template-columns: 1fr; }
+  .effort-choices button { min-height: 68px; display: flex; align-items: center; gap: 12px; text-align: left; }
+  .effort-choices button span { margin: 0; }
+  .mission-report-card,
+  .parent-base-card { padding: 22px 14px; border-width: 4px; }
+  .parent-review-actions { grid-template-columns: 1fr; }
+  .parent-queue__heading { align-items: stretch; flex-direction: column; }
+  .base-collection-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .parent-base-toggle.has-pending { animation: none; }
+  .mission-report-overlay,
+  .parent-base-overlay,
+  .mission-report-card,
+  .parent-base-card { transition: none; }
+  .base-collection-grid li.is-built { animation: none; }
+}

--- a/src/styles/_family-missions-pixel.scss
+++ b/src/styles/_family-missions-pixel.scss
@@ -409,6 +409,46 @@ body:has(.family-missions) {
 
 .scout-portrait-pixel.is-rendered { opacity: 1; }
 
+.scout-reaction {
+  position: absolute;
+  z-index: 8;
+  top: 7%;
+  left: 68%;
+  width: min(245px, 70vw);
+  padding: 12px 14px;
+  border: 4px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background: #fffbe9;
+  box-shadow: 6px 6px 0 var(--pixel-shadow);
+  font-size: 0.78rem;
+  font-weight: 900;
+  line-height: 1.55;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(16px) scale(.8);
+}
+
+.scout-reaction i {
+  position: absolute;
+  left: 20px;
+  bottom: -15px;
+  width: 20px;
+  height: 20px;
+  border-right: 4px solid var(--pixel-ink);
+  border-bottom: 4px solid var(--pixel-ink);
+  background: inherit;
+  transform: rotate(45deg);
+}
+
+.scout-reaction[data-mood='cheer'] { background: #fff0a1; }
+.scout-reaction[data-mood='hint'] { background: #dff4ff; }
+.scout-reaction[data-mood='perfect'] { color: #fff; background: var(--accent); }
+.scout-reaction.is-visible { animation: pixel-speech-in 2.8s steps(8, end) both; }
+
+.scout-story-card.is-cheering .scout-portrait-frame {
+  animation: pixel-scout-cheer 1.5s steps(8, end) both;
+}
+
 .portrait-pin {
   border: 3px solid var(--pixel-ink);
   border-radius: 0;
@@ -782,6 +822,31 @@ body:has(.family-missions) {
   box-shadow: 2px 2px 0 var(--pixel-shadow);
 }
 
+.mission-win__counter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  margin: 12px auto;
+  font-size: 1rem;
+  font-weight: 950;
+}
+
+.mission-win__counter span,
+.mission-win__counter strong {
+  min-width: 62px;
+  padding: 7px 9px;
+  border: 3px solid var(--pixel-ink);
+  background: #fff;
+  box-shadow: 3px 3px 0 var(--pixel-shadow);
+}
+
+.mission-win__counter strong {
+  color: #725000;
+  background: var(--pixel-gold);
+  animation: pixel-counter-pop 650ms steps(5, end) 420ms both;
+}
+
 .rank-up-overlay {
   background:
     repeating-linear-gradient(0deg, transparent 0 7px, rgba(255,255,255,.08) 7px 8px),
@@ -841,6 +906,222 @@ body:has(.family-missions) {
 .pixel-combo.is-visible {
   animation: pixel-combo-in 1.5s steps(7, end) both;
 }
+
+.quest-chain-hud {
+  position: fixed;
+  z-index: 65;
+  left: 18px;
+  bottom: 18px;
+  width: 250px;
+  padding: 10px 12px 11px;
+  border: 4px solid var(--pixel-ink);
+  color: #fff;
+  background: rgba(48, 38, 77, .96);
+  box-shadow: 6px 6px 0 rgba(15, 12, 26, .72);
+  pointer-events: none;
+}
+
+.quest-chain-hud__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: #bdb3d0;
+  font-size: .62rem;
+  font-weight: 950;
+  letter-spacing: .08em;
+}
+
+.quest-chain-hud__title strong { color: var(--pixel-gold); }
+
+.quest-chain-track {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 5px;
+  margin: 8px 0 6px;
+}
+
+.quest-chain-track i {
+  display: grid;
+  place-items: center;
+  height: 24px;
+  border: 2px solid #85799a;
+  color: #6f647f;
+  background: #211a33;
+  box-shadow: inset 2px 2px 0 #100d1a;
+  font-style: normal;
+}
+
+.quest-chain-track i.is-current {
+  border-color: #fff4ac;
+  color: #fff4ac;
+  animation: pixel-chain-next 760ms steps(2, end) infinite;
+}
+
+.quest-chain-track i.is-lit {
+  border-color: var(--pixel-ink);
+  color: #6e4c00;
+  background: var(--pixel-gold);
+  box-shadow: 3px 3px 0 #a66f09;
+  animation: pixel-chain-lit 500ms steps(4, end) both;
+}
+
+.quest-chain-hud > small {
+  display: block;
+  color: #d9d1e6;
+  font-size: .58rem;
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+.quest-chain-hud.is-pulsing { animation: pixel-hud-pulse 1s steps(6, end); }
+.quest-chain-hud.is-perfect {
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: 6px 6px 0 #9d690a, 9px 9px 0 var(--pixel-shadow);
+}
+.quest-chain-hud.is-perfect .quest-chain-hud__title,
+.quest-chain-hud.is-perfect .quest-chain-hud__title strong,
+.quest-chain-hud.is-perfect > small { color: var(--pixel-ink); }
+
+.ability-level-up {
+  position: fixed;
+  z-index: 88;
+  top: 18%;
+  left: 50%;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: 10px;
+  align-items: center;
+  width: min(380px, calc(100% - 28px));
+  padding: 12px 15px;
+  border: 5px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background: #e2f8ca;
+  box-shadow: 8px 8px 0 var(--pixel-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50px) scale(.65);
+}
+
+.ability-level-up > small {
+  grid-column: 1 / -1;
+  color: #337348;
+  font-size: .68rem;
+  font-weight: 950;
+  letter-spacing: .17em;
+}
+
+.ability-level-up > span {
+  display: grid;
+  place-items: center;
+  width: 54px;
+  height: 54px;
+  border: 3px solid var(--pixel-ink);
+  background: #fff;
+  box-shadow: 4px 4px 0 #64a94e;
+  font-size: 1.8rem;
+}
+
+.ability-level-up > div { display: grid; gap: 4px; }
+.ability-level-up strong { font-size: 1rem; }
+.ability-level-up b { color: #28623b; font-size: 1.15rem; }
+.ability-level-up.is-visible { animation: pixel-ability-banner 2.1s steps(9, end) both; }
+
+.daily-clear-overlay {
+  position: fixed;
+  z-index: 190;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  overflow: hidden;
+  background: rgba(24, 18, 40, .9);
+  opacity: 0;
+  transition: opacity 180ms steps(2, end);
+}
+
+.daily-clear-overlay[hidden] { display: none; }
+.daily-clear-overlay.is-visible { opacity: 1; }
+
+.daily-clear-rays {
+  position: absolute;
+  width: min(820px, 130vw);
+  aspect-ratio: 1;
+  background: repeating-conic-gradient(from 0deg, rgba(255,224,79,.9) 0 8deg, transparent 8deg 18deg);
+  mask: radial-gradient(circle, #000 0 56%, transparent 76%);
+  animation: pixel-clear-rays 9s steps(18, end) infinite;
+}
+
+.daily-clear-card {
+  position: relative;
+  z-index: 2;
+  width: min(500px, calc(100% - 12px));
+  padding: 28px 24px 24px;
+  border: 6px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background:
+    linear-gradient(45deg, rgba(255,255,255,.45) 25%, transparent 25% 75%, rgba(255,255,255,.45) 75%) 0 0 / 16px 16px,
+    #fff2a0;
+  box-shadow: 0 0 0 6px #fff7d0, 12px 12px 0 var(--pixel-shadow);
+  text-align: center;
+  transform: translateY(80px) scale(.55);
+}
+
+.daily-clear-overlay.is-visible .daily-clear-card { animation: pixel-clear-card 760ms steps(9, end) both; }
+.daily-clear-card > p { margin: 0; color: #a04b26; font-size: .78rem; font-weight: 950; letter-spacing: .18em; }
+.daily-clear-card > strong { display: block; margin: 10px 0; font-size: clamp(1.6rem, 7vw, 2.7rem); }
+.daily-clear-card > span { display: block; color: #5a4663; font-weight: 900; line-height: 1.65; }
+
+.daily-clear-chest {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 112px;
+  height: 80px;
+  margin: 24px auto 18px;
+  border: 5px solid var(--pixel-ink);
+  background: #d17d2d;
+  box-shadow: inset 0 -18px 0 #9c4d25, 7px 7px 0 var(--pixel-shadow);
+  animation: pixel-chest-bounce 900ms steps(7, end) 500ms both;
+}
+
+.daily-clear-chest::before {
+  position: absolute;
+  top: -27px;
+  left: -5px;
+  width: 112px;
+  height: 28px;
+  border: 5px solid var(--pixel-ink);
+  background: #ed9c36;
+  content: '';
+  transform-origin: bottom left;
+  animation: pixel-chest-open 700ms steps(6, end) 900ms both;
+}
+
+.daily-clear-chest span { position: relative; z-index: 2; color: var(--pixel-gold); font-size: 2.5rem; text-shadow: 3px 3px 0 #6f3a15; }
+
+.daily-clear-stars { display: flex; justify-content: center; gap: 8px; margin: 14px 0 18px; }
+.daily-clear-stars i { color: #c98c00; font-size: 1.55rem; font-style: normal; text-shadow: 2px 2px 0 #fff; animation: pixel-clear-star 700ms steps(5, end) both; }
+.daily-clear-stars i:nth-child(2) { animation-delay: 100ms; }
+.daily-clear-stars i:nth-child(3) { animation-delay: 200ms; }
+.daily-clear-stars i:nth-child(4) { animation-delay: 300ms; }
+.daily-clear-stars i:nth-child(5) { animation-delay: 400ms; }
+
+.daily-clear-card button {
+  min-height: 56px;
+  margin-top: 22px;
+  padding: 0 20px;
+  border: 4px solid var(--pixel-ink);
+  color: #fff;
+  background: var(--accent);
+  box-shadow: 0 7px 0 var(--accent-dark), 0 11px 0 var(--pixel-ink);
+  font: inherit;
+  font-weight: 950;
+  cursor: pointer;
+}
+
+.daily-clear-card button:active { transform: translateY(8px); box-shadow: 0 2px 0 var(--pixel-ink); }
 
 .pixel-hit-layer {
   position: fixed;
@@ -968,6 +1249,63 @@ a:focus-visible {
   64% { transform: translate(3px, 2px); }
 }
 
+@keyframes pixel-speech-in {
+  0% { opacity: 0; transform: translateY(16px) scale(.8); }
+  12%, 82% { opacity: 1; transform: translateY(0) scale(1); }
+  88% { transform: translateY(-3px) scale(1); }
+  100% { opacity: 0; transform: translateY(-10px) scale(.92); }
+}
+
+@keyframes pixel-scout-cheer {
+  0%, 100% { transform: translate(0) rotate(0); filter: none; }
+  16% { transform: translateY(-13px) rotate(-3deg); filter: brightness(1.12); }
+  32% { transform: translateY(0) rotate(3deg); }
+  48% { transform: translateY(-9px) rotate(-2deg); }
+  64% { transform: translateY(0) rotate(2deg); }
+}
+
+@keyframes pixel-counter-pop {
+  0% { opacity: 0; transform: scale(.45); }
+  55% { opacity: 1; transform: scale(1.25); filter: brightness(1.3); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+@keyframes pixel-chain-next { 50% { color: var(--pixel-gold); transform: translateY(-2px); } }
+@keyframes pixel-chain-lit {
+  0% { transform: translateY(-14px) scale(1.7); filter: brightness(1.5); }
+  100% { transform: translateY(0) scale(1); filter: none; }
+}
+@keyframes pixel-hud-pulse {
+  0%, 100% { transform: translate(0); }
+  25% { transform: translateY(-8px) scale(1.04); filter: brightness(1.3); }
+  55% { transform: translateY(2px) scale(.98); }
+}
+
+@keyframes pixel-ability-banner {
+  0% { opacity: 0; transform: translate(-50%, -50px) scale(.65); }
+  14%, 72% { opacity: 1; transform: translate(-50%, 0) scale(1); }
+  24% { transform: translate(-50%, 0) scale(1.08); filter: brightness(1.2); }
+  100% { opacity: 0; transform: translate(-50%, 28px) scale(.88); }
+}
+
+@keyframes pixel-clear-rays { to { transform: rotate(360deg); } }
+@keyframes pixel-clear-card {
+  0% { transform: translateY(80px) scale(.55); }
+  65% { transform: translateY(-12px) scale(1.05); }
+  100% { transform: translateY(0) scale(1); }
+}
+@keyframes pixel-chest-bounce {
+  0% { transform: translateY(-60px) scale(.7); opacity: 0; }
+  55% { transform: translateY(8px) scale(1.08); opacity: 1; }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+@keyframes pixel-chest-open { to { transform: rotate(-25deg) translate(-5px, -12px); } }
+@keyframes pixel-clear-star {
+  0% { opacity: 0; transform: translateY(18px) scale(.3) rotate(-25deg); }
+  65% { opacity: 1; transform: translateY(-5px) scale(1.35) rotate(8deg); }
+  100% { opacity: 1; transform: none; }
+}
+
 @media (max-width: 820px) {
   .family-missions {
     background:
@@ -1052,6 +1390,29 @@ a:focus-visible {
     top: 12%;
     right: 18px;
   }
+
+  .scout-reaction {
+    top: 5%;
+    right: -4px;
+    left: auto;
+    width: min(230px, 74vw);
+  }
+
+  .quest-chain-hud {
+    right: 12px;
+    bottom: 12px;
+    left: auto;
+    width: 178px;
+    padding: 8px 9px;
+  }
+
+  .quest-chain-hud > small { display: none; }
+  .quest-chain-track { margin-bottom: 0; }
+  .quest-chain-track i { height: 21px; font-size: .7rem; }
+
+  .ability-level-up { top: 15%; }
+
+  .daily-clear-card { padding: 24px 17px 20px; }
 }
 
 @media (max-width: 420px) {
@@ -1071,6 +1432,13 @@ a:focus-visible {
   .pixel-hero-hud span:first-child { display: none; }
   .pixel-hero-hud span:nth-child(2) { border-left: 0; }
   .mission-card { min-height: 400px; }
+
+  .scout-reaction {
+    top: 3%;
+    width: min(205px, 70vw);
+    padding: 9px 10px;
+    font-size: .7rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1085,9 +1453,23 @@ a:focus-visible {
   .pixel-combo,
   .pixel-hit-layer i,
   .quest-warp,
-  .family-missions.is-pixel-hit {
+  .family-missions.is-pixel-hit,
+  .scout-reaction,
+  .scout-story-card.is-cheering .scout-portrait-frame,
+  .mission-win__counter strong,
+  .quest-chain-track i,
+  .quest-chain-hud,
+  .ability-level-up,
+  .daily-clear-rays,
+  .daily-clear-card,
+  .daily-clear-chest,
+  .daily-clear-chest::before,
+  .daily-clear-stars i {
     animation: none;
   }
 
   .quest-warp.is-visible { opacity: 1; transform: none; }
+  .scout-reaction.is-visible { opacity: 1; transform: none; }
+  .ability-level-up.is-visible { opacity: 1; transform: translateX(-50%); }
+  .daily-clear-overlay.is-visible .daily-clear-card { transform: none; }
 }

--- a/src/styles/_family-missions-pixel.scss
+++ b/src/styles/_family-missions-pixel.scss
@@ -1,0 +1,1064 @@
+/* 16-bit visual layer for the hidden family quest page.
+ * This intentionally sits after the original layout stylesheet: structure and
+ * accessibility stay intact while every visible surface shares one game UI.
+ */
+
+body:has(.family-missions) {
+  background: #15152b;
+}
+
+.family-missions {
+  --pixel-ink: #241b35;
+  --pixel-deep: #30264d;
+  --pixel-panel: #fff5cf;
+  --pixel-panel-light: #fffbea;
+  --pixel-gold: #ffd84a;
+  --pixel-green: #5bca83;
+  --pixel-blue: #57a9e8;
+  --pixel-shadow: #161225;
+  --pixel-unit: 4px;
+  color: var(--pixel-ink);
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.055) 1px, transparent 1px) 0 0 / 8px 8px,
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px) 0 0 / 8px 8px,
+    linear-gradient(180deg, #5aa9dc 0 680px, #89d19b 680px 692px, #f7e6ac 692px 100%);
+  font-family: 'Courier New', 'Noto Sans TC', ui-monospace, monospace;
+  image-rendering: pixelated;
+}
+
+.family-missions[data-theme='apple'] {
+  --accent: #f05d78;
+  --accent-dark: #9f2f4f;
+  --accent-soft: #ffe0e4;
+  --accent-shadow: #b83e5b;
+}
+
+.family-missions[data-theme='amy'] {
+  --accent: #6b79df;
+  --accent-dark: #3f459c;
+  --accent-soft: #dfe6ff;
+  --accent-shadow: #4654af;
+}
+
+.pixel-screen-grid {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(180deg, transparent 0 3px, rgba(30, 24, 52, 0.035) 3px 4px);
+  mix-blend-mode: multiply;
+}
+
+.pixel-scroll-meter {
+  position: fixed;
+  z-index: 120;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 8px;
+  border-bottom: 2px solid var(--pixel-shadow);
+  background: #33284d;
+}
+
+.pixel-scroll-meter span {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: repeating-linear-gradient(90deg, var(--pixel-gold) 0 12px, #fff2a2 12px 16px);
+  box-shadow: 0 0 0 2px rgba(255, 225, 86, 0.22);
+  transition: width 100ms linear;
+}
+
+.quest-hero {
+  width: min(1380px, calc(100% - 32px));
+  height: min(650px, 70vw);
+  margin-top: 20px;
+  border: 5px solid var(--pixel-ink);
+  border-radius: 0;
+  background: #8cd0ed;
+  box-shadow:
+    0 0 0 5px #f9e986,
+    0 0 0 9px var(--pixel-ink),
+    12px 14px 0 rgba(24, 18, 40, 0.52);
+  clip-path: polygon(0 16px, 16px 16px, 16px 0, calc(100% - 20px) 0, calc(100% - 20px) 8px, 100% 8px, 100% calc(100% - 20px), calc(100% - 12px) calc(100% - 20px), calc(100% - 12px) 100%, 12px 100%, 12px calc(100% - 8px), 0 calc(100% - 8px));
+}
+
+.quest-hero::after {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  content: '';
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.12) 25%, transparent 25% 75%, rgba(34, 25, 54, 0.08) 75%) 0 0 / 8px 8px,
+    repeating-linear-gradient(0deg, transparent 0 5px, rgba(255, 255, 255, 0.08) 5px 6px);
+  mix-blend-mode: overlay;
+}
+
+.quest-hero__art {
+  image-rendering: pixelated;
+  filter: saturate(1.35) contrast(1.16) brightness(0.92);
+  transform: scale(1.05);
+}
+
+.family-missions.is-ready .quest-hero__art {
+  animation: pixel-hero-pan 12s steps(12, end) infinite alternate;
+}
+
+.quest-hero__shade {
+  z-index: 1;
+  background: linear-gradient(90deg, rgba(255, 247, 210, 0.98) 0 31%, rgba(255, 247, 210, 0.86) 31% 44%, rgba(255, 247, 210, 0.2) 58%, transparent 72%);
+}
+
+.home-link,
+.sound-toggle {
+  z-index: 5;
+  min-height: 46px;
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  color: var(--pixel-ink);
+  background: var(--pixel-panel-light);
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+  backdrop-filter: none;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.home-link:hover,
+.sound-toggle:hover {
+  color: var(--accent-dark);
+  border-color: var(--pixel-ink);
+  background: #fff3a8;
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--pixel-shadow);
+}
+
+.home-link:active,
+.sound-toggle:active {
+  transform: translate(3px, 3px);
+  box-shadow: 1px 1px 0 var(--pixel-shadow);
+}
+
+.quest-hero__copy {
+  z-index: 4;
+}
+
+.eyebrow,
+.section-heading p,
+.story-label {
+  color: var(--accent-dark);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-shadow: 2px 2px 0 rgba(255, 255, 255, 0.75);
+}
+
+.quest-hero h1 {
+  color: var(--pixel-ink);
+  font-size: clamp(3rem, 7vw, 6.15rem);
+  line-height: 0.98;
+  letter-spacing: 0.02em;
+  text-shadow:
+    4px 0 0 #fff7cd,
+    -4px 0 0 #fff7cd,
+    0 4px 0 #fff7cd,
+    0 -4px 0 #fff7cd,
+    7px 7px 0 rgba(36, 27, 53, 0.22);
+}
+
+.quest-hero__copy > p:not(.eyebrow) {
+  color: #514461;
+  line-height: 1.65;
+}
+
+.date-sticker {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  color: #5c4502;
+  background: var(--pixel-gold);
+  box-shadow: 4px 4px 0 var(--pixel-ink);
+}
+
+.hero-command {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.hero-command button {
+  min-height: 58px;
+  padding: 0 22px;
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  color: #fff;
+  background: var(--accent);
+  box-shadow: 0 7px 0 var(--accent-dark), 0 11px 0 var(--pixel-ink);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 950;
+  cursor: pointer;
+  animation: pixel-start-pulse 1.35s steps(2, end) infinite;
+}
+
+.hero-command button:hover {
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  animation: none;
+  transform: translateY(-3px);
+  box-shadow: 0 10px 0 #ba8614, 0 14px 0 var(--pixel-ink);
+}
+
+.hero-command button:active {
+  transform: translateY(8px);
+  box-shadow: 0 2px 0 var(--pixel-ink);
+}
+
+.hero-command small {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #514461;
+  font-size: 0.65rem;
+  font-weight: 900;
+}
+
+.hero-command small i {
+  width: 10px;
+  height: 10px;
+  background: #56cb76;
+  box-shadow: 0 0 0 2px var(--pixel-ink);
+  animation: pixel-led 850ms steps(2, end) infinite;
+}
+
+.quest-hero__seal {
+  z-index: 4;
+  width: 104px;
+  height: 104px;
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: 7px 7px 0 var(--pixel-ink);
+  transform: rotate(3deg);
+  clip-path: polygon(16% 0, 84% 0, 84% 8%, 100% 8%, 100% 84%, 92% 84%, 92% 100%, 16% 100%, 16% 92%, 0 92%, 0 16%, 8% 16%, 8% 8%, 16% 8%);
+}
+
+.family-missions.is-ready .quest-hero__seal {
+  animation: pixel-seal-bob 1.4s steps(2, end) infinite;
+}
+
+.pixel-hero-hud {
+  position: absolute;
+  z-index: 4;
+  right: 24px;
+  bottom: 22px;
+  display: flex;
+  border: 3px solid var(--pixel-ink);
+  color: #fff;
+  background: rgba(36, 27, 53, 0.92);
+  box-shadow: 5px 5px 0 rgba(18, 14, 30, 0.75);
+}
+
+.pixel-hero-hud span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 0 10px;
+  border-right: 2px solid #726488;
+  color: #b9b0cb;
+  font-size: 0.64rem;
+  font-weight: 900;
+}
+
+.pixel-hero-hud span:last-child { border-right: 0; }
+.pixel-hero-hud b { color: var(--pixel-gold); font-size: 0.78rem; }
+
+.quest-shell {
+  margin-top: -36px;
+}
+
+.scout-picker,
+.scout-story-card,
+.mission-board,
+.ability-garden,
+.badge-shelf,
+.rank-journey,
+.family-rule {
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.75), transparent 32%),
+    var(--pixel-panel);
+  box-shadow:
+    inset 0 0 0 3px #fff9e2,
+    8px 8px 0 var(--pixel-shadow);
+  backdrop-filter: none;
+  clip-path: polygon(0 12px, 12px 12px, 12px 0, calc(100% - 12px) 0, calc(100% - 12px) 8px, 100% 8px, 100% calc(100% - 12px), calc(100% - 8px) calc(100% - 12px), calc(100% - 8px) 100%, 8px 100%, 8px calc(100% - 8px), 0 calc(100% - 8px));
+}
+
+.scout-picker {
+  border-color: var(--pixel-ink);
+  border-radius: 0;
+}
+
+.section-heading__icon {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--accent-soft);
+  box-shadow: 4px 4px 0 var(--accent-shadow);
+}
+
+.section-heading h2 {
+  color: var(--pixel-ink);
+  letter-spacing: 0.03em;
+}
+
+.section-heading > div > span {
+  color: #6c6071;
+}
+
+.scout-tab {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: #fff8dd;
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+  transition: transform 100ms steps(2, end), box-shadow 100ms steps(2, end);
+}
+
+.scout-tab:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: 7px 7px 0 var(--pixel-shadow);
+}
+
+.scout-tab:active {
+  transform: translate(3px, 3px);
+  box-shadow: 1px 1px 0 var(--pixel-shadow);
+}
+
+.scout-tab img {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  image-rendering: pixelated;
+  filter: saturate(1.28) contrast(1.1);
+  box-shadow: 3px 3px 0 var(--accent-shadow);
+}
+
+.scout-tab__check {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+}
+
+.scout-tab--apple.is-active,
+.scout-tab--amy.is-active {
+  border-color: var(--pixel-ink);
+  background: var(--accent-soft);
+  box-shadow: 6px 6px 0 var(--accent-shadow);
+}
+
+.scout-tab.is-active::before {
+  position: absolute;
+  left: -14px;
+  content: '▶';
+  color: var(--pixel-gold);
+  font-size: 1rem;
+  text-shadow: 2px 2px 0 var(--pixel-ink);
+  animation: pixel-cursor 700ms steps(2, end) infinite;
+}
+
+.scout-portrait-frame {
+  border: 5px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--accent-soft);
+  box-shadow: 0 0 0 5px #fff3c5, 10px 10px 0 var(--accent-shadow), 15px 15px 0 var(--pixel-ink);
+  transform: none;
+  clip-path: polygon(0 18px, 18px 18px, 18px 0, calc(100% - 18px) 0, calc(100% - 18px) 10px, 100% 10px, 100% calc(100% - 18px), calc(100% - 10px) calc(100% - 18px), calc(100% - 10px) 100%, 10px 100%, 10px calc(100% - 10px), 0 calc(100% - 10px));
+}
+
+.scout-portrait-frame img {
+  image-rendering: pixelated;
+  filter: saturate(1.34) contrast(1.12);
+}
+
+.portrait-pin {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+}
+
+.scout-story-card__copy h2 {
+  color: var(--pixel-ink);
+  text-shadow: 3px 3px 0 var(--accent-soft);
+}
+
+.rank-overview,
+.rank-progress {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--accent-soft);
+  box-shadow: 4px 4px 0 var(--accent-shadow);
+}
+
+.rank-medal,
+.star-wallet {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 3px 3px 0 rgba(36, 27, 53, 0.28);
+}
+
+.star-wallet {
+  background: var(--pixel-gold);
+}
+
+.rank-progress__track,
+.ability-card__meter {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+  background: #b9af9d;
+  box-shadow: inset 2px 2px 0 rgba(36, 27, 53, 0.24);
+}
+
+.rank-progress__track::-webkit-progress-bar,
+.ability-card__meter::-webkit-progress-bar { background: #b9af9d; }
+.rank-progress__track::-webkit-progress-value { background: repeating-linear-gradient(90deg, var(--accent) 0 10px, #fff 10px 12px); }
+.rank-progress__track::-moz-progress-bar { background: var(--accent); }
+
+.mini-star-trail {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: #39304c;
+  box-shadow: inset 3px 3px 0 #1e192a;
+}
+
+.mini-star-trail span {
+  color: #71677c;
+  text-shadow: 2px 2px 0 #1d1828;
+}
+
+.mini-star-trail span.is-lit {
+  color: var(--pixel-gold);
+  text-shadow: 2px 2px 0 #8e6205;
+  animation: pixel-star-pop 850ms steps(3, end) infinite alternate;
+}
+
+.mission-board,
+.ability-garden,
+.badge-shelf,
+.rank-journey {
+  margin-top: 32px;
+}
+
+.mission-count {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--pixel-gold);
+  box-shadow: 4px 4px 0 #a87510;
+}
+
+.mission-card {
+  --tilt-x: 0deg;
+  --tilt-y: 0deg;
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  background: #fff9df;
+  box-shadow: 7px 7px 0 var(--mission-color), 11px 11px 0 var(--pixel-ink);
+  transform: perspective(750px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
+  transition: transform 120ms steps(3, end), box-shadow 120ms steps(3, end), filter 120ms linear;
+  clip-path: polygon(0 10px, 10px 10px, 10px 0, calc(100% - 10px) 0, calc(100% - 10px) 6px, 100% 6px, 100% calc(100% - 10px), calc(100% - 6px) calc(100% - 10px), calc(100% - 6px) 100%, 6px 100%, 6px calc(100% - 6px), 0 calc(100% - 6px));
+}
+
+.mission-card::before {
+  height: 10px;
+  border-radius: 0;
+  background: repeating-linear-gradient(90deg, var(--mission-color) 0 12px, color-mix(in srgb, var(--mission-color) 45%, #fff) 12px 16px);
+}
+
+.mission-card:hover {
+  z-index: 3;
+  border-color: var(--pixel-ink);
+  box-shadow: 9px 9px 0 var(--mission-color), 15px 15px 0 var(--pixel-ink);
+  transform: perspective(750px) translateY(-7px) rotateX(var(--tilt-x)) rotateY(var(--tilt-y));
+  filter: saturate(1.12);
+}
+
+.mission-card:hover::after {
+  position: absolute;
+  z-index: 5;
+  top: 12px;
+  left: -13px;
+  content: '▶';
+  color: var(--pixel-gold);
+  text-shadow: 2px 2px 0 var(--pixel-ink);
+  animation: pixel-cursor 700ms steps(2, end) infinite;
+}
+
+.mission-card__number,
+.difficulty-tag,
+.mission-card__details span,
+.ability-reward-list i {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 rgba(36, 27, 53, 0.18);
+}
+
+.mission-card__illustration {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background:
+    linear-gradient(45deg, rgba(255,255,255,.6) 25%, transparent 25% 75%, rgba(255,255,255,.6) 75%) 0 0 / 12px 12px,
+    var(--mission-soft);
+  box-shadow: inset 4px 4px 0 rgba(36, 27, 53, 0.12);
+}
+
+.mission-card__illustration > span {
+  filter: saturate(1.25) contrast(1.1) drop-shadow(5px 5px 0 rgba(36, 27, 53, 0.22));
+  animation: pixel-item-idle 1.1s steps(2, end) infinite;
+}
+
+.mission-guide-toggle,
+.ability-inspect,
+.rank-chapter__toggle {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  color: var(--pixel-ink);
+  background: #fff1aa;
+  box-shadow: 0 4px 0 #aa7d19, 0 7px 0 var(--pixel-ink);
+}
+
+.mission-guide-toggle:hover,
+.ability-inspect:hover,
+.rank-chapter__toggle:hover {
+  color: #fff;
+  background: var(--accent);
+  transform: translateY(-2px);
+}
+
+.mission-guide-toggle:active,
+.ability-inspect:active,
+.rank-chapter__toggle:active {
+  transform: translateY(5px);
+  box-shadow: 0 1px 0 var(--pixel-ink);
+}
+
+.mission-guide li > span {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 var(--pixel-ink);
+}
+
+.mission-card__reward {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--mission-soft);
+  box-shadow: inset 3px 3px 0 rgba(255,255,255,.62);
+}
+
+.mission-complete {
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  background: var(--mission-color);
+  box-shadow: 0 7px 0 color-mix(in srgb, var(--mission-color) 58%, #1d1728), 0 11px 0 var(--pixel-ink);
+  letter-spacing: 0.04em;
+  text-shadow: 2px 2px 0 rgba(36, 27, 53, 0.42);
+}
+
+.mission-complete:hover:not(:disabled) {
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: 0 10px 0 #a7770a, 0 14px 0 var(--pixel-ink);
+  transform: translateY(-3px);
+}
+
+.mission-complete:active:not(:disabled) {
+  box-shadow: 0 2px 0 var(--pixel-ink);
+  transform: translateY(8px);
+}
+
+.mission-card.is-completed {
+  border-color: var(--pixel-ink);
+  background: #dcf8ca;
+  box-shadow: 7px 7px 0 #53aa62, 11px 11px 0 var(--pixel-ink);
+}
+
+.mission-card.is-completed::after {
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  color: #fff;
+  background: #52ad68;
+  box-shadow: 4px 4px 0 var(--pixel-ink);
+  transform: rotate(-4deg);
+}
+
+.mission-complete:disabled {
+  border: 4px solid var(--pixel-ink);
+  color: #24462a;
+  background: #84d68f;
+  box-shadow: 0 4px 0 #387449, 0 8px 0 var(--pixel-ink);
+}
+
+.ability-scale,
+.ability-card,
+.badge-card,
+.rank-chapter {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 5px 5px 0 rgba(36, 27, 53, 0.34);
+}
+
+.ability-scale {
+  background: #fff1ad;
+}
+
+.ability-scale li {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 2px 2px 0 rgba(36, 27, 53, 0.25);
+}
+
+.ability-card {
+  transition: transform 120ms steps(2, end), box-shadow 120ms steps(2, end);
+}
+
+.ability-card:hover {
+  transform: translate(-3px, -3px);
+  box-shadow: 8px 8px 0 var(--ability-color), 11px 11px 0 var(--pixel-ink);
+}
+
+.ability-card__icon,
+.ability-card__title span {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 3px 3px 0 var(--ability-color);
+}
+
+.ability-card__meter::-webkit-progress-value { background: repeating-linear-gradient(90deg, var(--ability-color) 0 9px, #fff 9px 11px); }
+.ability-card__meter::-moz-progress-bar { background: var(--ability-color); }
+
+.ability-ladder span {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+}
+
+.ability-ladder span.is-current {
+  box-shadow: 3px 3px 0 var(--pixel-ink);
+  animation: pixel-current-skill 900ms steps(2, end) infinite;
+}
+
+.badge-card__seal,
+.rank-chapter__symbol,
+.rank-step__dot {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 3px 3px 0 rgba(36, 27, 53, 0.32);
+}
+
+.badge-card.is-unlocked {
+  border-color: var(--pixel-ink);
+  background: #fff0a1;
+  box-shadow: 5px 5px 0 #bc8611, 8px 8px 0 var(--pixel-ink);
+}
+
+.badge-card.is-unlocked .badge-card__seal {
+  animation: pixel-badge-glow 1.2s steps(3, end) infinite alternate;
+}
+
+.rank-map { gap: 20px; }
+
+.rank-chapter {
+  background: #d9d4c8;
+  opacity: 0.78;
+}
+
+.rank-chapter.is-current {
+  border-color: var(--pixel-ink);
+  background: #fff5c7;
+  box-shadow: 7px 7px 0 var(--accent), 11px 11px 0 var(--pixel-ink);
+  animation: pixel-map-current 1.4s steps(2, end) infinite alternate;
+}
+
+.rank-chapter.is-complete {
+  border-color: var(--pixel-ink);
+  background: #fff0a1;
+  box-shadow: 5px 5px 0 #bd8918;
+}
+
+.rank-chapter__header {
+  border-bottom: 3px dashed var(--pixel-ink);
+  background: rgba(255, 251, 228, 0.85);
+}
+
+.rank-chapter__number {
+  border: 2px solid var(--pixel-ink);
+  border-radius: 0;
+  color: #fff;
+  background: var(--pixel-deep);
+}
+
+.rank-chapter__steps::before {
+  width: 5px;
+  border-radius: 0;
+  background: repeating-linear-gradient(180deg, var(--pixel-ink) 0 7px, transparent 7px 11px);
+}
+
+.rank-chapter__steps li.is-reached .rank-step__dot {
+  border-color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: 3px 3px 0 #a8790c;
+}
+
+.family-rule {
+  background: #dff3c3;
+}
+
+.mission-toast,
+.mission-win__card,
+.rank-up-card {
+  border: 5px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 9px 9px 0 var(--pixel-shadow);
+}
+
+.mission-toast {
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+}
+
+.mission-win::before {
+  background: rgba(24, 18, 40, 0.7);
+}
+
+.mission-win__card {
+  background:
+    linear-gradient(45deg, rgba(255,255,255,.45) 25%, transparent 25% 75%, rgba(255,255,255,.45) 75%) 0 0 / 16px 16px,
+    var(--pixel-panel);
+}
+
+.mission-win__icon,
+#mission-win-rewards span,
+.rank-up-medal,
+.rank-up-unlock,
+.rank-up-card button {
+  border: 4px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 5px 5px 0 var(--pixel-shadow);
+}
+
+.mission-win__icon {
+  background: var(--pixel-gold);
+}
+
+#mission-win-rewards span {
+  border-width: 2px;
+  background: var(--accent-soft);
+  box-shadow: 2px 2px 0 var(--pixel-shadow);
+}
+
+.rank-up-overlay {
+  background:
+    repeating-linear-gradient(0deg, transparent 0 7px, rgba(255,255,255,.08) 7px 8px),
+    rgba(28, 22, 51, 0.9);
+  backdrop-filter: none;
+}
+
+.rank-up-card {
+  background: var(--pixel-panel);
+}
+
+.rank-up-card button {
+  background: var(--accent);
+}
+
+.reward-particle {
+  border: 3px solid var(--pixel-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+}
+
+.celebration span {
+  font-family: monospace;
+  text-shadow: 3px 3px 0 var(--pixel-shadow);
+}
+
+.pixel-combo {
+  position: fixed;
+  z-index: 82;
+  top: 17%;
+  right: 5%;
+  display: grid;
+  justify-items: end;
+  color: #fff;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(60px) scale(0.6);
+}
+
+.pixel-combo small {
+  padding: 5px 8px;
+  border: 3px solid var(--pixel-ink);
+  color: var(--pixel-ink);
+  background: var(--pixel-gold);
+  box-shadow: 4px 4px 0 var(--pixel-shadow);
+  font-size: 0.62rem;
+  font-weight: 900;
+}
+
+.pixel-combo strong {
+  color: #fff;
+  font-size: clamp(3rem, 9vw, 6rem);
+  line-height: 1;
+  text-shadow: 5px 0 0 var(--pixel-ink), -5px 0 0 var(--pixel-ink), 0 5px 0 var(--pixel-ink), 7px 7px 0 var(--accent-dark);
+}
+
+.pixel-combo.is-visible {
+  animation: pixel-combo-in 1.5s steps(7, end) both;
+}
+
+.pixel-hit-layer {
+  position: fixed;
+  z-index: 130;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.pixel-hit-layer i {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 8px;
+  height: 8px;
+  background: var(--hit-color);
+  box-shadow: 2px 2px 0 var(--pixel-shadow);
+  transform: translate(var(--hit-x), var(--hit-y));
+  animation: pixel-pointer-burst 480ms steps(6, end) both;
+}
+
+.quest-warp {
+  position: fixed;
+  z-index: 150;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  color: #fff;
+  background: var(--pixel-deep);
+  opacity: 0;
+  pointer-events: none;
+  transform: scaleY(0);
+  text-align: center;
+}
+
+.quest-warp::before,
+.quest-warp::after {
+  position: absolute;
+  inset: 0;
+  content: '';
+  background: repeating-linear-gradient(90deg, transparent 0 24px, rgba(255,255,255,.06) 24px 28px);
+}
+
+.quest-warp::after {
+  background: radial-gradient(circle, transparent 0 28%, rgba(0,0,0,.55) 76%);
+}
+
+.quest-warp span,
+.quest-warp small {
+  position: relative;
+  z-index: 2;
+}
+
+.quest-warp span {
+  color: var(--pixel-gold);
+  font-size: clamp(2.5rem, 9vw, 7rem);
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  text-shadow: 6px 0 0 var(--pixel-shadow), -6px 0 0 var(--pixel-shadow), 0 6px 0 var(--pixel-shadow), 10px 10px 0 var(--accent-dark);
+}
+
+.quest-warp small {
+  margin-top: 16px;
+  font-size: 0.9rem;
+  font-weight: 900;
+  letter-spacing: 0.2em;
+}
+
+.quest-warp.is-visible {
+  animation: pixel-warp 920ms steps(8, end) both;
+}
+
+.family-missions.is-pixel-hit {
+  animation: pixel-screen-hit 520ms steps(6, end);
+}
+
+button:focus-visible,
+a:focus-visible {
+  outline: 4px solid #fff;
+  outline-offset: 4px;
+  box-shadow: 0 0 0 8px var(--pixel-ink);
+}
+
+@keyframes pixel-hero-pan {
+  from { transform: scale(1.05) translateX(0); }
+  to { transform: scale(1.11) translateX(-2%); }
+}
+
+@keyframes pixel-start-pulse {
+  0%, 100% { filter: brightness(1); }
+  50% { filter: brightness(1.2); }
+}
+
+@keyframes pixel-led { 50% { opacity: 0.25; } }
+@keyframes pixel-seal-bob { 50% { transform: translateY(-8px) rotate(-2deg); } }
+@keyframes pixel-cursor { 50% { transform: translateX(-5px); } }
+@keyframes pixel-item-idle { 50% { transform: translateY(-7px); } }
+@keyframes pixel-star-pop { to { transform: translateY(-2px) scale(1.08); } }
+@keyframes pixel-current-skill { 50% { filter: brightness(1.35); transform: scale(1.1); } }
+@keyframes pixel-badge-glow { to { filter: brightness(1.18); transform: translateY(-3px); } }
+@keyframes pixel-map-current { to { transform: translateY(-4px); } }
+
+@keyframes pixel-combo-in {
+  0% { opacity: 0; transform: translateX(60px) scale(.5); }
+  20%, 72% { opacity: 1; transform: translateX(0) scale(1); }
+  100% { opacity: 0; transform: translateX(-20px) scale(1.15); }
+}
+
+@keyframes pixel-pointer-burst {
+  0% { opacity: 1; transform: translate(var(--hit-x), var(--hit-y)) scale(1); }
+  100% { opacity: 0; transform: translate(calc(var(--hit-x) + var(--hit-dx)), calc(var(--hit-y) + var(--hit-dy))) scale(.3); }
+}
+
+@keyframes pixel-warp {
+  0% { opacity: 0; transform: scaleY(0); }
+  16%, 68% { opacity: 1; transform: scaleY(1); }
+  100% { opacity: 0; transform: scaleY(0); }
+}
+
+@keyframes pixel-screen-hit {
+  0%, 100% { transform: translate(0); filter: none; }
+  16% { transform: translate(-7px, 3px); filter: brightness(1.18); }
+  32% { transform: translate(6px, -2px); }
+  48% { transform: translate(-4px, -2px); }
+  64% { transform: translate(3px, 2px); }
+}
+
+@media (max-width: 820px) {
+  .family-missions {
+    background:
+      linear-gradient(rgba(255, 255, 255, 0.045) 1px, transparent 1px) 0 0 / 8px 8px,
+      linear-gradient(180deg, #5aa9dc 0 640px, #89d19b 640px 652px, #f7e6ac 652px 100%);
+  }
+
+  .quest-hero {
+    height: 620px;
+    border-width: 4px;
+    box-shadow: 0 0 0 4px #f9e986, 0 0 0 8px var(--pixel-ink), 8px 10px 0 rgba(24,18,40,.52);
+  }
+
+  .quest-hero__shade {
+    background: linear-gradient(180deg, rgba(255,247,210,.98) 0 42%, rgba(255,247,210,.54) 58%, transparent 76%);
+  }
+
+  .quest-hero__copy {
+    top: 90px;
+  }
+
+  .quest-hero h1 {
+    font-size: clamp(2.65rem, 14vw, 4.25rem);
+  }
+
+  .hero-command {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .hero-command button {
+    min-height: 54px;
+    padding-inline: 17px;
+  }
+
+  .quest-hero__seal {
+    bottom: 70px;
+    width: 78px;
+    height: 78px;
+  }
+
+  .pixel-hero-hud {
+    right: 10px;
+    bottom: 12px;
+    left: 10px;
+    justify-content: space-between;
+  }
+
+  .pixel-hero-hud span {
+    flex: 1;
+    justify-content: center;
+    padding-inline: 4px;
+    font-size: 0.52rem;
+  }
+
+  .pixel-hero-hud b { font-size: 0.62rem; }
+
+  .quest-shell { margin-top: -18px; }
+
+  .scout-picker,
+  .scout-story-card,
+  .mission-board,
+  .ability-garden,
+  .badge-shelf,
+  .rank-journey,
+  .family-rule {
+    border-width: 3px;
+    box-shadow: inset 0 0 0 2px #fff9e2, 6px 6px 0 var(--pixel-shadow);
+  }
+
+  .mission-card {
+    box-shadow: 5px 5px 0 var(--mission-color), 8px 8px 0 var(--pixel-ink);
+  }
+
+  .mission-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 6px 6px 0 var(--mission-color), 10px 10px 0 var(--pixel-ink);
+  }
+
+  .pixel-combo {
+    top: 12%;
+    right: 18px;
+  }
+}
+
+@media (max-width: 420px) {
+  .home-link {
+    max-width: 48px;
+    overflow: hidden;
+    padding-inline: 12px;
+    white-space: nowrap;
+  }
+
+  .quest-hero__copy > p:not(.eyebrow) {
+    max-width: 290px;
+    font-size: 0.84rem;
+  }
+
+  .hero-command small { display: none; }
+  .pixel-hero-hud span:first-child { display: none; }
+  .pixel-hero-hud span:nth-child(2) { border-left: 0; }
+  .mission-card { min-height: 400px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-command button,
+  .hero-command small i,
+  .quest-hero__seal,
+  .mission-card__illustration > span,
+  .mini-star-trail span.is-lit,
+  .ability-ladder span.is-current,
+  .badge-card.is-unlocked .badge-card__seal,
+  .rank-chapter.is-current,
+  .pixel-combo,
+  .pixel-hit-layer i,
+  .quest-warp,
+  .family-missions.is-pixel-hit {
+    animation: none;
+  }
+
+  .quest-warp.is-visible { opacity: 1; transform: none; }
+}

--- a/src/styles/_family-missions.scss
+++ b/src/styles/_family-missions.scss
@@ -50,6 +50,11 @@ body:has(.family-missions) {
   height: 100%;
   object-fit: cover;
   object-position: center;
+  transform: scale(1.035);
+}
+
+.family-missions.is-ready .quest-hero__art {
+  animation: family-hero-breathe 11s ease-in-out infinite alternate;
 }
 
 .quest-hero__shade {
@@ -82,6 +87,45 @@ body:has(.family-missions) {
   color: var(--accent-dark);
   border-color: var(--accent);
   transform: translateY(-1px);
+}
+
+.sound-toggle {
+  position: absolute;
+  z-index: 4;
+  top: 24px;
+  right: 24px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 14px;
+  border: 2px solid rgba(63, 64, 88, 0.14);
+  border-radius: 999px;
+  color: var(--family-ink);
+  background: rgba(255, 255, 255, 0.84);
+  box-shadow: 0 7px 16px rgba(58, 78, 96, 0.12);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+}
+
+.sound-toggle small {
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.sound-toggle__off,
+.sound-toggle.is-muted .sound-toggle__on {
+  display: none;
+}
+
+.sound-toggle.is-muted .sound-toggle__off {
+  display: inline;
+}
+
+.sound-toggle:active {
+  transform: translateY(2px) scale(0.98);
 }
 
 .quest-hero__copy {
@@ -149,6 +193,10 @@ body:has(.family-missions) {
   box-shadow: 0 12px 25px rgba(77, 58, 11, 0.22);
   text-align: center;
   transform: rotate(7deg);
+}
+
+.family-missions.is-ready .quest-hero__seal {
+  animation: family-seal-bob 3.4s ease-in-out infinite;
 }
 
 .quest-hero__seal span {
@@ -259,6 +307,11 @@ body:has(.family-missions) {
   transform: translateY(-2px);
 }
 
+.scout-tab:active {
+  transform: translateY(4px) scale(0.985);
+  box-shadow: 0 2px 0 rgba(77, 83, 96, 0.1);
+}
+
 .scout-tab img {
   width: 66px;
   height: 66px;
@@ -325,6 +378,14 @@ body:has(.family-missions) {
   border-radius: 38px;
 }
 
+.scout-story-card.is-switching .scout-portrait-frame {
+  animation: family-portrait-switch 620ms cubic-bezier(.2, .9, .25, 1) both;
+}
+
+.scout-story-card.is-switching .scout-story-card__copy {
+  animation: family-copy-switch 560ms cubic-bezier(.2, .9, .25, 1) both;
+}
+
 .scout-portrait-wrap {
   position: relative;
   width: min(100%, 400px);
@@ -343,6 +404,7 @@ body:has(.family-missions) {
 .scout-portrait-frame img {
   display: block;
   width: 100%;
+  height: auto;
   aspect-ratio: 1;
   object-fit: cover;
 }
@@ -375,6 +437,14 @@ body:has(.family-missions) {
   background: #ffdc68;
   font-size: 2rem;
   transform: rotate(8deg);
+}
+
+.family-missions.is-ready .portrait-pin--top {
+  animation: family-pin-float 3.6s ease-in-out infinite alternate;
+}
+
+.family-missions.is-ready .portrait-pin--bottom {
+  animation: family-pin-float 3.1s ease-in-out -1.4s infinite alternate-reverse;
 }
 
 .scout-story-card__copy h2 {
@@ -452,6 +522,10 @@ body:has(.family-missions) {
   background: #fff3b7;
 }
 
+.star-wallet.is-rewarded {
+  animation: family-wallet-reward 920ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
 .star-wallet > span {
   color: #e1a900;
   font-size: 1.35rem;
@@ -517,6 +591,51 @@ body:has(.family-missions) {
   background: linear-gradient(90deg, var(--accent), #ffd567);
 }
 
+.mini-star-trail {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 6px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 2px dashed color-mix(in srgb, var(--accent) 28%, #fff);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.mini-star-trail::before {
+  position: absolute;
+  z-index: 0;
+  top: 50%;
+  left: 8%;
+  right: 8%;
+  height: 3px;
+  content: '';
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 18%, #e5e2dc);
+  transform: translateY(-50%);
+}
+
+.mini-star-trail span {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  color: #d7d5ce;
+  font-size: clamp(0.75rem, 2vw, 1rem);
+  filter: drop-shadow(0 2px 0 #fff);
+  transition: color 220ms ease, transform 220ms ease, filter 220ms ease;
+}
+
+.mini-star-trail span.is-lit {
+  color: #f2b900;
+  filter: drop-shadow(0 0 5px rgba(255, 202, 43, 0.65));
+}
+
+.mini-star-trail span.is-new {
+  animation: family-new-trail-star 980ms cubic-bezier(.18, .92, .22, 1.2) both;
+}
+
 .mission-board,
 .ability-garden,
 .badge-shelf,
@@ -540,6 +659,10 @@ body:has(.family-missions) {
   color: var(--accent-dark);
   background: var(--accent-soft);
   text-align: center;
+}
+
+.mission-count.is-rewarded {
+  animation: family-count-pop 720ms cubic-bezier(.18, .9, .22, 1) both;
 }
 
 .mission-count strong {
@@ -579,7 +702,20 @@ body:has(.family-missions) {
   background: #fff;
   box-shadow: 0 10px 22px rgba(72, 78, 91, 0.08);
   transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  transform-style: preserve-3d;
+  will-change: transform;
 }
+
+.mission-card.is-entering {
+  animation: family-card-deal 620ms cubic-bezier(.2, .88, .22, 1) both;
+  animation-delay: calc(var(--enter-order, 0) * 70ms);
+}
+
+.mission-card--order-1 { --enter-order: 0; }
+.mission-card--order-2 { --enter-order: 1; }
+.mission-card--order-3 { --enter-order: 2; }
+.mission-card--order-4 { --enter-order: 3; }
+.mission-card--order-5 { --enter-order: 4; }
 
 .mission-card:nth-child(4) {
   grid-column: 2 / span 2;
@@ -588,7 +724,7 @@ body:has(.family-missions) {
 .mission-card:hover {
   border-color: var(--mission-color);
   box-shadow: 0 16px 30px rgba(72, 78, 91, 0.14);
-  transform: translateY(-4px) rotate(-0.3deg);
+  transform: perspective(900px) translateY(-5px) rotateX(var(--tilt-x, 0deg)) rotateY(var(--tilt-y, 0deg));
 }
 
 .mission-card--math {
@@ -655,6 +791,10 @@ body:has(.family-missions) {
   filter: drop-shadow(0 5px 3px rgba(73, 74, 88, 0.12));
 }
 
+.mission-card:hover .mission-card__illustration > span {
+  animation: family-mission-icon 620ms cubic-bezier(.18, .9, .22, 1);
+}
+
 .mission-card__illustration i {
   position: absolute;
   bottom: -14px;
@@ -690,6 +830,75 @@ body:has(.family-missions) {
   line-height: 1.55;
 }
 
+.mission-guide-toggle {
+  width: 100%;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin: 0 0 10px;
+  border: 2px dashed color-mix(in srgb, var(--mission-color) 44%, #fff);
+  border-radius: 13px;
+  color: var(--mission-color);
+  background: color-mix(in srgb, var(--mission-soft) 78%, #fff);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.mission-guide-toggle i {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--mission-color);
+  font-style: normal;
+}
+
+.mission-guide {
+  max-height: 0;
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0 5px;
+  overflow: hidden;
+  opacity: 0;
+  list-style: none;
+  transition: max-height 320ms ease, opacity 220ms ease, margin 320ms ease;
+}
+
+.mission-card.is-guide-open .mission-guide {
+  max-height: 180px;
+  margin: 0 0 12px;
+  opacity: 1;
+}
+
+.mission-guide li {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  color: var(--family-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.mission-guide li > span {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: #fff;
+  background: var(--mission-color);
+  font-size: 0.65rem;
+}
+
 .mission-card__details {
   display: flex;
   flex-wrap: wrap;
@@ -719,13 +928,30 @@ body:has(.family-missions) {
   font-weight: 900;
 }
 
+.ability-reward-list {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.ability-reward-list i {
+  padding: 2px 5px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.66);
+  font-style: normal;
+  white-space: nowrap;
+}
+
 .mission-card__reward strong {
+  flex: 0 0 auto;
   color: #8a6711;
+  white-space: nowrap;
 }
 
 .mission-complete {
   width: 100%;
-  min-height: 48px;
+  min-height: 56px;
   border: 0;
   border-radius: 15px;
   color: #fff;
@@ -772,6 +998,14 @@ body:has(.family-missions) {
   transform: rotate(-12deg);
 }
 
+.mission-card.is-just-completed::after {
+  animation: family-stamp-slam 920ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
+.mission-card.is-just-completed {
+  animation: family-card-success 1050ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
 .mission-complete:disabled {
   color: #35704b;
   background: #ccebd7;
@@ -800,6 +1034,74 @@ body:has(.family-missions) {
   margin-top: 24px;
 }
 
+.ability-scale {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 14px 20px;
+  align-items: center;
+  margin-top: 24px;
+  padding: 18px 20px;
+  border: 2px solid #efe6c8;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #fffdf4, #fff6d4);
+}
+
+.ability-scale > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.ability-scale > div strong {
+  color: #7d621a;
+  font-size: 1rem;
+}
+
+.ability-scale > div span,
+.ability-scale p {
+  color: var(--family-muted);
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+.ability-scale ol {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(44px, 1fr));
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ability-scale li {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 7px 4px 5px;
+  border: 2px solid #fff;
+  border-radius: 12px;
+  color: #6c577c;
+  background: color-mix(in srgb, var(--accent-soft) 75%, #fff);
+  box-shadow: 0 4px 8px rgba(75, 72, 89, 0.07);
+  font-size: 1rem;
+  font-weight: 950;
+}
+
+.ability-scale li small {
+  color: #9a8fa0;
+  font-size: 0.55rem;
+  letter-spacing: 0.02em;
+}
+
+.ability-scale p {
+  grid-column: 1 / -1;
+  margin: 0;
+  text-align: center;
+}
+
+.ability-scale p span {
+  color: #e5ad14;
+}
+
 .ability-card {
   --ability-color: #f28779;
   --ability-soft: #fff0eb;
@@ -811,6 +1113,81 @@ body:has(.family-missions) {
   border: 2px solid color-mix(in srgb, var(--ability-color) 24%, #fff);
   border-radius: 23px;
   background: var(--ability-soft);
+}
+
+.ability-inspect {
+  width: 100%;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 10px;
+  border: 0;
+  border-radius: 11px;
+  color: var(--ability-color);
+  background: rgba(255, 255, 255, 0.72);
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.ability-inspect span {
+  transition: transform 220ms ease;
+}
+
+.ability-card.is-expanded .ability-inspect span {
+  transform: rotate(180deg);
+}
+
+.ability-ladder {
+  max-height: 0;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 5px;
+  margin-top: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 360ms ease, opacity 220ms ease, margin 300ms ease;
+}
+
+.ability-card.is-expanded .ability-ladder {
+  max-height: 150px;
+  margin-top: 10px;
+  opacity: 1;
+}
+
+.ability-ladder span {
+  min-height: 25px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--ability-color) 18%, #fff);
+  border-radius: 7px;
+  color: #aaa7ae;
+  background: rgba(255, 255, 255, 0.62);
+  font-size: 0.58rem;
+  font-weight: 900;
+}
+
+.ability-ladder span.is-earned {
+  color: var(--ability-color);
+  background: #fff;
+}
+
+.ability-ladder span.is-current {
+  color: #fff;
+  background: var(--ability-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ability-color) 18%, transparent);
+  transform: scale(1.08);
+}
+
+.ability-card.is-just-grown {
+  animation: family-ability-grow 1050ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
+.ability-card.is-just-grown .ability-grade {
+  animation: family-grade-shine 1050ms ease both;
 }
 
 .ability-card--math { --ability-color: #5b9ee6; --ability-soft: #eaf5ff; }
@@ -831,6 +1208,10 @@ body:has(.family-missions) {
   font-size: 1.9rem;
 }
 
+.ability-card__icon.is-sparkling {
+  animation: family-ability-icon 760ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
 .ability-card__title {
   display: flex;
   justify-content: space-between;
@@ -844,12 +1225,15 @@ body:has(.family-missions) {
 }
 
 .ability-card__title span {
-  padding: 3px 7px;
-  border-radius: 999px;
+  min-width: 48px;
+  padding: 5px 8px;
+  border: 2px solid color-mix(in srgb, var(--ability-color) 25%, #fff);
+  border-radius: 12px;
   color: var(--ability-color);
   background: #fff;
-  font-size: 0.7rem;
+  font-size: 0.95rem;
   font-weight: 950;
+  text-align: center;
 }
 
 .ability-card p {
@@ -861,6 +1245,20 @@ body:has(.family-missions) {
 
 .ability-card__meter {
   height: 9px;
+}
+
+.ability-stage-stars {
+  display: flex;
+  gap: 3px;
+  margin: 0 0 6px;
+  color: color-mix(in srgb, var(--ability-color) 24%, #fff);
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.ability-stage-stars .is-filled {
+  color: var(--ability-color);
+  filter: drop-shadow(0 2px 1px rgba(63, 64, 88, 0.1));
 }
 
 .ability-card__meter::-webkit-progress-value,
@@ -877,7 +1275,7 @@ body:has(.family-missions) {
 }
 
 .badge-grid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 .badge-card {
@@ -935,77 +1333,196 @@ body:has(.family-missions) {
   filter: none;
 }
 
-.rank-trail {
-  position: relative;
+.rank-map {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 10px;
-  margin: 30px 0 0;
-  padding: 0;
-  list-style: none;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 28px;
 }
 
-.rank-trail::before {
-  position: absolute;
-  top: 31px;
-  left: 7%;
-  right: 7%;
-  height: 6px;
-  content: '';
-  border-radius: 999px;
-  background: #e7e4dd;
+.rank-chapter {
+  overflow: hidden;
+  border: 2px solid #e8e5dd;
+  border-radius: 26px;
+  background: #faf9f5;
+  opacity: 0.72;
+  transition: border-color 180ms ease, box-shadow 180ms ease, opacity 180ms ease, transform 180ms ease;
 }
 
-.rank-trail li {
-  position: relative;
-  z-index: 2;
-  text-align: center;
-  opacity: 0.58;
+.rank-chapter.is-current {
+  border-color: var(--accent);
+  background: #fff;
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--accent) 18%, transparent);
+  opacity: 1;
+  transform: translateY(-2px);
 }
 
-.rank-trail__symbol {
-  width: 64px;
-  height: 64px;
-  display: grid;
-  place-items: center;
-  margin: 0 auto 10px;
-  border: 5px solid #fff;
-  border-radius: 50%;
-  background: #e8e6e0;
-  box-shadow: 0 5px 12px rgba(63, 64, 88, 0.12);
-  font-size: 1.7rem;
-  filter: grayscale(1);
-}
-
-.rank-trail small {
-  color: var(--family-muted);
-  font-size: 0.67rem;
-  font-weight: 900;
-}
-
-.rank-trail h3 {
-  margin: 3px 0;
-  font-size: 0.82rem;
-}
-
-.rank-trail p {
-  margin: 0;
-  color: var(--family-muted);
-  font-size: 0.65rem;
-  font-weight: 650;
-  line-height: 1.4;
-}
-
-.rank-trail li.is-reached {
+.rank-chapter.is-complete {
+  border-color: #e9cf62;
+  background: #fffdf2;
   opacity: 1;
 }
 
-.rank-trail li.is-reached .rank-trail__symbol {
-  background: #fff1a8;
-  filter: none;
+.rank-chapter__header {
+  display: grid;
+  grid-template-columns: auto 48px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 14px;
+  border-bottom: 2px dashed #e6e3dc;
+  background: rgba(255, 255, 255, 0.72);
 }
 
-.rank-trail li.is-reached h3 {
+.rank-chapter__toggle {
+  grid-column: 1 / -1;
+  min-height: 38px;
+  border: 0;
+  border-radius: 12px;
+  color: var(--accent-dark);
+  background: var(--accent-soft);
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.rank-chapter__toggle span {
+  display: inline-block;
+  transition: transform 220ms ease;
+}
+
+.rank-chapter.is-open .rank-chapter__toggle span {
+  transform: rotate(180deg);
+}
+
+.rank-chapter__number {
+  align-self: start;
+  padding: 3px 7px;
+  border-radius: 999px;
+  color: var(--family-muted);
+  background: #efede7;
+  font-size: 0.58rem;
+  font-weight: 950;
+  white-space: nowrap;
+}
+
+.rank-chapter__symbol {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border: 3px solid #fff;
+  border-radius: 15px;
+  background: var(--accent-soft);
+  box-shadow: 0 4px 10px rgba(63, 64, 88, 0.1);
+  font-size: 1.45rem;
+}
+
+.rank-chapter__header h3 {
+  margin: 0;
+  color: var(--family-ink);
+  font-size: 1rem;
+}
+
+.rank-chapter__header p {
+  margin: 3px 0 0;
+  color: var(--family-muted);
+  font-size: 0.67rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.rank-chapter__header > strong {
+  color: #8a6711;
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+
+.rank-chapter__steps {
+  position: relative;
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0 14px;
+  list-style: none;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: max-height 460ms cubic-bezier(.2, .8, .2, 1), opacity 260ms ease, padding 320ms ease;
+}
+
+.rank-chapter.is-open .rank-chapter__steps {
+  max-height: 520px;
+  padding: 8px 14px 14px;
+  opacity: 1;
+}
+
+.rank-chapter__steps::before {
+  position: absolute;
+  top: 24px;
+  bottom: 30px;
+  left: 31px;
+  width: 4px;
+  content: '';
+  border-radius: 999px;
+  background: #e5e2dc;
+}
+
+.rank-chapter__steps li {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 7px 0;
+  opacity: 0.58;
+}
+
+.rank-step__dot {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: 4px solid #fff;
+  border-radius: 50%;
+  color: #8c8b92;
+  background: #dfddd7;
+  box-shadow: 0 3px 8px rgba(63, 64, 88, 0.12);
+  font-size: 0.66rem;
+  font-weight: 950;
+}
+
+.rank-chapter__steps small {
+  color: var(--family-muted);
+  font-size: 0.6rem;
+  font-weight: 900;
+}
+
+.rank-chapter__steps h4 {
+  margin: 1px 0;
+  color: var(--family-ink);
+  font-size: 0.8rem;
+}
+
+.rank-chapter__steps p {
+  margin: 0;
+  color: var(--family-muted);
+  font-size: 0.64rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.rank-chapter__steps li.is-reached {
+  opacity: 1;
+}
+
+.rank-chapter__steps li.is-reached .rank-step__dot {
+  color: #765600;
+  background: #ffdf68;
+}
+
+.rank-chapter__steps li.is-reached h4 {
   color: var(--accent-dark);
 }
 
@@ -1059,6 +1576,132 @@ body:has(.family-missions) {
   transform: translate(-50%, 0) scale(1);
 }
 
+.mission-win {
+  position: fixed;
+  z-index: 70;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+}
+
+.mission-win.is-visible {
+  opacity: 1;
+}
+
+.mission-win::before {
+  position: absolute;
+  inset: 0;
+  content: '';
+  background: radial-gradient(circle at center, rgba(255, 246, 181, 0.8), rgba(63, 72, 111, 0.28) 52%, transparent 74%);
+  opacity: 0;
+}
+
+.mission-win.is-visible::before {
+  animation: family-win-flash 1250ms ease-out both;
+}
+
+.mission-win__card {
+  position: relative;
+  z-index: 2;
+  width: min(410px, calc(100% - 20px));
+  padding: 26px 24px 22px;
+  border: 7px solid #fff;
+  border-radius: 38px 38px 64px 38px;
+  color: var(--family-ink);
+  background:
+    radial-gradient(circle at 14% 20%, rgba(255, 219, 89, 0.28) 0 4px, transparent 5px),
+    linear-gradient(155deg, #fffef7, #effaff);
+  box-shadow: 0 28px 80px rgba(48, 55, 91, 0.32), 0 9px 0 rgba(255, 214, 72, 0.62);
+  text-align: center;
+  opacity: 0;
+  transform: translateY(50px) scale(0.6) rotate(-6deg);
+}
+
+.mission-win.is-visible .mission-win__card {
+  animation: family-win-card 1800ms cubic-bezier(.18, .9, .22, 1) both;
+}
+
+.mission-win__card > small {
+  display: block;
+  color: #bc7c04;
+  font-size: 0.68rem;
+  font-weight: 950;
+  letter-spacing: 0.22em;
+}
+
+.mission-win__icon {
+  width: 86px;
+  height: 86px;
+  display: grid;
+  place-items: center;
+  margin: 12px auto 8px;
+  border: 6px double #e6b52c;
+  border-radius: 34% 66% 52% 48% / 51% 43% 57% 49%;
+  background: #fff8cf;
+  box-shadow: 0 8px 0 #f0cb59;
+  font-size: 2.8rem;
+}
+
+.mission-win__card > strong {
+  display: block;
+  font-size: clamp(1.45rem, 6vw, 2.15rem);
+  line-height: 1.15;
+}
+
+#mission-win-rewards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  margin: 14px 0 10px;
+}
+
+#mission-win-rewards span {
+  padding: 6px 9px;
+  border-radius: 999px;
+  color: var(--accent-dark);
+  background: var(--accent-soft);
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.mission-win__card p {
+  margin: 0;
+  color: var(--family-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.mission-win__card b {
+  color: #a97700;
+}
+
+.mission-win__burst span {
+  position: absolute;
+  z-index: 1;
+  left: 50%;
+  top: 50%;
+  width: 18px;
+  height: 180px;
+  border-radius: 999px;
+  background: linear-gradient(transparent, rgba(255, 217, 72, 0.78), transparent);
+  opacity: 0;
+  transform-origin: 50% 50%;
+}
+
+.mission-win.is-visible .mission-win__burst span {
+  animation: family-win-ray 1200ms ease-out both;
+}
+
+.mission-win__burst span:nth-child(1) { --ray-rotate: 0deg; }
+.mission-win__burst span:nth-child(2) { --ray-rotate: 60deg; }
+.mission-win__burst span:nth-child(3) { --ray-rotate: 120deg; }
+
 .celebration span {
   position: fixed;
   z-index: 25;
@@ -1080,6 +1723,211 @@ body:has(.family-missions) {
 .celebration span:nth-child(4) { --x: 150px; --y: -170px; color: #4fbd82; animation-delay: 40ms; }
 .celebration span:nth-child(5) { --x: 190px; --y: -40px; animation-delay: 100ms; }
 .celebration span:nth-child(6) { --x: -200px; --y: 10px; color: #57a6eb; animation-delay: 80ms; }
+.celebration span:nth-child(7) { --x: -235px; --y: 120px; color: #f490a8; animation-delay: 160ms; }
+.celebration span:nth-child(8) { --x: -80px; --y: 190px; color: #ffbe2e; animation-delay: 30ms; }
+.celebration span:nth-child(9) { --x: 60px; --y: 210px; color: #5dca92; animation-delay: 130ms; }
+.celebration span:nth-child(10) { --x: 210px; --y: 130px; color: #7f6bea; animation-delay: 190ms; }
+.celebration span:nth-child(11) { --x: 250px; --y: 35px; color: #ffbf2d; animation-delay: 10ms; }
+.celebration span:nth-child(12) { --x: 10px; --y: -285px; color: #f0788f; animation-delay: 220ms; }
+
+.reward-flight-layer {
+  position: fixed;
+  z-index: 55;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.reward-particle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  margin: -21px 0 0 -21px;
+  border: 4px solid #fff;
+  border-radius: 50%;
+  background: #fff8cf;
+  box-shadow: 0 8px 22px rgba(90, 67, 16, 0.25);
+  font-size: 1.25rem;
+  opacity: 0;
+}
+
+.reward-particle--star {
+  color: #b67b00;
+  background: #ffe57f;
+}
+
+.reward-particle--ability {
+  background: #fff;
+}
+
+.rank-up-overlay {
+  position: fixed;
+  z-index: 90;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(255, 245, 166, 0.94), transparent 24rem),
+    rgba(69, 77, 119, 0.72);
+  opacity: 0;
+  backdrop-filter: blur(12px);
+  transition: opacity 260ms ease;
+}
+
+.rank-up-overlay[hidden] {
+  display: none;
+}
+
+.rank-up-overlay.is-visible {
+  opacity: 1;
+}
+
+.rank-up-sky span {
+  position: absolute;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: clamp(3rem, 11vw, 8rem);
+  pointer-events: none;
+}
+
+.rank-up-sky span:nth-child(1) { top: 7%; left: 4%; animation: family-cloud-drift 4s ease-in-out infinite alternate; }
+.rank-up-sky span:nth-child(2) { top: 10%; right: 16%; color: #ffe37a; font-size: 3rem; animation: family-rank-star 1.6s ease-in-out infinite; }
+.rank-up-sky span:nth-child(3) { right: 3%; bottom: 7%; animation: family-cloud-drift 4.8s ease-in-out -2s infinite alternate-reverse; }
+
+.rank-up-card {
+  position: relative;
+  width: min(470px, 100%);
+  padding: 30px clamp(22px, 6vw, 46px) 34px;
+  border: 8px solid #fff;
+  border-radius: 46px 46px 80px 46px;
+  color: var(--family-ink);
+  background:
+    radial-gradient(circle at 15% 18%, rgba(255, 226, 105, 0.28) 0 4px, transparent 5px),
+    radial-gradient(circle at 85% 24%, rgba(119, 143, 226, 0.2) 0 5px, transparent 6px),
+    linear-gradient(155deg, #fffef8, #eef7ff);
+  box-shadow: 0 30px 90px rgba(31, 37, 70, 0.35), 0 12px 0 rgba(255, 224, 105, 0.45);
+  text-align: center;
+  transform: translateY(30px) scale(0.68) rotate(-4deg);
+}
+
+.rank-up-overlay.is-visible .rank-up-card {
+  animation: family-rank-card-in 720ms cubic-bezier(.18, .92, .2, 1.15) both;
+}
+
+.rank-up-eyebrow {
+  margin: 0;
+  color: #be7d07;
+  font-size: 0.78rem;
+  font-weight: 950;
+  letter-spacing: 0.25em;
+}
+
+.rank-up-level {
+  display: inline-flex;
+  margin-top: 8px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  color: #72570d;
+  background: #fff0a6;
+  font-size: 0.78rem;
+  font-weight: 950;
+}
+
+.rank-up-medal {
+  width: 112px;
+  height: 112px;
+  display: grid;
+  place-items: center;
+  margin: 18px auto 12px;
+  border: 8px double #e1ad29;
+  border-radius: 36% 64% 49% 51% / 48% 39% 61% 52%;
+  background: #fff9d7;
+  box-shadow: 0 10px 0 #f0c751, 0 16px 30px rgba(133, 97, 11, 0.2);
+  font-size: 3.4rem;
+  animation: family-medal-glow 1.8s ease-in-out infinite alternate;
+}
+
+.rank-up-name {
+  margin: 16px 0 3px;
+  color: var(--accent-dark);
+  font-size: 0.88rem;
+  font-weight: 950;
+}
+
+.rank-up-card h2 {
+  margin: 0;
+  color: #3d4059;
+  font-size: clamp(2rem, 7vw, 3rem);
+  line-height: 1.12;
+}
+
+.rank-up-unlock {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0;
+  padding: 14px;
+  border: 2px dashed #dfbf55;
+  border-radius: 20px;
+  color: #6e5717;
+  background: rgba(255, 246, 202, 0.72);
+  text-align: left;
+}
+
+.rank-up-unlock > span {
+  flex: 0 0 auto;
+  font-size: 1.8rem;
+}
+
+.rank-up-unlock div {
+  display: flex;
+  flex-direction: column;
+}
+
+.rank-up-unlock small {
+  color: #9b7a1d;
+  font-size: 0.67rem;
+  font-weight: 900;
+}
+
+.rank-up-unlock strong {
+  margin-top: 2px;
+  font-size: 0.92rem;
+}
+
+#rank-up-close {
+  width: 100%;
+  min-height: 58px;
+  border: 0;
+  border-radius: 18px;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  box-shadow: 0 7px 0 color-mix(in srgb, var(--accent-dark) 74%, #40435a);
+  font: inherit;
+  font-weight: 950;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+#rank-up-close:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 9px 0 color-mix(in srgb, var(--accent-dark) 74%, #40435a);
+}
+
+#rank-up-close:active {
+  transform: translateY(5px);
+  box-shadow: 0 2px 0 color-mix(in srgb, var(--accent-dark) 74%, #40435a);
+}
+
+#rank-up-close:focus-visible {
+  outline: 4px solid #f7c945;
+  outline-offset: 4px;
+}
 
 .floating-sparkles span {
   position: absolute;
@@ -1096,9 +1944,39 @@ body:has(.family-missions) {
 
 .scout-tab:focus-visible,
 .mission-complete:focus-visible,
+.mission-guide-toggle:focus-visible,
+.ability-inspect:focus-visible,
+.rank-chapter__toggle:focus-visible,
+.sound-toggle:focus-visible,
 .home-link:focus-visible {
   outline: 4px solid #f7c945;
   outline-offset: 3px;
+}
+
+@keyframes family-new-trail-star {
+  0% { color: #fff; transform: scale(0.1) rotate(-80deg); filter: drop-shadow(0 0 0 rgba(255, 202, 43, 0)); }
+  42% { color: #ffc51f; transform: scale(1.9) rotate(18deg); filter: drop-shadow(0 0 14px rgba(255, 202, 43, 0.95)); }
+  72% { transform: scale(0.82) rotate(-8deg); }
+  100% { color: #f2b900; transform: scale(1) rotate(0); }
+}
+
+@keyframes family-win-flash {
+  0% { opacity: 0; transform: scale(0.45); }
+  24% { opacity: 1; }
+  100% { opacity: 0; transform: scale(1.35); }
+}
+
+@keyframes family-win-card {
+  0% { opacity: 0; transform: translateY(50px) scale(0.6) rotate(-6deg); }
+  23% { opacity: 1; transform: translateY(-10px) scale(1.05) rotate(2deg); }
+  38%, 78% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
+  100% { opacity: 0; transform: translateY(-28px) scale(0.94) rotate(2deg); }
+}
+
+@keyframes family-win-ray {
+  0% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--ray-rotate, 0deg)) scaleY(0.2); }
+  30% { opacity: 0.72; }
+  100% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--ray-rotate, 0deg)) scaleY(1.8); }
 }
 
 @keyframes family-celebrate {
@@ -1110,6 +1988,106 @@ body:has(.family-missions) {
 @keyframes family-float {
   from { transform: translateY(-8px) rotate(-8deg); }
   to { transform: translateY(18px) rotate(8deg); }
+}
+
+@keyframes family-hero-breathe {
+  from { transform: scale(1.035) translate3d(-0.4%, 0, 0); }
+  to { transform: scale(1.075) translate3d(0.8%, -0.6%, 0); }
+}
+
+@keyframes family-seal-bob {
+  0%, 100% { transform: translateY(0) rotate(7deg) scale(1); }
+  50% { transform: translateY(-8px) rotate(1deg) scale(1.04); }
+}
+
+@keyframes family-pin-float {
+  from { transform: translateY(-3px) rotate(-10deg); }
+  to { transform: translateY(8px) rotate(-2deg); }
+}
+
+@keyframes family-portrait-switch {
+  0% { opacity: 0.2; transform: translateX(-26px) rotate(-8deg) scale(0.88); }
+  58% { opacity: 1; transform: translateX(7px) rotate(2deg) scale(1.035); }
+  100% { opacity: 1; transform: translateX(0) rotate(-2deg) scale(1); }
+}
+
+@keyframes family-copy-switch {
+  from { opacity: 0; transform: translateX(24px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes family-card-deal {
+  from { opacity: 0; transform: translateY(32px) rotate(2deg) scale(0.94); }
+  65% { opacity: 1; transform: translateY(-4px) rotate(-0.6deg) scale(1.01); }
+  to { opacity: 1; transform: translateY(0) rotate(0) scale(1); }
+}
+
+@keyframes family-mission-icon {
+  0%, 100% { transform: translateY(0) rotate(0) scale(1); }
+  35% { transform: translateY(-9px) rotate(-9deg) scale(1.12); }
+  70% { transform: translateY(-3px) rotate(8deg) scale(1.06); }
+}
+
+@keyframes family-stamp-slam {
+  0% { opacity: 0; transform: translate(32px, -38px) rotate(24deg) scale(2.7); }
+  58% { opacity: 1; transform: translate(0, 0) rotate(-17deg) scale(0.86); }
+  78% { transform: rotate(-9deg) scale(1.12); }
+  100% { opacity: 1; transform: rotate(-12deg) scale(1); }
+}
+
+@keyframes family-card-success {
+  0%, 100% { box-shadow: 0 10px 22px rgba(72, 78, 91, 0.08); }
+  40% { border-color: #54bd80; box-shadow: 0 0 0 8px rgba(95, 202, 138, 0.16), 0 20px 35px rgba(70, 145, 98, 0.23); transform: translateY(-5px) scale(1.018); }
+}
+
+@keyframes family-wallet-reward {
+  0%, 100% { transform: scale(1) rotate(0); }
+  28% { transform: scale(1.24) rotate(-7deg); box-shadow: 0 0 0 10px rgba(255, 214, 70, 0.22); }
+  55% { transform: scale(0.95) rotate(4deg); }
+  76% { transform: scale(1.08) rotate(-2deg); }
+}
+
+@keyframes family-count-pop {
+  0%, 100% { transform: scale(1); }
+  38% { transform: scale(1.18) rotate(-4deg); box-shadow: 0 0 0 8px var(--accent-soft); }
+}
+
+@keyframes family-ability-grow {
+  0%, 100% { transform: scale(1); box-shadow: none; }
+  35% { transform: translateY(-7px) scale(1.035); box-shadow: 0 0 0 8px color-mix(in srgb, var(--ability-color) 16%, transparent), 0 18px 32px color-mix(in srgb, var(--ability-color) 22%, transparent); }
+  70% { transform: translateY(1px) scale(0.99); }
+}
+
+@keyframes family-grade-shine {
+  0%, 100% { transform: scale(1); }
+  42% { color: #fff; background: var(--ability-color); transform: scale(1.18) rotate(5deg); box-shadow: 0 0 20px color-mix(in srgb, var(--ability-color) 60%, transparent); }
+}
+
+@keyframes family-ability-icon {
+  0%, 100% { transform: scale(1) rotate(0); }
+  35% { transform: scale(1.28) rotate(-12deg); box-shadow: 0 0 0 8px rgba(255, 255, 255, 0.75); }
+  70% { transform: scale(0.95) rotate(8deg); }
+}
+
+@keyframes family-rank-card-in {
+  0% { opacity: 0; transform: translateY(60px) scale(0.56) rotate(-8deg); }
+  68% { opacity: 1; transform: translateY(-8px) scale(1.045) rotate(2deg); }
+  100% { opacity: 1; transform: translateY(0) scale(1) rotate(0); }
+}
+
+@keyframes family-medal-glow {
+  from { transform: rotate(-3deg) scale(0.98); filter: drop-shadow(0 0 0 rgba(255, 210, 57, 0)); }
+  to { transform: rotate(3deg) scale(1.045); filter: drop-shadow(0 0 12px rgba(255, 210, 57, 0.68)); }
+}
+
+@keyframes family-cloud-drift {
+  from { transform: translateX(-14px) translateY(4px); }
+  to { transform: translateX(22px) translateY(-7px); }
+}
+
+@keyframes family-rank-star {
+  0%, 100% { opacity: 0.55; transform: scale(0.75) rotate(0); }
+  50% { opacity: 1; transform: scale(1.25) rotate(45deg); }
 }
 
 @media (max-width: 980px) {
@@ -1152,13 +2130,8 @@ body:has(.family-missions) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .rank-trail {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 22px 10px;
-  }
-
-  .rank-trail::before {
-    display: none;
+  .rank-map {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1183,6 +2156,22 @@ body:has(.family-missions) {
   .home-link {
     top: 14px;
     left: 14px;
+  }
+
+  .sound-toggle {
+    top: 14px;
+    right: 14px;
+    width: 46px;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .sound-toggle small {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
   }
 
   .quest-hero__copy {
@@ -1274,6 +2263,19 @@ body:has(.family-missions) {
     grid-template-columns: 1fr;
   }
 
+  .ability-scale {
+    grid-template-columns: 1fr;
+    padding: 15px;
+  }
+
+  .ability-scale ol {
+    grid-template-columns: repeat(4, minmax(42px, 1fr));
+  }
+
+  .ability-scale p {
+    text-align: left;
+  }
+
   .mission-card,
   .mission-card:last-child {
     grid-column: auto;
@@ -1284,8 +2286,23 @@ body:has(.family-missions) {
     min-height: 410px;
   }
 
-  .rank-trail {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .mini-star-trail {
+    gap: 3px;
+    padding-inline: 7px;
+  }
+
+  .mission-win__card {
+    padding: 23px 17px 20px;
+    border-width: 6px;
+    border-radius: 32px 32px 52px 32px;
+  }
+
+  .rank-chapter__header {
+    grid-template-columns: auto 44px minmax(0, 1fr);
+  }
+
+  .rank-chapter__header > strong {
+    grid-column: 2 / -1;
   }
 
   .family-rule {
@@ -1312,15 +2329,72 @@ body:has(.family-missions) {
     flex-direction: column;
     gap: 3px;
   }
+
+  .rank-up-overlay {
+    padding: 12px;
+  }
+
+  .rank-up-card {
+    padding: 24px 18px 26px;
+    border-width: 6px;
+    border-radius: 34px 34px 58px 34px;
+  }
+
+  .rank-up-medal {
+    width: 92px;
+    height: 92px;
+    margin-top: 13px;
+    font-size: 2.8rem;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .quest-hero__art,
+  .quest-hero__seal,
+  .portrait-pin,
   .scout-tab,
+  .scout-story-card,
+  .scout-portrait-frame,
+  .scout-story-card__copy,
   .mission-card,
+  .mission-card__illustration > span,
   .mission-complete,
+  .mission-count,
+  .star-wallet,
+  .ability-card,
+  .ability-card__icon,
+  .ability-grade,
   .mission-toast,
   .floating-sparkles,
-  .is-celebrating .celebration span {
-    display: none;
+  .is-celebrating .celebration span,
+  .rank-up-overlay,
+  .rank-up-card,
+  .rank-up-medal,
+  .rank-up-sky span {
+    animation: none;
+    transition: none;
+  }
+
+  .mini-star-trail span,
+  .mission-guide,
+  .ability-ladder,
+  .rank-chapter__steps,
+  .mission-win,
+  .mission-win::before,
+  .mission-win__card,
+  .mission-win__burst span {
+    animation: none;
+    transition: none;
+  }
+
+  .mission-win.is-visible .mission-win__card {
+    opacity: 1;
+    transform: none;
+  }
+
+  .rank-up-overlay.is-visible,
+  .rank-up-overlay.is-visible .rank-up-card {
+    opacity: 1;
+    transform: none;
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -45,6 +45,7 @@
 
 // 雙羽家庭任務頁
 @use "family-missions";
+@use "family-missions-pixel";
 
 // RPG 遊戲介面
 // 引入 status-bar 樣式

--- a/tests/e2e/family-missions.spec.ts
+++ b/tests/e2e/family-missions.spec.ts
@@ -22,6 +22,7 @@ test.describe('雙羽任務所', () => {
     await page.getByRole('button', { name: '進入今日任務' }).click();
     await expect(page.locator('#quest-warp')).toHaveClass(/is-visible/);
     await expect(page.locator('#quest-warp')).toContainText('QUEST START!');
+    await expect(page.locator('#quest-chain-count')).toHaveText('0 / 5');
   });
 
   test('孩子可以切換角色並回報生活任務', async ({ page }) => {
@@ -39,6 +40,12 @@ test.describe('雙羽任務所', () => {
     await expect(page.getByTestId('ability-responsibility')).toHaveClass(/is-just-grown/);
     await expect(page.locator('.star-wallet')).toHaveClass(/is-rewarded/);
     await expect(page.locator('#mission-win')).toHaveClass(/is-visible/);
+    await expect(page.locator('#mission-win-stars-before')).toHaveText('39');
+    await expect(page.locator('#mission-win-stars-after')).toHaveText('40 ★');
+    await expect(page.locator('#quest-chain-count')).toHaveText('1 / 5');
+    await expect(page.locator('#quest-chain-track .is-lit')).toHaveCount(1);
+    await expect(page.locator('#scout-reaction-text')).toContainText('星星和能力都變強了');
+    await expect(page.locator('#ability-level-up')).toHaveClass(/is-visible/);
     await expect(page.locator('#mini-star-trail .is-lit')).toHaveCount(0);
     await expect(page.getByText('已回報', { exact: true })).toBeVisible();
 
@@ -58,6 +65,21 @@ test.describe('雙羽任務所', () => {
     await expect(page.getByTestId('scout-rank')).toContainText('小兵');
     await expect(page.getByTestId('star-count')).toHaveText('11');
     await expect(page.getByTestId('scout-portrait')).toHaveAttribute('src', /amy-scout/);
+  });
+
+  test('完成五個任務會開啟今日全破寶箱', async ({ page }) => {
+    await page.getByRole('tab', { name: /Amy/ }).click();
+    for (let index = 0; index < 5; index += 1) {
+      await page.locator('.mission-complete:not(:disabled)').first().click();
+    }
+
+    await expect(page.locator('#quest-chain-count')).toHaveText('5 / 5');
+    await expect(page.locator('#quest-chain-hud')).toHaveClass(/is-perfect/);
+    const dailyClear = page.getByRole('dialog', { name: '今日任務全破' });
+    await expect(dailyClear).toBeVisible();
+    await expect(dailyClear).toContainText('Amy 今日全破');
+    await dailyClear.getByRole('button', { name: '查看今天成長的能力' }).click();
+    await expect(dailyClear).toBeHidden();
   });
 
   test('任務與屬性以圖文並茂的靜態內容呈現', async ({ page }) => {

--- a/tests/e2e/family-missions.spec.ts
+++ b/tests/e2e/family-missions.spec.ts
@@ -16,22 +16,35 @@ test.describe('雙羽任務所', () => {
     await expect(page.getByRole('heading', { name: '雙羽星光任務所' })).toBeVisible();
     await expect(page.getByTestId('scout-name')).toContainText('林芮羽 Apple');
     await expect(page.getByTestId('scout-rank')).toContainText('初級偵查兵');
-    await expect(page.getByTestId('star-count')).toHaveText('80');
+    await expect(page.getByTestId('star-count')).toHaveText('39');
     await expect(page.getByTestId('scout-portrait')).toHaveAttribute('src', /apple-scout/);
 
     await page.getByRole('button', { name: '完成：整理自己的物品' }).click();
     await expect(page.getByRole('status')).toContainText('任務完成回報');
-    await expect(page.getByTestId('star-count')).toHaveText('82');
+    await expect(page.getByTestId('star-count')).toHaveText('40');
+    await expect(page.getByTestId('scout-rank')).toContainText('中級偵查兵');
     await expect(page.getByTestId('ability-responsibility')).toContainText('責任');
+    await expect(page.getByTestId('ability-responsibility')).toHaveClass(/is-just-grown/);
+    await expect(page.locator('.star-wallet')).toHaveClass(/is-rewarded/);
+    await expect(page.locator('#mission-win')).toHaveClass(/is-visible/);
+    await expect(page.locator('#mini-star-trail .is-lit')).toHaveCount(0);
     await expect(page.getByText('已回報', { exact: true })).toBeVisible();
 
+    const rankUp = page.getByRole('dialog', { name: '升階成功' });
+    await expect(rankUp).toBeVisible();
+    await expect(rankUp).toContainText('第 4 階');
+    await expect(rankUp).toContainText('中級偵查兵');
+    await expect(rankUp).toContainText('能準備自己的小裝備');
+    await rankUp.getByRole('button', { name: '收下新軍階' }).click();
+    await expect(rankUp).toBeHidden();
+
     await page.reload();
-    await expect(page.getByTestId('star-count')).toHaveText('82');
+    await expect(page.getByTestId('star-count')).toHaveText('40');
 
     await page.getByRole('tab', { name: /Amy/ }).click();
     await expect(page.getByTestId('scout-name')).toContainText('林彥羽 Amy');
     await expect(page.getByTestId('scout-rank')).toContainText('小兵');
-    await expect(page.getByTestId('star-count')).toHaveText('0');
+    await expect(page.getByTestId('star-count')).toHaveText('11');
     await expect(page.getByTestId('scout-portrait')).toHaveAttribute('src', /amy-scout/);
   });
 
@@ -51,6 +64,37 @@ test.describe('雙羽任務所', () => {
     await expect(abilityGarden).toContainText('責任');
 
     await expect(page.getByRole('region', { name: '成長徽章' })).toContainText('自理小達人');
-    await expect(page.getByRole('region', { name: '升階旅程' })).toContainText('中級偵查兵');
+    const rankJourney = page.getByRole('region', { name: '升階旅程' });
+    await expect(rankJourney).toContainText('500 星・50 階成長地圖');
+    await expect(rankJourney.locator('[data-rank-stars]')).toHaveCount(50);
+  });
+
+  test('角色切換與任務卡具有清楚的動態操作狀態', async ({ page }) => {
+    await expect(page.locator('.family-missions')).toHaveAttribute('data-motion-ready', 'true');
+    await page.getByRole('tab', { name: /Amy/ }).click();
+    await expect(page.locator('.scout-story-card')).toHaveClass(/is-switching/);
+    await expect(page.locator('.mission-card').first()).toHaveClass(/is-entering/);
+
+    const completeButton = page.getByRole('button', { name: '完成：玩具回家任務' });
+    await expect(completeButton).toHaveAttribute('data-reward-preview', '責任 +1、任務星 +1');
+  });
+
+  test('任務口訣、能力軌道與成長地圖可以展開探索', async ({ page }) => {
+    const missionCard = page.locator('.mission-card').first();
+    const missionGuideButton = missionCard.getByRole('button', { name: /三步任務口訣/ });
+    await missionGuideButton.click();
+    await expect(missionGuideButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(missionCard.locator('.mission-guide')).toHaveAttribute('aria-hidden', 'false');
+    await expect(missionCard.locator('.mission-guide li')).toHaveCount(3);
+
+    const responsibility = page.getByTestId('ability-responsibility');
+    const abilityButton = responsibility.getByRole('button', { name: /成長軌道/ });
+    await abilityButton.click();
+    await expect(abilityButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(responsibility.locator('.ability-ladder span')).toHaveCount(21);
+
+    const currentChapter = page.locator('.rank-chapter.is-current');
+    await expect(currentChapter).toHaveClass(/is-open/);
+    await expect(currentChapter.getByRole('button', { name: /五個軍階/ })).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/tests/e2e/family-missions.spec.ts
+++ b/tests/e2e/family-missions.spec.ts
@@ -17,6 +17,8 @@ test.describe('雙羽任務所', () => {
   test('像素冒險介面提供 HUD 與任務開始過場', async ({ page }) => {
     await expect(page.locator('.pixel-hero-hud')).toContainText('APPLE');
     await expect(page.locator('.pixel-hero-hud')).toContainText('039');
+    await expect(page.locator('#hero-pixel-art')).toHaveClass(/is-rendered/);
+    await expect(page.locator('#scout-portrait-pixel')).toHaveClass(/is-rendered/);
     await page.getByRole('button', { name: '進入今日任務' }).click();
     await expect(page.locator('#quest-warp')).toHaveClass(/is-visible/);
     await expect(page.locator('#quest-warp')).toContainText('QUEST START!');

--- a/tests/e2e/family-missions.spec.ts
+++ b/tests/e2e/family-missions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test.describe('雙羽任務所', () => {
+test.describe('雙羽任務所行為回饋循環', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/family-missions');
     await page.evaluate(() => window.localStorage.clear());
@@ -14,121 +14,94 @@ test.describe('雙羽任務所', () => {
     await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', /noindex/i);
   });
 
-  test('像素冒險介面提供 HUD 與任務開始過場', async ({ page }) => {
-    await expect(page.locator('.pixel-hero-hud')).toContainText('APPLE');
-    await expect(page.locator('.pixel-hero-hud')).toContainText('039');
-    await expect(page.locator('#hero-pixel-art')).toHaveClass(/is-rendered/);
-    await expect(page.locator('#scout-portrait-pixel')).toHaveClass(/is-rendered/);
-    await page.getByRole('button', { name: '進入今日任務' }).click();
-    await expect(page.locator('#quest-warp')).toHaveClass(/is-visible/);
-    await expect(page.locator('#quest-warp')).toContainText('QUEST START!');
-    await expect(page.locator('#quest-chain-count')).toHaveText('0 / 5');
-  });
-
-  test('孩子可以切換角色並回報生活任務', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: '雙羽星光任務所' })).toBeVisible();
-    await expect(page.getByTestId('scout-name')).toContainText('林芮羽 Apple');
-    await expect(page.getByTestId('scout-rank')).toContainText('初級偵查兵');
-    await expect(page.getByTestId('star-count')).toHaveText('39');
-    await expect(page.getByTestId('scout-portrait')).toHaveAttribute('src', /apple-scout/);
-
-    await page.getByRole('button', { name: '完成：整理自己的物品' }).click();
-    await expect(page.getByRole('status')).toContainText('任務完成回報');
-    await expect(page.getByTestId('star-count')).toHaveText('40');
-    await expect(page.getByTestId('scout-rank')).toContainText('中級偵查兵');
-    await expect(page.getByTestId('ability-responsibility')).toContainText('責任');
-    await expect(page.getByTestId('ability-responsibility')).toHaveClass(/is-just-grown/);
-    await expect(page.locator('.star-wallet')).toHaveClass(/is-rewarded/);
-    await expect(page.locator('#mission-win')).toHaveClass(/is-visible/);
-    await expect(page.locator('#mission-win-stars-before')).toHaveText('39');
-    await expect(page.locator('#mission-win-stars-after')).toHaveText('40 ★');
-    await expect(page.locator('#quest-chain-count')).toHaveText('1 / 5');
-    await expect(page.locator('#quest-chain-track .is-lit')).toHaveCount(1);
-    await expect(page.locator('#scout-reaction-text')).toContainText('星星和能力都變強了');
-    await expect(page.locator('#ability-level-up')).toHaveClass(/is-visible/);
-    await expect(page.locator('#mini-star-trail .is-lit')).toHaveCount(0);
-    await expect(page.getByText('已回報', { exact: true })).toBeVisible();
-
-    const rankUp = page.getByRole('dialog', { name: '升階成功' });
-    await expect(rankUp).toBeVisible();
-    await expect(rankUp).toContainText('第 4 階');
-    await expect(rankUp).toContainText('中級偵查兵');
-    await expect(rankUp).toContainText('能準備自己的小裝備');
-    await rankUp.getByRole('button', { name: '收下新軍階' }).click();
-    await expect(rankUp).toBeHidden();
-
-    await page.reload();
-    await expect(page.getByTestId('star-count')).toHaveText('40');
-
-    await page.getByRole('tab', { name: /Amy/ }).click();
-    await expect(page.getByTestId('scout-name')).toContainText('林彥羽 Amy');
-    await expect(page.getByTestId('scout-rank')).toContainText('小兵');
-    await expect(page.getByTestId('star-count')).toHaveText('11');
-    await expect(page.getByTestId('scout-portrait')).toHaveAttribute('src', /amy-scout/);
-  });
-
-  test('完成五個任務會開啟今日全破寶箱', async ({ page }) => {
-    await page.getByRole('tab', { name: /Amy/ }).click();
-    for (let index = 0; index < 5; index += 1) {
-      await page.locator('.mission-complete:not(:disabled)').first().click();
-    }
-
-    await expect(page.locator('#quest-chain-count')).toHaveText('5 / 5');
-    await expect(page.locator('#quest-chain-hud')).toHaveClass(/is-perfect/);
-    const dailyClear = page.getByRole('dialog', { name: '今日任務全破' });
-    await expect(dailyClear).toBeVisible();
-    await expect(dailyClear).toContainText('Amy 今日全破');
-    await dailyClear.getByRole('button', { name: '查看今天成長的能力' }).click();
-    await expect(dailyClear).toBeHidden();
-  });
-
-  test('任務與屬性以圖文並茂的靜態內容呈現', async ({ page }) => {
-    await expect(page.getByRole('img', { name: /雙羽小小偵查員/ })).toBeVisible();
+  test('任務、成長與收藏拆成三個清楚畫面', async ({ page }) => {
     await expect(page.getByRole('heading', { name: '今天的任務地圖' })).toBeVisible();
-    await expect(page.locator('.mission-card')).toHaveCount(5);
-
-    const abilityGarden = page.getByRole('region', { name: '能力花園' });
-    await expect(abilityGarden).toBeVisible();
-    await expect(abilityGarden.locator('.ability-card')).toHaveCount(6);
-    await expect(abilityGarden).toContainText('國文');
-    await expect(abilityGarden).toContainText('數學');
-    await expect(abilityGarden).toContainText('英文');
-    await expect(abilityGarden).toContainText('禮儀');
-    await expect(abilityGarden).toContainText('友善');
-    await expect(abilityGarden).toContainText('責任');
-
-    await expect(page.getByRole('region', { name: '成長徽章' })).toContainText('自理小達人');
-    const rankJourney = page.getByRole('region', { name: '升階旅程' });
-    await expect(rankJourney).toContainText('500 星・50 階成長地圖');
-    await expect(rankJourney.locator('[data-rank-stars]')).toHaveCount(50);
+    await expect(page.getByRole('region', { name: '能力花園' })).toBeHidden();
+    await page.getByRole('tab', { name: /成長手冊/ }).click();
+    await expect(page.getByRole('region', { name: '能力花園' })).toBeVisible();
+    await expect(page.getByText('萌芽 1', { exact: true }).first()).toBeVisible();
+    await page.getByRole('tab', { name: /收藏地圖/ }).click();
+    await expect(page.getByRole('region', { name: '升階旅程' })).toBeVisible();
   });
 
-  test('角色切換與任務卡具有清楚的動態操作狀態', async ({ page }) => {
-    await expect(page.locator('.family-missions')).toHaveAttribute('data-motion-ready', 'true');
-    await page.getByRole('tab', { name: /Amy/ }).click();
-    await expect(page.locator('.scout-story-card')).toHaveClass(/is-switching/);
-    await expect(page.locator('.mission-card').first()).toHaveClass(/is-entering/);
+  test('孩子必須先接取、回報感受，再等待家長確認', async ({ page }) => {
+    const card = page.locator('.mission-card').first();
+    await expect(card).toContainText('主線');
+    await card.getByRole('button', { name: /接下這個任務/ }).click();
+    await expect(card.getByRole('button', { name: /我回來了/ })).toBeVisible();
+    await expect(page.getByTestId('star-count')).toHaveText('39');
 
-    const completeButton = page.getByRole('button', { name: '完成：玩具回家任務' });
-    await expect(completeButton).toHaveAttribute('data-reward-preview', '責任 +1、任務星 +1');
+    await card.getByRole('button', { name: /我回來了/ }).click();
+    const report = page.getByRole('dialog', { name: /回報：整理自己的物品/ });
+    await report.getByRole('radio', { name: '我自己完成' }).click();
+    await report.getByRole('button', { name: /投入星光信箱/ }).click();
+
+    await expect(card).toContainText('等待家長確認');
+    await expect(page.getByTestId('star-count')).toHaveText('39');
+    await expect(page.locator('#parent-pending-count')).toHaveText('1');
   });
 
-  test('任務口訣、能力軌道與成長地圖可以展開探索', async ({ page }) => {
-    const missionCard = page.locator('.mission-card').first();
-    const missionGuideButton = missionCard.getByRole('button', { name: /三步任務口訣/ });
-    await missionGuideButton.click();
-    await expect(missionGuideButton).toHaveAttribute('aria-expanded', 'true');
-    await expect(missionCard.locator('.mission-guide')).toHaveAttribute('aria-hidden', 'false');
-    await expect(missionCard.locator('.mission-guide li')).toHaveCount(3);
+  test('家長確認後才加榮譽星與能力成長', async ({ page }) => {
+    const card = page.locator('.mission-card').first();
+    await card.getByRole('button', { name: /接下這個任務/ }).click();
+    await card.getByRole('button', { name: /我回來了/ }).click();
+    await page.getByRole('radio', { name: '我自己完成' }).click();
+    await page.getByRole('button', { name: /投入星光信箱/ }).click();
 
-    const responsibility = page.getByTestId('ability-responsibility');
-    const abilityButton = responsibility.getByRole('button', { name: /成長軌道/ });
-    await abilityButton.click();
-    await expect(abilityButton).toHaveAttribute('aria-expanded', 'true');
-    await expect(responsibility.locator('.ability-ladder span')).toHaveCount(21);
+    await page.getByRole('button', { name: /家長基地/ }).click();
+    await page.locator('#parent-pin-input').fill('0921');
+    await page.getByRole('button', { name: '進入家長基地' }).click();
+    await expect(page.getByText('可以這樣說：')).toBeVisible();
+    await page.getByRole('button', { name: /確認完成/ }).click();
 
-    const currentChapter = page.locator('.rank-chapter.is-current');
-    await expect(currentChapter).toHaveClass(/is-open/);
-    await expect(currentChapter.getByRole('button', { name: /五個軍階/ })).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('star-count')).toHaveText('40');
+    await expect(page.locator('#mission-win')).toHaveClass(/is-visible/);
+    await expect(page.locator('#mission-win-praise')).toContainText('自己完成了');
+    await expect(page.getByTestId('ability-responsibility')).toContainText('熟悉 3');
+  });
+
+  test('還差一小步不判定失敗，任務回到進行中', async ({ page }) => {
+    const card = page.locator('.mission-card').first();
+    await card.getByRole('button', { name: /接下這個任務/ }).click();
+    await card.getByRole('button', { name: /我回來了/ }).click();
+    await page.getByRole('radio', { name: '有點難，我有試' }).click();
+    await page.getByRole('button', { name: /投入星光信箱/ }).click();
+
+    await page.getByRole('button', { name: /家長基地/ }).click();
+    await page.locator('#parent-pin-input').fill('1234');
+    await page.getByRole('button', { name: '進入家長基地' }).click();
+    await page.getByRole('button', { name: /還差一小步/ }).click();
+
+    await expect(card).toContainText('最後一條線索');
+    await expect(card).toContainText('回頭檢查桌面和地板');
+    await expect(card.getByRole('button', { name: /我回來了/ })).toBeVisible();
+    await expect(page.getByTestId('star-count')).toHaveText('39');
+  });
+
+  test('同一能力每天最多成長一次，自由挑戰不增加榮譽星', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('supergalen-family-parent-pin', '0921');
+    });
+
+    const completeAndConfirm = async (cardIndex: number) => {
+      const card = page.locator('.mission-card').nth(cardIndex);
+      await card.getByRole('button', { name: /接下這個任務/ }).click();
+      await card.getByRole('button', { name: /我回來了/ }).click();
+      await page.getByRole('radio', { name: '有人幫我' }).click();
+      await page.getByRole('button', { name: /投入星光信箱/ }).click();
+      await page.getByRole('button', { name: /家長基地/ }).click();
+      await page.locator('#parent-pin-input').fill('0921');
+      await page.getByRole('button', { name: '進入家長基地' }).click();
+      await page.getByRole('button', { name: /這次一起完成/ }).click();
+    };
+
+    await completeAndConfirm(0);
+    await completeAndConfirm(1);
+    await expect(page.getByTestId('star-count')).toHaveText('40');
+    await expect(page.getByTestId('ability-responsibility')).toContainText('熟悉 3');
+
+    await completeAndConfirm(3);
+    await expect(page.getByTestId('star-count')).toHaveText('40');
+    await expect(page.locator('#mission-win-star-note')).toContainText('基地收藏');
   });
 });

--- a/tests/e2e/family-missions.spec.ts
+++ b/tests/e2e/family-missions.spec.ts
@@ -7,9 +7,19 @@ test.describe('雙羽任務所', () => {
     await page.reload();
   });
 
-  test('從主站導覽可進入任務頁', async ({ page }) => {
+  test('任務頁維持隱藏且不出現在主站導覽', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('a[href="/family-missions"]').first()).toContainText('雙羽任務');
+    await expect(page.locator('a[href="/family-missions"]')).toHaveCount(0);
+    await page.goto('/family-missions');
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', /noindex/i);
+  });
+
+  test('像素冒險介面提供 HUD 與任務開始過場', async ({ page }) => {
+    await expect(page.locator('.pixel-hero-hud')).toContainText('APPLE');
+    await expect(page.locator('.pixel-hero-hud')).toContainText('039');
+    await page.getByRole('button', { name: '進入今日任務' }).click();
+    await expect(page.locator('#quest-warp')).toHaveClass(/is-visible/);
+    await expect(page.locator('#quest-warp')).toContainText('QUEST START!');
   });
 
   test('孩子可以切換角色並回報生活任務', async ({ page }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,15 @@
   "outputDirectory": "dist",
   "headers": [
     {
+      "source": "/family-missions/:path*",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive, nosnippet, noimageindex"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## What changed

- expands the family mission system to 50 ranks and 500 total stars
- keeps the cohesive 16-bit pixel adventure interface and existing child-focused feedback effects
- replaces instant rewards with a four-state mission loop: available → in progress → awaiting parent confirmation → confirmed
- adds a child mission-report ritual with three effort choices: completed independently, completed with help, or difficult but tried
- adds a device-local four-digit parent base with confirm, one-more-step, and complete-together responses
- splits the long page into Today’s Missions, Growth Handbook, and Collection Map views
- changes daily pacing to three main quests plus two optional challenges
- awards at most two honor stars per day: one for the first confirmed main quest and one for confirming all three
- limits each ability to one growth step per day
- replaces F− through S+ labels with child-readable stages from 萌芽 to 閃耀
- turns optional challenges into persistent base collections and adds a visibly growing Starlight Base
- migrates existing v3 local progress without clearing Apple or Amy data
- keeps Apple and Amy data independent
- keeps the family page hidden from navigation, sitemap, and search indexing

## Why

The previous version made the completion animation strong, but a child could press five buttons and immediately receive every reward. That disconnected the game from the real-life behavior it was meant to support, made ability growth too fast, and made the 500-star journey finish in roughly three months.

The new loop gives immediate feedback for reporting while reserving formal rewards for an adult-confirmed real action. It also avoids failure language: “one more step” returns the mission to progress with a concrete final clue.

## Validation

- family mission data tests: 5/5 passed
- Sass compilation passed
- focused production Astro build passed
- compiled-page runtime smoke passed for child report, parent confirmation, daily two-star cap, one-growth-per-ability cap, optional collection reward, three-main celebration, and one-more-step recovery
- Playwright coverage updated for the new child and parent flows
- hidden-page noindex behavior remains covered
