### PR TITLE
test(caravan): isolate M55 balance failure

### DIFF
--- a/.github/workflows/caravan-m55-ci.yml
+++ b/.github/workflows/caravan-m55-ci.yml
@@ -1,0 +1,130 @@
+name: Caravan M55 Battlefield Cover CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m55-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m55-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M55 battlefield cover rules
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldTerrain.m55.test.ts
+
+      - name: M55 live battlefield cover integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldTerrain.integration.m55.test.ts
+
+      - name: M55 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts
+
+      - name: M54 enemy formation regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enemyFormation.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.integration.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.balance.m54.test.ts
+
+      - name: M53 reach and polearm regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/reachPolearms.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
+
+      - name: M52 shield and handedness regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/offhandShields.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+          src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+
+      - name: M51 veteran mastery regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/.github/workflows/diag-m55-balance.yml
+++ b/.github/workflows/diag-m55-balance.yml
@@ -1,0 +1,20 @@
+name: Diagnostic M55 Balance
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - '.github/workflows/diag-m55-balance.yml'
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: M55 balance only
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -14,6 +14,7 @@ import {
 } from './data/armorProfiles.m48';
 import {
   canGuardIntercept,
+  engagementForMove,
   formationAttackProfile,
   type EngagementBand,
 } from './data/martialEngagement.m49';
@@ -25,6 +26,14 @@ import {
   initializeEnemyFormation,
   legalEnemyTargets,
 } from './data/enemyFormation.m54';
+import {
+  battlefieldTerrain,
+  projectileCoverProfile,
+  type BattlefieldTerrain,
+  type BattlefieldTerrainId,
+  type BattlefieldSide,
+  type ProjectileCoverProfile,
+} from './data/battlefieldTerrain.m55';
 
 export interface Move {
   id: string; name: string;
@@ -104,6 +113,8 @@ export interface EnemyUnit extends CombatantBase {
   intents: Array<{ weight: number; moveId: string }>;
   /** M54：敵人也使用與玩家相同的前後排距離規則；缺少時由開戰規則推導。 */
   formationRow?: FormationRow;
+  /** M55：遭遇可由其中一名敵方資料標記戰場；只存在 combat runtime，不進存檔。 */
+  battlefieldTerrainId?: BattlefieldTerrainId;
   /** M15 弱點屬性：命中 ×1.5 並削 1 護勢 */
   weaknesses?: Element[];
   /** M15 抗性屬性：命中 ×0.5 */
@@ -128,6 +139,8 @@ export interface CombatState {
   party: PartyMember[]; enemies: EnemyUnit[];
   guarding: Record<string, boolean>;
   enemyIntents: Record<string, string>;
+  /** M55：本場地形只存在戰鬥 runtime；未設定即沿用舊版開闊戰場。 */
+  terrain?: BattlefieldTerrain;
   log: CombatEvent[];
   outcome: 'ongoing' | 'victory' | 'defeat' | 'retreated';
 }
@@ -157,7 +170,25 @@ export interface PartyActionResult {
 
 const VETERAN_RANK_LABEL = ['', 'I', 'II', 'III'] as const;
 
-export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]): CombatState {
+function authoredTerrainForEnemies(enemies: EnemyUnit[], override?: BattlefieldTerrainId): BattlefieldTerrain | undefined {
+  if (override) return battlefieldTerrain(override);
+  const authored = [...new Set(
+    enemies
+      .map((enemy) => enemy.battlefieldTerrainId)
+      .filter((id): id is BattlefieldTerrainId => id !== undefined)
+  )];
+  if (authored.length > 1) {
+    throw new Error(`同一遭遇宣告了互相衝突的戰場地形：${authored.join('、')}`);
+  }
+  return battlefieldTerrain(authored[0]);
+}
+
+export function startCombat(
+  rng: Rng,
+  party: PartyMember[],
+  enemies: EnemyUnit[],
+  terrainOverride?: BattlefieldTerrainId,
+): CombatState {
   // M41/M44：雙方施法者共用同一套招式裝飾、秘法／神恩容量與恢復手段。
   for (const member of party) prepareMysticPartyMember(member);
   for (const enemy of enemies) prepareMysticPartyMember(enemy);
@@ -173,7 +204,7 @@ export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]
   rolled.sort((a, b) => b.init - a.init || tieBreakIndex.get(a.id)! - tieBreakIndex.get(b.id)!);
   const state: CombatState = {
     round: 1, order: rolled.map((r) => r.id), turnIndex: 0,
-    party, enemies, guarding: {}, enemyIntents: {}, log: [], outcome: 'ongoing',
+    party, enemies, guarding: {}, enemyIntents: {}, terrain: authoredTerrainForEnemies(enemies, terrainOverride), log: [], outcome: 'ongoing',
   };
   const enemyFormation = initializeEnemyFormation(enemies);
   for (const enemy of enemies) {
@@ -182,6 +213,9 @@ export function startCombat(rng: Rng, party: PartyMember[], enemies: EnemyUnit[]
   }
   state.log.push({ kind: 'info', text: '戰鬥開始！' });
   collapseFrontLineIfNeeded(state);
+  if (state.terrain && state.terrain.id !== 'open-ground') {
+    state.log.push({ kind: 'info', text: `地形：${state.terrain.name}——${state.terrain.description}` });
+  }
   const enemyFront = enemies.filter((enemy) => enemy.hp > 0 && enemy.formationRow !== 'back').map((enemy) => enemy.name);
   const enemyBack = enemies.filter((enemy) => enemy.hp > 0 && enemy.formationRow === 'back').map((enemy) => enemy.name);
   state.log.push({
@@ -396,6 +430,29 @@ function performFormationShift(state: CombatState, actor: PartyMember): void {
   refreshFormationRuntime(state);
 }
 
+function emptyCoverProfile(): ProjectileCoverProfile {
+  return { grade: 'none', hitModifier: 0, applies: false, message: '' };
+}
+
+/** M55：提供 UI、測試與正式命中結算同一份「這個目標現在有沒有投射掩體」真相。 */
+export function targetCoverForecast(
+  state: CombatState,
+  move: Move,
+  target: CombatantBase,
+): ProjectileCoverProfile {
+  if (move.kind !== 'attack') return emptyCoverProfile();
+  const partyTarget = state.party.find((member) => member.id === target.id);
+  const enemyTarget = state.enemies.find((enemy) => enemy.id === target.id);
+  const side: BattlefieldSide | null = partyTarget ? 'party' : enemyTarget ? 'enemy' : null;
+  if (!side) return emptyCoverProfile();
+  const row = partyTarget?.formationRow ?? enemyTarget?.formationRow;
+  const sideUnits = side === 'party' ? state.party : state.enemies;
+  const frontlineAlive = sideUnits.some((unit) => unit.hp > 0 && unit.formationRow !== 'back');
+  const isMystic = !!mysticRuleForMove(move);
+  const engagement = engagementForMove(move, isMystic);
+  return projectileCoverProfile(state.terrain, side, row, engagement, isMystic, frontlineAlive);
+}
+
 function performMove(
   rng: Rng,
   state: CombatState,
@@ -444,13 +501,15 @@ function performMove(
   const partyActor = state.party.find((member) => member.id === actor.id);
   const enemyActor = state.enemies.find((member) => member.id === actor.id);
   const formation = formationAttackProfile(partyActor?.formationRow ?? enemyActor?.formationRow, move, !!spellRule);
+  const cover = targetCoverForecast(state, move, target);
+  if (cover.message) state.log.push({ kind: 'info', text: `${target.name}：${cover.message}` });
   const die = rng.d20();
   const defense = target.defense + guardingDefenseBonus(state, target);
   const hit = die === 20
     ? true
     : die === 1
       ? false
-      : die + statMod(actor.stats[move.hitStat]) + (move.hitBonus ?? 0) + formation.hitModifier >= defense;
+      : die + statMod(actor.stats[move.hitStat]) + (move.hitBonus ?? 0) + formation.hitModifier + cover.hitModifier >= defense;
   if (!hit) {
     state.log.push({ kind: 'action', text: `${actor.name}的${move.name}落空了！` });
     return;

--- a/src/scripts/games/caravan/data/ashenReliquaryCombat.ts
+++ b/src/scripts/games/caravan/data/ashenReliquaryCombat.ts
@@ -107,6 +107,7 @@ const cinderSidearm: Move = {
 function ashKnight(): EnemyUnit {
   return {
     id: 'reliquary-ash-knight', name: '灰燼騎士・守橋者',
+    battlefieldTerrainId: 'broken-stone-bridge',
     stats: { str: 16, dex: 10, int: 10, cha: 8, con: 16 }, maxHp: 28, hp: 28, defense: 15,
     weaknesses: ['holy', 'blunt'], resists: ['fire', 'slash'], maxPoise: 4,
     armorProtection: armorProtectionForDiscipline('mail'),

--- a/src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  legalEnemyTargetsForMove,
+  startCombat,
+  targetCoverForecast,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { projectileCoverProfile } from './battlefieldTerrain.m55';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 10,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const melee: Move = {
+  id: 'm55-melee', name: '劍擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}攻擊{target}，造成 {amount} 點傷害！',
+};
+const reach: Move = {
+  id: 'm55-reach', name: '長槍刺擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'pierce', engagement: 'reach',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}以長槍刺向{target}，造成 {amount} 點傷害！',
+};
+const ranged: Move = {
+  id: 'm55-ranged', name: '長弓射擊', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射向{target}，造成 {amount} 點傷害！',
+};
+const rangedArea: Move = {
+  ...ranged, id: 'm55-volley', name: '箭雨', area: true,
+};
+const spell: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 6, bonusStat: 'int' }, narration: '{actor}以火球攻擊{target}，造成 {amount} 點傷害！',
+};
+
+function member(id: string, row: 'front' | 'back', moves: Move[]): PartyMember {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 14, dex: 14, int: 14, cha: 10, con: 14 }, maxHp: 30, hp: 30, defense: 12, moves,
+  };
+}
+
+function simpleEnemy(id: string, row: 'front' | 'back'): EnemyUnit {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 12, dex: 12, int: 8, cha: 8, con: 12 }, maxHp: 20, hp: 20, defense: 12,
+    moves: [melee], intents: [{ weight: 1, moveId: melee.id }],
+  };
+}
+
+describe('M55 multidimensional player adversarial review', () => {
+  it('keeps physical ranged attacks legal under cover instead of turning terrain into a hard ban', () => {
+    const shooter = member('shooter', 'back', [ranged]);
+    const state = startCombat(rng, [member('front', 'front', [melee]), shooter], createReliquaryEncounter(1));
+    const targets = legalEnemyTargetsForMove(state, ranged);
+    expect(targets.map((target) => target.id)).toContain('reliquary-cinder-squire');
+    const squire = targets.find((target) => target.id === 'reliquary-cinder-squire')!;
+    expect(targetCoverForecast(state, ranged, squire)).toMatchObject({ applies: true, hitModifier: -1 });
+  });
+
+  it('preserves a non-magical counter-route: melee and reach can break the screen that enables rear cover', () => {
+    const state = startCombat(rng, [
+      member('sword', 'front', [melee]),
+      member('spear', 'back', [reach]),
+    ], createReliquaryEncounter(1));
+    const knightId = 'reliquary-ash-knight';
+    const squireId = 'reliquary-cinder-squire';
+    expect(legalEnemyTargetsForMove(state, melee).map((target) => target.id)).toEqual([knightId]);
+    expect(legalEnemyTargetsForMove(state, reach).map((target) => target.id)).toEqual([knightId]);
+    expect(legalEnemyTargetsForMove(state, ranged).map((target) => target.id)).toEqual([knightId, squireId]);
+  });
+
+  it('does not make spellcraft strictly stronger by adding a positive terrain bonus', () => {
+    const state = startCombat(rng, [member('front', 'front', [melee]), member('mage', 'back', [spell])], createReliquaryEncounter(1));
+    const squire = state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    const magic = targetCoverForecast(state, spell, squire);
+    expect(magic.hitModifier).toBe(0);
+    expect(magic.applies).toBe(false);
+  });
+
+  it('applies cover per target so an area volley cannot give frontline bodies fake cover', () => {
+    const front = simpleEnemy('enemy-front', 'front');
+    front.battlefieldTerrainId = 'ruined-battlements';
+    const back = simpleEnemy('enemy-back', 'back');
+    const state = startCombat(rng, [member('archer', 'back', [rangedArea])], [front, back]);
+    expect(targetCoverForecast(state, rangedArea, front).hitModifier).toBe(0);
+    expect(targetCoverForecast(state, rangedArea, back).hitModifier).toBe(-2);
+  });
+
+  it('keeps symmetric bridge cover at the same -1 for both armies', () => {
+    const state = startCombat(rng, [member('front', 'front', [melee]), member('rear', 'back', [ranged])], createReliquaryEncounter(1));
+    const enemyRear = state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    const partyRear = state.party.find((unit) => unit.id === 'rear')!;
+    expect(targetCoverForecast(state, ranged, enemyRear).hitModifier).toBe(-1);
+    expect(projectileCoverProfile(state.terrain, 'party', partyRear.formationRow, 'ranged', false, true).hitModifier).toBe(-1);
+  });
+
+  it('bounds every published cover grade at -2 or better so experimentation stays playable', () => {
+    for (const side of ['party', 'enemy'] as const) {
+      for (const terrainId of ['open-ground', 'broken-stone-bridge', 'ruined-battlements'] as const) {
+        const terrain = terrainId === 'open-ground'
+          ? { id: terrainId, name: 'open', description: '', partyRearCover: 'none' as const, enemyRearCover: 'none' as const }
+          : terrainId === 'broken-stone-bridge'
+            ? { id: terrainId, name: 'bridge', description: '', partyRearCover: 'partial' as const, enemyRearCover: 'partial' as const }
+            : { id: terrainId, name: 'walls', description: '', partyRearCover: 'partial' as const, enemyRearCover: 'strong' as const };
+        const modifier = projectileCoverProfile(terrain, side, 'back', 'ranged', false, true).hitModifier;
+        expect(modifier).toBeGreaterThanOrEqual(-2);
+        expect(modifier).toBeLessThanOrEqual(0);
+      }
+    }
+  });
+
+  it('does not randomly invent terrain for legacy encounters that authored none', () => {
+    const state = startCombat(rng, [member('hero', 'front', [melee])], [simpleEnemy('legacy-enemy', 'front')]);
+    expect(state.terrain).toBeUndefined();
+    expect(targetCoverForecast(state, ranged, state.enemies[0])).toMatchObject({ applies: false, hitModifier: 0 });
+  });
+
+  it('keeps M55 entirely runtime-scoped instead of introducing persistent combat terrain on party members', () => {
+    const hero = member('hero', 'front', [melee]);
+    const beforeKeys = Object.keys(hero).sort();
+    startCombat(rng, [hero], [simpleEnemy('legacy-enemy', 'front')], 'broken-stone-bridge');
+    expect(Object.keys(hero).sort()).toEqual(beforeKeys);
+    expect('terrain' in hero).toBe(false);
+    expect('battlefieldTerrainId' in hero).toBe(false);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldTerrain.integration.m55.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldTerrain.integration.m55.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  partyAct,
+  startCombat,
+  targetCoverForecast,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { createReliquaryEncounter } from './ashenReliquaryCombat';
+
+function scriptedRng(values: number[] = [20, 19, 18, 17, 1]): Rng {
+  let index = 0;
+  const take = () => values[index++ % Math.max(1, values.length)] ?? 10;
+  return {
+    next: () => 0,
+    roll: take,
+    d20: take,
+    pick: (items) => items[0],
+    weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+  };
+}
+
+const sword: Move = {
+  id: 'm55-sword', name: '長劍', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 1, bonusStat: 'str' }, narration: '{actor}斬向{target}，造成 {amount} 點傷害！',
+};
+const arrow: Move = {
+  id: 'm55-arrow', name: '獵弓箭', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 1, bonusStat: 'dex' }, narration: '{actor}射向{target}，造成 {amount} 點傷害！',
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 1, bonusStat: 'int' }, narration: '{actor}以火球轟擊{target}，造成 {amount} 點傷害！',
+};
+
+function frontliner(): PartyMember {
+  return {
+    id: 'front', name: '前衛', formationRow: 'front',
+    stats: { str: 16, dex: 10, int: 8, cha: 8, con: 16 }, maxHp: 50, hp: 50, defense: 12, moves: [sword],
+  };
+}
+function ranger(): PartyMember {
+  return {
+    id: 'ranger', name: '弓手', formationRow: 'back',
+    stats: { str: 10, dex: 16, int: 8, cha: 8, con: 12 }, maxHp: 30, hp: 30, defense: 12, moves: [arrow],
+  };
+}
+function mage(): PartyMember {
+  return {
+    id: 'mage', name: '法師', formationRow: 'back',
+    stats: { str: 8, dex: 12, int: 16, cha: 10, con: 10 }, maxHp: 28, hp: 28, defense: 12, moves: [fireball],
+  };
+}
+
+function forceTurn(state: ReturnType<typeof startCombat>, id: string): void {
+  state.turnIndex = state.order.indexOf(id);
+}
+
+describe('M55 live battlefield cover integration', () => {
+  it('authors the Ashen Reliquary bridge as a real broken-stone battlefield and publishes it in the log', () => {
+    const encounter = createReliquaryEncounter(1);
+    const state = startCombat(scriptedRng(), [frontliner(), ranger()], encounter);
+    expect(state.terrain?.id).toBe('broken-stone-bridge');
+    expect(state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')?.formationRow).toBe('back');
+    expect(state.log.some((entry) => entry.text.includes('地形：斷裂石橋'))).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('物理遠程命中 -1'))).toBe(true);
+  });
+
+  it('turns the same borderline player arrow from an open-ground hit into a covered miss', () => {
+    const openRanger = ranger();
+    const open = startCombat(scriptedRng(), [frontliner(), openRanger], createReliquaryEncounter(1), 'open-ground');
+    const openSquire = open.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    forceTurn(open, openRanger.id);
+    partyAct(scriptedRng([9, 1]), open, openRanger.id, arrow.id, openSquire.id);
+    expect(openSquire.hp).toBeLessThan(openSquire.maxHp);
+
+    const bridgeRanger = ranger();
+    const bridge = startCombat(scriptedRng(), [frontliner(), bridgeRanger], createReliquaryEncounter(1));
+    const bridgeSquire = bridge.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    forceTurn(bridge, bridgeRanger.id);
+    partyAct(scriptedRng([9, 1]), bridge, bridgeRanger.id, arrow.id, bridgeSquire.id);
+    expect(bridgeSquire.hp).toBe(bridgeSquire.maxHp);
+    expect(bridge.log.some((entry) => entry.text.includes('遮蔽投射線'))).toBe(true);
+  });
+
+  it('applies the same bridge cover when the enemy throws a physical spear at the player rear', () => {
+    const openFront = frontliner();
+    const openRear = ranger();
+    openRear.maxHp = openRear.hp = 20;
+    const open = startCombat(scriptedRng(), [openFront, openRear], createReliquaryEncounter(1), 'open-ground');
+    const openSquire = open.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    forceTurn(open, openSquire.id);
+    open.enemyIntents[openSquire.id] = 'reliquary-cinder-spear';
+    enemyAct(scriptedRng([10, 1]), open, openSquire.id);
+    expect(openRear.hp).toBeLessThan(20);
+
+    const bridgeFront = frontliner();
+    const bridgeRear = ranger();
+    bridgeRear.maxHp = bridgeRear.hp = 20;
+    const bridge = startCombat(scriptedRng(), [bridgeFront, bridgeRear], createReliquaryEncounter(1));
+    const bridgeSquire = bridge.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    forceTurn(bridge, bridgeSquire.id);
+    bridge.enemyIntents[bridgeSquire.id] = 'reliquary-cinder-spear';
+    enemyAct(scriptedRng([10, 1]), bridge, bridgeSquire.id);
+    expect(bridgeRear.hp).toBe(20);
+  });
+
+  it('keeps genuine magic on its own geometry instead of treating a spell like an arrow', () => {
+    const caster = mage();
+    const state = startCombat(scriptedRng(), [frontliner(), caster], createReliquaryEncounter(1));
+    const squire = state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    expect(targetCoverForecast(state, fireball, squire)).toMatchObject({ applies: false, hitModifier: 0 });
+    forceTurn(state, caster.id);
+    partyAct(scriptedRng([9, 1]), state, caster.id, fireball.id, squire.id);
+    expect(squire.hp).toBeLessThan(squire.maxHp);
+  });
+
+  it('removes rear cover the moment the screen falls and the squire is forced to the frontline', () => {
+    const front = frontliner();
+    const back = ranger();
+    const state = startCombat(scriptedRng(), [front, back], createReliquaryEncounter(1));
+    const knight = state.enemies.find((enemy) => enemy.id === 'reliquary-ash-knight')!;
+    const squire = state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    expect(targetCoverForecast(state, arrow, squire).hitModifier).toBe(-1);
+
+    knight.hp = 1;
+    forceTurn(state, front.id);
+    partyAct(scriptedRng([20, 1]), state, front.id, sword.id, knight.id);
+    expect(knight.hp).toBe(0);
+    expect(squire.formationRow).toBe('front');
+    expect(targetCoverForecast(state, arrow, squire)).toMatchObject({ applies: false, hitModifier: 0 });
+    expect(state.log.some((entry) => entry.text.includes('敵方前線崩潰'))).toBe(true);
+  });
+
+  it('keeps Guard interception distinct from cover by resolving the redirected shot against the frontline guardian', () => {
+    const guard = frontliner();
+    const rear = ranger();
+    rear.maxHp = rear.hp = 20;
+    const state = startCombat(scriptedRng(), [guard, rear], createReliquaryEncounter(1));
+    const squire = state.enemies.find((enemy) => enemy.id === 'reliquary-cinder-squire')!;
+    state.guarding[guard.id] = true;
+    forceTurn(state, squire.id);
+    state.enemyIntents[squire.id] = 'reliquary-cinder-spear';
+    const before = state.log.length;
+    enemyAct(scriptedRng([20, 1]), state, squire.id);
+    const newLog = state.log.slice(before).map((entry) => entry.text);
+    expect(newLog.some((line) => line.includes('替弓手攔下攻擊'))).toBe(true);
+    expect(newLog.some((line) => line.includes('遮蔽投射線'))).toBe(false);
+    expect(rear.hp).toBe(20);
+  });
+
+  it('rejects contradictory terrain authorship instead of silently choosing one battlefield', () => {
+    const enemy = (id: string, terrain: EnemyUnit['battlefieldTerrainId']): EnemyUnit => ({
+      id, name: id, battlefieldTerrainId: terrain,
+      stats: { str: 10, dex: 10, int: 8, cha: 8, con: 10 }, maxHp: 10, hp: 10, defense: 10,
+      moves: [sword], intents: [{ weight: 1, moveId: sword.id }],
+    });
+    expect(() => startCombat(scriptedRng(), [frontliner()], [
+      enemy('one', 'broken-stone-bridge'),
+      enemy('two', 'ruined-battlements'),
+    ])).toThrow(/互相衝突的戰場地形/);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldTerrain.m55.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldTerrain.m55.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BATTLEFIELD_TERRAINS,
+  battlefieldTerrain,
+  projectileCoverProfile,
+  rearCoverForSide,
+} from './battlefieldTerrain.m55';
+
+describe('M55 battlefield terrain and projectile cover rules', () => {
+  it('keeps open ground behavior identical to pre-M55 combat', () => {
+    const open = battlefieldTerrain('open-ground')!;
+    expect(projectileCoverProfile(open, 'enemy', 'back', 'ranged', false, true)).toMatchObject({
+      grade: 'none', hitModifier: 0, applies: false,
+    });
+  });
+
+  it('gives a protected rear rank bounded physical projectile cover', () => {
+    const bridge = battlefieldTerrain('broken-stone-bridge')!;
+    expect(projectileCoverProfile(bridge, 'enemy', 'back', 'ranged', false, true)).toMatchObject({
+      grade: 'partial', hitModifier: -1, applies: true,
+    });
+    expect(projectileCoverProfile(BATTLEFIELD_TERRAINS['ruined-battlements'], 'enemy', 'back', 'ranged', false, true)).toMatchObject({
+      grade: 'strong', hitModifier: -2, applies: true,
+    });
+  });
+
+  it('uses side-specific cover instead of granting the same fortification to both armies', () => {
+    const walls = BATTLEFIELD_TERRAINS['ruined-battlements'];
+    expect(rearCoverForSide(walls, 'party')).toBe('partial');
+    expect(rearCoverForSide(walls, 'enemy')).toBe('strong');
+    expect(projectileCoverProfile(walls, 'party', 'back', 'ranged', false, true).hitModifier).toBe(-1);
+    expect(projectileCoverProfile(walls, 'enemy', 'back', 'ranged', false, true).hitModifier).toBe(-2);
+  });
+
+  it('never turns projectile cover into a melee or reach tax', () => {
+    const bridge = BATTLEFIELD_TERRAINS['broken-stone-bridge'];
+    expect(projectileCoverProfile(bridge, 'enemy', 'back', 'melee', false, true).hitModifier).toBe(0);
+    expect(projectileCoverProfile(bridge, 'enemy', 'back', 'reach', false, true).hitModifier).toBe(0);
+  });
+
+  it('keeps genuine spellcraft separate from mundane projectile cover', () => {
+    const bridge = BATTLEFIELD_TERRAINS['broken-stone-bridge'];
+    expect(projectileCoverProfile(bridge, 'enemy', 'back', 'mystic', true, true)).toMatchObject({
+      hitModifier: 0, applies: false,
+    });
+  });
+
+  it('does not protect frontline bodies merely because terrain exists', () => {
+    const bridge = BATTLEFIELD_TERRAINS['broken-stone-bridge'];
+    expect(projectileCoverProfile(bridge, 'enemy', 'front', 'ranged', false, true)).toMatchObject({
+      hitModifier: 0, applies: false,
+    });
+  });
+
+  it('removes rear cover once no living frontline can hold the shooting lane', () => {
+    const bridge = BATTLEFIELD_TERRAINS['broken-stone-bridge'];
+    expect(projectileCoverProfile(bridge, 'enemy', 'back', 'ranged', false, false)).toMatchObject({
+      hitModifier: 0, applies: false,
+    });
+  });
+
+  it('keeps cover penalties bounded so terrain changes choices rather than forbidding attacks', () => {
+    const penalties = Object.values(BATTLEFIELD_TERRAINS).flatMap((terrain) => [
+      projectileCoverProfile(terrain, 'party', 'back', 'ranged', false, true).hitModifier,
+      projectileCoverProfile(terrain, 'enemy', 'back', 'ranged', false, true).hitModifier,
+    ]);
+    expect(Math.min(...penalties)).toBeGreaterThanOrEqual(-2);
+    expect(Math.max(...penalties)).toBe(0);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldTerrain.m55.ts
+++ b/src/scripts/games/caravan/data/battlefieldTerrain.m55.ts
@@ -1,0 +1,88 @@
+import type { FormationRow } from '../save';
+import type { EngagementBand } from './martialEngagement.m49';
+
+export type BattlefieldTerrainId = 'open-ground' | 'broken-stone-bridge' | 'ruined-battlements';
+export type BattlefieldSide = 'party' | 'enemy';
+export type CoverGrade = 'none' | 'partial' | 'strong';
+
+export interface BattlefieldTerrain {
+  id: BattlefieldTerrainId;
+  name: string;
+  description: string;
+  partyRearCover: CoverGrade;
+  enemyRearCover: CoverGrade;
+}
+
+export interface ProjectileCoverProfile {
+  grade: CoverGrade;
+  hitModifier: number;
+  applies: boolean;
+  message: string;
+}
+
+export const BATTLEFIELD_TERRAINS: Record<BattlefieldTerrainId, BattlefieldTerrain> = {
+  'open-ground': {
+    id: 'open-ground',
+    name: '開闊地',
+    description: '沒有足以改變投射命中的固定掩體。',
+    partyRearCover: 'none',
+    enemyRearCover: 'none',
+  },
+  'broken-stone-bridge': {
+    id: 'broken-stone-bridge',
+    name: '斷裂石橋',
+    description: '殘破女牆與橋柱替雙方仍受前線保護的後排提供部分投射掩體；物理遠程命中 -1。前線崩潰、後排被迫上前後便失去這項保護。',
+    partyRearCover: 'partial',
+    enemyRearCover: 'partial',
+  },
+  'ruined-battlements': {
+    id: 'ruined-battlements',
+    name: '傾圮城垛',
+    description: '守方殘牆形成更厚實的射線遮蔽；部分掩體命中 -1，強掩體命中 -2。',
+    partyRearCover: 'partial',
+    enemyRearCover: 'strong',
+  },
+};
+
+const COVER_HIT_MODIFIER: Record<CoverGrade, number> = {
+  none: 0,
+  partial: -1,
+  strong: -2,
+};
+
+export function battlefieldTerrain(id: BattlefieldTerrainId | undefined): BattlefieldTerrain | undefined {
+  return id ? BATTLEFIELD_TERRAINS[id] : undefined;
+}
+
+export function rearCoverForSide(terrain: BattlefieldTerrain, side: BattlefieldSide): CoverGrade {
+  return side === 'party' ? terrain.partyRearCover : terrain.enemyRearCover;
+}
+
+/**
+ * M55 only models partial projectile cover, not solid line-of-sight blockers.
+ * It therefore modifies physical ranged attacks against a protected rear rank and nothing else:
+ * melee/reach are already governed by the line model, while genuine spellcraft keeps its own
+ * magical geometry until a future explicit LOS system exists.
+ */
+export function projectileCoverProfile(
+  terrain: BattlefieldTerrain | undefined,
+  targetSide: BattlefieldSide,
+  targetRow: FormationRow | undefined,
+  engagement: EngagementBand,
+  isMystic: boolean,
+  frontlineAlive: boolean,
+): ProjectileCoverProfile {
+  if (!terrain || !frontlineAlive || targetRow !== 'back' || engagement !== 'ranged' || isMystic) {
+    return { grade: 'none', hitModifier: 0, applies: false, message: '' };
+  }
+  const grade = rearCoverForSide(terrain, targetSide);
+  const hitModifier = COVER_HIT_MODIFIER[grade];
+  if (hitModifier === 0) return { grade, hitModifier: 0, applies: false, message: '' };
+  const label = grade === 'strong' ? '強掩體' : '部分掩體';
+  return {
+    grade,
+    hitModifier,
+    applies: true,
+    message: `${terrain.name}的${label}遮蔽投射線，物理遠程命中 ${hitModifier}。`,
+  };
+}


### PR DESCRIPTION
Temporary diagnostic draft. Runs only the eight M55 multidimensional battlefield-cover tests on the exact failing code head so the failed assertion can be identified without production-build log noise. No gameplay changes. Close unmerged after diagnosis.