### PR TITLE
test(caravan): diagnose pre-M54 arcane endurance baseline

### DIFF
--- a/src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+++ b/src/scripts/games/caravan/data/endurance.balance.m42.test.ts
@@ -234,6 +234,11 @@ describe('M42 automated player-perspective balance probes', () => {
     expectViableButNotGuaranteed(report('arcane', 9160));
   });
 
+  it('stress-checks the pre-M54 double-mage baseline across 200 seeds', () => {
+    const stress = compositionReport('arcane-pre-m54-stress', COMPOSITIONS.arcane, 9360, 200);
+    expect(stress.total).toBe(200);
+  });
+
   it('party without cleric has viable but non-guaranteed outcomes', () => {
     expectViableButNotGuaranteed(report('noCleric', 9180));
   });


### PR DESCRIPTION
Temporary diagnostic draft only. Adds a 200-seed double-mage endurance probe on the validated M53 base to distinguish a pre-existing M42 balance distribution from an M54 regression. No gameplay code changes. This PR will be closed after the baseline result is captured.