### PR TITLE
feat(caravan): add M51 veteran mastery and tactical repositioning

### DIFF
--- a/.github/workflows/caravan-m51-ci.yml
+++ b/.github/workflows/caravan-m51-ci.yml
@@ -1,0 +1,101 @@
+name: Caravan M51 Veteran Mastery CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m51-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m51-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M51 veteran progression gates
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+
+      - name: M51 live tactical reposition integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+
+      - name: M51 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/docs/caravan-m51-veteran-mastery.md
+++ b/docs/caravan-m51-veteran-mastery.md
@@ -1,0 +1,121 @@
+# Caravan M51 — Veteran Mastery & Tactical Repositioning
+
+## Problem
+
+《商隊與劍》的角色職涯以 Lv1–Lv5 為完整弧線：成長潛力、職涯里程碑、專精與既有 UI 都把 Lv5 當成成熟角色的共同邊界。但無盡契約會繼續提高難度、繼續發放 XP。若 Lv5 後 XP 只剩數字增加，玩家會失去一條重要的角色層長期目標。
+
+M51 不把等級上限硬拉到 Lv10，也不在封頂後無限疊攻擊、生命或屬性。它把既有 XP 轉成三階、有限、橫向的「老兵精通」，讓成熟角色得到新的戰術選擇，而不是新的數值通膨。
+
+## Progression
+
+| 條件 | 精通 | 解鎖 |
+| --- | --- | --- |
+| Lv5 且 320 XP | I | 戰術換位 |
+| Lv5 且 500 XP | II | 前進接戰時同時進入守勢 |
+| Lv5 且 750 XP | III | 最後前排可由後排隊友接替後撤 |
+
+- Lv4 即使囤積大量 XP 也不會提前取得老兵精通。
+- 750 XP 後精通封頂，不建立無限 post-cap ladder。
+- 使用既有 `level` / `xp` 推導，不新增存檔欄位、不升 save version。
+- 無盡契約原本就會持續給 XP，因此不需要另一種抽象貨幣。
+
+## Tactical Repositioning
+
+`戰術換位` 是額外的 veteran action，不佔原本四格戰技配置。
+
+### Rear → Front
+
+- 花掉完整一回合。
+- Rank I：單純進入前排。
+- Rank II+：進入前排的同時使用既有 `guarding` 規則建立守勢。
+- 不造成傷害、不恢復生命、不增加永久屬性。
+
+### Front → Rear
+
+- 花掉完整一回合。
+- 若還有另一名存活前排，可正常後撤。
+- Rank I–II 若自己是最後一名前排，不能後撤。
+- Rank III 若自己是最後一名前排，但仍有存活後排，必須先由一名後排隊友接替前線才可後撤。
+- 接替者依「防禦 → 當前 HP → 名冊順序」決定，確保 deterministic，不引入另一層目標選擇 UI。
+- 若沒有人能接替，Rank III 也不能憑空消失到後排。
+
+## Why the shift costs a full turn
+
+M49 已讓劍、弓與前後排形成真實取捨。如果換位是免費操作，玩家可以在出手前永久切到最佳射程，M49 的站位系統會失去意義，也會形成無成本 kite。
+
+因此 M51 把「站位修正」本身變成一個回合決策：
+
+- 現在就輸出，承擔錯排 `-2`；或
+- 花一回合重新整隊，換取後續更好的武器射程／護衛位置。
+
+這使換位是戰術投資，而不是必按的免費最佳化。
+
+## Why Rank II uses existing Guard
+
+Rank II 沒有新增專屬減傷、護盾值或新的 buff 種類。前進接戰的老兵直接使用既有 `guarding`：
+
+- 規則可讀；
+- 只維持到該角色下一次自身行動前；
+- 前排仍會實際承受敵人攻擊；
+- 不增加新的疊乘防禦公式。
+
+## Why Rank III requires a real replacement
+
+允許最後一名前排直接後撤會重新製造 M49 已經消滅的「全員安全後排」。Rank III 的價值不是逃離戰場，而是老兵懂得做戰線輪替。
+
+因此後撤必須把另一個活人暴露到前線。威脅沒有消失，只是重新分配。
+
+## Player-facing information contract
+
+M50 的原則延伸到 M51：如果玩家按下一個按鈕會改變站位，他必須在按下前知道結果。
+
+動態 action label：
+
+- `戰術換位〔前進〕`
+- `戰術換位〔前進・守勢〕`
+- `戰術換位〔後撤〕`
+- `戰術換位〔輪替後撤〕`
+- `戰術換位〔無人接替〕`
+
+被禁止的「無人接替」不消耗回合。戰鬥開始 log 也會顯示目前老兵精通與下一個 XP 門檻。
+
+## Multidimensional adversarial review
+
+Automated gates attack the feature from multiple player perspectives:
+
+1. **Power creep** — Rank I/II/III must not change stats, max HP, defense or damage bonus.
+2. **Early farming** — pre-Lv5 XP stockpiling cannot bypass the career boundary.
+3. **Infinite ladder** — mastery caps at Rank III even at enormous XP.
+4. **Free kiting** — every successful shift consumes the actor's full turn.
+5. **Phantom safe row** — no legal shift may leave zero living frontliners.
+6. **Bad-button punishment** — an illegal last-front fallback returns `acted:false` and does not consume the turn.
+7. **Information fairness** — live labels must say advance, guarded advance, fallback, rotation, or no replacement before click.
+8. **Dynamic battlefield truth** — M49 frontline collapse and M51 repositioning use the same runtime `formationRow`; labels follow the new row automatically.
+9. **Idempotency** — repeated combat initialization cannot stack M51 suffixes.
+10. **Regression** — M40–M50 combat, spellcraft, endurance, armory, rituals, convoy, morale, armor and formation tests remain green.
+
+## Rejected alternatives
+
+### Raise level cap to Lv10
+
+Rejected for M51. Lv5 is a shared structural boundary in genesis/growth/career/specialization systems. Raising it requires a broader progression redesign, not a combat patch.
+
+### Infinite veteran ranks
+
+Rejected. Endless numerical growth would eventually trivialize old content and force enemy stat inflation.
+
+### Passive +damage / +HP per post-cap XP
+
+Rejected. It provides no new decision and makes veteran progression mandatory power instead of optional tactical mastery.
+
+### Free once-per-round reposition
+
+Rejected. It deletes the cost of M49's range system and enables stance dancing before every attack.
+
+### Last front may simply retreat at Rank III
+
+Rejected. It recreates an all-rear exploit. Rank III is a rotation, not invisibility.
+
+## Save compatibility
+
+No new persistent field is required. Veteran rank is derived from existing `record.level` and `record.xp`; combat-only row/guard/runtime flags remain ephemeral. Old saves therefore obtain the correct mastery automatically from their existing values.

--- a/docs/caravan-m51-veteran-mastery.md
+++ b/docs/caravan-m51-veteran-mastery.md
@@ -92,7 +92,8 @@ Automated gates attack the feature from multiple player perspectives:
 7. **Information fairness** — live labels must say advance, guarded advance, fallback, rotation, or no replacement before click.
 8. **Dynamic battlefield truth** — M49 frontline collapse and M51 repositioning use the same runtime `formationRow`; labels follow the new row automatically.
 9. **Idempotency** — repeated combat initialization cannot stack M51 suffixes.
-10. **Regression** — M40–M50 combat, spellcraft, endurance, armory, rituals, convoy, morale, armor and formation tests remain green.
+10. **Save compatibility** — mastery is derived from existing fields and cannot mutate the persistent character record.
+11. **Regression** — M40–M50 combat, spellcraft, endurance, armory, rituals, convoy, morale, armor and formation tests remain green.
 
 ## Rejected alternatives
 
@@ -118,4 +119,4 @@ Rejected. It recreates an all-rear exploit. Rank III is a rotation, not invisibi
 
 ## Save compatibility
 
-No new persistent field is required. Veteran rank is derived from existing `record.level` and `record.xp`; combat-only row/guard/runtime flags remain ephemeral. Old saves therefore obtain the correct mastery automatically from their existing values.
+No new persistent field is required. Veteran rank is derived from existing `record.level` and `record.xp`; combat-only row/guard/runtime flags remain ephemeral. `memberFromRecord()` is regression-tested not to mutate the source character record. Old saves therefore obtain the correct mastery automatically from their existing values.

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -31,6 +31,8 @@ export interface Move {
   armorPiercing?: number;
   /** M49：可覆寫自動判定的交戰距離；真正魔法仍由 arcana 規則優先判定。 */
   engagement?: EngagementBand;
+  /** M51：老兵橫向戰術——花完整一回合切換前後排。 */
+  formationShift?: 'toggle';
   damage?: { dice: number; sides: number; bonusStat?: Stat };
   heal?: { dice: number; sides: number; bonusStat?: Stat };
   /** M44：ward 為一次性魔法護法；remaining 代表可抵擋的命中次數。 */
@@ -79,6 +81,13 @@ export interface PartyMember extends CombatantBase {
   isProtagonist?: boolean;
   /** M17 前後排：單體敵襲優先鎖定仍存活的前排。 */
   formationRow?: FormationRow;
+  /** M51：不寫回存檔的老兵精通 runtime。 */
+  veteranMasteryRank?: number;
+  veteranNextXp?: number | null;
+  /** 目前是否可安全後撤；由整隊即時站位計算。 */
+  formationCanFallBack?: boolean;
+  /** 精通 III：最後前排可由後排隊友接替。 */
+  formationReliefFallback?: boolean;
 }
 
 export interface EnemyUnit extends CombatantBase {
@@ -129,6 +138,8 @@ export interface PartyActionResult {
   reason?: string;
 }
 
+const VETERAN_RANK_LABEL = ['', 'I', 'II', 'III'] as const;
+
 export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]): CombatState {
   // M41/M44：雙方施法者共用同一套招式裝飾、秘法／神恩容量與恢復手段。
   for (const member of party) prepareMysticPartyMember(member);
@@ -154,6 +165,14 @@ export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]
   state.log.push({ kind: 'info', text: '戰鬥開始！' });
   collapseFrontLineIfNeeded(state);
   for (const member of party) {
+    const rank = Math.max(0, Math.min(3, Math.floor(member.veteranMasteryRank ?? 0)));
+    if (rank > 0) {
+      const next = member.veteranNextXp;
+      state.log.push({
+        kind: 'info',
+        text: `${member.name}：老兵精通 ${VETERAN_RANK_LABEL[rank]}${next ? `；下一階需 ${next} XP` : '；已完成全部精通'}。`,
+      });
+    }
     if (member.mystic) state.log.push({ kind: 'info', text: `${member.name}：${mysticPowerText(member.mystic)}。` });
   }
   for (const enemy of enemies) {
@@ -214,6 +233,24 @@ function checkOutcome(state: CombatState): void {
   }
 }
 
+/** M51：把「能不能後撤」預先算進角色 runtime，讓所有戰鬥 UI 共用同一真相。 */
+function refreshFormationRuntime(state: CombatState): void {
+  const alive = state.party.filter((member) => member.hp > 0);
+  const fronts = alive.filter((member) => member.formationRow !== 'back');
+  const rears = alive.filter((member) => member.formationRow === 'back');
+  for (const member of state.party) {
+    if (member.hp <= 0 || member.formationRow === 'back') {
+      member.formationCanFallBack = false;
+      member.formationReliefFallback = false;
+      continue;
+    }
+    const hasOtherFront = fronts.some((front) => front.id !== member.id);
+    const canRelief = !hasOtherFront && (member.veteranMasteryRank ?? 0) >= 3 && rears.length > 0;
+    member.formationCanFallBack = hasOtherFront || canRelief;
+    member.formationReliefFallback = canRelief;
+  }
+}
+
 /**
  * M49：前排一旦全數倒下，後排就不再享有「安全距離」的假象。
  * 將仍存活的後排提升為前排，讓近戰恢復正常貼身命中、弓弩承受近身壓力，
@@ -222,9 +259,11 @@ function checkOutcome(state: CombatState): void {
 function collapseFrontLineIfNeeded(state: CombatState): void {
   const aliveParty = state.party.filter((member) => member.hp > 0);
   if (aliveParty.length === 0) return;
-  if (aliveParty.some((member) => member.formationRow !== 'back')) return;
-  for (const member of aliveParty) member.formationRow = 'front';
-  state.log.push({ kind: 'info', text: '前線崩潰！後排成員被迫上前接戰。' });
+  if (!aliveParty.some((member) => member.formationRow !== 'back')) {
+    for (const member of aliveParty) member.formationRow = 'front';
+    state.log.push({ kind: 'info', text: '前線崩潰！後排成員被迫上前接戰。' });
+  }
+  refreshFormationRuntime(state);
 }
 
 function applyDamage(state: CombatState, target: CombatantBase, amount: number): void {
@@ -271,6 +310,47 @@ function consumeStrength(actor: CombatantBase): number {
   return strength.potency;
 }
 
+/** M51：精通換位只改站位與既有守勢，不直接碰攻擊、屬性或生命。 */
+function performFormationShift(state: CombatState, actor: PartyMember): void {
+  if (actor.formationRow === 'back') {
+    actor.formationRow = 'front';
+    if ((actor.veteranMasteryRank ?? 0) >= 2) {
+      state.guarding[actor.id] = true;
+      state.log.push({ kind: 'action', text: `${actor.name}從後排前進接戰，並在踏入前線時架起守勢。` });
+    } else {
+      state.log.push({ kind: 'action', text: `${actor.name}抓住空隙，從後排前進接戰。` });
+    }
+    refreshFormationRuntime(state);
+    return;
+  }
+
+  if (!actor.formationCanFallBack) {
+    state.log.push({ kind: 'info', text: `${actor.name}無法後撤：至少要有人留在前線接敵。` });
+    return;
+  }
+
+  if (actor.formationReliefFallback) {
+    const relief = state.party
+      .filter((member) => member.hp > 0 && member.id !== actor.id && member.formationRow === 'back')
+      .sort((a, b) => b.defense - a.defense || b.hp - a.hp || state.party.indexOf(a) - state.party.indexOf(b))[0];
+    if (!relief) {
+      actor.formationCanFallBack = false;
+      actor.formationReliefFallback = false;
+      state.log.push({ kind: 'info', text: `${actor.name}找不到能接替前線的隊友，後撤中止。` });
+      return;
+    }
+    actor.formationRow = 'back';
+    relief.formationRow = 'front';
+    state.log.push({ kind: 'action', text: `${actor.name}老練地退出接戰線，${relief.name}立刻接替前線。` });
+    refreshFormationRuntime(state);
+    return;
+  }
+
+  actor.formationRow = 'back';
+  state.log.push({ kind: 'action', text: `${actor.name}趁同伴穩住前線，後撤到安全距離。` });
+  refreshFormationRuntime(state);
+}
+
 function performMove(
   rng: Rng,
   state: CombatState,
@@ -282,6 +362,11 @@ function performMove(
   if (move.kind === 'guard') {
     state.guarding[actor.id] = true;
     state.log.push({ kind: 'action', text: fillNarration(move.narration, actor.name, actor.name, 0) });
+    return;
+  }
+  if (move.kind === 'support' && move.formationShift) {
+    const partyActor = state.party.find((member) => member.id === actor.id);
+    if (partyActor) performFormationShift(state, partyActor);
     return;
   }
   if (move.kind === 'support' && !move.heal && move.applyStatus) {
@@ -415,6 +500,25 @@ export function partyMoveAvailability(
   move: Move,
   options: PartyActionOptions = {},
 ): PartyMoveAvailability {
+  if (move.formationShift) {
+    if (actor.formationRow === 'back') {
+      return { allowed: true, canOvercast: false, cost: 0, current: 0, shortfall: 0, backlash: 0, reason: '' };
+    }
+    const allowed = actor.formationCanFallBack === true;
+    return {
+      allowed,
+      canOvercast: false,
+      cost: 0,
+      current: 0,
+      shortfall: 0,
+      backlash: 0,
+      reason: allowed
+        ? ''
+        : (actor.veteranMasteryRank ?? 0) >= 3
+          ? '後排沒有能接替前線的存活隊友，現在不能後撤。'
+          : '至少需要另一名存活前排隊友接敵，現在不能後撤。',
+    };
+  }
   const rule = mysticRuleForMove(move);
   if (!rule) {
     return { allowed: true, canOvercast: false, cost: 0, current: 0, shortfall: 0, backlash: 0, reason: '' };

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -112,6 +112,7 @@ export function mysticRuleForMove(move: Move): MysticMoveRule | null {
 
 function stripM50Suffix(name: string): string {
   return name
+    .replace(/〔(?:前進(?:・守勢)?|後撤|輪替後撤|無人接替)〕$/u, '')
     .replace(/〔(?:近戰|遠程)(?: -2)?〕$/u, '')
     .replace(/〔(?:近戰|遠程)・(?:命中 -2|站位適配)〕$/u, '')
     .replace(/〔(?:護衛|自保)〕$/u, '')
@@ -171,7 +172,7 @@ function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
 /**
  * 雖沿用 M41 名稱，M44 開始敵人也會走同一條初始化路徑。
  * EnemyUnit 在結構上相容 PartyMember（額外欄位不影響），因此可共享同一套魔力公平規則。
- * M50 再把玩家目前前後排對招式的影響直接灌進 runtime 名稱，所有戰鬥頁自動共用。
+ * M50/M51 再把玩家目前前後排與老兵換位資訊灌進 runtime 名稱，所有戰鬥頁自動共用。
  */
 export function prepareMysticPartyMember(member: PartyMember): PartyMember {
   const copiedMoves = member.moves.map((move) => ({ ...move }));

--- a/src/scripts/games/caravan/data/combatReadability.m50.ts
+++ b/src/scripts/games/caravan/data/combatReadability.m50.ts
@@ -14,6 +14,7 @@ const ROW_LABEL: Record<'front' | 'back', string> = {
 
 /**
  * M50：把 M49 已經存在的站位規則在玩家按下招式前就說清楚。
+ * M51 延伸同一資訊契約：老兵換位也必須在出手前說明會前進、後撤或輪替。
  * isMystic 由 M41/M44 的 arcana 真實規則提供，避免用元素外觀猜測魔法。
  */
 export function combatMoveForecast(
@@ -22,6 +23,38 @@ export function combatMoveForecast(
   isMystic = false,
 ): CombatMoveForecast {
   const row = actor.formationRow === 'back' ? 'back' : 'front';
+
+  if (move.formationShift) {
+    if (row === 'back') {
+      const guardedAdvance = (actor.veteranMasteryRank ?? 0) >= 2;
+      return {
+        shortLabel: guardedAdvance ? '前進・守勢' : '前進',
+        hint: guardedAdvance
+          ? '花費完整一回合進入前排；精通 II 會同時進入守勢，直到下一次自身行動前有效。'
+          : '花費完整一回合從後排進入前排，不造成傷害。',
+        penalized: false,
+      };
+    }
+    if (actor.formationReliefFallback) {
+      return {
+        shortLabel: '輪替後撤',
+        hint: '精通 III：由後排中防禦最高的存活隊友接替前線後，你才會退到後排。',
+        penalized: false,
+      };
+    }
+    if (actor.formationCanFallBack) {
+      return {
+        shortLabel: '後撤',
+        hint: '花費完整一回合退到後排；其他存活前排會繼續接敵。',
+        penalized: false,
+      };
+    }
+    return {
+      shortLabel: '無人接替',
+      hint: '你是目前最後一名前排，而且沒有符合精通 III 輪替條件的後排隊友；現在不能後撤。',
+      penalized: false,
+    };
+  }
 
   if (move.kind === 'guard') {
     return row === 'front'
@@ -70,7 +103,7 @@ export function combatMoveForecast(
 
 /**
  * 所有戰鬥頁本來就直接顯示 move.name；M50 在 runtime 讓名稱成為可預判資訊，
- * 因此前線崩潰改變 formationRow 後，下一次 render 也會同步反映新站位。
+ * 因此前線崩潰或 M51 老兵換位改變 formationRow 後，下一次 render 都會同步反映。
  * 按鈕只顯示最短必要資訊，完整理由仍由 forecast/log 提供。
  */
 export function combatMoveDisplayName(
@@ -80,6 +113,7 @@ export function combatMoveDisplayName(
 ): string {
   const forecast = combatMoveForecast(actor, move, isMystic);
   const baseName = move.kind === 'guard' ? '防禦架勢' : move.name;
+  if (move.formationShift) return `${baseName}〔${forecast.shortLabel}〕`;
   if (move.kind === 'guard') {
     return `${baseName}〔${actor.formationRow === 'back' ? '自保' : '護衛'}〕`;
   }

--- a/src/scripts/games/caravan/data/jobs.ts
+++ b/src/scripts/games/caravan/data/jobs.ts
@@ -12,6 +12,7 @@ import {
 } from '../roster';
 import { ITEMS } from './items';
 import { adjustMovesForArmory, armoryProfile, type ArmoryProfile } from './armory';
+import { appendVeteranMasteryMoves, veteranMasteryProfile } from './veteranMastery.m51';
 
 export type JobId = 'swordsman' | 'ranger' | 'mage' | 'cleric';
 
@@ -35,6 +36,9 @@ export interface ArmoryPartyMemberRuntime {
   armoryProfile?: ArmoryProfile;
   /** M48：實際受擊時使用的護甲材質輪廓。 */
   armorProtection?: ArmoryProfile['armorProtection'];
+  /** M51：Lv5 後以既有 XP 驅動的橫向老兵精通，不寫回新欄位。 */
+  veteranMasteryRank?: number;
+  veteranNextXp?: number | null;
 }
 
 /** M18：每名角色最多攜帶四招，讓升級後的技能選擇形成構築取捨。 */
@@ -232,11 +236,13 @@ export function setPreparedMoves(record: CompanionRecord, moveIds: string[]): st
  * 將角色成長、裝備、特質、專精、武裝熟練與戰技配置整合成實際戰鬥成員。
  * M43 不禁止跨職裝備，而是把不合訓練的代價公開轉成命中、屬性、負重與施法上限。
  * M48 再把護甲材質輪廓帶入戰鬥，使斬、刺、鈍與真正魔法在受擊端產生可讀差異。
+ * M51 只以 Lv5 後既有 XP 解鎖橫向戰術，不增加角色永久數值，也不佔四格戰技配置。
  */
 export function memberFromRecord(record: CompanionRecord): PartyMember {
   const job = JOBS[record.job];
   const bonus = equipmentBonus(record);
   const armory = armoryProfile(record);
+  const veteran = veteranMasteryProfile(record);
   const stats: StatBlock = effectiveStats(record);
   for (const stat of Object.keys(armory.statAdjustments) as Array<keyof StatBlock>) {
     stats[stat] += armory.statAdjustments[stat] ?? 0;
@@ -246,6 +252,8 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
   const bondHp = bondTier(record.bond) * BOND_HP_PER_TIER;
   const maxHp = Math.max(1, record.maxHp + bonus.maxHp + (trait?.maxHpBonus ?? 0)
     + (spec?.maxHp ?? 0) + bondHp + armory.maxHpAdjustment);
+  const prepared = adjustMovesForArmory(record, preparedMovesFromRecord(record));
+  const combatMoves = appendVeteranMasteryMoves(record, prepared);
 
   const member: PartyMember & ArmoryPartyMemberRuntime = {
     id: record.id,
@@ -254,7 +262,7 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     maxHp,
     hp: maxHp,
     defense: Math.max(1, job.defense + bonus.defense + (spec?.defense ?? 0) + armory.defenseAdjustment),
-    moves: adjustMovesForArmory(record, preparedMovesFromRecord(record)),
+    moves: combatMoves,
     damageBonus: (bonus.damageBonus ?? 0) + armory.damageAdjustment,
     isProtagonist: record.id === 'protagonist',
     mysticCapacityBonus: armory.mysticCapacity,
@@ -264,6 +272,8 @@ export function memberFromRecord(record: CompanionRecord): PartyMember {
     armoryWarnings: [...armory.warnings],
     armoryProfile: armory,
     armorProtection: armory.armorProtection,
+    veteranMasteryRank: veteran.rank,
+    veteranNextXp: veteran.nextXp,
   };
   return member;
 }

--- a/src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+++ b/src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { partyAct, startCombat, type EnemyUnit, type PartyMember } from '../combat';
+import type { Rng } from '../rng';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { VETERAN_REPOSITION_MOVE_ID, veteranMasteryRank } from './veteranMastery.m51';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 3,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+function record(xp: number): CompanionRecord {
+  return {
+    id: `fighter-${xp}`, name: '老兵', job: 'swordsman', level: 5, xp,
+    stats: { str: 14, dex: 10, int: 8, cha: 10, con: 14 },
+    maxHp: 26, injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+function enemy(): EnemyUnit {
+  return {
+    id: 'foe', name: '敵人', stats: { str: 12, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 30, hp: 30, defense: 12,
+    moves: [{ id: 'hit', name: '攻擊', kind: 'attack', target: 'enemy', hitStat: 'str', damage: { dice: 1, sides: 4 }, narration: '' }],
+    intents: [{ weight: 1, moveId: 'hit' }],
+  };
+}
+
+function anchor(id: string, row: 'front' | 'back' = 'front'): PartyMember {
+  return {
+    id, name: id, stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 20, hp: 20, defense: 12, formationRow: row,
+    moves: [{ id: `${id}-attack`, name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str', narration: '' }],
+  };
+}
+
+function combatSnapshot(member: PartyMember) {
+  return {
+    stats: member.stats,
+    maxHp: member.maxHp,
+    defense: member.defense,
+    damageBonus: member.damageBonus ?? 0,
+  };
+}
+
+describe('M51 multidimensional player adversarial review', () => {
+  it('adds no passive power from rank I through III', () => {
+    const rank1 = memberFromRecord(record(320));
+    const rank2 = memberFromRecord(record(500));
+    const rank3 = memberFromRecord(record(750));
+    expect(combatSnapshot(rank2)).toEqual(combatSnapshot(rank1));
+    expect(combatSnapshot(rank3)).toEqual(combatSnapshot(rank1));
+  });
+
+  it('keeps mastery bounded instead of creating an endless post-cap stat ladder', () => {
+    expect(veteranMasteryRank({ level: 5, xp: 750 })).toBe(3);
+    expect(veteranMasteryRank({ level: 5, xp: 750000 })).toBe(3);
+  });
+
+  it('cannot be unlocked early by stockpiling XP below Lv5', () => {
+    expect(veteranMasteryRank({ level: 4, xp: 750000 })).toBe(0);
+  });
+
+  it('never creates a zero-frontline safe state after a legal veteran action', () => {
+    for (const xp of [320, 500, 750]) {
+      const veteran = memberFromRecord(record(xp));
+      veteran.formationRow = 'front';
+      const otherFront = anchor(`front-${xp}`, 'front');
+      const rear = anchor(`rear-${xp}`, 'back');
+      const state = startCombat(rng, [veteran, otherFront, rear], [enemy()]);
+      state.turnIndex = state.order.indexOf(veteran.id);
+      const action = partyAct(rng, state, veteran.id, VETERAN_REPOSITION_MOVE_ID, veteran.id);
+      expect(action.acted).toBe(true);
+      expect(state.party.some((member) => member.hp > 0 && member.formationRow !== 'back')).toBe(true);
+    }
+  });
+
+  it('makes every successful shift consume the actor turn, preventing free ranged/melee stance dancing', () => {
+    const veteran = memberFromRecord(record(750));
+    veteran.formationRow = 'back';
+    const state = startCombat(rng, [anchor('front'), veteran], [enemy()]);
+    state.turnIndex = state.order.indexOf(veteran.id);
+    const before = state.turnIndex;
+    const result = partyAct(rng, state, veteran.id, VETERAN_REPOSITION_MOVE_ID, veteran.id);
+    expect(result.acted).toBe(true);
+    expect(state.turnIndex).not.toBe(before);
+  });
+
+  it('does not consume a turn when the UI says there is nobody to replace the last front', () => {
+    const veteran = memberFromRecord(record(320));
+    veteran.formationRow = 'front';
+    const state = startCombat(rng, [veteran, anchor('rear', 'back')], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toContain('無人接替');
+    state.turnIndex = state.order.indexOf(veteran.id);
+    const before = state.turnIndex;
+    const result = partyAct(rng, state, veteran.id, move.id, veteran.id);
+    expect(result.acted).toBe(false);
+    expect(state.turnIndex).toBe(before);
+  });
+
+  it('does not stack dynamic reposition suffixes when a runtime member enters combat repeatedly', () => {
+    const veteran = memberFromRecord(record(500));
+    veteran.formationRow = 'back';
+    startCombat(rng, [anchor('front-a'), veteran], [enemy()]);
+    const once = veteran.moves.find((move) => move.id === VETERAN_REPOSITION_MOVE_ID)!.name;
+    startCombat(rng, [anchor('front-b'), veteran], [enemy()]);
+    const twice = veteran.moves.find((move) => move.id === VETERAN_REPOSITION_MOVE_ID)!.name;
+    expect(twice).toBe(once);
+    expect((twice.match(/前進/g) ?? []).length).toBe(1);
+  });
+
+  it('normalizes an impossible all-rear veteran opening instead of letting mastery preserve phantom safety', () => {
+    const veteran = memberFromRecord(record(750));
+    veteran.formationRow = 'back';
+    const rear = anchor('rear', 'back');
+    const state = startCombat(rng, [veteran, rear], [enemy()]);
+    expect(state.party.every((member) => member.formationRow === 'front')).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('前線崩潰'))).toBe(true);
+  });
+});

--- a/src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+++ b/src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
@@ -123,4 +123,13 @@ describe('M51 multidimensional player adversarial review', () => {
     expect(state.party.every((member) => member.formationRow === 'front')).toBe(true);
     expect(state.log.some((entry) => entry.text.includes('前線崩潰'))).toBe(true);
   });
+
+  it('derives mastery without mutating the persistent character record or adding save fields', () => {
+    const source = record(750);
+    const before = JSON.parse(JSON.stringify(source)) as CompanionRecord;
+    const member = memberFromRecord(source);
+    expect(source).toEqual(before);
+    expect('veteranMasteryRank' in source).toBe(false);
+    expect(member.veteranMasteryRank).toBe(3);
+  });
 });

--- a/src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+++ b/src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  partyAct,
+  partyMoveAvailability,
+  startCombat,
+  type EnemyUnit,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { VETERAN_REPOSITION_MOVE_ID } from './veteranMastery.m51';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 4,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+function record(id: string, xp: number, job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id,
+    name: id,
+    job,
+    level: 5,
+    xp,
+    stats: job === 'ranger'
+      ? { str: 10, dex: 16, int: 10, cha: 10, con: 10 }
+      : { str: 14, dex: 10, int: 8, cha: 10, con: 14 },
+    maxHp: job === 'ranger' ? 20 : 26,
+    injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+function enemy(): EnemyUnit {
+  return {
+    id: 'foe', name: '伏兵',
+    stats: { str: 12, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 40, hp: 40, defense: 12,
+    moves: [{
+      id: 'club', name: '棍擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 4, bonusStat: 'str' }, narration: '{actor}攻擊{target}，造成 {amount} 點傷害。',
+    }],
+    intents: [{ weight: 1, moveId: 'club' }],
+  };
+}
+
+function plainMember(id: string, row: 'front' | 'back', defense = 12): PartyMember {
+  return {
+    id, name: id,
+    stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 20, hp: 20, defense, formationRow: row,
+    moves: [{ id: `${id}-strike`, name: '攻擊', kind: 'attack', target: 'enemy', hitStat: 'str', narration: '' }],
+  };
+}
+
+function actVeteran(state: ReturnType<typeof startCombat>, actor: PartyMember) {
+  state.turnIndex = state.order.indexOf(actor.id);
+  return partyAct(rng, state, actor.id, VETERAN_REPOSITION_MOVE_ID, actor.id);
+}
+
+describe('M51 live veteran mastery', () => {
+  it('adds the veteran action outside the four-slot prepared loadout and reports mastery at combat start', () => {
+    const veteran = memberFromRecord(record('veteran', 320));
+    veteran.formationRow = 'back';
+    const preparedCount = veteran.moves.filter((move) => move.id !== VETERAN_REPOSITION_MOVE_ID).length;
+    expect(preparedCount).toBeLessThanOrEqual(4);
+    expect(veteran.moves.some((move) => move.id === VETERAN_REPOSITION_MOVE_ID)).toBe(true);
+
+    const state = startCombat(rng, [plainMember('anchor', 'front'), veteran], [enemy()]);
+    expect(veteran.moves.find((move) => move.id === VETERAN_REPOSITION_MOVE_ID)?.name).toBe('戰術換位〔前進〕');
+    expect(state.log.some((entry) => entry.text.includes('老兵精通 I') && entry.text.includes('500 XP'))).toBe(true);
+  });
+
+  it('rank I spends a full turn to advance without gaining free damage or guard', () => {
+    const veteran = memberFromRecord(record('veteran', 320));
+    veteran.formationRow = 'back';
+    const foe = enemy();
+    const state = startCombat(rng, [plainMember('anchor', 'front'), veteran], [foe]);
+    state.turnIndex = state.order.indexOf(veteran.id);
+    const beforeTurn = state.turnIndex;
+    const beforeHp = foe.hp;
+
+    const result = partyAct(rng, state, veteran.id, VETERAN_REPOSITION_MOVE_ID, veteran.id);
+
+    expect(result.acted).toBe(true);
+    expect(veteran.formationRow).toBe('front');
+    expect(state.guarding[veteran.id]).not.toBe(true);
+    expect(foe.hp).toBe(beforeHp);
+    expect(state.turnIndex).not.toBe(beforeTurn);
+    expect(veteran.moves.find((move) => move.id === VETERAN_REPOSITION_MOVE_ID)?.name).toBe('戰術換位〔後撤〕');
+  });
+
+  it('rank I can fall back only while another living frontline member remains', () => {
+    const veteran = memberFromRecord(record('veteran', 320));
+    veteran.formationRow = 'front';
+    const anchor = plainMember('anchor', 'front');
+    const state = startCombat(rng, [veteran, anchor], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toBe('戰術換位〔後撤〕');
+    expect(partyMoveAvailability(veteran, move).allowed).toBe(true);
+
+    actVeteran(state, veteran);
+    expect(veteran.formationRow).toBe('back');
+    expect(anchor.formationRow).toBe('front');
+  });
+
+  it('blocks a last-frontline fallback without consuming the turn or creating an all-rear exploit', () => {
+    const veteran = memberFromRecord(record('veteran', 320));
+    veteran.formationRow = 'front';
+    const rear = plainMember('rear', 'back');
+    const state = startCombat(rng, [veteran, rear], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toBe('戰術換位〔無人接替〕');
+    expect(partyMoveAvailability(veteran, move).allowed).toBe(false);
+
+    state.turnIndex = state.order.indexOf(veteran.id);
+    const beforeTurn = state.turnIndex;
+    const result = partyAct(rng, state, veteran.id, move.id, veteran.id);
+    expect(result.acted).toBe(false);
+    expect(state.turnIndex).toBe(beforeTurn);
+    expect(veteran.formationRow).toBe('front');
+    expect(state.party.some((member) => member.hp > 0 && member.formationRow !== 'back')).toBe(true);
+  });
+
+  it('rank II turns a costly rear-to-front advance into a guarded entry, not a passive stat bonus', () => {
+    const veteran = memberFromRecord(record('veteran', 500));
+    veteran.formationRow = 'back';
+    const state = startCombat(rng, [plainMember('anchor', 'front'), veteran], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toBe('戰術換位〔前進・守勢〕');
+
+    actVeteran(state, veteran);
+    expect(veteran.formationRow).toBe('front');
+    expect(state.guarding[veteran.id]).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('前進接戰') && entry.text.includes('守勢'))).toBe(true);
+  });
+
+  it('rank III lets the last front rotate out only by exposing the strongest rear defender', () => {
+    const veteran = memberFromRecord(record('veteran', 750));
+    veteran.formationRow = 'front';
+    const rearWeak = plainMember('rear-weak', 'back', 11);
+    const rearStrong = plainMember('rear-strong', 'back', 16);
+    const state = startCombat(rng, [veteran, rearWeak, rearStrong], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toBe('戰術換位〔輪替後撤〕');
+    expect(partyMoveAvailability(veteran, move).allowed).toBe(true);
+
+    actVeteran(state, veteran);
+    expect(veteran.formationRow).toBe('back');
+    expect(rearStrong.formationRow).toBe('front');
+    expect(rearWeak.formationRow).toBe('back');
+    expect(state.party.some((member) => member.hp > 0 && member.formationRow !== 'back')).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('rear-strong') && entry.text.includes('接替前線'))).toBe(true);
+  });
+
+  it('rank III still cannot disappear from the frontline when nobody can replace it', () => {
+    const veteran = memberFromRecord(record('veteran', 750));
+    veteran.formationRow = 'front';
+    const state = startCombat(rng, [veteran], [enemy()]);
+    const move = veteran.moves.find((candidate) => candidate.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(move.name).toBe('戰術換位〔無人接替〕');
+    expect(partyMoveAvailability(veteran, move).allowed).toBe(false);
+  });
+});

--- a/src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+++ b/src/scripts/games/caravan/data/veteranMastery.m51.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord } from '../save';
+import type { Move } from '../combat';
+import {
+  VETERAN_REPOSITION_MOVE_ID,
+  VETERAN_XP_THRESHOLDS,
+  appendVeteranMasteryMoves,
+  veteranMasteryProfile,
+  veteranMasteryRank,
+} from './veteranMastery.m51';
+
+const record = (level: number, xp: number): CompanionRecord => ({
+  id: `veteran-${level}-${xp}`,
+  name: '老兵候補',
+  job: 'swordsman',
+  level,
+  xp,
+  stats: { str: 14, dex: 12, int: 8, cha: 10, con: 14 },
+  maxHp: 26,
+  injuredForTrips: 0,
+  equipment: { weapon: null, armor: null, trinket: null },
+});
+
+const strike: Move = {
+  id: 'test-strike', name: '試斬', kind: 'attack', target: 'enemy', hitStat: 'str',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '',
+};
+
+describe('M51 veteran mastery progression', () => {
+  it('never lets pre-cap XP farming bypass the Lv5 career boundary', () => {
+    expect(veteranMasteryRank(record(4, 9999))).toBe(0);
+  });
+
+  it('turns Lv5 and post-cap XP into three bounded horizontal mastery milestones', () => {
+    expect(VETERAN_XP_THRESHOLDS).toEqual([320, 500, 750]);
+    expect(veteranMasteryRank(record(5, 319))).toBe(0);
+    expect(veteranMasteryRank(record(5, 320))).toBe(1);
+    expect(veteranMasteryRank(record(5, 499))).toBe(1);
+    expect(veteranMasteryRank(record(5, 500))).toBe(2);
+    expect(veteranMasteryRank(record(5, 749))).toBe(2);
+    expect(veteranMasteryRank(record(5, 750))).toBe(3);
+    expect(veteranMasteryRank(record(5, 99999))).toBe(3);
+  });
+
+  it('shows the next concrete XP goal instead of silently discarding post-cap XP meaning', () => {
+    expect(veteranMasteryProfile(record(5, 320))).toMatchObject({ rank: 1, nextXp: 500 });
+    expect(veteranMasteryProfile(record(5, 500))).toMatchObject({ rank: 2, nextXp: 750 });
+    expect(veteranMasteryProfile(record(5, 750))).toMatchObject({ rank: 3, nextXp: null });
+  });
+
+  it('adds tactical reposition as a bonus mastery action without consuming or duplicating prepared moves', () => {
+    const before = [strike];
+    expect(appendVeteranMasteryMoves(record(4, 9999), before).map((move) => move.id)).toEqual(['test-strike']);
+    const veteran = appendVeteranMasteryMoves(record(5, 320), before);
+    expect(veteran.map((move) => move.id)).toEqual(['test-strike', VETERAN_REPOSITION_MOVE_ID]);
+    expect(before).toHaveLength(1);
+    expect(appendVeteranMasteryMoves(record(5, 750), veteran).filter((move) => move.id === VETERAN_REPOSITION_MOVE_ID)).toHaveLength(1);
+  });
+});

--- a/src/scripts/games/caravan/data/veteranMastery.m51.ts
+++ b/src/scripts/games/caravan/data/veteranMastery.m51.ts
@@ -1,0 +1,59 @@
+import type { Move } from '../combat';
+import type { CompanionRecord } from '../save';
+
+export type VeteranMasteryRank = 0 | 1 | 2 | 3;
+
+/**
+ * Lv5 本身就是第一階老兵門檻；之後讓既有、仍持續累積的 XP 成為橫向精通進度。
+ * 不抬高角色等級，也不增加永久屬性，避免破壞 M22–M30 的 Lv1–Lv5 職涯邊界。
+ */
+export const VETERAN_XP_THRESHOLDS = [320, 500, 750] as const;
+
+export interface VeteranMasteryProfile {
+  rank: VeteranMasteryRank;
+  nextXp: number | null;
+  title: string;
+}
+
+export const VETERAN_REPOSITION_MOVE_ID = 'veteran-reposition';
+
+export const VETERAN_REPOSITION_MOVE: Move = {
+  id: VETERAN_REPOSITION_MOVE_ID,
+  name: '戰術換位',
+  kind: 'support',
+  target: 'self',
+  hitStat: 'dex',
+  formationShift: 'toggle',
+  narration: '{actor}抓住陣線空隙重新調整站位。',
+};
+
+export function veteranMasteryRank(record: Pick<CompanionRecord, 'level' | 'xp'>): VeteranMasteryRank {
+  if (record.level < 5 || record.xp < VETERAN_XP_THRESHOLDS[0]) return 0;
+  if (record.xp >= VETERAN_XP_THRESHOLDS[2]) return 3;
+  if (record.xp >= VETERAN_XP_THRESHOLDS[1]) return 2;
+  return 1;
+}
+
+export function veteranMasteryProfile(record: Pick<CompanionRecord, 'level' | 'xp'>): VeteranMasteryProfile {
+  const rank = veteranMasteryRank(record);
+  const nextXp = rank === 0
+    ? VETERAN_XP_THRESHOLDS[0]
+    : rank === 1
+      ? VETERAN_XP_THRESHOLDS[1]
+      : rank === 2
+        ? VETERAN_XP_THRESHOLDS[2]
+        : null;
+  return {
+    rank,
+    nextXp,
+    title: rank === 0 ? '尚未成為老兵' : `老兵精通 ${['', 'I', 'II', 'III'][rank]}`,
+  };
+}
+
+/** 老兵戰術屬於職涯之外的通用戰場素養，不佔原本四格戰技配置。 */
+export function appendVeteranMasteryMoves(record: Pick<CompanionRecord, 'level' | 'xp'>, moves: Move[]): Move[] {
+  if (veteranMasteryRank(record) === 0 || moves.some((move) => move.id === VETERAN_REPOSITION_MOVE_ID)) {
+    return moves.map((move) => ({ ...move }));
+  }
+  return [...moves.map((move) => ({ ...move })), { ...VETERAN_REPOSITION_MOVE }];
+}


### PR DESCRIPTION
## Stacked dependency

This is a stacked draft on top of #248 / `agent/caravan-m49-martial-engagement`. It contains only the M51 post-cap progression layer; #248 remains independently validated and mergeable.

## Summary

M51 addresses the player-facing long-term progression hole left by the intentional Lv5 character cap. Endless contracts continue to award XP, but simply raising the cap or adding permanent post-cap damage would break the existing Lv1–Lv5 career/growth boundary and create power creep.

Instead, existing XP now unlocks three bounded horizontal veteran mastery ranks:

- **Lv5 / 320 XP — Mastery I:** unlock `戰術換位` as a bonus combat action outside the four prepared-move slots
- **500 XP — Mastery II:** advancing rear → front also enters the existing guard stance
- **750 XP — Mastery III:** the last frontliner may fall back only if a living rear ally actually replaces them in front

No new save field or save-version migration is required. Mastery derives from the existing `level` and `xp` fields, and `memberFromRecord()` is tested not to mutate the persistent character record.

## Tactical rules

- every successful formation shift consumes the actor's full turn
- rear → front never deals damage; Rank II+ guarded entry reuses the existing `guarding` system
- front → rear is legal only while another frontliner remains
- Rank III can rotate the last frontliner out by exposing a rear ally; deterministic replacement chooses highest defense, then HP, then party order
- no legal action can create an all-rear safe state
- a blocked `無人接替` action returns `acted:false` and does not consume the turn
- mastery adds no passive stats, max HP, defense or damage bonus
- mastery caps at Rank III rather than creating an endless post-cap power ladder

## Pre-action readability

M50's information-fairness contract is extended to M51. The live action name tells the player what will happen before click:

- `戰術換位〔前進〕`
- `戰術換位〔前進・守勢〕`
- `戰術換位〔後撤〕`
- `戰術換位〔輪替後撤〕`
- `戰術換位〔無人接替〕`

The labels are runtime getters, so M49 frontline collapse and M51 repositioning immediately update subsequent action labels. Combat start also reports the current mastery rank and next XP threshold.

## Multidimensional player adversarial review

Dedicated gates verify:
- no passive stat / HP / defense / damage increase across Mastery I–III
- pre-Lv5 XP hoarding cannot unlock mastery early
- mastery is capped at Rank III even at extreme XP
- every successful shift consumes a full turn, preventing free stance dancing / kiting
- no legal shift leaves zero living frontliners
- illegal last-front fallback costs no turn
- Rank III must expose a real replacement instead of deleting frontline threat
- dynamic labels do not stack across repeated combat initialization
- mastery derivation does not mutate persistent `CompanionRecord` data
- veteran action is added outside the four prepared-move slots
- impossible all-rear openings are still normalized by M49
- M49/M50 formation and readability behavior remains the same

## Additional medieval-fantasy consistency fix in the stacked base

While reviewing M51, a residual M50 wording bug was found and fixed in #248: guard interception still logged `持盾上前` even though the generic guard no longer assumes a shield item. It now says `挺身上前`, with a regression test preventing the fake shield wording from returning. The #248 head passes all 13 Caravan workflows and its Vercel preview succeeds.

## Validation

Latest M51 head `4749ee95bec1b787655990b5c0fa1d684567d45a` passed **all 14 Caravan workflows** triggered by the PR, including the dedicated `Caravan M51 Veteran Mastery CI`.

The M51 gate completed successfully with:
- production build
- M51 progression gates
- live `memberFromRecord → startCombat → partyAct` reposition integration
- M51 multidimensional adversarial player review
- M49–M50 formation/readability regressions
- core combat + M41 magic
- M40 Reliquary
- M42 endurance/composition
- M43 armory/endurance
- M44 spellcraft
- M45 rituals
- M46 convoy + M47 morale
- M48 armor

The latest Vercel preview also succeeds. PR #249 is draft, open and mergeable.

See `docs/caravan-m51-veteran-mastery.md` for design rationale, save-compatibility rules and rejected exploit-prone alternatives.