### PR TITLE
feat(caravan): add M52 offhand shields and handedness

### DIFF
--- a/.github/workflows/caravan-m52-ci.yml
+++ b/.github/workflows/caravan-m52-ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: M52 multidimensional player adversarial review
         run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
 
+      - name: M52 bulwark equipment semantics
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+
       - name: M51 veteran mastery regression
         run: >-
           npx vitest run --reporter=verbose

--- a/.github/workflows/caravan-m52-ci.yml
+++ b/.github/workflows/caravan-m52-ci.yml
@@ -1,0 +1,108 @@
+name: Caravan M52 Offhand Shield CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m52-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m52-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M52 handedness and shield rules
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/offhandShields.m52.test.ts
+
+      - name: M52 live shield combat integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+
+      - name: M52 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+
+      - name: M51 veteran mastery regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/docs/caravan-m52-offhand-shields.md
+++ b/docs/caravan-m52-offhand-shields.md
@@ -1,0 +1,169 @@
+# Caravan M52 — Offhand Shields & Handedness
+
+## Problem
+
+M43–M51 已經讓《商隊與劍》的武器熟練、護甲材質、前後排、魔法資源、守勢與老兵換位形成可玩的戰術網路，但「角色有幾隻手」仍不存在於規則裡。
+
+這造成三個中世紀劍與魔法世界不應存在的漏洞：
+
+1. 弓與法杖可以在概念上和任何副手防禦同時存在；
+2. 通用守勢與鐵壁衛曾使用盾牌語彙，卻沒有真正的盾牌裝備來源；
+3. 若只是新增第四個裝備欄並給常駐 Defense，盾牌會變成所有角色無腦必裝的第四件護甲。
+
+M52 補的是「手部占用與主動守勢」而不是另一層被動數值。
+
+## Equipment model
+
+M52 以 optional `offhand` 軟擴充現有 v6 `equipment` JSON：
+
+- 舊存檔仍只有 `weapon / armor / trinket` 也完全合法；
+- 讀取舊角色不會因為檢查副手而修改存檔；
+- 新副手值可自然由 JSON 持久化，不需要提升 save version；
+- 既有三欄強化規則不會把副手誤當成第四條鍛造數值線。
+
+## Handedness
+
+目前明確視為雙手武器：
+
+- 霧嶺反曲弓
+- 幽焰法杖
+- 鹽晶法杖
+- 劍聖木刀
+
+其他既有刀劍／錘杖視為單手。
+
+游俠即使武器 item 欄是空的，職業基礎招式仍明確使用弓，因此其預設弓也視為雙手。這阻止玩家利用「空裝備欄」在射箭時偷開盾牌。
+
+## Shields
+
+### 橡木小圓盾
+
+- 啟程之鎮可買
+- 負重 1
+- 真正持用時，`防禦架勢` 額外 +1 Defense
+- 無常駐 Defense
+
+### 鹽鋼鳶盾
+
+- 鹽泉城可買，Lv3+
+- 負重 2
+- 真正持用時，`防禦架勢` 額外 +2 Defense
+- 真正持用時秘法上限 -1
+- 無常駐 Defense
+
+盾牌加成被硬性限制在 +2 以內，避免後續裝備把守勢堆成接近不可命中的狀態。
+
+## Stowed shield rule
+
+若角色目前使用雙手武器，副手盾牌不會被系統自動卸下或丟回背包，而是進入「收起」狀態：
+
+- 盾牌仍算負重；
+- 不提供守勢加成；
+- 鹽鋼鳶盾的持盾施法干擾也不生效；
+- 換回單手武器後，盾牌自然重新可用。
+
+這保留玩家的裝備意圖，不讓切武器變成背包管理副作用，同時堵住雙手武器＋盾牌的戰鬥 exploit。
+
+## Guard integration
+
+基礎守勢仍然是 +4 Defense。
+
+M52 只在 `state.guarding` 為真時額外加入 ready shield bonus：
+
+- 無盾／盾收起：+4
+- 橡木小圓盾：+5
+- 鹽鋼鳶盾：+6
+
+角色面板的常駐 `member.defense` 完全不因盾牌改變。
+
+因此「帶盾」本身不是收益；玩家必須花一個回合進入守勢，或透過 M51 精通 II 的 guarded advance 才能兌現盾牌價值。
+
+## M51 interaction
+
+精通 II 的 `戰術換位〔前進・守勢〕` 使用同一個 `state.guarding`。
+
+若盾牌 ready，按鈕會在出手前直接顯示：
+
+- `戰術換位〔前進・守勢・盾+1〕`
+
+並在提示裡顯示實際總 Defense bonus。盾牌收起時不顯示任何盾牌加成。
+
+## Bulwark semantic correction
+
+為了維持舊存檔與測試相容，鐵壁衛技能內部 ID `shield-bash` 不改。
+
+實戰玩家面向則跟真正裝備同步：
+
+- 盾牌 ready：`盾牆猛擊`
+- 沒盾／盾收起：`壁壘猛擊`
+
+無盾版本改用肩甲、護具與武器架勢撞擊，不會憑空生成盾牌；技能仍然可用，因此不會把既有 Lv4 專精變成死 Build。
+
+## Player information contract
+
+武裝整備所會在出發前顯示：
+
+- 單手／雙手
+- 副手盾牌名稱
+- 盾牌「就緒」或「收起」
+- 守勢額外加值
+- 副手負重
+- 大盾的秘法代價
+
+戰鬥 action label 也會顯示 ready shield，例如：
+
+- `防禦架勢〔護衛・盾+2〕`
+- `防禦架勢〔自保・盾+1〕`
+- `戰術換位〔前進・守勢・盾+1〕`
+
+收起的盾不會出現在 action bonus 上。
+
+## Multidimensional adversarial review
+
+M52 automated gates attack the feature from these player perspectives:
+
+1. **Mandatory-slot abuse** — shield must not change passive stats, HP, Defense or damage.
+2. **Two-hand exploit** — bow/staff/two-hand weapon + shield cannot receive active shield guard.
+3. **Empty-slot exploit** — ranger default bow remains two-handed even without a weapon item.
+4. **Burden laundering** — stowed shield still counts its full burden.
+5. **Caster punishment truth** — kite-shield mana penalty applies only while physically ready.
+6. **Strict upgrade dominance** — stronger kite shield pays more burden and casting opportunity cost than buckler.
+7. **Information fairness** — pre-action label/hint must match the exact guard bonus used by combat.
+8. **Guard math** — deterministic A/B verifies +4 / +5 / +6 thresholds.
+9. **M51 interaction** — guarded advance receives shield bonus through the same guard state, not a parallel buff.
+10. **Bulwark compatibility** — `shield-bash` ID remains stable; text adapts to actual equipment.
+11. **Save compatibility** — reading legacy three-slot equipment does not mutate it or require migration.
+12. **Economy integration** — both shields must be obtainable in actual town stock.
+13. **Regression** — M40–M51 combat, magic, armory, endurance, rituals, convoy, morale, armor, formation and veteran gates remain green.
+
+## Rejected alternatives
+
+### Shield = permanent Defense bonus
+
+Rejected. This turns offhand into a mandatory fourth armor slot and gives shield value without a player decision.
+
+### Equipping a two-handed weapon automatically unequips the shield
+
+Rejected. It repeatedly mutates the player's inventory/loadout when switching weapons and creates unnecessary equipment churn.
+
+### Carry shield with a two-handed weapon and keep shield benefit
+
+Rejected. It is physically incoherent and strictly dominates two-handed loadouts without offhand.
+
+### Give shield its own attack move
+
+Rejected for M52. That would make shield automatically increase both offense and defense and create another move-loadout axis. M52's purpose is to deepen guard decisions first.
+
+### Require a shield for the Bulwark specialization
+
+Rejected. Existing characters chose Bulwark before shields existed; hard-requiring one would retroactively create dead buttons. The technique instead adapts its narration and name to real equipment.
+
+## Acceptance target
+
+A successful M52 means choosing a shield is a meaningful medieval-fantasy loadout decision:
+
+- one-handed + shield gains stronger *active* defense;
+- two-handed weapon retains its weapon identity but gives up active offhand defense;
+- heavy shield is stronger at guarding but heavier and more awkward for arcane casting;
+- no choice becomes a universal passive upgrade;
+- the player can see every important consequence before committing either equipment or combat actions.

--- a/src/pages/caravan/armory.astro
+++ b/src/pages/caravan/armory.astro
@@ -4,14 +4,14 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
 <BaseLayout
   title="武裝整備所 — 商隊與劍"
-  description="依照中世紀劍與魔法世界的武器熟練、護甲材質、施法媒介與負重整備遠征隊。"
+  description="依照中世紀劍與魔法世界的武器熟練、雙手武器、副手盾牌、護甲材質、施法媒介與負重整備遠征隊。"
   lang="zh-TW"
 >
   <main class="armory-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M48 ARMOR PROFILES</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M52 HANDS &amp; SHIELDS</p>
       <h1>武裝整備所</h1>
-      <p>鋼鐵不再只是一個防禦數字。鎖甲擅長吃下刀斬與部分箭刺，輕甲提供有限斬擊保護；法袍與聖衣則把重量換成秘法、神恩與對應魔法防護。跨職裝備仍不禁止，但每個代價都必須能被玩家看見。</p>
+      <p>鋼鐵不再只是一個防禦數字。刀劍、弓弩、法杖與錘杖有不同訓練；弓與法杖等雙手武器會占滿雙手，盾牌則只有在真正持用並主動進入守勢時才強化防禦。跨職與混裝仍不禁止，但重量、手部占用、施法干擾與實際收益都必須先讓玩家看見。</p>
       <nav>
         <a href="/caravan/play">返回主冒險</a>
         <a href="/caravan/endurance">前往餘燼朝聖</a>
@@ -22,11 +22,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       <h2>整備原則</h2>
       <div class="doctrine-grid">
         <article><strong>武器熟練</strong><span>熟練流派命中 +1；勉強運用命中 -2、傷害 -1，仍保留跨職構築。</span></article>
+        <article><strong>手部占用</strong><span>刀劍與錘杖多為單手；反曲弓、法杖與部分長兵器視為雙手。雙手武器在使用時會讓副手盾牌收起。</span></article>
+        <article><strong>盾牌守勢</strong><span>盾牌不提供常駐防禦。只有主動使用防禦架勢時才增加額外防禦，因此盾牌是回合決策，不是免費第四件護甲。</span></article>
         <article><strong>護甲材質</strong><span>鎖甲抗斬、略抗刺，但不會神奇吸收鈍擊；穿甲箭可削掉物理護甲減傷。</span></article>
         <article><strong>秘法織物</strong><span>法袍能削減少量火／霜魔法；聖衣對神聖衝擊最可靠。這些防護不會替代一次性護法。</span></article>
         <article><strong>護甲重量</strong><span>鎖甲防護最穩，但降低敏捷並干擾秘法手勢；超過個人負重容量會再扣敏捷與生命。</span></article>
-        <article><strong>施法媒介</strong><span>法杖與法袍提高秘法上限；錘杖、聖衣與王室聖印提高神恩上限。</span></article>
-        <article><strong>遠征負重</strong><span>負重會進入朝聖整備快照，影響紮營效率與強行軍疲勞。</span></article>
+        <article><strong>施法媒介</strong><span>法杖與法袍提高秘法上限；錘杖、聖衣與王室聖印提高神恩上限。大型盾真正持在手上時也可能妨礙秘法手勢。</span></article>
+        <article><strong>遠征負重</strong><span>武器、護甲、飾品與副手都計入負重；盾就算收在背上仍然有重量，並會進入朝聖整備快照。</span></article>
       </div>
     </section>
 
@@ -51,8 +53,14 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     equippableInventory,
     partyArmoryLoad,
     unequipArmoryItem,
+    type ArmoryEquipSlot,
     type ArmoryProfile,
   } from '@scripts/games/caravan/data/armory';
+  import {
+    offhandId,
+    shieldRule,
+    weaponHands,
+  } from '@scripts/games/caravan/data/offhandShields.m52';
 
   const noticeEl = document.getElementById('notice')!;
   const loadEl = document.getElementById('party-load')!;
@@ -92,6 +100,15 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     return `${weapon}｜${armor}`;
   }
 
+  function handText(profile: ArmoryProfile): string {
+    const hands = profile.weaponHands === 2 ? '雙手武器' : profile.weaponHands === 1 ? '單手武器' : '未持武器';
+    if (!profile.offhandId) return `${hands}｜副手空置`;
+    const shield = itemName(profile.offhandId);
+    return profile.shieldReady
+      ? `${hands}｜${shield}就緒・防禦架勢額外 +${profile.shieldGuardBonus}`
+      : `${hands}｜${shield}收起・目前無守勢加成`;
+  }
+
   function equip(record: CompanionRecord, itemId: string): void {
     if (!save) return;
     try {
@@ -104,7 +121,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     }
   }
 
-  function unequip(record: CompanionRecord, slot: keyof CompanionRecord['equipment']): void {
+  function unequip(record: CompanionRecord, slot: ArmoryEquipSlot): void {
     if (!save) return;
     try {
       unequipArmoryItem(save, record.id, slot);
@@ -116,11 +133,16 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     }
   }
 
-  function equipmentLine(record: CompanionRecord, slot: keyof CompanionRecord['equipment'], label: string): HTMLElement {
+  function equippedId(record: CompanionRecord, slot: ArmoryEquipSlot): string | null {
+    return slot === 'offhand' ? offhandId(record) : record.equipment[slot];
+  }
+
+  function equipmentLine(record: CompanionRecord, slot: ArmoryEquipSlot, label: string): HTMLElement {
     const row = document.createElement('div');
     row.className = 'equipment-row';
-    row.append(text('span', `${label}：${itemName(record.equipment[slot])}`));
-    if (record.equipment[slot]) row.append(button('卸下', () => unequip(record, slot)));
+    const itemId = equippedId(record, slot);
+    row.append(text('span', `${label}：${itemName(itemId)}`));
+    if (itemId) row.append(button('卸下', () => unequip(record, slot)));
     return row;
   }
 
@@ -138,6 +160,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       text('p', `Lv${record.level}｜防禦 ${member.defense}｜生命 ${member.maxHp}｜敏捷 ${member.stats.dex}`, 'summary'),
       text('p', `個人負重 ${profile.burden}/${profile.capacity}${profile.overload ? `｜超載 ${profile.overload}` : ''}`, 'load'),
       text('p', fitText(record, profile), 'fit'),
+      text('p', handText(profile), profile.shieldReady ? 'hands shield-ready' : 'hands'),
       text('p', `材質防護：${armorProtectionText(profile.armorProtection)}`, 'protection'),
       text('p', `秘法上限修正 ${profile.mysticCapacity.mana >= 0 ? '+' : ''}${profile.mysticCapacity.mana}｜神恩上限修正 ${profile.mysticCapacity.favor >= 0 ? '+' : ''}${profile.mysticCapacity.favor}`, 'mystic'),
     );
@@ -146,6 +169,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     equipment.className = 'equipment';
     equipment.append(
       equipmentLine(record, 'weapon', '武器'),
+      equipmentLine(record, 'offhand', '副手'),
       equipmentLine(record, 'armor', '護甲'),
       equipmentLine(record, 'trinket', '飾品'),
     );
@@ -167,8 +191,19 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       const required = item.equip?.minLevel ?? 1;
       const disabled = record.level < required;
       const rule = armoryRuleForItem(item.id);
-      const tags = [item.equip?.slot, rule?.weapon ? WEAPON_DISCIPLINE_LABELS[rule.weapon] : '', rule?.armor ? ARMOR_DISCIPLINE_LABELS[rule.armor] : '', `負重 ${rule?.burden ?? 0}`]
-        .filter(Boolean).join('｜');
+      const shield = shieldRule(item.id);
+      const slotLabel: Record<string, string> = { weapon: '武器', offhand: '副手', armor: '護甲', trinket: '飾品' };
+      const handTag = item.equip?.slot === 'weapon'
+        ? weaponHands(item.id) === 2 ? '雙手' : '單手'
+        : shield ? `盾牌・守勢 +${shield.guardBonus}` : '';
+      const burden = rule?.burden ?? shield?.burden ?? 0;
+      const tags = [
+        slotLabel[item.equip?.slot ?? ''] ?? '裝備',
+        handTag,
+        rule?.weapon ? WEAPON_DISCIPLINE_LABELS[rule.weapon] : '',
+        rule?.armor ? ARMOR_DISCIPLINE_LABELS[rule.armor] : '',
+        `負重 ${burden}`,
+      ].filter(Boolean).join('｜');
       const option = document.createElement('article');
       option.className = 'inventory-item';
       option.append(
@@ -192,7 +227,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     loadEl.replaceChildren(
       text('h2', '目前出征隊負重'),
       text('p', `${partyLoad.burden}/${partyLoad.capacity}${partyLoad.overload ? `｜超載 ${partyLoad.overload}` : '｜整隊可負荷'}`),
-      text('p', '護甲材質、武器熟練與負重都已進入實際戰鬥：鎖甲會削斬／刺傷害、法袍與聖衣會處理特定魔法，穿甲技則能削弱物理減傷；餘燼朝聖仍會把整備快照鎖入行程。'),
+      text('p', '護甲材質、武器熟練、手部占用、副手盾牌與負重都已進入實際戰鬥：盾牌只有在單手／空手狀態下能強化守勢，雙手武器會把盾收起；餘燼朝聖仍會把完整整備快照鎖入行程。'),
     );
     const members = [save.protagonist, ...save.companions];
     rosterEl.replaceChildren(...members.map(memberCard));
@@ -202,7 +237,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   if (!save) {
     noticeEl.replaceChildren(text('h2', '尚未建立商隊'), text('p', '請先返回主冒險建立角色與存檔。'));
   } else {
-    noticeEl.textContent = '武裝報告會即時計算，不會隱藏跨職裝備、負重或材質防護的代價。';
+    noticeEl.textContent = '武裝報告會即時計算，不會隱藏跨職裝備、雙手占用、盾牌收起、負重或材質防護的代價。';
     render();
   }
 </script>
@@ -223,7 +258,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .member-card { padding: 1.25rem; border: 1px solid #5e503d; background: #1b1713; }
   .member-card.overloaded { border-color: #a54b3b; box-shadow: inset 4px 0 #a54b3b; }
   .member-card h2 { margin: .2rem 0 .5rem; font-size: 1.8rem; }
-  .summary, .load, .fit, .protection, .mystic { color: #d7c7aa; }
+  .summary, .load, .fit, .hands, .protection, .mystic { color: #d7c7aa; }
+  .hands.shield-ready { color: #e1c98f; }
   .protection { color: #e1c98f; }
   .equipment { display: grid; gap: .45rem; margin: 1rem 0; }
   .equipment-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .6rem .75rem; background: #282117; }

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -88,6 +88,8 @@ export interface PartyMember extends CombatantBase {
   formationCanFallBack?: boolean;
   /** 精通 III：最後前排可由後排隊友接替。 */
   formationReliefFallback?: boolean;
+  /** M43/M52 jobs runtime：盾牌只在 guarding 時計入防禦，不改面板常駐 defense。 */
+  armoryProfile?: { shieldReady?: boolean; shieldGuardBonus?: number };
 }
 
 export interface EnemyUnit extends CombatantBase {
@@ -221,6 +223,16 @@ function rollDice(rng: Rng, dice: number, sides: number): number {
   let sum = 0;
   for (let i = 0; i < dice; i++) sum += rng.roll(sides);
   return sum;
+}
+
+/** M52：盾牌只在已進入 guarding 時增加命中門檻；未架勢時完全不改常駐 defense。 */
+function guardingDefenseBonus(state: CombatState, target: CombatantBase): number {
+  if (!state.guarding[target.id]) return 0;
+  const partyTarget = state.party.find((member) => member.id === target.id);
+  const shieldBonus = partyTarget?.armoryProfile?.shieldReady
+    ? partyTarget.armoryProfile.shieldGuardBonus ?? 0
+    : 0;
+  return 4 + shieldBonus;
 }
 
 function checkOutcome(state: CombatState): void {
@@ -399,7 +411,7 @@ function performMove(
   const partyActor = state.party.find((member) => member.id === actor.id);
   const formation = formationAttackProfile(partyActor?.formationRow, move, !!spellRule);
   const die = rng.d20();
-  const defense = target.defense + (state.guarding[target.id] ? 4 : 0);
+  const defense = target.defense + guardingDefenseBonus(state, target);
   const hit = die === 20
     ? true
     : die === 1

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -24,17 +24,12 @@ const RULES: Record<string, MysticMoveRule> = {
   'frost-bind': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
   'meteor-fall': { kind: 'mana', school: 'pyromancy', cost: 4, gain: 0, overcast: true, strainRelief: 0 },
   'arcane-focus': { kind: 'mana', school: 'arcane', cost: 0, gain: 3, overcast: false, strainRelief: 1 },
-  // M44：鹽晶亡魂的投刃由寒鹽魔力凝成，敵方同樣受秘法資源限制。
   'salt-shard-throw': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
-  // M44：無舌領唱者是以亡魂秘法模仿聖歌，不應同時要求另一條神恩資源。
   'reliquary-silent-chorus': { kind: 'mana', school: 'arcane', cost: 3, gain: 0, overcast: false, strainRelief: 0 },
   'reliquary-lament-touch': { kind: 'mana', school: 'cryomancy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
-  // M45：心火吐息是古龍心火術式，不再被當成無限免費的魅力系普通攻擊。
   'reliquary-ember-breath': { kind: 'mana', school: 'pyromancy', cost: 4, gain: 0, overcast: false, strainRelief: 0 },
-  // M44：兩個 Lv4 法師專精的代表招式明確歸屬學派，不再只靠元素 fallback 推斷。
   'chain-lightning': { kind: 'mana', school: 'pyromancy', cost: 3, gain: 0, overcast: true, strainRelief: 0 },
   'corrosive-curse': { kind: 'mana', school: 'arcane', cost: 2, gain: 0, overcast: true, strainRelief: 0 },
-
   'holy-strike': { kind: 'favor', school: 'theurgy', cost: 0, gain: 1, overcast: false, strainRelief: 0 },
   heal: { kind: 'favor', school: 'theurgy', cost: 1, gain: 0, overcast: false, strainRelief: 0 },
   'holy-nova': { kind: 'favor', school: 'theurgy', cost: 2, gain: 0, overcast: false, strainRelief: 0 },
@@ -43,39 +38,19 @@ const RULES: Record<string, MysticMoveRule> = {
   'field-prayer': { kind: 'favor', school: 'theurgy', cost: 0, gain: 1, overcast: false, strainRelief: 0 },
 };
 
-export const MYSTIC_KIND_LABELS: Record<MysticKind, string> = {
-  mana: '秘法',
-  favor: '神恩',
-};
-
+export const MYSTIC_KIND_LABELS: Record<MysticKind, string> = { mana: '秘法', favor: '神恩' };
 export const MYSTIC_SCHOOL_LABELS: Record<MysticSchool, string> = {
-  pyromancy: '炎術',
-  cryomancy: '霜術',
-  arcane: '秘術',
-  theurgy: '神術',
+  pyromancy: '炎術', cryomancy: '霜術', arcane: '秘術', theurgy: '神術',
 };
 
-/**
- * M44：秘法恢復不再只是空過一回合。
- * 施法者在收束魔力時，可把護幕覆到一名隊友身上；護法只抵擋下一次魔法命中。
- */
 export const ARCANE_FOCUS_MOVE: Move = {
-  id: 'arcane-focus',
-  name: '秘法護持',
-  kind: 'support',
-  target: 'ally',
-  hitStat: 'int',
+  id: 'arcane-focus', name: '秘法護持', kind: 'support', target: 'ally', hitStat: 'int',
   applyStatus: { kind: 'ward', duration: 1, potency: 4 },
   narration: '{actor}收束散亂的魔力，將重排的符文化作護幕覆在{target}身上。',
 };
 
-/** M44：戰地禱告同時把一次神聖護佑交給一名隊友。 */
 export const FIELD_PRAYER_MOVE: Move = {
-  id: 'field-prayer',
-  name: '戰地祝禱',
-  kind: 'support',
-  target: 'ally',
-  hitStat: 'cha',
+  id: 'field-prayer', name: '戰地祝禱', kind: 'support', target: 'ally', hitStat: 'cha',
   applyStatus: { kind: 'ward', duration: 1, potency: 3 },
   narration: '{actor}低聲重申誓詞，讓神恩回應並護佑{target}。',
 };
@@ -88,24 +63,10 @@ export function mysticRuleForMove(move: Move): MysticMoveRule | null {
   const explicit = RULES[move.id];
   if (explicit) return explicit;
   if (move.hitStat === 'int' && (move.element === 'fire' || move.element === 'frost')) {
-    return {
-      kind: 'mana',
-      school: move.element === 'fire' ? 'pyromancy' : 'cryomancy',
-      cost: move.area ? 3 : 2,
-      gain: 0,
-      overcast: true,
-      strainRelief: 0,
-    };
+    return { kind: 'mana', school: move.element === 'fire' ? 'pyromancy' : 'cryomancy', cost: move.area ? 3 : 2, gain: 0, overcast: true, strainRelief: 0 };
   }
   if (move.hitStat === 'cha' && (move.element === 'holy' || move.heal)) {
-    return {
-      kind: 'favor',
-      school: 'theurgy',
-      cost: move.area || (move.heal?.dice ?? 0) >= 2 ? 2 : 1,
-      gain: 0,
-      overcast: false,
-      strainRelief: 0,
-    };
+    return { kind: 'favor', school: 'theurgy', cost: move.area || (move.heal?.dice ?? 0) >= 2 ? 2 : 1, gain: 0, overcast: false, strainRelief: 0 };
   }
   return null;
 }
@@ -126,17 +87,12 @@ function decoratedMove(move: Move): Move {
   if (!rule || cleanMove.name.includes('〔')) return { ...cleanMove };
   const resource = MYSTIC_KIND_LABELS[rule.kind];
   const school = MYSTIC_SCHOOL_LABELS[rule.school];
-  const suffix = rule.cost > 0
-    ? `${resource} ${rule.cost}`
-    : rule.gain > 0
-      ? `${resource} +${rule.gain}`
-      : resource;
+  const suffix = rule.cost > 0 ? `${resource} ${rule.cost}` : rule.gain > 0 ? `${resource} +${rule.gain}` : resource;
   return { ...cleanMove, name: `${school}・${cleanMove.name}〔${suffix}〕` };
 }
 
 function readableCombatMove(member: PartyMember, move: Move): Move {
   const decorated = decoratedMove(move);
-  // 敵人沒有玩家編隊 row，不額外灌入玩家站位 UI；維持公開意圖文案乾淨。
   if (member.formationRow === undefined) return decorated;
 
   const baseForForecast = { ...decorated, name: stripM50Suffix(decorated.name) };
@@ -144,6 +100,15 @@ function readableCombatMove(member: PartyMember, move: Move): Move {
   const readable: Move = { ...decorated };
   if (readable.kind === 'guard') {
     readable.narration = '{actor}穩住腳步，以武器與護具架起防禦。';
+  }
+  if (readable.id === 'shield-bash') {
+    Object.defineProperty(readable, 'narration', {
+      enumerable: true,
+      configurable: true,
+      get: () => member.armoryProfile?.shieldReady
+        ? '{actor}以盾面與全身重量撞向{target}，造成 {amount} 點傷害並將其震得失去平衡！'
+        : '{actor}以肩甲、護具與武器架勢強行撞開{target}，造成 {amount} 點傷害並將其震得失去平衡！',
+    });
   }
   Object.defineProperty(readable, 'name', {
     enumerable: true,
@@ -161,19 +126,9 @@ function maximumPower(member: PartyMember, kind: MysticKind): number {
 
 function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
   const max = maximumPower(member, kind);
-  return {
-    kind,
-    max,
-    current: kind === 'mana' ? max : 1,
-    strain: 0,
-  };
+  return { kind, max, current: kind === 'mana' ? max : 1, strain: 0 };
 }
 
-/**
- * 雖沿用 M41 名稱，M44 開始敵人也會走同一條初始化路徑。
- * EnemyUnit 在結構上相容 PartyMember（額外欄位不影響），因此可共享同一套魔力公平規則。
- * M50/M51/M52 把玩家目前前後排、老兵換位與可用盾牌資訊灌進 runtime 名稱，所有戰鬥頁自動共用。
- */
 export function prepareMysticPartyMember(member: PartyMember): PartyMember {
   const copiedMoves = member.moves.map((move) => ({ ...move }));
   const hasMana = copiedMoves.some((move) => mysticRuleForMove(move)?.kind === 'mana');

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -112,11 +112,11 @@ export function mysticRuleForMove(move: Move): MysticMoveRule | null {
 
 function stripM50Suffix(name: string): string {
   return name
-    .replace(/〔(?:前進(?:・守勢)?|後撤|輪替後撤|無人接替)〕$/u, '')
+    .replace(/〔(?:前進(?:・守勢)?(?:・盾\+\d+)?|後撤|輪替後撤|無人接替)〕$/u, '')
     .replace(/〔(?:近戰|遠程)(?: -2)?〕$/u, '')
     .replace(/〔(?:近戰|遠程)・(?:命中 -2|站位適配)〕$/u, '')
-    .replace(/〔(?:護衛|自保)〕$/u, '')
-    .replace(/〔守勢・(?:可護衛|自保)〕$/u, '');
+    .replace(/〔(?:護衛|自保)(?:・盾\+\d+)?〕$/u, '')
+    .replace(/〔守勢・(?:可護衛|自保)(?:・盾\+\d+)?〕$/u, '');
 }
 
 function decoratedMove(move: Move): Move {
@@ -172,7 +172,7 @@ function powerFor(member: PartyMember, kind: MysticKind): MysticPower {
 /**
  * 雖沿用 M41 名稱，M44 開始敵人也會走同一條初始化路徑。
  * EnemyUnit 在結構上相容 PartyMember（額外欄位不影響），因此可共享同一套魔力公平規則。
- * M50/M51 再把玩家目前前後排與老兵換位資訊灌進 runtime 名稱，所有戰鬥頁自動共用。
+ * M50/M51/M52 把玩家目前前後排、老兵換位與可用盾牌資訊灌進 runtime 名稱，所有戰鬥頁自動共用。
  */
 export function prepareMysticPartyMember(member: PartyMember): PartyMember {
   const copiedMoves = member.moves.map((move) => ({ ...move }));

--- a/src/scripts/games/caravan/data/armory.ts
+++ b/src/scripts/games/caravan/data/armory.ts
@@ -243,6 +243,15 @@ export function adjustMovesForArmory(record: CompanionRecord, moves: Move[]): Mo
   return moves.map((move) => {
     const adjusted: Move = { ...move };
     if (move.id === 'piercing-arrow') adjusted.armorPiercing = Math.max(adjusted.armorPiercing ?? 0, 2);
+    if (move.id === 'shield-bash') {
+      if (profile.shieldReady) {
+        adjusted.name = '盾牆猛擊';
+        adjusted.narration = '{actor}架起手中盾牌猛撞{target}，造成 {amount} 點傷害並將其震得暈頭轉向！';
+      } else {
+        adjusted.name = '壁壘猛擊';
+        adjusted.narration = '{actor}以肩甲與武器護手猛撞{target}，造成 {amount} 點傷害並將其震得暈頭轉向！';
+      }
+    }
     if (weaponMoveId && move.id === weaponMoveId) {
       adjusted.hitBonus = (move.hitBonus ?? 0) + profile.weaponHitBonus;
     }

--- a/src/scripts/games/caravan/data/armory.ts
+++ b/src/scripts/games/caravan/data/armory.ts
@@ -6,10 +6,18 @@ import {
   armorProtectionForDiscipline,
   type ArmorProtection,
 } from './armorProfiles.m48';
+import {
+  M52_OFFHAND_ITEMS,
+  equipOffhandItem,
+  handLoadoutProfile,
+  unequipOffhandItem,
+  type M52OffhandItem,
+} from './offhandShields.m52';
 
 export type WeaponDiscipline = 'blade' | 'bow' | 'staff' | 'mace';
 export type ArmorDiscipline = 'light' | 'mail' | 'robe' | 'vestment';
 export type GearFit = 'mastered' | 'trained' | 'strained';
+export type ArmoryEquipSlot = keyof CompanionRecord['equipment'] | 'offhand';
 
 export interface ArmoryItemRule {
   itemId: string;
@@ -33,6 +41,11 @@ export interface ArmoryProfile {
   statAdjustments: Partial<StatBlock>;
   mysticCapacity: { mana: number; favor: number };
   armorProtection?: ArmorProtection;
+  /** M52：武器實際佔用手數與副手守勢。 */
+  weaponHands: 0 | 1 | 2;
+  offhandId: string | null;
+  shieldReady: boolean;
+  shieldGuardBonus: number;
   warnings: string[];
 }
 
@@ -141,6 +154,7 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
   const weaponRule = armoryRuleForItem(record.equipment.weapon);
   const armorRule = armoryRuleForItem(record.equipment.armor);
   const trinketRule = armoryRuleForItem(record.equipment.trinket);
+  const hand = handLoadoutProfile(record);
   const weaponFit = weaponRule?.weapon
     ? specializationWeaponFit(record, weaponRule.weapon, WEAPON_FIT[record.job][weaponRule.weapon])
     : null;
@@ -148,7 +162,7 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
     ? specializationArmorFit(record, armorRule.armor, ARMOR_FIT[record.job][armorRule.armor])
     : null;
 
-  let burden = (weaponRule?.burden ?? 0) + (armorRule?.burden ?? 0) + (trinketRule?.burden ?? 0);
+  let burden = (weaponRule?.burden ?? 0) + (armorRule?.burden ?? 0) + (trinketRule?.burden ?? 0) + hand.offhandBurden;
   if (weaponFit === 'strained') burden += 1;
   if (armorFit === 'strained') burden += 1;
   const capacity = armoryCarryCapacity(record);
@@ -158,7 +172,7 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
   let defenseAdjustment = 0;
   let maxHpAdjustment = 0;
   let damageAdjustment = 0;
-  let mana = (weaponRule?.manaCapacity ?? 0) + (armorRule?.manaCapacity ?? 0) + (trinketRule?.manaCapacity ?? 0);
+  let mana = (weaponRule?.manaCapacity ?? 0) + (armorRule?.manaCapacity ?? 0) + (trinketRule?.manaCapacity ?? 0) + hand.manaCapacity;
   let favor = (weaponRule?.favorCapacity ?? 0) + (armorRule?.favorCapacity ?? 0) + (trinketRule?.favorCapacity ?? 0);
   const warnings: string[] = [];
 
@@ -184,6 +198,14 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
   if (weaponRule?.weapon === 'staff' && record.job !== 'mage') mana = Math.min(0, mana);
   if (weaponRule?.weapon === 'mace' && record.job !== 'cleric') favor = Math.min(0, favor);
 
+  if (hand.warning) warnings.push(hand.warning);
+  if (hand.shieldReady && hand.shieldGuardBonus > 0) {
+    warnings.push(`盾牌就緒：主動防禦架勢額外 +${hand.shieldGuardBonus} 防禦；平時不提供常駐防禦。`);
+  }
+  if (hand.shieldReady && hand.manaCapacity < 0) {
+    warnings.push(`大型盾遮蔽秘法手勢：秘法上限 ${hand.manaCapacity}。`);
+  }
+
   if (overload > 0) {
     statAdjustments.dex = (statAdjustments.dex ?? 0) - overload;
     maxHpAdjustment -= overload * 2;
@@ -206,6 +228,10 @@ export function armoryProfile(record: CompanionRecord): ArmoryProfile {
     statAdjustments,
     mysticCapacity: { mana, favor },
     armorProtection: armorProtectionForDiscipline(armorRule?.armor),
+    weaponHands: hand.weaponHands,
+    offhandId: hand.offhandId,
+    shieldReady: hand.shieldReady,
+    shieldGuardBonus: hand.shieldGuardBonus,
     warnings,
   };
 }
@@ -243,6 +269,10 @@ export function partyArmoryLoad(save: SaveData, memberIds?: string[]): PartyArmo
 export function equipArmoryItem(save: SaveData, memberId: string, itemId: string): ArmoryProfile {
   const record = memberById(save, memberId);
   if (!record) throw new Error(`找不到成員「${memberId}」。`);
+  if (M52_OFFHAND_ITEMS[itemId]) {
+    equipOffhandItem(save, record, itemId);
+    return armoryProfile(record);
+  }
   const item = ITEMS[itemId];
   if (!item?.equip) throw new Error(`「${itemId}」不是可裝備物品。`);
   if (item.equip.minLevel !== undefined && record.level < item.equip.minLevel) {
@@ -258,9 +288,13 @@ export function equipArmoryItem(save: SaveData, memberId: string, itemId: string
   return armoryProfile(record);
 }
 
-export function unequipArmoryItem(save: SaveData, memberId: string, slot: keyof CompanionRecord['equipment']): ArmoryProfile {
+export function unequipArmoryItem(save: SaveData, memberId: string, slot: ArmoryEquipSlot): ArmoryProfile {
   const record = memberById(save, memberId);
   if (!record) throw new Error(`找不到成員「${memberId}」。`);
+  if (slot === 'offhand') {
+    unequipOffhandItem(save, record);
+    return armoryProfile(record);
+  }
   const previous = record.equipment[slot];
   if (previous) {
     record.equipment[slot] = null;
@@ -269,10 +303,11 @@ export function unequipArmoryItem(save: SaveData, memberId: string, slot: keyof 
   return armoryProfile(record);
 }
 
-export function equippableInventory(save: SaveData): Array<{ item: ItemDef; count: number }> {
+export function equippableInventory(save: SaveData): Array<{ item: ItemDef | M52OffhandItem; count: number }> {
+  const catalog = ITEMS as unknown as Record<string, ItemDef | M52OffhandItem>;
   return Object.entries(save.inventory)
     .filter(([, count]) => count > 0)
-    .map(([itemId, count]) => ({ item: ITEMS[itemId], count }))
-    .filter((entry): entry is { item: ItemDef; count: number } => !!entry.item?.equip)
+    .map(([itemId, count]) => ({ item: catalog[itemId], count }))
+    .filter((entry): entry is { item: ItemDef | M52OffhandItem; count: number } => !!entry.item?.equip)
     .sort((a, b) => a.item.value - b.item.value || a.item.name.localeCompare(b.item.name));
 }

--- a/src/scripts/games/caravan/data/combatReadability.m50.ts
+++ b/src/scripts/games/caravan/data/combatReadability.m50.ts
@@ -46,24 +46,12 @@ export function combatMoveForecast(
       };
     }
     if (actor.formationReliefFallback) {
-      return {
-        shortLabel: '輪替後撤',
-        hint: '精通 III：由後排中防禦最高的存活隊友接替前線後，你才會退到後排。',
-        penalized: false,
-      };
+      return { shortLabel: '輪替後撤', hint: '精通 III：由後排中防禦最高的存活隊友接替前線後，你才會退到後排。', penalized: false };
     }
     if (actor.formationCanFallBack) {
-      return {
-        shortLabel: '後撤',
-        hint: '花費完整一回合退到後排；其他存活前排會繼續接敵。',
-        penalized: false,
-      };
+      return { shortLabel: '後撤', hint: '花費完整一回合退到後排；其他存活前排會繼續接敵。', penalized: false };
     }
-    return {
-      shortLabel: '無人接替',
-      hint: '你是目前最後一名前排，而且沒有符合精通 III 輪替條件的後排隊友；現在不能後撤。',
-      penalized: false,
-    };
+    return { shortLabel: '無人接替', hint: '你是目前最後一名前排，而且沒有符合精通 III 輪替條件的後排隊友；現在不能後撤。', penalized: false };
   }
 
   if (move.kind === 'guard') {
@@ -71,72 +59,42 @@ export function combatMoveForecast(
     const guardTotal = 4 + shieldBonus;
     const defenseText = `防禦 +${guardTotal}${shieldBonus > 0 ? `（含盾牌 +${shieldBonus}）` : ''}`;
     return row === 'front'
-      ? {
-          shortLabel: shieldBonus > 0 ? `守勢・可護衛・盾+${shieldBonus}` : '守勢・可護衛',
-          hint: `${defenseText}；位於前排時可替隊友攔截敵方單體攻擊。`,
-          penalized: false,
-        }
-      : {
-          shortLabel: shieldBonus > 0 ? `守勢・自保・盾+${shieldBonus}` : '守勢・自保',
-          hint: `${defenseText}；後排守勢只能保護自己，不能隔空替前排隊友攔截。`,
-          penalized: false,
-        };
+      ? { shortLabel: shieldBonus > 0 ? `守勢・可護衛・盾+${shieldBonus}` : '守勢・可護衛', hint: `${defenseText}；位於前排時可替隊友攔截敵方單體攻擊。`, penalized: false }
+      : { shortLabel: shieldBonus > 0 ? `守勢・自保・盾+${shieldBonus}` : '守勢・自保', hint: `${defenseText}；後排守勢只能保護自己，不能隔空替前排隊友攔截。`, penalized: false };
   }
 
-  if (move.kind !== 'attack') {
-    return { shortLabel: '', hint: '', penalized: false };
-  }
+  if (move.kind !== 'attack') return { shortLabel: '', hint: '', penalized: false };
 
   const formation = formationAttackProfile(actor.formationRow, move, isMystic);
   const rowLabel = ROW_LABEL[row];
-
   if (formation.engagement === 'mystic') {
-    return {
-      shortLabel: '魔法・站位自由',
-      hint: `${rowLabel}施法：真正的秘法／神術不受近戰與遠程的站位命中懲罰。`,
-      penalized: false,
-    };
+    return { shortLabel: '魔法・站位自由', hint: `${rowLabel}施法：真正的秘法／神術不受近戰與遠程的站位命中懲罰。`, penalized: false };
   }
 
   const kindLabel = formation.engagement === 'ranged' ? '遠程' : '近戰';
   if (formation.hitModifier < 0) {
-    return {
-      shortLabel: `${kindLabel}・命中 ${formation.hitModifier}`,
-      hint: formation.message,
-      penalized: true,
-    };
+    return { shortLabel: `${kindLabel}・命中 ${formation.hitModifier}`, hint: formation.message, penalized: true };
   }
-
-  return {
-    shortLabel: `${kindLabel}・站位適配`,
-    hint: `${rowLabel}${kindLabel}：目前站位不會受到額外命中懲罰。`,
-    penalized: false,
-  };
+  return { shortLabel: `${kindLabel}・站位適配`, hint: `${rowLabel}${kindLabel}：目前站位不會受到額外命中懲罰。`, penalized: false };
 }
 
-/**
- * 所有戰鬥頁本來就直接顯示 move.name；M50 在 runtime 讓名稱成為可預判資訊，
- * 因此前線崩潰或 M51 老兵換位改變 formationRow 後，下一次 render 都會同步反映。
- * M52 盾牌亦只在真正 ready 時加上簡短標記；收在背上的盾不會污染按鈕。
- */
-export function combatMoveDisplayName(
-  actor: PartyMember,
-  move: Move,
-  isMystic = false,
-): string {
+/** M50–M52：action name 必須反映當下真正可用的站位／盾牌狀態。 */
+export function combatMoveDisplayName(actor: PartyMember, move: Move, isMystic = false): string {
   const forecast = combatMoveForecast(actor, move, isMystic);
-  const baseName = move.kind === 'guard' ? '防禦架勢' : move.name;
+  const shieldBonus = readyShieldBonus(actor);
+  const baseName = move.kind === 'guard'
+    ? '防禦架勢'
+    : move.id === 'shield-bash'
+      ? shieldBonus > 0 ? '盾牆猛擊' : '壁壘猛擊'
+      : move.name;
   if (move.formationShift) return `${baseName}〔${forecast.shortLabel}〕`;
   if (move.kind === 'guard') {
-    const shieldBonus = readyShieldBonus(actor);
     const role = actor.formationRow === 'back' ? '自保' : '護衛';
     return `${baseName}〔${role}${shieldBonus > 0 ? `・盾+${shieldBonus}` : ''}〕`;
   }
   if (move.kind === 'attack' && !isMystic) {
     const kindLabel = forecast.shortLabel.startsWith('遠程') ? '遠程' : '近戰';
-    return forecast.penalized
-      ? `${baseName}〔${kindLabel} -2〕`
-      : `${baseName}〔${kindLabel}〕`;
+    return forecast.penalized ? `${baseName}〔${kindLabel} -2〕` : `${baseName}〔${kindLabel}〕`;
   }
   return baseName;
 }

--- a/src/scripts/games/caravan/data/combatReadability.m50.ts
+++ b/src/scripts/games/caravan/data/combatReadability.m50.ts
@@ -12,9 +12,15 @@ const ROW_LABEL: Record<'front' | 'back', string> = {
   back: '後排',
 };
 
+function readyShieldBonus(actor: PartyMember): number {
+  const armory = actor.armoryProfile;
+  return armory?.shieldReady ? Math.max(0, armory.shieldGuardBonus ?? 0) : 0;
+}
+
 /**
  * M50：把 M49 已經存在的站位規則在玩家按下招式前就說清楚。
  * M51 延伸同一資訊契約：老兵換位也必須在出手前說明會前進、後撤或輪替。
+ * M52 再要求盾牌的守勢收益在按下防禦以前可見，且收起的盾不能假裝生效。
  * isMystic 由 M41/M44 的 arcana 真實規則提供，避免用元素外觀猜測魔法。
  */
 export function combatMoveForecast(
@@ -27,10 +33,14 @@ export function combatMoveForecast(
   if (move.formationShift) {
     if (row === 'back') {
       const guardedAdvance = (actor.veteranMasteryRank ?? 0) >= 2;
+      const shieldBonus = guardedAdvance ? readyShieldBonus(actor) : 0;
+      const guardTotal = 4 + shieldBonus;
       return {
-        shortLabel: guardedAdvance ? '前進・守勢' : '前進',
+        shortLabel: guardedAdvance
+          ? shieldBonus > 0 ? `前進・守勢・盾+${shieldBonus}` : '前進・守勢'
+          : '前進',
         hint: guardedAdvance
-          ? '花費完整一回合進入前排；精通 II 會同時進入守勢，直到下一次自身行動前有效。'
+          ? `花費完整一回合進入前排；精通 II 會同時進入守勢，防禦 +${guardTotal}${shieldBonus > 0 ? `（含盾牌 +${shieldBonus}）` : ''}，直到下一次自身行動前有效。`
           : '花費完整一回合從後排進入前排，不造成傷害。',
         penalized: false,
       };
@@ -57,15 +67,18 @@ export function combatMoveForecast(
   }
 
   if (move.kind === 'guard') {
+    const shieldBonus = readyShieldBonus(actor);
+    const guardTotal = 4 + shieldBonus;
+    const defenseText = `防禦 +${guardTotal}${shieldBonus > 0 ? `（含盾牌 +${shieldBonus}）` : ''}`;
     return row === 'front'
       ? {
-          shortLabel: '守勢・可護衛',
-          hint: '防禦 +4；位於前排時可替隊友攔截敵方單體攻擊。',
+          shortLabel: shieldBonus > 0 ? `守勢・可護衛・盾+${shieldBonus}` : '守勢・可護衛',
+          hint: `${defenseText}；位於前排時可替隊友攔截敵方單體攻擊。`,
           penalized: false,
         }
       : {
-          shortLabel: '守勢・自保',
-          hint: '防禦 +4；後排守勢只能保護自己，不能隔空替前排隊友攔截。',
+          shortLabel: shieldBonus > 0 ? `守勢・自保・盾+${shieldBonus}` : '守勢・自保',
+          hint: `${defenseText}；後排守勢只能保護自己，不能隔空替前排隊友攔截。`,
           penalized: false,
         };
   }
@@ -104,7 +117,7 @@ export function combatMoveForecast(
 /**
  * 所有戰鬥頁本來就直接顯示 move.name；M50 在 runtime 讓名稱成為可預判資訊，
  * 因此前線崩潰或 M51 老兵換位改變 formationRow 後，下一次 render 都會同步反映。
- * 按鈕只顯示最短必要資訊，完整理由仍由 forecast/log 提供。
+ * M52 盾牌亦只在真正 ready 時加上簡短標記；收在背上的盾不會污染按鈕。
  */
 export function combatMoveDisplayName(
   actor: PartyMember,
@@ -115,7 +128,9 @@ export function combatMoveDisplayName(
   const baseName = move.kind === 'guard' ? '防禦架勢' : move.name;
   if (move.formationShift) return `${baseName}〔${forecast.shortLabel}〕`;
   if (move.kind === 'guard') {
-    return `${baseName}〔${actor.formationRow === 'back' ? '自保' : '護衛'}〕`;
+    const shieldBonus = readyShieldBonus(actor);
+    const role = actor.formationRow === 'back' ? '自保' : '護衛';
+    return `${baseName}〔${role}${shieldBonus > 0 ? `・盾+${shieldBonus}` : ''}〕`;
   }
   if (move.kind === 'attack' && !isMystic) {
     const kindLabel = forecast.shortLabel.startsWith('遠程') ? '遠程' : '近戰';

--- a/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import { startCombat, type EnemyUnit } from '../combat';
+import type { Rng } from '../rng';
 import type { CompanionRecord } from '../save';
 import { memberFromRecord } from './jobs';
 import { TOWNS } from './towns';
@@ -10,6 +12,21 @@ import {
 } from './offhandShields.m52';
 import { combatMoveForecast } from './combatReadability.m50';
 
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 2,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const dummy = (): EnemyUnit => ({
+  id: 'dummy', name: '木樁', stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+  maxHp: 30, hp: 30, defense: 10,
+  moves: [{ id: 'dummy-hit', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str', narration: '' }],
+  intents: [{ weight: 1, moveId: 'dummy-hit' }],
+});
+
 function record(job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
   return {
     id: `m52-${job}`, name: '審查角色', job, level: 5, xp: 750,
@@ -19,33 +36,21 @@ function record(job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
   };
 }
 
-function passiveSnapshot(record: CompanionRecord) {
-  const member = memberFromRecord(record);
-  return {
-    stats: member.stats,
-    defense: member.defense,
-    maxHp: member.maxHp,
-    damageBonus: member.damageBonus ?? 0,
-  };
+function passiveSnapshot(source: CompanionRecord) {
+  const member = memberFromRecord(source);
+  return { stats: member.stats, defense: member.defense, maxHp: member.maxHp, damageBonus: member.damageBonus ?? 0 };
 }
 
 describe('M52 multidimensional player adversarial review', () => {
   it('prevents shields from becoming a mandatory passive fourth armor slot', () => {
-    const plain = record();
-    plain.equipment.weapon = 'salt-crystal-blade';
-    const buckler = record();
-    buckler.equipment.weapon = 'salt-crystal-blade';
-    setOffhandId(buckler, 'oak-buckler');
+    const plain = record(); plain.equipment.weapon = 'salt-crystal-blade';
+    const buckler = record(); buckler.equipment.weapon = 'salt-crystal-blade'; setOffhandId(buckler, 'oak-buckler');
     expect(passiveSnapshot(buckler)).toEqual(passiveSnapshot(plain));
   });
 
   it('makes stronger guard protection pay more burden instead of strictly dominating the buckler', () => {
-    const buckler = record();
-    buckler.equipment.weapon = 'salt-crystal-blade';
-    setOffhandId(buckler, 'oak-buckler');
-    const kite = record();
-    kite.equipment.weapon = 'salt-crystal-blade';
-    setOffhandId(kite, 'salt-rim-kite-shield');
+    const buckler = record(); buckler.equipment.weapon = 'salt-crystal-blade'; setOffhandId(buckler, 'oak-buckler');
+    const kite = record(); kite.equipment.weapon = 'salt-crystal-blade'; setOffhandId(kite, 'salt-rim-kite-shield');
     const light = handLoadoutProfile(buckler);
     const heavy = handLoadoutProfile(kite);
     expect(heavy.shieldGuardBonus).toBeGreaterThan(light.shieldGuardBonus);
@@ -54,18 +59,14 @@ describe('M52 multidimensional player adversarial review', () => {
   });
 
   it('gives two-handed loadouts a real opportunity cost instead of allowing bow/staff plus active shield', () => {
-    const bow = record('ranger');
-    bow.equipment.weapon = 'ridge-mist-bow';
-    setOffhandId(bow, 'salt-rim-kite-shield');
+    const bow = record('ranger'); bow.equipment.weapon = 'ridge-mist-bow'; setOffhandId(bow, 'salt-rim-kite-shield');
     const bowProfile = armoryProfile(bow);
     expect(bowProfile.weaponHands).toBe(2);
     expect(bowProfile.shieldReady).toBe(false);
     expect(bowProfile.shieldGuardBonus).toBe(0);
     expect(bowProfile.burden).toBeGreaterThan(0);
 
-    const staff = record('mage');
-    staff.equipment.weapon = 'brine-crystal-staff';
-    setOffhandId(staff, 'salt-rim-kite-shield');
+    const staff = record('mage'); staff.equipment.weapon = 'brine-crystal-staff'; setOffhandId(staff, 'salt-rim-kite-shield');
     const staffProfile = armoryProfile(staff);
     expect(staffProfile.weaponHands).toBe(2);
     expect(staffProfile.shieldReady).toBe(false);
@@ -73,20 +74,16 @@ describe('M52 multidimensional player adversarial review', () => {
   });
 
   it('does not let a ranger exploit an empty weapon item slot to activate a shield beside the implicit bow', () => {
-    const ranger = record('ranger');
-    setOffhandId(ranger, 'oak-buckler');
+    const ranger = record('ranger'); setOffhandId(ranger, 'oak-buckler');
     const profile = handLoadoutProfile(ranger);
     expect(profile.weaponHands).toBe(2);
     expect(profile.shieldReady).toBe(false);
   });
 
   it('keeps heavy-shield casting interference contextual: active in hand, absent while stowed', () => {
-    const active = record('mage');
-    setOffhandId(active, 'salt-rim-kite-shield');
+    const active = record('mage'); setOffhandId(active, 'salt-rim-kite-shield');
     const activeProfile = armoryProfile(active);
-    const stowed = record('mage');
-    stowed.equipment.weapon = 'ghostflame-staff';
-    setOffhandId(stowed, 'salt-rim-kite-shield');
+    const stowed = record('mage'); stowed.equipment.weapon = 'ghostflame-staff'; setOffhandId(stowed, 'salt-rim-kite-shield');
     const stowedProfile = armoryProfile(stowed);
     expect(activeProfile.shieldReady).toBe(true);
     expect(activeProfile.mysticCapacity.mana).toBe(-1);
@@ -95,11 +92,8 @@ describe('M52 multidimensional player adversarial review', () => {
   });
 
   it('makes pre-action guard information match the actual shield-ready profile', () => {
-    const source = record();
-    source.equipment.weapon = 'salt-crystal-blade';
-    setOffhandId(source, 'salt-rim-kite-shield');
-    const member = memberFromRecord(source);
-    member.formationRow = 'front';
+    const source = record(); source.equipment.weapon = 'salt-crystal-blade'; setOffhandId(source, 'salt-rim-kite-shield');
+    const member = memberFromRecord(source); member.formationRow = 'front';
     const guard = member.moves.find((move) => move.id === 'guard')!;
     const forecast = combatMoveForecast(member, guard);
     expect(forecast.shortLabel).toContain('盾+2');
@@ -107,12 +101,34 @@ describe('M52 multidimensional player adversarial review', () => {
     expect(forecast.hint).toContain('含盾牌 +2');
 
     source.equipment.weapon = 'swordsaint-bokken';
-    const stowed = memberFromRecord(source);
-    stowed.formationRow = 'front';
+    const stowed = memberFromRecord(source); stowed.formationRow = 'front';
     const stowedGuard = stowed.moves.find((move) => move.id === 'guard')!;
     const stowedForecast = combatMoveForecast(stowed, stowedGuard);
     expect(stowedForecast.shortLabel).not.toContain('盾+');
     expect(stowedForecast.hint).toContain('防禦 +4');
+  });
+
+  it('keeps the bulwark specialization playable without inventing a shield, while using shield wording when one is real', () => {
+    const unshielded = record();
+    unshielded.specialization = 'bulwark';
+    unshielded.equipment.weapon = 'swordsaint-bokken';
+    setOffhandId(unshielded, 'oak-buckler'); // stowed by the two-handed weapon
+    const noShieldMember = memberFromRecord(unshielded); noShieldMember.formationRow = 'front';
+    startCombat(rng, [noShieldMember], [dummy()]);
+    const noShieldBash = noShieldMember.moves.find((move) => move.id === 'shield-bash')!;
+    expect(noShieldBash.name).toContain('壁壘猛擊');
+    expect(noShieldBash.name).not.toContain('盾牆');
+    expect(noShieldBash.narration).not.toContain('盾面');
+
+    const shielded = record();
+    shielded.specialization = 'bulwark';
+    shielded.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(shielded, 'oak-buckler');
+    const shieldMember = memberFromRecord(shielded); shieldMember.formationRow = 'front';
+    startCombat(rng, [shieldMember], [dummy()]);
+    const shieldBash = shieldMember.moves.find((move) => move.id === 'shield-bash')!;
+    expect(shieldBash.name).toContain('盾牆猛擊');
+    expect(shieldBash.narration).toContain('盾面');
   });
 
   it('keeps both shields in the real economy instead of making them debug-only equipment', () => {
@@ -124,9 +140,7 @@ describe('M52 multidimensional player adversarial review', () => {
 
   it('bounds shield guard bonus so later gear cannot silently turn guard into near-invulnerability', () => {
     for (const item of Object.values(M52_OFFHAND_ITEMS)) {
-      const source = record();
-      source.equipment.weapon = 'salt-crystal-blade';
-      setOffhandId(source, item.id);
+      const source = record(); source.equipment.weapon = 'salt-crystal-blade'; setOffhandId(source, item.id);
       const profile = handLoadoutProfile(source);
       expect(profile.shieldGuardBonus).toBeGreaterThanOrEqual(0);
       expect(profile.shieldGuardBonus).toBeLessThanOrEqual(2);

--- a/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { TOWNS } from './towns';
+import { armoryProfile } from './armory';
+import {
+  M52_OFFHAND_ITEMS,
+  handLoadoutProfile,
+  setOffhandId,
+} from './offhandShields.m52';
+import { combatMoveForecast } from './combatReadability.m50';
+
+function record(job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id: `m52-${job}`, name: '審查角色', job, level: 5, xp: 750,
+    stats: { str: 14, dex: 14, int: 16, cha: 14, con: 14 },
+    maxHp: 28, injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+function passiveSnapshot(record: CompanionRecord) {
+  const member = memberFromRecord(record);
+  return {
+    stats: member.stats,
+    defense: member.defense,
+    maxHp: member.maxHp,
+    damageBonus: member.damageBonus ?? 0,
+  };
+}
+
+describe('M52 multidimensional player adversarial review', () => {
+  it('prevents shields from becoming a mandatory passive fourth armor slot', () => {
+    const plain = record();
+    plain.equipment.weapon = 'salt-crystal-blade';
+    const buckler = record();
+    buckler.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(buckler, 'oak-buckler');
+    expect(passiveSnapshot(buckler)).toEqual(passiveSnapshot(plain));
+  });
+
+  it('makes stronger guard protection pay more burden instead of strictly dominating the buckler', () => {
+    const buckler = record();
+    buckler.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(buckler, 'oak-buckler');
+    const kite = record();
+    kite.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(kite, 'salt-rim-kite-shield');
+    const light = handLoadoutProfile(buckler);
+    const heavy = handLoadoutProfile(kite);
+    expect(heavy.shieldGuardBonus).toBeGreaterThan(light.shieldGuardBonus);
+    expect(heavy.offhandBurden).toBeGreaterThan(light.offhandBurden);
+    expect(heavy.manaCapacity).toBeLessThanOrEqual(light.manaCapacity);
+  });
+
+  it('gives two-handed loadouts a real opportunity cost instead of allowing bow/staff plus active shield', () => {
+    const bow = record('ranger');
+    bow.equipment.weapon = 'ridge-mist-bow';
+    setOffhandId(bow, 'salt-rim-kite-shield');
+    const bowProfile = armoryProfile(bow);
+    expect(bowProfile.weaponHands).toBe(2);
+    expect(bowProfile.shieldReady).toBe(false);
+    expect(bowProfile.shieldGuardBonus).toBe(0);
+    expect(bowProfile.burden).toBeGreaterThan(0);
+
+    const staff = record('mage');
+    staff.equipment.weapon = 'brine-crystal-staff';
+    setOffhandId(staff, 'salt-rim-kite-shield');
+    const staffProfile = armoryProfile(staff);
+    expect(staffProfile.weaponHands).toBe(2);
+    expect(staffProfile.shieldReady).toBe(false);
+    expect(staffProfile.mysticCapacity.mana).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not let a ranger exploit an empty weapon item slot to activate a shield beside the implicit bow', () => {
+    const ranger = record('ranger');
+    setOffhandId(ranger, 'oak-buckler');
+    const profile = handLoadoutProfile(ranger);
+    expect(profile.weaponHands).toBe(2);
+    expect(profile.shieldReady).toBe(false);
+  });
+
+  it('keeps heavy-shield casting interference contextual: active in hand, absent while stowed', () => {
+    const active = record('mage');
+    setOffhandId(active, 'salt-rim-kite-shield');
+    const activeProfile = armoryProfile(active);
+    const stowed = record('mage');
+    stowed.equipment.weapon = 'ghostflame-staff';
+    setOffhandId(stowed, 'salt-rim-kite-shield');
+    const stowedProfile = armoryProfile(stowed);
+    expect(activeProfile.shieldReady).toBe(true);
+    expect(activeProfile.mysticCapacity.mana).toBe(-1);
+    expect(stowedProfile.shieldReady).toBe(false);
+    expect(stowedProfile.mysticCapacity.mana).toBe(1);
+  });
+
+  it('makes pre-action guard information match the actual shield-ready profile', () => {
+    const source = record();
+    source.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(source, 'salt-rim-kite-shield');
+    const member = memberFromRecord(source);
+    member.formationRow = 'front';
+    const guard = member.moves.find((move) => move.id === 'guard')!;
+    const forecast = combatMoveForecast(member, guard);
+    expect(forecast.shortLabel).toContain('盾+2');
+    expect(forecast.hint).toContain('防禦 +6');
+    expect(forecast.hint).toContain('含盾牌 +2');
+
+    source.equipment.weapon = 'swordsaint-bokken';
+    const stowed = memberFromRecord(source);
+    stowed.formationRow = 'front';
+    const stowedGuard = stowed.moves.find((move) => move.id === 'guard')!;
+    const stowedForecast = combatMoveForecast(stowed, stowedGuard);
+    expect(stowedForecast.shortLabel).not.toContain('盾+');
+    expect(stowedForecast.hint).toContain('防禦 +4');
+  });
+
+  it('keeps both shields in the real economy instead of making them debug-only equipment', () => {
+    expect(TOWNS['starting-town'].stock).toContain('oak-buckler');
+    expect(TOWNS['salt-spring-city'].stock).toContain('salt-rim-kite-shield');
+    expect(M52_OFFHAND_ITEMS['oak-buckler'].value).toBeGreaterThan(0);
+    expect(M52_OFFHAND_ITEMS['salt-rim-kite-shield'].value).toBeGreaterThan(M52_OFFHAND_ITEMS['oak-buckler'].value);
+  });
+
+  it('bounds shield guard bonus so later gear cannot silently turn guard into near-invulnerability', () => {
+    for (const item of Object.values(M52_OFFHAND_ITEMS)) {
+      const source = record();
+      source.equipment.weapon = 'salt-crystal-blade';
+      setOffhandId(source, item.id);
+      const profile = handLoadoutProfile(source);
+      expect(profile.shieldGuardBonus).toBeGreaterThanOrEqual(0);
+      expect(profile.shieldGuardBonus).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
@@ -118,7 +118,7 @@ describe('M52 multidimensional player adversarial review', () => {
     const noShieldBash = noShieldMember.moves.find((move) => move.id === 'shield-bash')!;
     expect(noShieldBash.name).toContain('壁壘猛擊');
     expect(noShieldBash.name).not.toContain('盾牆');
-    expect(noShieldBash.narration).not.toContain('盾面');
+    expect(noShieldBash.narration).not.toContain('盾');
 
     const shielded = record();
     shielded.specialization = 'bulwark';
@@ -128,7 +128,7 @@ describe('M52 multidimensional player adversarial review', () => {
     startCombat(rng, [shieldMember], [dummy()]);
     const shieldBash = shieldMember.moves.find((move) => move.id === 'shield-bash')!;
     expect(shieldBash.name).toContain('盾牆猛擊');
-    expect(shieldBash.narration).toContain('盾面');
+    expect(shieldBash.narration).toContain('盾');
   });
 
   it('keeps both shields in the real economy instead of making them debug-only equipment', () => {

--- a/src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { setOffhandId } from './offhandShields.m52';
+import { VETERAN_REPOSITION_MOVE_ID } from './veteranMastery.m51';
+
+const initRng: Rng = {
+  next: () => 0,
+  roll: () => 2,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+function attackRng(d20: number, damage = 2): Rng {
+  return {
+    next: () => 0,
+    roll: () => damage,
+    d20: () => d20,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+function record(xp = 320): CompanionRecord {
+  return {
+    id: `fighter-${xp}`, name: '盾兵', job: 'swordsman', level: 5, xp,
+    stats: { str: 14, dex: 10, int: 8, cha: 10, con: 14 },
+    maxHp: 26, injuredForTrips: 0,
+    equipment: { weapon: 'salt-crystal-blade', armor: null, trinket: null },
+  };
+}
+
+function enemy(): EnemyUnit {
+  return {
+    id: 'foe', name: '測試敵兵',
+    stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 40, hp: 40, defense: 12,
+    moves: [{
+      id: 'enemy-strike', name: '刀擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 4 }, narration: '{actor}攻擊{target}，造成 {amount} 點傷害！',
+    }],
+    intents: [{ weight: 1, moveId: 'enemy-strike' }],
+  };
+}
+
+function guardMove(member: PartyMember) {
+  const move = member.moves.find((candidate) => candidate.id === 'guard');
+  if (!move) throw new Error('test member has no guard');
+  return move;
+}
+
+function setEnemyTurn(state: ReturnType<typeof startCombat>): void {
+  state.turnIndex = state.order.indexOf('foe');
+}
+
+function runGuardedHit(offhand: string | null, weapon = 'salt-crystal-blade', die = 16): { hp: number; member: PartyMember } {
+  const source = record();
+  source.equipment.weapon = weapon;
+  if (offhand) setOffhandId(source, offhand);
+  const defender = memberFromRecord(source);
+  defender.formationRow = 'front';
+  defender.defense = 12; // isolate guard math from job/equipment base defense
+  const state = startCombat(initRng, [defender], [enemy()]);
+  state.guarding[defender.id] = true;
+  setEnemyTurn(state);
+  enemyAct(attackRng(die), state, 'foe');
+  return { hp: defender.hp, member: defender };
+}
+
+describe('M52 live shield combat integration', () => {
+  it('does not change passive defense or unguarded hit resolution', () => {
+    const plain = memberFromRecord(record());
+    const shieldRecord = record();
+    setOffhandId(shieldRecord, 'salt-rim-kite-shield');
+    const shielded = memberFromRecord(shieldRecord);
+    expect(shielded.defense).toBe(plain.defense);
+
+    plain.formationRow = 'front';
+    shielded.formationRow = 'front';
+    plain.defense = 12;
+    shielded.defense = 12;
+    const plainState = startCombat(initRng, [plain], [enemy()]);
+    const shieldState = startCombat(initRng, [shielded], [enemy()]);
+    setEnemyTurn(plainState);
+    setEnemyTurn(shieldState);
+    enemyAct(attackRng(12), plainState, 'foe');
+    enemyAct(attackRng(12), shieldState, 'foe');
+    expect(plain.hp).toBeLessThan(plain.maxHp);
+    expect(shielded.hp).toBeLessThan(shielded.maxHp);
+    expect(shielded.hp).toBe(plain.hp);
+  });
+
+  it('resolves base guard, buckler guard and kite-shield guard as +4 / +5 / +6', () => {
+    const baseAt16 = runGuardedHit(null, 'salt-crystal-blade', 16);
+    const bucklerAt16 = runGuardedHit('oak-buckler', 'salt-crystal-blade', 16);
+    const kiteAt17 = runGuardedHit('salt-rim-kite-shield', 'salt-crystal-blade', 17);
+    const kiteAt18 = runGuardedHit('salt-rim-kite-shield', 'salt-crystal-blade', 18);
+
+    expect(baseAt16.hp).toBeLessThan(baseAt16.member.maxHp); // DEF 12 + guard 4 = 16, hit
+    expect(bucklerAt16.hp).toBe(bucklerAt16.member.maxHp); // 12 + 4 + 1 = 17, miss
+    expect(kiteAt17.hp).toBe(kiteAt17.member.maxHp); // 12 + 4 + 2 = 18, miss
+    expect(kiteAt18.hp).toBeLessThan(kiteAt18.member.maxHp); // exact 18 hits
+  });
+
+  it('stows the shield under a two-handed weapon, falling back to ordinary +4 guard', () => {
+    const result = runGuardedHit('salt-rim-kite-shield', 'swordsaint-bokken', 16);
+    expect(result.member.armoryProfile?.shieldReady).toBe(false);
+    expect(result.member.armoryProfile?.shieldGuardBonus).toBe(0);
+    expect(result.hp).toBeLessThan(result.member.maxHp);
+    expect(guardMove(result.member).name).not.toContain('盾+');
+  });
+
+  it('shows the real shield guard value in the live pre-action guard label', () => {
+    const source = record();
+    setOffhandId(source, 'salt-rim-kite-shield');
+    const member = memberFromRecord(source);
+    member.formationRow = 'front';
+    startCombat(initRng, [member], [enemy()]);
+    expect(guardMove(member).name).toBe('防禦架勢〔護衛・盾+2〕');
+  });
+
+  it('lets M51 mastery-II guarded advance benefit from a ready shield, with the result visible before click', () => {
+    const source = record(500);
+    setOffhandId(source, 'oak-buckler');
+    const veteran = memberFromRecord(source);
+    veteran.formationRow = 'back';
+    veteran.defense = 12;
+    const anchor: PartyMember = {
+      id: 'anchor', name: '前排同伴',
+      stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+      maxHp: 30, hp: 30, defense: 12, formationRow: 'front',
+      moves: [{ id: 'anchor-hit', name: '揮擊', kind: 'attack', target: 'enemy', hitStat: 'str', narration: '' }],
+    };
+    const state = startCombat(initRng, [anchor, veteran], [enemy()]);
+    const shift = veteran.moves.find((move) => move.id === VETERAN_REPOSITION_MOVE_ID)!;
+    expect(shift.name).toContain('前進・守勢・盾+1');
+
+    state.turnIndex = state.order.indexOf(veteran.id);
+    const acted = partyAct(initRng, state, veteran.id, shift.id, veteran.id);
+    expect(acted.acted).toBe(true);
+    expect(veteran.formationRow).toBe('front');
+    expect(state.guarding[veteran.id]).toBe(true);
+
+    veteran.hp = 5; // make enemy choose the guarded veteran over anchor
+    setEnemyTurn(state);
+    enemyAct(attackRng(16), state, 'foe');
+    expect(veteran.hp).toBe(5); // DEF 12 + guard 4 + buckler 1 = 17
+  });
+
+  it('does not duplicate shield suffixes after repeated combat initialization', () => {
+    const source = record();
+    setOffhandId(source, 'oak-buckler');
+    const member = memberFromRecord(source);
+    member.formationRow = 'front';
+    startCombat(initRng, [member], [enemy()]);
+    const once = guardMove(member).name;
+    startCombat(initRng, [member], [enemy()]);
+    const twice = guardMove(member).name;
+    expect(twice).toBe(once);
+    expect((twice.match(/盾\+1/g) ?? []).length).toBe(1);
+  });
+});

--- a/src/scripts/games/caravan/data/offhandShields.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.m52.test.ts
@@ -40,6 +40,17 @@ describe('M52 offhand and handedness rules', () => {
     expect(weaponHands('swordsaint-bokken')).toBe(2);
   });
 
+  it('treats the ranger default bow as two-handed even with an empty weapon item slot', () => {
+    const ranger = record('ranger');
+    setOffhandId(ranger, 'oak-buckler');
+    const hand = handLoadoutProfile(ranger);
+    expect(ranger.equipment.weapon).toBeNull();
+    expect(hand.weaponHands).toBe(2);
+    expect(hand.shieldReady).toBe(false);
+    expect(hand.shieldGuardBonus).toBe(0);
+    expect(hand.warning).toContain('游俠的預設弓');
+  });
+
   it('makes a buckler ready beside a one-handed weapon but never grants passive defense', () => {
     const fighter = record();
     fighter.equipment.weapon = 'salt-crystal-blade';

--- a/src/scripts/games/caravan/data/offhandShields.m52.test.ts
+++ b/src/scripts/games/caravan/data/offhandShields.m52.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord } from '../save';
+import { armoryProfile } from './armory';
+import {
+  M52_OFFHAND_ITEMS,
+  equipOffhandItem,
+  equipmentView,
+  handLoadoutProfile,
+  offhandId,
+  setOffhandId,
+  unequipOffhandItem,
+  weaponHands,
+} from './offhandShields.m52';
+
+function record(job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id: 'm52-test', name: '測試者', job, level: 5, xp: 750,
+    stats: { str: 14, dex: 12, int: 14, cha: 12, con: 14 },
+    maxHp: 28, injuredForTrips: 0,
+    equipment: { weapon: null, armor: null, trinket: null },
+  };
+}
+
+describe('M52 offhand and handedness rules', () => {
+  it('keeps legacy v6 three-slot records valid without mutating them just by reading', () => {
+    const legacy = record();
+    const before = JSON.stringify(legacy);
+    expect(offhandId(legacy)).toBeNull();
+    expect(handLoadoutProfile(legacy).shieldReady).toBe(false);
+    expect(JSON.stringify(legacy)).toBe(before);
+    expect('offhand' in equipmentView(legacy)).toBe(false);
+  });
+
+  it('classifies one-handed and two-handed weapons explicitly', () => {
+    expect(weaponHands('salt-crystal-blade')).toBe(1);
+    expect(weaponHands('brine-blessed-mace')).toBe(1);
+    expect(weaponHands('ridge-mist-bow')).toBe(2);
+    expect(weaponHands('ghostflame-staff')).toBe(2);
+    expect(weaponHands('brine-crystal-staff')).toBe(2);
+    expect(weaponHands('swordsaint-bokken')).toBe(2);
+  });
+
+  it('makes a buckler ready beside a one-handed weapon but never grants passive defense', () => {
+    const fighter = record();
+    fighter.equipment.weapon = 'salt-crystal-blade';
+    setOffhandId(fighter, 'oak-buckler');
+    const hand = handLoadoutProfile(fighter);
+    const profile = armoryProfile(fighter);
+    expect(hand.shieldReady).toBe(true);
+    expect(hand.shieldGuardBonus).toBe(1);
+    expect(hand.offhandBurden).toBe(1);
+    expect(profile.defenseAdjustment).toBe(0);
+    expect(profile.shieldGuardBonus).toBe(1);
+    expect(profile.burden).toBeGreaterThanOrEqual(3);
+  });
+
+  it('stows a shield under a two-handed weapon while keeping its burden', () => {
+    const archer = record('ranger');
+    archer.equipment.weapon = 'ridge-mist-bow';
+    setOffhandId(archer, 'oak-buckler');
+    const hand = handLoadoutProfile(archer);
+    expect(hand.weaponHands).toBe(2);
+    expect(hand.shieldReady).toBe(false);
+    expect(hand.shieldGuardBonus).toBe(0);
+    expect(hand.offhandBurden).toBe(1);
+    expect(hand.warning).toContain('佔滿雙手');
+    expect(hand.warning).toContain('守勢加成不生效');
+  });
+
+  it('applies the heavy shield casting penalty only while the shield is actually in hand', () => {
+    const mage = record('mage');
+    mage.equipment.weapon = null;
+    setOffhandId(mage, 'salt-rim-kite-shield');
+    const ready = handLoadoutProfile(mage);
+    expect(ready.shieldReady).toBe(true);
+    expect(ready.shieldGuardBonus).toBe(2);
+    expect(ready.manaCapacity).toBe(-1);
+
+    mage.equipment.weapon = 'ghostflame-staff';
+    const stowed = handLoadoutProfile(mage);
+    expect(stowed.shieldReady).toBe(false);
+    expect(stowed.shieldGuardBonus).toBe(0);
+    expect(stowed.manaCapacity).toBe(0);
+    expect(stowed.offhandBurden).toBe(2);
+  });
+
+  it('moves shields between inventory and the optional offhand slot without a new save schema', () => {
+    const fighter = record();
+    const save = { inventory: { 'oak-buckler': 1, 'salt-rim-kite-shield': 1 } };
+    equipOffhandItem(save, fighter, 'oak-buckler');
+    expect(offhandId(fighter)).toBe('oak-buckler');
+    expect(save.inventory['oak-buckler']).toBeUndefined();
+
+    equipOffhandItem(save, fighter, 'salt-rim-kite-shield');
+    expect(offhandId(fighter)).toBe('salt-rim-kite-shield');
+    expect(save.inventory['oak-buckler']).toBe(1);
+    expect(save.inventory['salt-rim-kite-shield']).toBeUndefined();
+
+    unequipOffhandItem(save, fighter);
+    expect(offhandId(fighter)).toBeNull();
+    expect(save.inventory['salt-rim-kite-shield']).toBe(1);
+  });
+
+  it('keeps the M52 item definitions bounded to guard utility rather than passive stat bundles', () => {
+    for (const shield of Object.values(M52_OFFHAND_ITEMS)) {
+      expect(shield.equip.slot).toBe('offhand');
+      expect(shield.equip.offhandKind).toBe('shield');
+      expect('bonus' in shield.equip).toBe(false);
+      expect('defense' in shield.equip).toBe(false);
+      expect('maxHp' in shield.equip).toBe(false);
+      expect('move' in shield.equip).toBe(false);
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/offhandShields.m52.ts
+++ b/src/scripts/games/caravan/data/offhandShields.m52.ts
@@ -90,18 +90,28 @@ export function weaponHands(itemId: string | null | undefined): 0 | 1 | 2 {
   return TWO_HANDED_WEAPONS.has(itemId) ? 2 : 1;
 }
 
+function recordWeaponHands(record: Pick<CompanionRecord, 'equipment' | 'job'>): 0 | 1 | 2 {
+  const equipped = weaponHands(record.equipment.weapon);
+  if (equipped > 0) return equipped;
+  // A ranger's base kit and class attacks explicitly use a bow even before a weapon item is equipped.
+  // Treat that implicit bow as two-handed so an empty equipment slot cannot bypass the shield rule.
+  if (record.job === 'ranger') return 2;
+  return 0;
+}
+
 export function shieldRule(itemId: string | null | undefined): ShieldRule | null {
   return itemId ? SHIELD_RULES[itemId] ?? null : null;
 }
 
-export function handLoadoutProfile(record: Pick<CompanionRecord, 'equipment'>): HandLoadoutProfile {
+export function handLoadoutProfile(record: Pick<CompanionRecord, 'equipment' | 'job'>): HandLoadoutProfile {
   const equipment = equipmentView(record);
-  const hands = weaponHands(equipment.weapon);
+  const hands = recordWeaponHands(record);
   const offhand = equipment.offhand ?? null;
   const shield = shieldRule(offhand);
   const ready = !!shield && hands < 2;
+  const implicitWeapon = !equipment.weapon && record.job === 'ranger' ? '游俠的預設弓' : '雙手武器';
   const warning = shield && !ready
-    ? `${ITEMS[equipment.weapon!]?.name ?? '雙手武器'}佔滿雙手；${M52_OFFHAND_ITEMS[shield.itemId]?.name ?? shield.itemId}目前只能收在背帶上，守勢加成不生效。`
+    ? `${equipment.weapon ? ITEMS[equipment.weapon]?.name ?? implicitWeapon : implicitWeapon}佔滿雙手；${M52_OFFHAND_ITEMS[shield.itemId]?.name ?? shield.itemId}目前只能收在背帶上，守勢加成不生效。`
     : '';
   return {
     weaponHands: hands,

--- a/src/scripts/games/caravan/data/offhandShields.m52.ts
+++ b/src/scripts/games/caravan/data/offhandShields.m52.ts
@@ -1,0 +1,145 @@
+import type { CompanionRecord } from '../save';
+import { ITEMS, type ItemDef } from './items';
+
+export type OffhandKind = 'shield';
+
+export interface M52OffhandEquip {
+  slot: 'offhand';
+  minLevel?: number;
+  offhandKind: OffhandKind;
+}
+
+export interface M52OffhandItem extends Omit<ItemDef, 'equip'> {
+  equip: M52OffhandEquip;
+}
+
+export interface M52EquipmentView {
+  weapon: string | null;
+  armor: string | null;
+  trinket: string | null;
+  offhand?: string | null;
+}
+
+export interface ShieldRule {
+  itemId: string;
+  guardBonus: number;
+  burden: number;
+  manaCapacity?: number;
+}
+
+export interface HandLoadoutProfile {
+  weaponHands: 0 | 1 | 2;
+  offhandId: string | null;
+  shieldId: string | null;
+  shieldReady: boolean;
+  shieldGuardBonus: number;
+  offhandBurden: number;
+  manaCapacity: number;
+  warning: string;
+}
+
+export const TWO_HANDED_WEAPONS = new Set([
+  'ridge-mist-bow',
+  'ghostflame-staff',
+  'brine-crystal-staff',
+  'swordsaint-bokken',
+]);
+
+export const SHIELD_RULES: Record<string, ShieldRule> = {
+  'oak-buckler': { itemId: 'oak-buckler', guardBonus: 1, burden: 1 },
+  'salt-rim-kite-shield': { itemId: 'salt-rim-kite-shield', guardBonus: 2, burden: 2, manaCapacity: -1 },
+};
+
+export const M52_OFFHAND_ITEMS: Record<string, M52OffhandItem> = {
+  'oak-buckler': {
+    id: 'oak-buckler',
+    name: '橡木小圓盾',
+    desc: '以數層橡木交錯壓合、外緣包鐵的小圓盾。真正價值不是讓人永遠更硬，而是在主動架勢時多接下一分力道。',
+    value: 48,
+    equip: { slot: 'offhand', offhandKind: 'shield' },
+  },
+  'salt-rim-kite-shield': {
+    id: 'salt-rim-kite-shield',
+    name: '鹽鋼鳶盾',
+    desc: '鹽泉鐵匠以鹽鍛鋼包覆長鳶形木芯的軍用盾。守勢極穩，但重量與遮蔽會妨礙精細秘法手勢。',
+    value: 118,
+    equip: { slot: 'offhand', minLevel: 3, offhandKind: 'shield' },
+  },
+};
+
+/**
+ * M52 uses a soft schema extension: existing v6 saves keep the three legacy keys,
+ * while the optional offhand key is persisted naturally by JSON without a save migration.
+ */
+export function equipmentView(record: Pick<CompanionRecord, 'equipment'>): M52EquipmentView {
+  return record.equipment as M52EquipmentView;
+}
+
+export function offhandId(record: Pick<CompanionRecord, 'equipment'>): string | null {
+  return equipmentView(record).offhand ?? null;
+}
+
+export function setOffhandId(record: Pick<CompanionRecord, 'equipment'>, itemId: string | null): void {
+  equipmentView(record).offhand = itemId;
+}
+
+export function weaponHands(itemId: string | null | undefined): 0 | 1 | 2 {
+  if (!itemId) return 0;
+  const item = ITEMS[itemId];
+  if (!item?.equip || item.equip.slot !== 'weapon') return 0;
+  return TWO_HANDED_WEAPONS.has(itemId) ? 2 : 1;
+}
+
+export function shieldRule(itemId: string | null | undefined): ShieldRule | null {
+  return itemId ? SHIELD_RULES[itemId] ?? null : null;
+}
+
+export function handLoadoutProfile(record: Pick<CompanionRecord, 'equipment'>): HandLoadoutProfile {
+  const equipment = equipmentView(record);
+  const hands = weaponHands(equipment.weapon);
+  const offhand = equipment.offhand ?? null;
+  const shield = shieldRule(offhand);
+  const ready = !!shield && hands < 2;
+  const warning = shield && !ready
+    ? `${ITEMS[equipment.weapon!]?.name ?? '雙手武器'}佔滿雙手；${M52_OFFHAND_ITEMS[shield.itemId]?.name ?? shield.itemId}目前只能收在背帶上，守勢加成不生效。`
+    : '';
+  return {
+    weaponHands: hands,
+    offhandId: offhand,
+    shieldId: shield?.itemId ?? null,
+    shieldReady: ready,
+    shieldGuardBonus: ready ? shield?.guardBonus ?? 0 : 0,
+    offhandBurden: shield?.burden ?? 0,
+    manaCapacity: shield?.manaCapacity ?? 0,
+    warning,
+  };
+}
+
+export function equipOffhandItem(save: { inventory: Record<string, number> }, record: CompanionRecord, itemId: string): HandLoadoutProfile {
+  const item = M52_OFFHAND_ITEMS[itemId];
+  if (!item) throw new Error(`「${itemId}」不是可用副手。`);
+  if (item.equip.minLevel !== undefined && record.level < item.equip.minLevel) {
+    throw new Error(`${record.name}需要 Lv${item.equip.minLevel} 才能裝備「${item.name}」。`);
+  }
+  if ((save.inventory[itemId] ?? 0) <= 0) throw new Error(`背包中沒有「${item.name}」。`);
+  const previous = offhandId(record);
+  save.inventory[itemId] -= 1;
+  if (save.inventory[itemId] <= 0) delete save.inventory[itemId];
+  if (previous) save.inventory[previous] = (save.inventory[previous] ?? 0) + 1;
+  setOffhandId(record, itemId);
+  return handLoadoutProfile(record);
+}
+
+export function unequipOffhandItem(save: { inventory: Record<string, number> }, record: CompanionRecord): HandLoadoutProfile {
+  const previous = offhandId(record);
+  if (previous) {
+    setOffhandId(record, null);
+    save.inventory[previous] = (save.inventory[previous] ?? 0) + 1;
+  }
+  return handLoadoutProfile(record);
+}
+
+// Register the two M52 items into the existing mutable item catalog without changing v6 item/save schema.
+for (const [id, item] of Object.entries(M52_OFFHAND_ITEMS)) {
+  (ITEMS as unknown as Record<string, ItemDef | M52OffhandItem>)[id] = item;
+}

--- a/src/scripts/games/caravan/data/offhandShields.m52.ts
+++ b/src/scripts/games/caravan/data/offhandShields.m52.ts
@@ -110,7 +110,7 @@ export function handLoadoutProfile(record: Pick<CompanionRecord, 'equipment'>): 
     shieldReady: ready,
     shieldGuardBonus: ready ? shield?.guardBonus ?? 0 : 0,
     offhandBurden: shield?.burden ?? 0,
-    manaCapacity: shield?.manaCapacity ?? 0,
+    manaCapacity: ready ? shield?.manaCapacity ?? 0 : 0,
     warning,
   };
 }

--- a/src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+++ b/src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+import { setOffhandId } from './offhandShields.m52';
+
+function bulwark(): CompanionRecord {
+  return {
+    id: 'bulwark-test',
+    name: '守衛',
+    job: 'swordsman',
+    level: 5,
+    xp: 750,
+    stats: { str: 14, dex: 10, int: 8, cha: 10, con: 16 },
+    maxHp: 30,
+    injuredForTrips: 0,
+    specialization: 'bulwark',
+    equipment: { weapon: 'salt-crystal-blade', armor: null, trinket: null },
+  };
+}
+
+function bulwarkMove(record: CompanionRecord) {
+  const member = memberFromRecord(record);
+  return member.moves.find((move) => move.id === 'shield-bash');
+}
+
+describe('M52 bulwark shield semantics', () => {
+  it('keeps the compatibility id but does not invent a shield when none is ready', () => {
+    const record = bulwark();
+    const move = bulwarkMove(record)!;
+    expect(move.id).toBe('shield-bash');
+    expect(move.name).toBe('壁壘猛擊');
+    expect(move.narration).not.toContain('盾');
+    expect(move.applyStatus?.kind).toBe('stun');
+  });
+
+  it('surfaces the shield-specific name and narration only with a ready shield', () => {
+    const record = bulwark();
+    setOffhandId(record, 'oak-buckler');
+    const move = bulwarkMove(record)!;
+    expect(move.id).toBe('shield-bash');
+    expect(move.name).toBe('盾牆猛擊');
+    expect(move.narration).toContain('盾');
+    expect(move.applyStatus?.kind).toBe('stun');
+  });
+
+  it('falls back to equipment-neutral semantics when a two-handed weapon stows the shield', () => {
+    const record = bulwark();
+    record.equipment.weapon = 'swordsaint-bokken';
+    setOffhandId(record, 'salt-rim-kite-shield');
+    const move = bulwarkMove(record)!;
+    expect(move.id).toBe('shield-bash');
+    expect(move.name).toBe('壁壘猛擊');
+    expect(move.narration).not.toContain('盾');
+  });
+});

--- a/src/scripts/games/caravan/data/towns.ts
+++ b/src/scripts/games/caravan/data/towns.ts
@@ -1,5 +1,6 @@
 import type { TownDef } from '../economy';
 import { registerTowns } from '../expedition';
+import './offhandShields.m52';
 
 /**
  * M4 首批城鎮：3 座。
@@ -10,6 +11,7 @@ import { registerTowns } from '../expedition';
  * M5 擴充第 4 鎮「鹽泉城」：霧嶺古道（reputation≥40）的終點，鹽與裝備溢價——
  * 押貨鹽晶洞窟（reputation≥60）掉落的「鹽」走霧嶺古道到此變現，是全遊戲最長
  * （legs6）也最賺的押貨路線（見 data.test.ts 經濟量級 sanity）。
+ * M52 再加入副手盾牌：基礎小圓盾可在啟程之鎮取得，鹽鋼鳶盾留給鹽泉城中期整備。
  */
 export const TOWNS: Record<string, TownDef> = {
   'starting-town': {
@@ -18,7 +20,7 @@ export const TOWNS: Record<string, TownDef> = {
     name: '啟程之鎮',
     desc: '商隊由此啟程，青石廣場終年人聲鼎沸，鐵匠爐火不熄，貨棧招牌層層疊疊，是踏上未知路途前最後一次安穩補給。',
     priceModifiers: {},
-    stock: ['herb', 'bandage', 'antidote', 'war-tonic', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest'],
+    stock: ['herb', 'bandage', 'antidote', 'war-tonic', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest', 'oak-buckler'],
   },
   'riverbend-town': {
     id: 'riverbend-town',
@@ -47,8 +49,9 @@ export const TOWNS: Record<string, TownDef> = {
       'brine-blessed-mace': 1.3,
       'saltforged-mail': 1.3,
       'brinewarded-vestment': 1.3,
+      'salt-rim-kite-shield': 1.25,
     },
-    stock: ['salt', 'salt-crystal-blade', 'brine-blessed-mace', 'saltforged-mail', 'brinewarded-vestment', 'brine-crystal-staff', 'pilgrim-warded-cloak', 'saltglass-talisman', 'herb', 'torch'],
+    stock: ['salt', 'salt-crystal-blade', 'brine-blessed-mace', 'saltforged-mail', 'brinewarded-vestment', 'brine-crystal-staff', 'pilgrim-warded-cloak', 'saltglass-talisman', 'salt-rim-kite-shield', 'herb', 'torch'],
   },
 };
 


### PR DESCRIPTION
## Stacked dependency

This is a stacked draft on top of #249 / `agent/caravan-m51-veteran-mastery`. It contains only the M52 hand/offhand equipment layer and its validation; #249 remains independently validated.

## Summary

M52 closes a medieval-fantasy equipment gap left after M43–M51: weapon disciplines, armor materials, formations and Guard all existed, but the game had no concept of how many hands a weapon occupies and no real shield equipment source.

### Handedness
- explicit two-handed equipment includes the ridge bow, both arcane staves and Sword Saint bokken
- one-handed blades/maces can coexist with a ready shield
- the Ranger's implicit/default bow is also treated as two-handed even when the weapon item slot is empty, preventing an empty-slot shield exploit

### Real shields
- **橡木小圓盾**: starting-town item, burden 1, active Guard +1
- **鹽鋼鳶盾**: Salt Spring City Lv3 item, burden 2, active Guard +2, Mana capacity -1 only while actually held
- shields do **not** change passive character Defense, HP, damage or stats
- base Guard stays +4; buckler Guard becomes +5; kite-shield Guard becomes +6

### Soft stow rule
A shield may remain equipped beside a two-handed weapon but is stowed:
- full burden still applies
- Guard benefit is disabled
- held-shield casting interference is disabled
- switching back to a one-handed weapon makes the shield ready again automatically

This avoids destructive inventory churn while still preventing bow/staff + shield exploitation.

### Save compatibility
M52 uses an optional `offhand` property in the existing equipment JSON. Legacy v6 records with only `weapon / armor / trinket` remain valid and are not mutated simply by reading M52 rules. No save-version migration is required.

### Player information contract
The Armory now shows before departure:
- one-/two-handed weapon state
- offhand item and ready/stowed state
- Guard bonus
- burden
- Mana-capacity penalty where relevant

Combat labels use the same runtime truth, e.g. `防禦架勢〔護衛・盾+2〕` and `戰術換位〔前進・守勢・盾+1〕`. A stowed shield never displays a fake combat bonus.

### Bulwark compatibility
The legacy internal move id `shield-bash` stays unchanged.
- ready shield -> `盾牆猛擊` with shield-specific narration
- no ready shield -> `壁壘猛擊` with equipment-neutral narration

Damage and stun remain unchanged, so existing Bulwark characters do not become dead builds when choosing no shield or a two-handed weapon.

## Multidimensional player adversarial review

Dedicated gates attack:
- mandatory passive fourth-slot shield builds
- two-handed weapon + active-shield exploits
- Ranger empty-weapon-slot bypasses
- stowed-shield burden laundering
- heavy-shield casting penalty applying while stowed
- strict kite-shield dominance over buckler
- UI/engine Guard-value mismatch
- unbounded Guard stacking
- M51 guarded-advance mismatch
- repeated combat label suffix duplication
- Bulwark phantom-shield wording
- legacy v6 equipment mutation
- debug-only shields with no economy path
- M49–M51 regression interactions

## Validation

Latest head `9e870d00119e90943bfa4e393531db780748792c` passed **all 15 Caravan workflows** triggered by the PR, including `Caravan M52 Offhand Shield CI`.

The dedicated M52 gate completed successfully with:
- production build
- M52 handedness and shield-rule tests
- deterministic live shield combat A/B integration
- M52 multidimensional adversarial player review
- M52 Bulwark equipment-semantics gate
- M51 veteran mastery regressions
- M49–M50 formation/readability regressions
- core combat + M41 magic
- M40 Reliquary
- M42 endurance/composition
- M43 armory/endurance
- M44 spellcraft
- M45 rituals
- M46 convoy + M47 morale
- M48 armor

The live A/B gate verifies identical hit rolls resolve as base Guard +4, buckler Guard +5 and kite-shield Guard +6, while unguarded Defense remains identical.

Vercel currently rejects only the preview because the account is at `build-rate-limit`; the independent GitHub production build and all gameplay gates pass.

PR #250 remains draft, open and mergeable. See `docs/caravan-m52-offhand-shields.md` for design rationale, save compatibility and rejected exploit-prone alternatives.