### PR TITLE
feat(caravan): add M53 reach and polearm doctrine

### DIFF
--- a/.github/workflows/caravan-m53-ci.yml
+++ b/.github/workflows/caravan-m53-ci.yml
@@ -1,0 +1,116 @@
+name: Caravan M53 Reach Polearm CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m53-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m53-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M53 reach and polearm rules
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/reachPolearms.m53.test.ts
+
+      - name: M53 live reach integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
+
+      - name: M53 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
+
+      - name: M52 shield and handedness regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/offhandShields.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+          src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+
+      - name: M51 veteran mastery regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/docs/caravan-m53-reach-polearms.md
+++ b/docs/caravan-m53-reach-polearms.md
@@ -1,0 +1,181 @@
+# Caravan M53 — Reach & Polearm Doctrine
+
+## Problem
+
+M49–M52 已經讓《商隊與劍》具備前後排、近戰／遠程距離、老兵換位、護甲材質、武器熟練、雙手武器與盾牌取捨，但物理武器距離仍幾乎只有兩種：
+
+- 前排刀劍／錘杖；
+- 後排弓弩。
+
+這不符合中世紀戰場最常見的第三種角色：站在前線後方、依靠長柄越過同伴肩線作戰的槍兵與長槍手。
+
+M53 加入 `reach` 交戰距離與 `polearm` 武器流派，目標不是再做一把傷害更大的劍，而是新增一個可被前線崩潰、負重、盾牌與跨職熟練反制的第三種站位構築。
+
+## Reach engagement
+
+`EngagementBand` 現在包含：
+
+- `melee`
+- `ranged`
+- `reach`
+- `mystic`
+
+### Reach in rear rank
+
+後排長柄攻擊命中修正 **0**。
+
+這代表只要仍有真正的存活前排，槍兵能從第二列越肩刺擊，不必像普通近戰一樣承受後排 `-2`。
+
+### Reach in front rank
+
+前排長柄攻擊命中 **-1**。
+
+長柄並非在近身時失去功能，因此沒有給到弓弩同等的 `-2`；但槍桿長度與展開空間仍使它不應成為無視站位的萬用武器。
+
+### No positive positioning bonus
+
+正確站位只移除懲罰，不提供 `+1/+2` 額外命中。
+
+這延續 M49/M50 的核心原則：站位選擇決定你是否承擔代價，不再疊一層隱藏的最佳解數值。
+
+## Frontline dependency
+
+Reach 的後排優勢不是永久安全區。
+
+M49 的前線崩潰規則仍然優先：
+
+1. 最後前排倒下；
+2. 存活後排被推進前線；
+3. 槍兵的 runtime `formationRow` 變成 `front`；
+4. 同一招式立即從 `〔長柄〕` 變成 `〔長柄 -1〕`。
+
+全員後排的非法開場也會被 M49 正規化成前排，因此不能靠全隊長槍建立「沒人接敵、大家卻都在安全第二列」的漏洞。
+
+## Polearm equipment
+
+### 白蠟木戰矛
+
+- 啟程之鎮可買
+- 無等級門檻
+- 負重 2
+- 雙手武器
+- 長柄 `reach`
+- 1d8 + STR 刺擊
+- 穿甲 1
+- 無被動屬性
+
+它刻意比鹽晶劍的直接輸出低，換取第二列作戰與少量穿甲能力。
+
+### 鹽鋼長槍
+
+- 鹽泉城可買
+- Lv3+
+- 負重 3
+- 雙手武器
+- 長柄 `reach`
+- 1d10 + STR 刺擊
+- 穿甲 2
+- 無被動屬性
+
+它是成熟的長柄選項，但仍不是古王之劍等高階刀劍的純傷害上位版；額外穿甲要用價格、等級與負重交換。
+
+## M43 armory integration
+
+新增 `polearm` 武器熟練：
+
+- 劍士：熟練
+- 游俠：可用
+- 教士：可用
+- 法師：勉強運用
+
+跨職不被禁止。
+
+法師硬拿戰矛仍能打，但會沿用 M43 的勉強運用代價：武器招式命中 -2、傷害 -1、負重 +1。
+
+這讓長柄身份由武器與訓練共同決定，而不是鎖死在某一職業。
+
+## M52 shield interaction
+
+兩把長柄都是雙手武器。
+
+若角色副手帶盾：
+
+- 盾牌仍留在裝備意圖中；
+- 盾牌仍算完整負重；
+- 盾牌進入收起狀態；
+- `shieldGuardBonus = 0`。
+
+因此長柄不能同時取得「第二列 reach」與「持盾守勢」兩套優勢。
+
+## M48 armor interaction
+
+長柄使用刺擊屬性，並且兩把實體長柄都有有限穿甲：
+
+- 戰矛：1
+- 鹽鋼長槍：2
+
+這讓長柄對鎖甲有戰術理由，但穿甲仍小於直接把護甲系統作廢的程度。
+
+## M50 player-information contract
+
+玩家按下攻擊以前就能看到：
+
+- 後排：`越肩突刺〔長柄〕`
+- 前排：`越肩突刺〔長柄 -1〕`
+
+完整 forecast 會說明前排的「長柄近身壓力」。
+
+前線崩潰或 M51 換位改變 runtime row 後，action label 使用 getter 即時更新，不保存過期提示。
+
+Arcana 的 M50/M51/M52 suffix cleanup 也加入長柄格式，避免重複進戰後出現 `〔長柄〕〔長柄〕`。
+
+## Multidimensional player adversarial review
+
+Automated gates attack M53 from these player perspectives:
+
+1. **Implicit-reach abuse** — 普通 STR 刺擊不能因為是 `pierce` 就自動變長柄；必須明確標記 `engagement: 'reach'`。
+2. **Phantom safe rank** — 沒有真正前排時，M49 仍會把長柄使用者推進前線。
+3. **Universal-row weapon** — reach 後排為 0、前排為 -1，不提供任何正命中加成。
+4. **Blade replacement** — 戰矛與長槍的純傷害上限低於相近刀劍，交換的是距離與穿甲。
+5. **Shield stacking** — 長柄是雙手武器，M52 盾牌只能收起且仍算負重。
+6. **Cross-training bypass** — polearm 必須完整走 M43 weapon-fit 代價。
+7. **Tier dominance** — 鹽鋼長槍比戰矛更強，但需 Lv3、更高價格與更高負重。
+8. **Feature smuggling** — 新武器不額外帶 AOE、暈眩、被動 Defense、HP 或屬性。
+9. **Magic truth** — 真正魔法永遠優先成為 `mystic`，即使資料誤帶 reach marker 也不吃物理站位懲罰。
+10. **Information fairness** — `長柄` / `長柄 -1` 在出手前必須與引擎真實修正一致。
+11. **Dynamic collapse truth** — 前線死亡後，實際 row 與 action label 必須同步更新。
+12. **Idempotency** — 重複 `startCombat()` 不得堆疊長柄 suffix。
+13. **Economy integration** — 兩把武器都必須有真實城鎮取得路徑。
+14. **Regression** — M40–M52 的魔法、耐久、武裝、儀式、護運、士氣、護甲、站位、老兵與盾牌 gate 全部保持綠燈。
+
+## Rejected alternatives
+
+### Reach has no frontline penalty
+
+Rejected. 這會讓長柄同時擁有後排安全與前排零代價，太接近萬用物理武器。
+
+### Reach gets +1 from rear rank
+
+Rejected. M49 起正確站位從來不是額外數值 buff；它只是避免錯位懲罰。
+
+### Treat spear as ranged
+
+Rejected. 這會讓長槍和弓弩共用前排 -2，並在 UI 上顯示「遠程」，失去長柄本身的戰場身份。
+
+### One-handed spear + shield for M53
+
+Rejected for this milestone. 那會同時引入單手／雙手握法切換與盾牌聯動，難以判斷到底是 reach 還是盾牌構築造成支配性。M53 先鎖定雙手戰矛／長槍。
+
+### Add automatic counterattack / brace
+
+Rejected for M53. 敵人目前沒有明確「衝鋒／進入射程」事件；直接做 brace counter 會建立一個缺乏可讀觸發條件的新反應系統。先讓 reach 本身成立，再考慮未來有公開意圖的衝鋒反制。
+
+## Acceptance target
+
+M53 成功時，玩家面前應形成三個清楚但互有代價的物理位置選擇：
+
+- 前排刀劍／錘杖：近身最穩，可搭盾；
+- 後排弓弩：遠程輸出強，被逼前排吃 -2；
+- 第二列長柄：用 STR 從後排作戰，被逼前排吃 -1，且雙手占用放棄盾牌。
+
+任何一種都不應成為所有角色、所有站位、所有敵人的普遍最佳答案。

--- a/src/scripts/games/caravan/data/arcana.ts
+++ b/src/scripts/games/caravan/data/arcana.ts
@@ -74,8 +74,8 @@ export function mysticRuleForMove(move: Move): MysticMoveRule | null {
 function stripM50Suffix(name: string): string {
   return name
     .replace(/〔(?:前進(?:・守勢)?(?:・盾\+\d+)?|後撤|輪替後撤|無人接替)〕$/u, '')
-    .replace(/〔(?:近戰|遠程)(?: -2)?〕$/u, '')
-    .replace(/〔(?:近戰|遠程)・(?:命中 -2|站位適配)〕$/u, '')
+    .replace(/〔(?:(?:近戰|遠程)(?: -2)?|長柄(?: -1)?)〕$/u, '')
+    .replace(/〔(?:(?:近戰|遠程)・(?:命中 -2|站位適配)|長柄・(?:命中 -1|站位適配))〕$/u, '')
     .replace(/〔(?:護衛|自保)(?:・盾\+\d+)?〕$/u, '')
     .replace(/〔守勢・(?:可護衛|自保)(?:・盾\+\d+)?〕$/u, '');
 }

--- a/src/scripts/games/caravan/data/armory.ts
+++ b/src/scripts/games/caravan/data/armory.ts
@@ -13,8 +13,9 @@ import {
   unequipOffhandItem,
   type M52OffhandItem,
 } from './offhandShields.m52';
+import './reachPolearms.m53';
 
-export type WeaponDiscipline = 'blade' | 'bow' | 'staff' | 'mace';
+export type WeaponDiscipline = 'blade' | 'bow' | 'staff' | 'mace' | 'polearm';
 export type ArmorDiscipline = 'light' | 'mail' | 'robe' | 'vestment';
 export type GearFit = 'mastered' | 'trained' | 'strained';
 export type ArmoryEquipSlot = keyof CompanionRecord['equipment'] | 'offhand';
@@ -64,6 +65,8 @@ const RULES: Record<string, ArmoryItemRule> = {
   'ghostflame-staff': { itemId: 'ghostflame-staff', burden: 1, weapon: 'staff', manaCapacity: 1 },
   'brine-crystal-staff': { itemId: 'brine-crystal-staff', burden: 1, weapon: 'staff', manaCapacity: 1 },
   'brine-blessed-mace': { itemId: 'brine-blessed-mace', burden: 2, weapon: 'mace', favorCapacity: 1 },
+  'ashwood-war-spear': { itemId: 'ashwood-war-spear', burden: 2, weapon: 'polearm' },
+  'saltsteel-pike': { itemId: 'saltsteel-pike', burden: 3, weapon: 'polearm' },
 
   'ridgeleather-vest': { itemId: 'ridgeleather-vest', burden: 1, armor: 'light' },
   'pilgrim-warded-cloak': { itemId: 'pilgrim-warded-cloak', burden: 2, armor: 'light' },
@@ -80,10 +83,10 @@ const RULES: Record<string, ArmoryItemRule> = {
 };
 
 const WEAPON_FIT: Record<CompanionRecord['job'], Record<WeaponDiscipline, GearFit>> = {
-  swordsman: { blade: 'mastered', mace: 'trained', bow: 'trained', staff: 'strained' },
-  ranger: { blade: 'trained', mace: 'strained', bow: 'mastered', staff: 'strained' },
-  mage: { blade: 'trained', mace: 'strained', bow: 'strained', staff: 'mastered' },
-  cleric: { blade: 'trained', mace: 'mastered', bow: 'strained', staff: 'trained' },
+  swordsman: { blade: 'mastered', mace: 'trained', bow: 'trained', staff: 'strained', polearm: 'mastered' },
+  ranger: { blade: 'trained', mace: 'strained', bow: 'mastered', staff: 'strained', polearm: 'trained' },
+  mage: { blade: 'trained', mace: 'strained', bow: 'strained', staff: 'mastered', polearm: 'strained' },
+  cleric: { blade: 'trained', mace: 'mastered', bow: 'strained', staff: 'trained', polearm: 'trained' },
 };
 
 const ARMOR_FIT: Record<CompanionRecord['job'], Record<ArmorDiscipline, GearFit>> = {
@@ -104,6 +107,7 @@ export const WEAPON_DISCIPLINE_LABELS: Record<WeaponDiscipline, string> = {
   bow: '弓弩',
   staff: '法杖',
   mace: '錘杖',
+  polearm: '長柄',
 };
 
 export const ARMOR_DISCIPLINE_LABELS: Record<ArmorDiscipline, string> = {

--- a/src/scripts/games/caravan/data/combatReadability.m50.ts
+++ b/src/scripts/games/caravan/data/combatReadability.m50.ts
@@ -17,10 +17,18 @@ function readyShieldBonus(actor: PartyMember): number {
   return armory?.shieldReady ? Math.max(0, armory.shieldGuardBonus ?? 0) : 0;
 }
 
+function engagementLabel(engagement: 'melee' | 'ranged' | 'reach' | 'mystic'): string {
+  if (engagement === 'ranged') return '遠程';
+  if (engagement === 'reach') return '長柄';
+  if (engagement === 'mystic') return '魔法';
+  return '近戰';
+}
+
 /**
  * M50：把 M49 已經存在的站位規則在玩家按下招式前就說清楚。
  * M51 延伸同一資訊契約：老兵換位也必須在出手前說明會前進、後撤或輪替。
  * M52 再要求盾牌的守勢收益在按下防禦以前可見，且收起的盾不能假裝生效。
+ * M53 把 reach 長柄距離也納入同一份預判：後排適配、前排近身命中 -1。
  * isMystic 由 M41/M44 的 arcana 真實規則提供，避免用元素外觀猜測魔法。
  */
 export function combatMoveForecast(
@@ -68,17 +76,17 @@ export function combatMoveForecast(
   const formation = formationAttackProfile(actor.formationRow, move, isMystic);
   const rowLabel = ROW_LABEL[row];
   if (formation.engagement === 'mystic') {
-    return { shortLabel: '魔法・站位自由', hint: `${rowLabel}施法：真正的秘法／神術不受近戰與遠程的站位命中懲罰。`, penalized: false };
+    return { shortLabel: '魔法・站位自由', hint: `${rowLabel}施法：真正的秘法／神術不受近戰、遠程或長柄武器的站位命中懲罰。`, penalized: false };
   }
 
-  const kindLabel = formation.engagement === 'ranged' ? '遠程' : '近戰';
+  const kindLabel = engagementLabel(formation.engagement);
   if (formation.hitModifier < 0) {
     return { shortLabel: `${kindLabel}・命中 ${formation.hitModifier}`, hint: formation.message, penalized: true };
   }
   return { shortLabel: `${kindLabel}・站位適配`, hint: `${rowLabel}${kindLabel}：目前站位不會受到額外命中懲罰。`, penalized: false };
 }
 
-/** M50–M52：action name 必須反映當下真正可用的站位／盾牌狀態。 */
+/** M50–M53：action name 必須反映當下真正可用的站位／盾牌／交戰距離。 */
 export function combatMoveDisplayName(actor: PartyMember, move: Move, isMystic = false): string {
   const forecast = combatMoveForecast(actor, move, isMystic);
   const shieldBonus = readyShieldBonus(actor);
@@ -93,8 +101,11 @@ export function combatMoveDisplayName(actor: PartyMember, move: Move, isMystic =
     return `${baseName}〔${role}${shieldBonus > 0 ? `・盾+${shieldBonus}` : ''}〕`;
   }
   if (move.kind === 'attack' && !isMystic) {
-    const kindLabel = forecast.shortLabel.startsWith('遠程') ? '遠程' : '近戰';
-    return forecast.penalized ? `${baseName}〔${kindLabel} -2〕` : `${baseName}〔${kindLabel}〕`;
+    const formation = formationAttackProfile(actor.formationRow, move, false);
+    const kindLabel = engagementLabel(formation.engagement);
+    return formation.hitModifier < 0
+      ? `${baseName}〔${kindLabel} ${formation.hitModifier}〕`
+      : `${baseName}〔${kindLabel}〕`;
   }
   return baseName;
 }

--- a/src/scripts/games/caravan/data/martialEngagement.m49.ts
+++ b/src/scripts/games/caravan/data/martialEngagement.m49.ts
@@ -1,7 +1,7 @@
 import type { Move } from '../combat';
 import type { FormationRow } from '../save';
 
-export type EngagementBand = 'melee' | 'ranged' | 'mystic';
+export type EngagementBand = 'melee' | 'ranged' | 'reach' | 'mystic';
 
 export interface FormationAttackProfile {
   engagement: EngagementBand;
@@ -11,6 +11,7 @@ export interface FormationAttackProfile {
 
 /**
  * M49：把既有前後排從「只影響誰先挨打」提升成可預測的武器距離規則。
+ * M53 加入 reach：長槍／長柄可隔著前排刺擊，但被逼到前線近身時會略顯笨重。
  * 真正的魔法由 arcana 規則判定，永遠優先視為 mystic，避免火球或重力術
  * 因為表面元素而被錯判成弓弩／近戰。
  */
@@ -23,7 +24,8 @@ export function engagementForMove(move: Move, isMystic: boolean): EngagementBand
 
 /**
  * 不做硬性「不能出招」，避免文字介面出現按了沒反應的隱性規則。
- * 錯誤站位只給 -2 命中，並回傳可直接寫入戰鬥紀錄的理由。
+ * M49 的劍／弓錯排維持 -2；M53 長柄在後排最舒適，前排近身只給 -1，
+ * 讓玩家仍可在崩線後應戰，但不能把 reach 當成無視站位的萬用武器。
  */
 export function formationAttackProfile(
   row: FormationRow | undefined,
@@ -46,6 +48,13 @@ export function formationAttackProfile(
       engagement,
       hitModifier: -2,
       message: `前排近身壓力：${move.name}難以穩定瞄準，命中 -2。`,
+    };
+  }
+  if (engagement === 'reach' && row === 'front') {
+    return {
+      engagement,
+      hitModifier: -1,
+      message: `長柄近身壓力：${move.name}在貼身混戰中難以完全展開，命中 -1。`,
     };
   }
   return { engagement, hitModifier: 0, message: '' };

--- a/src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
+++ b/src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { CompanionRecord } from '../save';
+import { ITEMS } from './items';
+import { armoryProfile, armoryRuleForItem } from './armory';
+import { formationAttackProfile } from './martialEngagement.m49';
+import { handLoadoutProfile, setOffhandId } from './offhandShields.m52';
+import { M53_POLEARM_ITEMS } from './reachPolearms.m53';
+
+function record(weapon: string, job: CompanionRecord['job'] = 'swordsman'): CompanionRecord {
+  return {
+    id: `${job}-${weapon}`,
+    name: '構築審查',
+    job,
+    level: 5,
+    xp: 750,
+    stats: { str: 14, dex: 14, int: 14, cha: 14, con: 14 },
+    maxHp: 28,
+    injuredForTrips: 0,
+    equipment: { weapon, armor: null, trinket: null },
+  };
+}
+
+function maxWeaponDice(itemId: string): number {
+  const damage = ITEMS[itemId]?.equip?.move?.damage;
+  return damage ? damage.dice * damage.sides : 0;
+}
+
+describe('M53 multidimensional player adversarial review', () => {
+  it('trades raw blade damage for reach instead of strictly upgrading swords', () => {
+    expect(maxWeaponDice('ashwood-war-spear')).toBeLessThan(maxWeaponDice('salt-crystal-blade'));
+    expect(maxWeaponDice('saltsteel-pike')).toBeLessThan(maxWeaponDice('ancient-king-blade'));
+    expect(M53_POLEARM_ITEMS['ashwood-war-spear'].equip?.bonus).toBeUndefined();
+    expect(M53_POLEARM_ITEMS['saltsteel-pike'].equip?.bonus).toBeUndefined();
+  });
+
+  it('makes the stronger pike pay progression, price and burden costs over the starter spear', () => {
+    const spear = M53_POLEARM_ITEMS['ashwood-war-spear'];
+    const pike = M53_POLEARM_ITEMS['saltsteel-pike'];
+    expect(pike.value).toBeGreaterThan(spear.value);
+    expect(pike.equip?.minLevel).toBe(3);
+    expect(armoryRuleForItem('saltsteel-pike')!.burden).toBeGreaterThan(armoryRuleForItem('ashwood-war-spear')!.burden);
+    expect(pike.equip?.move?.armorPiercing).toBeGreaterThan(spear.equip?.move?.armorPiercing ?? 0);
+  });
+
+  it('never turns correct reach positioning into a hidden positive hit bonus', () => {
+    for (const item of Object.values(M53_POLEARM_ITEMS)) {
+      const move = item.equip!.move!;
+      expect(formationAttackProfile('back', move, false).hitModifier).toBe(0);
+      expect(formationAttackProfile('front', move, false).hitModifier).toBe(-1);
+    }
+  });
+
+  it('keeps the frontline reach penalty bounded below the harsher bow/melee wrong-row penalty', () => {
+    const spear = M53_POLEARM_ITEMS['ashwood-war-spear'].equip!.move!;
+    const front = formationAttackProfile('front', spear, false);
+    expect(front.hitModifier).toBe(-1);
+    expect(front.hitModifier).toBeGreaterThanOrEqual(-1);
+  });
+
+  it('prevents polearm plus shield from becoming a universal offense-defense loadout', () => {
+    for (const weapon of Object.keys(M53_POLEARM_ITEMS)) {
+      const fighter = record(weapon);
+      setOffhandId(fighter, 'salt-rim-kite-shield');
+      const hand = handLoadoutProfile(fighter);
+      expect(hand.weaponHands).toBe(2);
+      expect(hand.shieldReady).toBe(false);
+      expect(hand.shieldGuardBonus).toBe(0);
+      expect(hand.offhandBurden).toBeGreaterThan(0);
+    }
+  });
+
+  it('makes cross-trained polearms pay the same M43 proficiency costs instead of bypassing armory rules', () => {
+    const swordsman = armoryProfile(record('ashwood-war-spear', 'swordsman'));
+    const ranger = armoryProfile(record('ashwood-war-spear', 'ranger'));
+    const mage = armoryProfile(record('ashwood-war-spear', 'mage'));
+    expect(swordsman.weaponFit).toBe('mastered');
+    expect(swordsman.weaponHitBonus).toBe(1);
+    expect(ranger.weaponFit).toBe('trained');
+    expect(ranger.weaponHitBonus).toBe(0);
+    expect(mage.weaponFit).toBe('strained');
+    expect(mage.weaponHitBonus).toBe(-2);
+    expect(mage.damageAdjustment).toBe(-1);
+    expect(mage.burden).toBeGreaterThan(swordsman.burden);
+  });
+
+  it('keeps reach identity move-based, not job-based', () => {
+    const move = M53_POLEARM_ITEMS['ashwood-war-spear'].equip!.move!;
+    expect(move.engagement).toBe('reach');
+    for (const job of ['swordsman', 'ranger', 'mage', 'cleric'] as const) {
+      const profile = armoryProfile(record('ashwood-war-spear', job));
+      expect(profile.weaponFit).not.toBeNull();
+    }
+  });
+
+  it('does not smuggle crowd control, area damage or passive stats into the new range archetype', () => {
+    for (const item of Object.values(M53_POLEARM_ITEMS)) {
+      const move = item.equip!.move!;
+      expect(move.area).not.toBe(true);
+      expect(move.applyStatus).toBeUndefined();
+      expect(item.equip?.defense).toBeUndefined();
+      expect(item.equip?.maxHp).toBeUndefined();
+      expect(item.equip?.bonus).toBeUndefined();
+    }
+  });
+});

--- a/src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
+++ b/src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import type { CompanionRecord } from '../save';
+import { memberFromRecord } from './jobs';
+
+function rng(d20 = 10, roll = 2): Rng {
+  return {
+    next: () => 0,
+    roll: () => roll,
+    d20: () => d20,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+function spearRecord(id: string): CompanionRecord {
+  return {
+    id,
+    name: '槍兵',
+    job: 'swordsman',
+    level: 5,
+    xp: 750,
+    stats: { str: 14, dex: 10, int: 8, cha: 10, con: 14 },
+    maxHp: 26,
+    injuredForTrips: 0,
+    equipment: { weapon: 'ashwood-war-spear', armor: null, trinket: null },
+  };
+}
+
+function anchor(id = 'anchor', hp = 20): PartyMember {
+  return {
+    id,
+    name: '前排同伴',
+    stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 20,
+    hp,
+    defense: 10,
+    formationRow: 'front',
+    moves: [{ id: `${id}-hit`, name: '短劍', kind: 'attack', target: 'enemy', hitStat: 'str', narration: '' }],
+  };
+}
+
+function enemy(id = 'foe', defense = 12): EnemyUnit {
+  return {
+    id,
+    name: '敵兵',
+    stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 },
+    maxHp: 30,
+    hp: 30,
+    defense,
+    moves: [{
+      id: 'foe-hit', name: '砍擊', kind: 'attack', target: 'enemy', hitStat: 'str',
+      damage: { dice: 1, sides: 4 }, narration: '{actor}砍向{target}，造成 {amount} 點傷害！',
+    }],
+    intents: [{ weight: 1, moveId: 'foe-hit' }],
+  };
+}
+
+function spearMove(member: PartyMember) {
+  const move = member.moves.find((candidate) => candidate.id === 'second-rank-thrust');
+  if (!move) throw new Error('missing M53 spear move');
+  return move;
+}
+
+describe('M53 live reach integration', () => {
+  it('turns the same borderline roll into a rear-rank hit and a frontline miss', () => {
+    const rearSpear = memberFromRecord(spearRecord('rear-spear'));
+    rearSpear.formationRow = 'back';
+    const rearEnemy = enemy('rear-foe');
+    const rearState = startCombat(rng(), [anchor('rear-anchor'), rearSpear], [rearEnemy]);
+    const rearMove = spearMove(rearSpear);
+    expect(rearMove.name).toBe('越肩突刺〔長柄〕');
+    partyAct(rng(9, 3), rearState, rearSpear.id, rearMove.id, rearEnemy.id);
+    expect(rearEnemy.hp).toBeLessThan(rearEnemy.maxHp);
+
+    const frontSpear = memberFromRecord(spearRecord('front-spear'));
+    frontSpear.formationRow = 'front';
+    const frontEnemy = enemy('front-foe');
+    const frontState = startCombat(rng(), [frontSpear], [frontEnemy]);
+    const frontMove = spearMove(frontSpear);
+    expect(frontMove.name).toBe('越肩突刺〔長柄 -1〕');
+    partyAct(rng(9, 3), frontState, frontSpear.id, frontMove.id, frontEnemy.id);
+    expect(frontEnemy.hp).toBe(frontEnemy.maxHp);
+    expect(frontState.log.some((entry) => entry.text.includes('長柄近身壓力') && entry.text.includes('命中 -1'))).toBe(true);
+  });
+
+  it('updates both real row and live label when the protecting frontline collapses', () => {
+    const spear = memberFromRecord(spearRecord('collapse-spear'));
+    spear.formationRow = 'back';
+    const fragile = anchor('fragile', 1);
+    const foe = enemy();
+    const state = startCombat(rng(), [fragile, spear], [foe]);
+    expect(spearMove(spear).name).toBe('越肩突刺〔長柄〕');
+
+    state.turnIndex = state.order.indexOf(foe.id);
+    enemyAct(rng(20, 3), state, foe.id);
+
+    expect(fragile.hp).toBe(0);
+    expect(spear.formationRow).toBe('front');
+    expect(spearMove(spear).name).toBe('越肩突刺〔長柄 -1〕');
+    expect(state.log.some((entry) => entry.text.includes('前線崩潰'))).toBe(true);
+  });
+
+  it('normalizes an impossible all-rear opening, so reach never creates a phantom safe rank', () => {
+    const spear = memberFromRecord(spearRecord('solo-spear'));
+    spear.formationRow = 'back';
+    const otherRear = anchor('other-rear');
+    otherRear.formationRow = 'back';
+    const state = startCombat(rng(), [spear, otherRear], [enemy()]);
+
+    expect(state.party.every((member) => member.formationRow === 'front')).toBe(true);
+    expect(spearMove(spear).name).toBe('越肩突刺〔長柄 -1〕');
+  });
+
+  it('keeps reach labels idempotent across repeated combat initialization', () => {
+    const spear = memberFromRecord(spearRecord('repeat-spear'));
+    spear.formationRow = 'back';
+    startCombat(rng(), [anchor('first-anchor'), spear], [enemy('first-foe')]);
+    const once = spearMove(spear).name;
+    startCombat(rng(), [anchor('second-anchor'), spear], [enemy('second-foe')]);
+    const twice = spearMove(spear).name;
+    expect(twice).toBe(once);
+    expect((twice.match(/長柄/g) ?? []).length).toBe(1);
+  });
+});

--- a/src/scripts/games/caravan/data/reachPolearms.m53.test.ts
+++ b/src/scripts/games/caravan/data/reachPolearms.m53.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { Move } from '../combat';
+import type { CompanionRecord } from '../save';
+import { armoryProfile, armoryRuleForItem, WEAPON_DISCIPLINE_LABELS } from './armory';
+import { engagementForMove, formationAttackProfile } from './martialEngagement.m49';
+import { handLoadoutProfile, setOffhandId, weaponHands } from './offhandShields.m52';
+import { M53_POLEARM_ITEMS } from './reachPolearms.m53';
+import { TOWNS } from './towns';
+
+function record(job: CompanionRecord['job'] = 'swordsman', weapon = 'ashwood-war-spear'): CompanionRecord {
+  return {
+    id: `m53-${job}`,
+    name: '長柄測試者',
+    job,
+    level: 5,
+    xp: 750,
+    stats: { str: 14, dex: 12, int: 12, cha: 12, con: 14 },
+    maxHp: 28,
+    injuredForTrips: 0,
+    equipment: { weapon, armor: null, trinket: null },
+  };
+}
+
+const plainPierce: Move = {
+  id: 'plain-pierce',
+  name: '短槍刺擊',
+  kind: 'attack',
+  target: 'enemy',
+  hitStat: 'str',
+  element: 'pierce',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' },
+  narration: '',
+};
+
+describe('M53 reach and polearm rules', () => {
+  it('requires an explicit reach declaration instead of treating every STR pierce attack as long-reach', () => {
+    expect(engagementForMove(plainPierce, false)).toBe('melee');
+    expect(M53_POLEARM_ITEMS['ashwood-war-spear'].equip?.move?.engagement).toBe('reach');
+    expect(M53_POLEARM_ITEMS['saltsteel-pike'].equip?.move?.engagement).toBe('reach');
+  });
+
+  it('makes reach comfortable in rear rank but mildly awkward when forced into the frontline', () => {
+    const spear = M53_POLEARM_ITEMS['ashwood-war-spear'].equip!.move!;
+    const rear = formationAttackProfile('back', spear, false);
+    const front = formationAttackProfile('front', spear, false);
+    expect(rear.engagement).toBe('reach');
+    expect(rear.hitModifier).toBe(0);
+    expect(front.engagement).toBe('reach');
+    expect(front.hitModifier).toBe(-1);
+    expect(front.message).toContain('長柄近身壓力');
+    expect(front.message).toContain('命中 -1');
+  });
+
+  it('keeps M49 melee and ranged penalties unchanged', () => {
+    const melee = { ...plainPierce, element: 'slash' as const };
+    const ranged = { ...plainPierce, hitStat: 'dex' as const };
+    expect(formationAttackProfile('back', melee, false).hitModifier).toBe(-2);
+    expect(formationAttackProfile('front', ranged, false).hitModifier).toBe(-2);
+  });
+
+  it('lets true magic override even an explicit reach marker', () => {
+    const fakeReachSpell: Move = {
+      ...plainPierce,
+      id: 'reach-spell',
+      engagement: 'reach',
+      hitStat: 'int',
+      element: 'fire',
+    };
+    const profile = formationAttackProfile('front', fakeReachSpell, true);
+    expect(profile.engagement).toBe('mystic');
+    expect(profile.hitModifier).toBe(0);
+  });
+
+  it('registers both polearms as two-handed armory weapons with real burden', () => {
+    expect(weaponHands('ashwood-war-spear')).toBe(2);
+    expect(weaponHands('saltsteel-pike')).toBe(2);
+    expect(armoryRuleForItem('ashwood-war-spear')).toMatchObject({ burden: 2, weapon: 'polearm' });
+    expect(armoryRuleForItem('saltsteel-pike')).toMatchObject({ burden: 3, weapon: 'polearm' });
+    expect(WEAPON_DISCIPLINE_LABELS.polearm).toBe('長柄');
+  });
+
+  it('uses cross-training rather than job locks for the polearm discipline', () => {
+    expect(armoryProfile(record('swordsman')).weaponFit).toBe('mastered');
+    expect(armoryProfile(record('ranger')).weaponFit).toBe('trained');
+    expect(armoryProfile(record('cleric')).weaponFit).toBe('trained');
+    expect(armoryProfile(record('mage')).weaponFit).toBe('strained');
+  });
+
+  it('stows a shield while a two-handed polearm is in use instead of granting both benefits', () => {
+    const fighter = record();
+    setOffhandId(fighter, 'salt-rim-kite-shield');
+    const hand = handLoadoutProfile(fighter);
+    expect(hand.weaponHands).toBe(2);
+    expect(hand.shieldReady).toBe(false);
+    expect(hand.shieldGuardBonus).toBe(0);
+    expect(hand.offhandBurden).toBe(2);
+  });
+
+  it('places both polearms in real town stock at distinct progression points', () => {
+    expect(TOWNS['starting-town'].stock).toContain('ashwood-war-spear');
+    expect(TOWNS['salt-spring-city'].stock).toContain('saltsteel-pike');
+    expect(M53_POLEARM_ITEMS['ashwood-war-spear'].equip?.minLevel).toBeUndefined();
+    expect(M53_POLEARM_ITEMS['saltsteel-pike'].equip?.minLevel).toBe(3);
+  });
+});

--- a/src/scripts/games/caravan/data/reachPolearms.m53.ts
+++ b/src/scripts/games/caravan/data/reachPolearms.m53.ts
@@ -1,0 +1,59 @@
+import { ITEMS, type ItemDef } from './items';
+import { TWO_HANDED_WEAPONS } from './offhandShields.m52';
+
+/**
+ * M53：長柄武器不是刀劍／弓的數值升級，而是第三種交戰距離。
+ * - 後排可隔著前線刺擊，不吃近戰 -2。
+ * - 被迫進入前排時因槍桿難以完全展開，吃 reach 專屬 -1。
+ * - 全部視為雙手武器，因此不能同時兌現 M52 盾牌守勢。
+ */
+export const M53_POLEARM_ITEMS: Record<string, ItemDef> = {
+  'ashwood-war-spear': {
+    id: 'ashwood-war-spear',
+    name: '白蠟木戰矛',
+    desc: '以韌性極佳的白蠟木作長桿，裝上窄葉鋼矛頭的商路護衛兵器。站在第二列時能越過前排肩線刺擊，真正被逼近身後反而難以完全施展。',
+    value: 62,
+    equip: {
+      slot: 'weapon',
+      move: {
+        id: 'second-rank-thrust',
+        name: '越肩突刺',
+        kind: 'attack',
+        target: 'enemy',
+        hitStat: 'str',
+        element: 'pierce',
+        engagement: 'reach',
+        armorPiercing: 1,
+        damage: { dice: 1, sides: 8, bonusStat: 'str' },
+        narration: '{actor}讓長矛越過前線肩側直刺{target}，造成 {amount} 點傷害！',
+      },
+    },
+  },
+  'saltsteel-pike': {
+    id: 'saltsteel-pike',
+    name: '鹽鋼長槍',
+    desc: '鹽泉城軍匠以鹽鍛鋼打造的長槍，細長四稜槍尖專為找尋甲片與鎖環間隙。它能從第二列維持威脅，但重量與長度讓貼身混戰更吃技巧。',
+    value: 128,
+    equip: {
+      slot: 'weapon',
+      minLevel: 3,
+      move: {
+        id: 'saltsteel-line-thrust',
+        name: '破列槍刺',
+        kind: 'attack',
+        target: 'enemy',
+        hitStat: 'str',
+        element: 'pierce',
+        engagement: 'reach',
+        armorPiercing: 2,
+        damage: { dice: 1, sides: 10, bonusStat: 'str' },
+        narration: '{actor}沉腰送出鹽鋼長槍，槍尖穿過陣線直取{target}，造成 {amount} 點傷害！',
+      },
+    },
+  },
+};
+
+for (const [id, item] of Object.entries(M53_POLEARM_ITEMS)) {
+  ITEMS[id] = item;
+  TWO_HANDED_WEAPONS.add(id);
+}

--- a/src/scripts/games/caravan/data/towns.ts
+++ b/src/scripts/games/caravan/data/towns.ts
@@ -1,6 +1,7 @@
 import type { TownDef } from '../economy';
 import { registerTowns } from '../expedition';
 import './offhandShields.m52';
+import './reachPolearms.m53';
 
 /**
  * M4 首批城鎮：3 座。
@@ -12,6 +13,7 @@ import './offhandShields.m52';
  * 押貨鹽晶洞窟（reputation≥60）掉落的「鹽」走霧嶺古道到此變現，是全遊戲最長
  * （legs6）也最賺的押貨路線（見 data.test.ts 經濟量級 sanity）。
  * M52 再加入副手盾牌：基礎小圓盾可在啟程之鎮取得，鹽鋼鳶盾留給鹽泉城中期整備。
+ * M53 加入長柄武器：基礎戰矛早期可買，鹽鋼長槍則留給鹽泉城較成熟的第二列構築。
  */
 export const TOWNS: Record<string, TownDef> = {
   'starting-town': {
@@ -20,7 +22,7 @@ export const TOWNS: Record<string, TownDef> = {
     name: '啟程之鎮',
     desc: '商隊由此啟程，青石廣場終年人聲鼎沸，鐵匠爐火不熄，貨棧招牌層層疊疊，是踏上未知路途前最後一次安穩補給。',
     priceModifiers: {},
-    stock: ['herb', 'bandage', 'antidote', 'war-tonic', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest', 'oak-buckler'],
+    stock: ['herb', 'bandage', 'antidote', 'war-tonic', 'torch', 'dried-rations', 'ore', 'spider-silk', 'spice-pouch', 'ridgeleather-vest', 'oak-buckler', 'ashwood-war-spear'],
   },
   'riverbend-town': {
     id: 'riverbend-town',
@@ -50,8 +52,9 @@ export const TOWNS: Record<string, TownDef> = {
       'saltforged-mail': 1.3,
       'brinewarded-vestment': 1.3,
       'salt-rim-kite-shield': 1.25,
+      'saltsteel-pike': 1.2,
     },
-    stock: ['salt', 'salt-crystal-blade', 'brine-blessed-mace', 'saltforged-mail', 'brinewarded-vestment', 'brine-crystal-staff', 'pilgrim-warded-cloak', 'saltglass-talisman', 'salt-rim-kite-shield', 'herb', 'torch'],
+    stock: ['salt', 'salt-crystal-blade', 'brine-blessed-mace', 'saltforged-mail', 'brinewarded-vestment', 'brine-crystal-staff', 'pilgrim-warded-cloak', 'saltglass-talisman', 'salt-rim-kite-shield', 'saltsteel-pike', 'herb', 'torch'],
   },
 };
 


### PR DESCRIPTION
## Stacked dependency

This is a stacked draft on top of #250 / `agent/caravan-m52-offhand-shields`. It contains only the M53 reach/polearm layer plus its validation; #250 remains independently validated.

## Summary

M53 adds a third physical engagement archetype for the medieval sword-and-magic combat model: **reach / polearms**.

M49 previously made mundane melee prefer the frontline and ranged weapons prefer the rear. M53 adds long-shaft weapons that can fight effectively from the second rank without turning them into ranged weapons or universal zero-penalty tools.

### Reach rules
- new `EngagementBand: 'reach'`
- rear-rank reach attack: hit modifier `0`
- frontline reach attack: hit modifier `-1` due close-quarters shaft handling
- ordinary rear melee remains `-2`
- ordinary frontline ranged remains `-2`
- true arcane/divine magic still overrides mundane engagement classification
- correct reach positioning never grants a positive hit bonus

### Real polearm equipment
- **白蠟木戰矛**: starting-town weapon, burden 2, two-handed, 1d8 + STR, pierce, armor piercing 1
- **鹽鋼長槍**: Salt Spring City Lv3 weapon, burden 3, two-handed, 1d10 + STR, pierce, armor piercing 2
- neither weapon grants passive stats, Defense, HP, crowd control or area damage

### M43 armory integration
New `polearm` proficiency discipline:
- swordsman: mastered
- ranger: trained
- cleric: trained
- mage: strained

Cross-training stays legal and continues to pay the existing M43 hit/damage/burden costs.

### M52 hand/offhand interaction
Both M53 weapons are two-handed. A carried shield remains equipped and still counts burden, but it is stowed and contributes no active shield Guard bonus while the polearm is in use.

### M50 player-information contract
Live action labels expose the real reach state before click:
- rear: `越肩突刺〔長柄〕`
- front: `越肩突刺〔長柄 -1〕`

When M49 frontline collapse forces a rear spearman into front rank, both the actual modifier and live label update immediately. Arcana suffix cleanup also handles reach labels so repeated `startCombat()` calls cannot stack them.

## Multidimensional player adversarial review

Dedicated gates verify:
- ordinary STR-pierce attacks do not become reach without an explicit marker
- all-rear openings cannot create a phantom-safe second rank
- reach has no positive correct-position bonus and still pays `-1` when pinned in front
- polearms do not strictly replace blades on raw damage
- polearm + shield cannot stack active benefits
- cross-trained users still pay M43 proficiency penalties
- the high-tier pike pays level, price and burden costs for stronger piercing
- the new archetype does not smuggle passive stats, AOE or crowd control
- true magic overrides physical reach classification
- live labels match the engine's `0 / -1` reach modifiers
- frontline collapse updates real row and UI together
- repeated combat initialization cannot duplicate `長柄` suffixes
- both weapons have real town acquisition paths

## Validation

Latest head `b19511c1246f59e07fddcc2e79bb3d5c5ddadbb8` passed **all 16 Caravan workflows** triggered by the PR, including the dedicated `Caravan M53 Reach Polearm CI`.

The M53 gate completed successfully with:
- production build
- M53 reach/polearm rule gates
- live `memberFromRecord → startCombat → partyAct` reach integration
- M53 multidimensional adversarial player review
- M52 shield/handedness regressions
- M51 veteran mastery regressions
- M49–M50 formation/readability regressions
- core combat + M41 magic
- M40 Reliquary
- M42 endurance/composition
- M43 armory/endurance
- M44 spellcraft
- M45 rituals
- M46 convoy + M47 morale
- M48 armor

The deterministic live gate verifies the same borderline hit roll succeeds from rear rank and misses after the spearman is forced into front rank, while the action label changes from `〔長柄〕` to `〔長柄 -1〕` at the same time.

Vercel currently rejects only the preview because the account is at `build-rate-limit`; the independent GitHub production build and every gameplay gate pass.

PR #251 remains draft, open and mergeable. See `docs/caravan-m53-reach-polearms.md` for design rationale and rejected exploit-prone alternatives.