### PR TITLE
feat(caravan): add M56 tactical readability

### DIFF
--- a/.github/workflows/caravan-m56-ci.yml
+++ b/.github/workflows/caravan-m56-ci.yml
@@ -1,0 +1,137 @@
+name: Caravan M56 Tactical Readability CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m56-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m56-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M56 tactical presentation rules
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/tacticalReadability.m56.test.ts
+
+      - name: M56 live and dedicated-page integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/tacticalReadability.integration.m56.test.ts
+
+      - name: M56 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/tacticalReadability.balance.m56.test.ts
+
+      - name: M55 battlefield cover regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/battlefieldTerrain.m55.test.ts
+          src/scripts/games/caravan/data/battlefieldTerrain.integration.m55.test.ts
+          src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts
+
+      - name: M54 enemy formation regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enemyFormation.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.integration.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.balance.m54.test.ts
+
+      - name: M53 reach and polearm regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/reachPolearms.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
+
+      - name: M52 shield and handedness regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/offhandShields.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+          src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+
+      - name: M51 veteran mastery regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/docs/caravan-m56-tactical-readability.md
+++ b/docs/caravan-m56-tactical-readability.md
@@ -1,0 +1,189 @@
+# Caravan M56 — Tactical Readability & Honest Targeting
+
+## Why M56 exists
+
+M49–M55 made the combat rules substantially deeper:
+
+- front and rear ranks;
+- melee / ranged / reach / mystic engagement bands;
+- enemy frontline screening;
+- Guard interception;
+- shields and two-handed weapons;
+- armor and armor piercing;
+- ritual telegraphs;
+- morale and convoy objectives;
+- authored projectile cover.
+
+The engine now knows more tactical truth than several battle pages show before the player clicks.
+
+Before M56, the three dedicated high-level battle pages (`ashen-reliquary-battle`, `endurance`, `convoy-defense`) still built attack targets with the equivalent of:
+
+> every living enemy is a normal button.
+
+That is no longer honest after M54. A protected rear archer can be visible but illegal for melee/reach. M55 can also make the same rear target legal for a bow while applying `-1` cover, and legal for true spellcraft without a projectile-cover modifier.
+
+M56 makes those differences visible without creating a second combat rules engine inside the UI.
+
+## One presentation source of truth
+
+`data/tacticalReadability.m56.ts` is a read-only adapter over existing combat APIs:
+
+- `partyTargetAvailability()` — exact target legality and reason;
+- `legalEnemyTargetsForMove()` — exact area target set;
+- `targetCoverForecast()` — exact current move/target cover modifier;
+- current runtime formation rows and terrain.
+
+Pages should consume this adapter rather than re-implementing `if front exists`, `if ranged`, `if magic`, or cover math.
+
+The adapter exposes:
+
+- `tacticalUnitSummary()` for visible unit cards;
+- `tacticalTargetChoices()` for pre-click action choices.
+
+It does not roll dice, spend resources, move turns, change rows, or mutate combat state.
+
+## Blocked targets stay visible
+
+M56 deliberately does **not** hide a protected rear enemy from a melee user.
+
+Instead the target remains visible but disabled, for example:
+
+- `灰火縱咒師【後排｜前線保護】`
+
+The button carries the engine's exact blocker reason.
+
+This teaches the player that the enemy exists and is tactically protected. Hiding the enemy would make the same rule feel like missing UI or an arbitrary target list.
+
+M56 also rejects auto-retargeting. If the player tried to attack a protected rear target, the game must not silently hit some frontline enemy instead. The M54 contract remains: the invalid action is informational and does not spend the turn.
+
+## Physical ranged cover is move-specific
+
+A target card can describe its general battlefield position, while an action choice describes what **this move** experiences.
+
+On the M55 broken stone bridge:
+
+- melee/reach against a protected rear: disabled by the frontline;
+- physical ranged against the rear: legal, label includes `掩體 -1`;
+- true spellcraft against the rear: legal, no projectile-cover label.
+
+M56 does not show a generic `+DEF` or permanent cover stat because M55 never created one.
+
+## Area actions show their real target set
+
+Before M56, a page could label any area attack as `敵方全體` even when M54 correctly restricted a physical close-combat area attack to the enemy frontline.
+
+M56 asks the engine for the real legal set:
+
+- physical close-combat area while a screen exists: `敵方前排全體 (N)`;
+- ranged/mystic area that can cross the line: `敵方全體 (N)`;
+- if physical ranged targets in the area are covered, the label reports how many targets are affected by cover.
+
+The UI therefore cannot advertise damage against units the resolver will not touch.
+
+## Unit cards
+
+Dedicated high-level battle pages now expose the same position language for both armies:
+
+- `前排｜正面接戰`
+- `後排｜受前線保護`
+- `後排｜受前線保護｜掩體 -1`
+- `倒下`
+
+When a frontline collapses and M54 promotes a rear unit, the summary is recomputed from runtime state and immediately becomes `前排｜正面接戰`.
+
+No cached tactical label survives a formation change.
+
+## Endurance invalid-click punishment fix
+
+M54's engine returns `acted:false` for an illegal protected-rear click and does not advance the turn.
+
+The dedicated Reliquary and convoy pages already respected that result. `endurance.astro` did not: it called `runEnemyTurns()` unconditionally after `partyAct()`.
+
+That meant a player could click an illegal rear target, spend no engine turn, and still be punished by enemy actions on the page.
+
+M56 changes the endurance page to:
+
+1. inspect `result.acted`;
+2. run enemy turns only after a real player action;
+3. still persist and re-render the battle so the blocker message is visible.
+
+This is a real fairness fix, not a tooltip-only change.
+
+## Convoy special actions stay special
+
+M46–M47 actions are not all weapon attacks:
+
+- `護住馬車` uses convoy protection rules;
+- `喝止` uses morale eligibility, Charisma DC and defiance;
+- weapon/spell buttons use M56 tactical target choices.
+
+M56 does not route convoy protection or surrender commands through weapon-line geometry. Doing so would make the UI "consistent" by making the game rules wrong.
+
+## Multidimensional player adversarial review
+
+M56 automated review attacks the feature from these perspectives:
+
+1. **Mystery-rule risk** — blocked rear enemies remain visible with a readable reason.
+2. **Turn fairness** — an illegal target click remains `acted:false` and cannot advance the combat turn.
+3. **No silent retarget** — the game does not secretly hit a frontline enemy after a blocked rear click.
+4. **Weapon identity** — melee and reach respect screens; bows retain legal pressure through cover.
+5. **Magic honesty** — true spellcraft is legal under its own geometry but receives no fake positive terrain bonus.
+6. **Area honesty** — labels report the same target set the resolver will actually hit.
+7. **Support isolation** — healing/support choices stay living-allies-only and are not polluted by enemy-line language.
+8. **Enemy/player symmetry** — both sides' cards use the same row/protection/cover vocabulary.
+9. **Dead-unit safety** — downed units can remain visible as battle history but are not selectable.
+10. **Runtime freshness** — formation collapse immediately changes legality and labels.
+11. **Read-only presentation** — opening or recomputing target choices cannot alter HP, resources, rows, terrain or turn order.
+12. **Page contract** — all three dedicated high-level battle pages consume the shared helper instead of keeping an hp-only attack-target helper.
+13. **Objective separation** — convoy Guard/brace/morale commands retain their own rules.
+14. **Historical regression** — M39–M55 gameplay, endurance, convoy, morale, armor, magic, rituals and formation rules must remain green.
+
+## Main `play.astro` scope limitation
+
+The main adventure battle UI has the same historical targeting debt: it still owns a large target-selection block inside a very large single Astro file.
+
+The current GitHub connector can only replace the entire file; it does not expose a safe line patch for this environment. Rewriting the whole main game page for a small targeting change would create disproportionate regression risk across town, market, roster, expedition, events, trade and battle UI.
+
+M56 therefore does **not** claim the main page is already wired.
+
+The milestone creates the reusable API specifically so a later safe local/patch-capable UI change can replace the main page's target logic with `tacticalTargetChoices()` and `tacticalUnitSummary()` without copying the combat rules.
+
+This limitation is explicit rather than hidden in the PR.
+
+## Rejected alternatives
+
+### Hide illegal rear targets
+
+Rejected. It removes tactical context and makes the frontline rule look like missing UI.
+
+### Keep all targets enabled and explain failures in the combat log
+
+Rejected. Players should be able to understand legality before committing an action.
+
+### Auto-retarget a blocked rear click onto the frontline
+
+Rejected. It converts an informational mistake into an irreversible action the player did not choose.
+
+### Copy M54/M55 conditions into each Astro page
+
+Rejected. Four subtly different UI implementations would drift away from the resolver again.
+
+### Weaken frontline rules to match the old UI
+
+Rejected. UI debt is not a reason to undo the medieval formation model.
+
+### Treat every convoy action as a tactical target choice
+
+Rejected. Morale commands and protecting the wagon have distinct objective rules and should remain distinct.
+
+### Rewrite the entire main `play.astro` through the connector
+
+Rejected for this milestone. The blast radius is far larger than the change and the connector cannot safely patch the few relevant lines.
+
+## Acceptance target
+
+M56 succeeds when a player can answer these questions **before clicking** on the dedicated high-level battle pages:
+
+> Is that enemy in front or rear? Is the rear protected? Can this specific sword, polearm, bow or spell target it? Does this specific shot suffer cover? If this is an area attack, who will actually be hit?
+
+And if the player still attempts an illegal target, the answer must remain informational rather than punitive.

--- a/src/pages/caravan/ashen-reliquary-battle.astro
+++ b/src/pages/caravan/ashen-reliquary-battle.astro
@@ -5,7 +5,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <BaseLayout title="灰燼聖匣戰鬥 — 商隊與劍" description="迎戰灰燼騎士、無舌唱詩班與龍燼化身。" lang="zh-TW">
   <main class="battle-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M45 RITUAL COUNTERPLAY</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M56 TACTICAL READABILITY</p>
       <h1 id="battle-title">灰燼聖匣戰鬥</h1>
       <p id="battle-copy">讀取敵方意圖，在輸出、防守、護法與中斷儀式之間做選擇。</p>
       <nav><a href="/caravan/ashen-reliquary">返回灰燼聖匣</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/play">返回主冒險</a></nav>
@@ -42,6 +42,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   import {
     ritualChargeFor, ritualEnemyAct, ritualIntentText,
   } from '@scripts/games/caravan/data/rituals.m45';
+  import { tacticalTargetChoices, tacticalUnitSummary } from '@scripts/games/caravan/data/tacticalReadability.m56';
 
   const titleEl = document.getElementById('battle-title')!;
   const copyEl = document.getElementById('battle-copy')!;
@@ -84,6 +85,10 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${statuses ? `｜${statuses}` : ''}`, 'unit-status'),
     );
 
+    if (combat) {
+      card.append(text('p', tacticalUnitSummary(combat, enemy ? 'enemy' : 'party', unit), 'tactical-position'));
+    }
+
     if (enemy) {
       const weak = (enemy.weaknesses ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       const resist = (enemy.resists ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
@@ -92,7 +97,6 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       if (charging) card.append(text('p', '⚠ 儀式蓄力中：在它下次行動前中斷', 'ritual-warning'));
     } else {
       const member = unit as PartyMember;
-      card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
       if (member.mystic) card.append(text('p', mysticPowerText(member.mystic), `mystic mystic-${member.mystic.kind}`));
     }
     return card;
@@ -138,18 +142,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     return element;
   }
 
-  function targetsFor(move: Move): Array<{ id: string; name: string }> {
-    if (!combat) return [];
-    if (move.target === 'self') return [];
-    if (move.kind === 'attack') {
-      const targets = combat.enemies.filter((enemy) => enemy.hp > 0);
-      if (move.area) return targets.length ? [{ id: targets[0].id, name: '敵方全體' }] : [];
-      return targets.map((target) => ({ id: target.id, name: target.name }));
-    }
-    return combat.party.filter((member) => member.hp > 0).map((target) => ({ id: target.id, name: target.name }));
-  }
-
   function labeledMoveButtons(actor: PartyMember, move: Move, overcast: boolean): HTMLButtonElement[] {
+    if (!combat) return [];
     const availability = partyMoveAvailability(actor, move, { overcast });
     const className = overcast ? 'overcast' : undefined;
     const prefix = overcast ? `禁式過載（反噬 ${availability.backlash}）・` : '';
@@ -162,12 +156,12 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
         availability.reason,
       )];
     }
-    return targetsFor(move).map((target) => button(
-      `${prefix}${move.name} → ${target.name}`,
+    return tacticalTargetChoices(combat, actor, move).map((target) => button(
+      `${prefix}${move.name} → ${target.label}`,
       () => act(actor.id, move.id, target.id, overcast),
       className,
-      !availability.allowed,
-      availability.reason,
+      !availability.allowed || !target.allowed,
+      availability.reason || target.reason,
     ));
   }
 
@@ -200,9 +194,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       : actor.mystic?.kind === 'favor'
         ? '神恩必須先建立再消耗；祝禱可護住隊友，但會犧牲當回合輸出。'
         : '物理職業不消耗魔力；利用盾擊、陷阱、弱點破勢或直接壓血都能處理儀式。';
+    const terrainHint = combat.terrain && combat.terrain.id !== 'open-ground'
+      ? `戰場：${combat.terrain.name}。目標按鈕會標出前後排與這一招實際承受的掩體；灰色後排目標仍看得見，但代表目前被前線擋住。`
+      : '目標按鈕會標出前後排；灰色後排目標仍看得見，但代表目前被前線擋住。';
     actionsEl.append(
       text('h2', `${actor.name}的行動${resource}`),
       text('p', `${baseHint}${ritualAdvice()}`),
+      text('p', terrainHint, 'tactical-hint'),
     );
     const grid = document.createElement('div');
     grid.className = 'action-grid';
@@ -339,12 +337,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .unit p { margin: 5px 0; font-size: 14px; line-height: 1.45; }
   .unit-status { color: #d8c9b4; }
   .affinity { color: #bdb09d; }
-  .formation { color: #a6b7c7; }
+  .tactical-position { color: #a6b7c7; font-weight: 700; }
   .mystic-mana { color: #9cb9ee; }
   .mystic-favor { color: #edd690; }
   .ritual-warning { color: #ffbd68; font-weight: 700; }
   .actions h2, .result h2 { margin: 0 0 8px; }
   .actions > p { color: #cfc0aa; line-height: 1.7; }
+  .actions > .tactical-hint { color: #aebfd0; border-top: 1px solid #34291e; padding-top: 9px; }
   .action-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 9px; }
   button { appearance: none; text-align: left; border: 1px solid #72583b; border-radius: 7px; background: #241b12; color: #eadfc9; padding: 11px 12px; cursor: pointer; line-height: 1.4; }
   button:hover:not(:disabled) { border-color: #d5a85f; background: #302217; }

--- a/src/pages/caravan/convoy-defense.astro
+++ b/src/pages/caravan/convoy-defense.astro
@@ -5,7 +5,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 <BaseLayout title="裂旗商路護運 — 商隊與劍" description="守住馬車、擊潰戰意，或迫使伏兵棄械。" lang="zh-TW">
   <main class="convoy-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M46–M47 OBJECTIVES &amp; MORALE</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M56 TACTICAL READABILITY</p>
       <h1>黑蠟急件｜裂旗商路護運</h1>
       <p>這不是討伐。車夫需要四輪時間拉開裂旗關的鎖鏈；你可以護住貨車、擊潰伏兵，也可以先打碎他們的戰意再喝令棄械。</p>
       <nav><a href="/caravan/play">返回啟程之鎮</a><a href="/caravan/mandates">行會文書</a><a href="/caravan/armory">武裝整備</a><a href="/caravan/endurance">餘燼朝聖</a></nav>
@@ -53,6 +53,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     type MoraleDisposition,
   } from '@scripts/games/caravan/data/convoyMorale.m47';
   import { ritualIntentText } from '@scripts/games/caravan/data/rituals.m45';
+  import { tacticalTargetChoices, tacticalUnitSummary } from '@scripts/games/caravan/data/tacticalReadability.m56';
 
   const noticeEl = document.getElementById('notice')!;
   const objectiveEl = document.getElementById('objective')!;
@@ -95,6 +96,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     const status = (unit.statuses ?? []).map((entry) => `${entry.kind} ${entry.remaining}`).join('、');
     const poise = enemy?.maxPoise !== undefined ? `｜護勢 ${enemy.poise ?? enemy.maxPoise}/${enemy.maxPoise}` : '';
     card.append(text('h3', unit.name), text('p', `HP ${unit.hp}/${unit.maxHp}${poise}${status ? `｜${status}` : ''}`));
+    if (battle) card.append(text('p', tacticalUnitSummary(battle.combat, enemy ? 'enemy' : 'party', unit), 'tactical-position'));
     if (enemy) {
       const weak = (enemy.weaknesses ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
       const resist = (enemy.resists ?? []).map((entry) => ELEMENT_LABELS[entry]).join('、') || '無';
@@ -107,7 +109,6 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       if (enemy.mystic) card.append(text('p', mysticPowerText(enemy.mystic), 'mystic'));
     } else {
       const member = unit as PartyMember;
-      card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
       if (member.mystic) card.append(text('p', mysticPowerText(member.mystic), 'mystic'));
     }
     return card;
@@ -139,16 +140,6 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     partyEl.replaceChildren(...battle.combat.party.map(unitCard));
   }
 
-  function targetsFor(move: Move): Array<{ id: string; name: string }> {
-    if (!battle || move.target === 'self') return [];
-    if (move.kind === 'attack') {
-      const targets = battle.combat.enemies.filter((enemy) => enemy.hp > 0);
-      if (move.area) return targets.length ? [{ id: targets[0].id, name: '敵方全體' }] : [];
-      return targets.map((target) => ({ id: target.id, name: target.name }));
-    }
-    return battle.combat.party.filter((member) => member.hp > 0).map((target) => ({ id: target.id, name: target.name }));
-  }
-
   function act(actorId: string, moveId: string, targetId: string, overcast = false): void {
     if (!battle || !rng || settled || awaitingAftermath) return;
     const result = moraleConvoyPartyAct(rng, battle, actorId, moveId, targetId, { overcast });
@@ -171,17 +162,25 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   }
 
   function moveButtons(actor: PartyMember, move: Move): HTMLButtonElement[] {
+    if (!battle) return [];
     const normal = partyMoveAvailability(actor, move);
-    const make = (targetId: string, targetName: string, overcast: boolean) => {
+    const targets = move.kind === 'guard' || move.target === 'self'
+      ? [{ id: actor.id, label: '', allowed: true, reason: '', targetCount: 1, coverHitModifier: 0 }]
+      : tacticalTargetChoices(battle.combat, actor, move);
+    const make = (target: typeof targets[number], overcast: boolean) => {
       const availability = partyMoveAvailability(actor, move, { overcast });
       const prefix = overcast ? `禁式過載（反噬 ${availability.backlash}）・` : '';
-      return button(`${prefix}${move.name}${targetName ? ` → ${targetName}` : ''}`, () => act(actor.id, move.id, targetId, overcast), overcast ? 'overcast' : '', !availability.allowed, availability.reason);
+      const targetLabel = target.label ? ` → ${target.label}` : '';
+      return button(
+        `${prefix}${move.name}${targetLabel}`,
+        () => act(actor.id, move.id, target.id, overcast),
+        overcast ? 'overcast' : '',
+        !availability.allowed || !target.allowed,
+        availability.reason || target.reason,
+      );
     };
-    const targets = move.kind === 'guard' || move.target === 'self'
-      ? [{ id: actor.id, name: '' }]
-      : targetsFor(move);
-    const buttons = targets.map((target) => make(target.id, target.name, false));
-    if (!normal.allowed && normal.canOvercast) buttons.push(...targets.map((target) => make(target.id, target.name, true)));
+    const buttons = targets.map((target) => make(target, false));
+    if (!normal.allowed && normal.canOvercast) buttons.push(...targets.map((target) => make(target, true)));
     return buttons;
   }
 
@@ -195,6 +194,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     actionsEl.append(
       text('h2', `${actor.name}的行動${actor.mystic ? `｜${mysticPowerText(actor.mystic)}` : ''}`),
       text('p', `護車建立 ${convoyBraceValue(actor)} 點防護；喝止則用魅力嘗試壓垮已動搖的敵人，但會消耗完整一回合，失敗還會提高對方抗拒。`, 'hint'),
+      text('p', '武器目標會標出前後排；灰色後排表示目前被前線保護。喝止與護車仍使用各自的護送／戰意規則，不會被武器射線規則誤判。', 'tactical-hint'),
     );
     const grid = document.createElement('div'); grid.className = 'action-grid';
     grid.append(button(`護住馬車（+${Math.min(convoyBraceValue(actor), Math.max(0, 10 - battle.protection))}）`, () => brace(actor), 'brace'));
@@ -356,7 +356,9 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .unit.down { opacity: .55; }
   .unit.routed { border-style: dashed; border-color: #77705f; }
   .affinity { color: #cfb68c; font-size: .9rem; }
-  .formation, .mystic, .hint { color: #baa98d; font-size: .92rem; }
+  .tactical-position, .mystic, .hint { color: #baa98d; font-size: .92rem; }
+  .tactical-position { color: #9fb4c4; font-weight: 700; }
+  .tactical-hint { color: #9fb4c4; font-size: .9rem; border-top: 1px solid #342a20; padding-top: .55rem; }
   .morale { color: #e0b978; font-size: .92rem; }
   .routed-label { color: #a7b29a; }
   .action-grid { display: flex; flex-wrap: wrap; gap: .55rem; }

--- a/src/pages/caravan/endurance.astro
+++ b/src/pages/caravan/endurance.astro
@@ -9,7 +9,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 >
   <main class="endurance-page">
     <header class="hero">
-      <p class="eyebrow">CARAVAN &amp; SWORD · M43 ARMORY ENDURANCE</p>
+      <p class="eyebrow">CARAVAN &amp; SWORD · M56 TACTICAL READABILITY</p>
       <h1>餘燼朝聖</h1>
       <p>三場戰鬥、兩次營地決策。生命、秘法、神恩、秘法灼傷與出發時的武裝負重不會在戰後自動重置；鋼鐵能保命，也會降低紮營效率並提高強行軍疲勞。</p>
       <nav>
@@ -66,6 +66,7 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     type EnduranceCampChoice,
     type EnduranceRun,
   } from '@scripts/games/caravan/data/enduranceArmory';
+  import { tacticalTargetChoices, tacticalUnitSummary } from '@scripts/games/caravan/data/tacticalReadability.m56';
 
   const RUN_KEY = 'caravan-endurance-armory-v1';
   const noticeEl = document.getElementById('notice')!;
@@ -141,13 +142,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
       text('h3', unit.name),
       text('p', `HP ${Math.max(0, unit.hp)}/${unit.maxHp}${poise}${statuses ? `｜${statuses}` : ''}`, 'unit-status'),
     );
+    if (combat) card.append(text('p', tacticalUnitSummary(combat, enemy ? 'enemy' : 'party', unit), 'tactical-position'));
     if (enemy) {
       const weak = (enemy.weaknesses ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       const resist = (enemy.resists ?? []).map((element) => ELEMENT_LABELS[element]).join('、') || '無';
       card.append(text('p', `弱點：${weak}｜抗性：${resist}`, 'affinity'));
     } else {
       const member = unit as PartyMember & { armoryBurden?: number; armoryCapacity?: number; armoryOverload?: number; armoryWarnings?: string[] };
-      card.append(text('p', member.formationRow === 'back' ? '後排' : '前排', 'formation'));
       card.append(text('p', `武裝負重 ${member.armoryBurden ?? 0}/${member.armoryCapacity ?? 0}${member.armoryOverload ? `｜超載 ${member.armoryOverload}` : ''}`, 'armory'));
       if (member.mystic) card.append(text('p', mysticPowerText(member.mystic), `mystic mystic-${member.mystic.kind}`));
       const costly = (member.armoryWarnings ?? []).filter((warning) => !warning.startsWith('武器熟練'));
@@ -177,30 +178,20 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     for (const entry of combat?.log.slice(-28) ?? []) logEl.append(text('p', entry.text, entry.kind));
   }
 
-  function targetsFor(move: Move): Array<{ id: string; name: string }> {
-    if (!combat) return [];
-    if (move.target === 'self') return [];
-    if (move.kind === 'attack') {
-      const targets = combat.enemies.filter((enemy) => enemy.hp > 0);
-      if (move.area) return targets.length ? [{ id: targets[0].id, name: '敵方全體' }] : [];
-      return targets.map((target) => ({ id: target.id, name: target.name }));
-    }
-    return combat.party.filter((member) => member.hp > 0).map((target) => ({ id: target.id, name: target.name }));
-  }
-
   function moveButtons(actor: PartyMember, move: Move, overcast: boolean): HTMLButtonElement[] {
+    if (!combat) return [];
     const availability = partyMoveAvailability(actor, move, { overcast });
     const prefix = overcast ? `禁式過載（反噬 ${availability.backlash}）・` : '';
     const className = overcast ? 'overcast' : '';
     if (move.kind === 'guard' || move.target === 'self') {
       return [button(`${prefix}${move.name}`, () => act(actor.id, move.id, actor.id, overcast), className, !availability.allowed, availability.reason)];
     }
-    return targetsFor(move).map((target) => button(
-      `${prefix}${move.name} → ${target.name}`,
+    return tacticalTargetChoices(combat, actor, move).map((target) => button(
+      `${prefix}${move.name} → ${target.label}`,
       () => act(actor.id, move.id, target.id, overcast),
       className,
-      !availability.allowed,
-      availability.reason,
+      !availability.allowed || !target.allowed,
+      availability.reason || target.reason,
     ));
   }
 
@@ -212,6 +203,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
     actionsEl.hidden = false;
     actionsEl.append(text('h2', `${actor.name}的行動`));
     if (actor.mystic) actionsEl.append(text('p', mysticPowerText(actor.mystic), 'action-resource'));
+    actionsEl.append(text(
+      'p',
+      combat.terrain && combat.terrain.id !== 'open-ground'
+        ? `戰場：${combat.terrain.name}。灰色後排目標仍會保留在畫面上並說明阻擋原因；可射擊的掩體目標則直接顯示這一招的命中修正。`
+        : '灰色後排目標仍會保留在畫面上並說明阻擋原因；遠程與真正魔法仍會顯示可合法越線的目標。',
+      'tactical-hint',
+    ));
     const grid = document.createElement('div');
     grid.className = 'action-grid';
     for (const move of actor.moves) {
@@ -244,8 +242,8 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
 
   function act(actorId: string, moveId: string, targetId: string, overcast: boolean): void {
     if (!combat || !rng || !run) return;
-    partyAct(rng, combat, actorId, moveId, targetId, { overcast });
-    runEnemyTurns();
+    const result = partyAct(rng, combat, actorId, moveId, targetId, { overcast });
+    if (result.acted) runEnemyTurns();
     persistCurrentBattle();
     settleBattle();
     render();
@@ -459,11 +457,13 @@ import BaseLayout from '@components/layout/BaseLayout.astro';
   .units { display: grid; gap: 10px; }
   .unit { padding: 15px; border: 1px solid #49362d; background: #201613; }
   .unit.down { opacity: .45; }
-  .unit-status { color: #d8b87d !important; } .affinity { color: #c89d88 !important; } .formation { color: #9fb88d !important; }
+  .unit-status { color: #d8b87d !important; } .affinity { color: #c89d88 !important; }
+  .tactical-position { color: #9fb88d !important; font-weight: 700; }
   .armory { color: #d7ad75 !important; } .armory-warning { color: #e18d73 !important; font-size: .86rem; }
   .mystic-mana { color: #8fc3df !important; } .mystic-favor { color: #e7cc75 !important; }
   .actions, .camp, .result, .log-panel { margin-top: 18px; padding: 22px; }
   .action-resource { color: #d8c284 !important; }
+  .tactical-hint { color: #9fb5c8 !important; border-top: 1px solid #3a2b22; padding-top: 9px; }
   .action-grid, .camp-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
   .camp-grid article { display: flex; flex-direction: column; padding: 17px; border: 1px solid #4a382d; background: #211713; }
   .camp-grid button { margin-top: auto; }

--- a/src/scripts/games/caravan/data/tacticalReadability.balance.m56.test.ts
+++ b/src/scripts/games/caravan/data/tacticalReadability.balance.m56.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { tacticalTargetChoices, tacticalUnitSummary } from './tacticalReadability.m56';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 4,
+  d20: () => 12,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const melee: Move = {
+  id: 'm56-balance-melee', name: '劍擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}斬向{target}。',
+};
+const reach: Move = {
+  id: 'm56-balance-reach', name: '長槍', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'pierce', engagement: 'reach',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}刺向{target}。',
+};
+const ranged: Move = {
+  id: 'm56-balance-ranged', name: '弓射', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射向{target}。',
+};
+const spell: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 6, bonusStat: 'int' }, narration: '{actor}施法攻擊{target}。',
+};
+const heal: Move = {
+  id: 'm56-balance-heal', name: '治療', kind: 'support', target: 'ally', hitStat: 'cha',
+  heal: { dice: 1, sides: 6, bonusStat: 'cha' }, narration: '{actor}治療{target}。',
+};
+
+function member(id: string, row: 'front' | 'back', moves: Move[]): PartyMember {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 16, dex: 16, int: 16, cha: 16, con: 14 }, maxHp: 30, hp: 30, defense: 12, moves,
+  };
+}
+
+function enemy(id: string, row: 'front' | 'back'): EnemyUnit {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 12, dex: 12, int: 8, cha: 8, con: 12 }, maxHp: 24, hp: 24, defense: 12,
+    moves: [melee], intents: [{ weight: 1, moveId: melee.id }],
+  };
+}
+
+function state() {
+  return startCombat(
+    rng,
+    [member('sword', 'front', [melee]), member('spear', 'back', [reach]), member('archer', 'back', [ranged]), member('mage', 'back', [spell, heal])],
+    [enemy('front', 'front'), enemy('rear', 'back')],
+    'broken-stone-bridge',
+  );
+}
+
+describe('M56 multidimensional player adversarial review', () => {
+  it('teaches blocked geometry instead of hiding the protected enemy and creating mystery rules', () => {
+    const combat = state();
+    const choices = tacticalTargetChoices(combat, combat.party[0], melee);
+    expect(choices.map((choice) => choice.id)).toEqual(['front', 'rear']);
+    const rear = choices[1];
+    expect(rear.allowed).toBe(false);
+    expect(rear.reason.length).toBeGreaterThan(0);
+    expect(rear.label).toContain('前線保護');
+  });
+
+  it('does not auto-retarget a blocked melee click and secretly spend the player turn on a different enemy', () => {
+    const combat = state();
+    const frontHp = combat.enemies[0].hp;
+    const beforeTurn = combat.turnIndex;
+    const result = partyAct(rng, combat, combat.party[0].id, melee.id, 'rear');
+    expect(result.acted).toBe(false);
+    expect(combat.enemies[0].hp).toBe(frontHp);
+    expect(combat.turnIndex).toBe(beforeTurn);
+  });
+
+  it('preserves distinct physical routes: swords break the screen, reach contributes safely, bows may pressure rear through cover', () => {
+    const combat = state();
+    const swordRear = tacticalTargetChoices(combat, combat.party[0], melee).find((choice) => choice.id === 'rear')!;
+    const spearRear = tacticalTargetChoices(combat, combat.party[1], reach).find((choice) => choice.id === 'rear')!;
+    const bowRear = tacticalTargetChoices(combat, combat.party[2], ranged).find((choice) => choice.id === 'rear')!;
+    expect(swordRear.allowed).toBe(false);
+    expect(spearRear.allowed).toBe(false);
+    expect(bowRear.allowed).toBe(true);
+    expect(bowRear.coverHitModifier).toBe(-1);
+  });
+
+  it('does not make magic look strictly buffed by terrain: it shows no positive bonus, only absence of projectile cover', () => {
+    const combat = state();
+    const magicRear = tacticalTargetChoices(combat, combat.party[3], spell).find((choice) => choice.id === 'rear')!;
+    expect(magicRear.allowed).toBe(true);
+    expect(magicRear.coverHitModifier).toBe(0);
+    expect(magicRear.label).not.toMatch(/\+\d/);
+  });
+
+  it('keeps support readable and available without exposing enemy-line jargon on ally choices', () => {
+    const combat = state();
+    combat.party[0].hp = 9;
+    const choices = tacticalTargetChoices(combat, combat.party[3], heal);
+    expect(choices.some((choice) => choice.label.includes('HP 9/30'))).toBe(true);
+    expect(choices.every((choice) => choice.allowed)).toBe(true);
+    expect(choices.every((choice) => !choice.label.includes('前線保護'))).toBe(true);
+  });
+
+  it('keeps information symmetric so player rear defenses are as legible as enemy rear defenses', () => {
+    const combat = state();
+    const playerRear = tacticalUnitSummary(combat, 'party', combat.party[2]);
+    const enemyRear = tacticalUnitSummary(combat, 'enemy', combat.enemies[1]);
+    expect(playerRear).toContain('後排｜受前線保護｜掩體 -1');
+    expect(enemyRear).toContain('後排｜受前線保護｜掩體 -1');
+  });
+
+  it('does not expose dead units as selectable targets even though their cards may remain visible as battle history', () => {
+    const combat = state();
+    combat.enemies[0].hp = 0;
+    combat.enemies[1].formationRow = 'front';
+    const choices = tacticalTargetChoices(combat, combat.party[2], ranged);
+    expect(choices.map((choice) => choice.id)).toEqual(['rear']);
+  });
+
+  it('updates from runtime truth after formation changes instead of caching stale target legality', () => {
+    const combat = state();
+    const rear = combat.enemies[1];
+    expect(tacticalTargetChoices(combat, combat.party[0], melee).find((choice) => choice.id === rear.id)?.allowed).toBe(false);
+    combat.enemies[0].hp = 0;
+    rear.formationRow = 'front';
+    expect(tacticalTargetChoices(combat, combat.party[0], melee).find((choice) => choice.id === rear.id)?.allowed).toBe(true);
+    expect(tacticalUnitSummary(combat, 'enemy', rear)).toBe('前排｜正面接戰');
+  });
+
+  it('keeps the presentation helper read-only so opening target menus cannot alter HP, rows, resources, or turn order', () => {
+    const combat = state();
+    const before = JSON.stringify(combat);
+    for (const actor of combat.party) {
+      for (const move of actor.moves) tacticalTargetChoices(combat, actor, move);
+      tacticalUnitSummary(combat, 'party', actor);
+    }
+    for (const foe of combat.enemies) tacticalUnitSummary(combat, 'enemy', foe);
+    expect(JSON.stringify(combat)).toBe(before);
+  });
+});

--- a/src/scripts/games/caravan/data/tacticalReadability.integration.m56.test.ts
+++ b/src/scripts/games/caravan/data/tacticalReadability.integration.m56.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  currentActor,
+  partyAct,
+  startCombat,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { tacticalTargetChoices, tacticalUnitSummary } from './tacticalReadability.m56';
+
+const fixedRng: Rng = {
+  next: () => 0,
+  roll: () => 4,
+  d20: () => 12,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const melee: Move = {
+  id: 'm56-live-melee', name: '劍擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}斬中{target}，造成 {amount} 點傷害！',
+};
+const ranged: Move = {
+  id: 'm56-live-ranged', name: '長弓', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射中{target}，造成 {amount} 點傷害！',
+};
+
+function hero(): PartyMember {
+  return {
+    id: 'hero', name: 'hero', formationRow: 'front',
+    stats: { str: 16, dex: 16, int: 10, cha: 10, con: 14 }, maxHp: 30, hp: 30, defense: 12,
+    moves: [melee, ranged],
+  };
+}
+
+function foe(id: string, row: 'front' | 'back', hp = 20): EnemyUnit {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 12, dex: 12, int: 8, cha: 8, con: 12 }, maxHp: hp, hp, defense: 12,
+    moves: [melee], intents: [{ weight: 1, moveId: melee.id }],
+  };
+}
+
+function dedicatedPage(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('M56 live tactical readability integration', () => {
+  it('blocked melee rear click is informational and does not advance the live combat turn', () => {
+    const actor = hero();
+    const state = startCombat(fixedRng, [actor], [foe('screen', 'front'), foe('rear', 'back')]);
+    expect(currentActor(state)).toEqual({ side: 'party', id: actor.id });
+    const beforeTurn = state.turnIndex;
+    const rearChoice = tacticalTargetChoices(state, actor, melee).find((choice) => choice.id === 'rear')!;
+    expect(rearChoice.allowed).toBe(false);
+
+    const result = partyAct(fixedRng, state, actor.id, melee.id, 'rear');
+    expect(result.acted).toBe(false);
+    expect(state.turnIndex).toBe(beforeTurn);
+    expect(currentActor(state)).toEqual({ side: 'party', id: actor.id });
+    expect(state.log.at(-1)?.text).toBe(rearChoice.reason);
+  });
+
+  it('the same protected rear target is legal for ranged and the UI forecast matches real terrain math', () => {
+    const actor = hero();
+    const state = startCombat(fixedRng, [actor], [foe('screen', 'front'), foe('rear', 'back')], 'broken-stone-bridge');
+    const rear = tacticalTargetChoices(state, actor, ranged).find((choice) => choice.id === 'rear')!;
+    expect(rear).toMatchObject({ allowed: true, coverHitModifier: -1 });
+    const result = partyAct(fixedRng, state, actor.id, ranged.id, 'rear');
+    expect(result.acted).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('斷裂石橋') && entry.text.includes('命中 -1'))).toBe(true);
+  });
+
+  it('frontline collapse immediately changes both the card summary and melee target availability', () => {
+    const actor = hero();
+    const front = foe('screen', 'front', 1);
+    const rear = foe('rear', 'back');
+    const state = startCombat(fixedRng, [actor], [front, rear], 'broken-stone-bridge');
+    expect(tacticalUnitSummary(state, 'enemy', rear)).toContain('受前線保護');
+    expect(tacticalTargetChoices(state, actor, melee).find((choice) => choice.id === rear.id)?.allowed).toBe(false);
+
+    partyAct(fixedRng, state, actor.id, melee.id, front.id);
+    expect(front.hp).toBe(0);
+    expect(rear.formationRow).toBe('front');
+    expect(tacticalUnitSummary(state, 'enemy', rear)).toBe('前排｜正面接戰');
+    expect(tacticalTargetChoices(state, actor, melee).find((choice) => choice.id === rear.id)?.allowed).toBe(true);
+  });
+
+  it('all three dedicated high-level battle pages use the shared M56 target source instead of hp-only target helpers', () => {
+    const pages = [
+      'src/pages/caravan/ashen-reliquary-battle.astro',
+      'src/pages/caravan/endurance.astro',
+      'src/pages/caravan/convoy-defense.astro',
+    ];
+    for (const path of pages) {
+      const source = dedicatedPage(path);
+      expect(source, `${path} should import tacticalTargetChoices`).toContain('tacticalTargetChoices');
+      expect(source, `${path} should display tacticalUnitSummary`).toContain('tacticalUnitSummary');
+      expect(source, `${path} should not keep the legacy hp-only targetsFor helper`).not.toContain('function targetsFor(move: Move)');
+    }
+  });
+
+  it('endurance page honors acted:false before allowing enemy turns', () => {
+    const source = dedicatedPage('src/pages/caravan/endurance.astro');
+    expect(source).toContain('const result = partyAct(rng, combat, actorId, moveId, targetId, { overcast });');
+    expect(source).toContain('if (result.acted) runEnemyTurns();');
+    const actBlock = source.slice(source.indexOf('function act(actorId'), source.indexOf('function retreat()', source.indexOf('function act(actorId')));
+    expect(actBlock.indexOf('const result = partyAct')).toBeLessThan(actBlock.indexOf('if (result.acted) runEnemyTurns();'));
+  });
+
+  it('convoy special actions keep their own objective/morale legality instead of being routed through weapon targeting', () => {
+    const source = dedicatedPage('src/pages/caravan/convoy-defense.astro');
+    expect(source).toContain('braceConvoy(rng, battle, actor.id)');
+    expect(source).toContain('commandAvailability(battle, actor, enemy)');
+    expect(source).toContain('commandMorale(rng, battle, actor.id, enemy.id)');
+    expect(source).toContain('tacticalTargetChoices(battle.combat, actor, move)');
+  });
+});

--- a/src/scripts/games/caravan/data/tacticalReadability.m56.test.ts
+++ b/src/scripts/games/caravan/data/tacticalReadability.m56.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { startCombat, type EnemyUnit, type Move, type PartyMember } from '../combat';
+import type { Rng } from '../rng';
+import { tacticalTargetChoices, tacticalUnitSummary } from './tacticalReadability.m56';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 10,
+  d20: () => 10,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const melee: Move = {
+  id: 'm56-melee', name: '劍擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}斬向{target}。',
+};
+const reach: Move = {
+  id: 'm56-reach', name: '長槍刺擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'pierce', engagement: 'reach',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}刺向{target}。',
+};
+const ranged: Move = {
+  id: 'm56-ranged', name: '長弓射擊', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射向{target}。',
+};
+const volley: Move = { ...ranged, id: 'm56-volley', name: '箭雨', area: true };
+const sweep: Move = { ...melee, id: 'm56-sweep', name: '橫掃', area: true };
+const spell: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 1, sides: 6, bonusStat: 'int' }, narration: '{actor}以火球轟擊{target}。',
+};
+const heal: Move = {
+  id: 'm56-heal', name: '治療', kind: 'support', target: 'ally', hitStat: 'cha',
+  heal: { dice: 1, sides: 6, bonusStat: 'cha' }, narration: '{actor}治療{target}。',
+};
+
+function member(id: string, row: 'front' | 'back', moves: Move[]): PartyMember {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 14, dex: 14, int: 14, cha: 14, con: 14 }, maxHp: 30, hp: 30, defense: 12, moves,
+  };
+}
+
+function enemy(id: string, row: 'front' | 'back'): EnemyUnit {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 12, dex: 12, int: 8, cha: 8, con: 12 }, maxHp: 20, hp: 20, defense: 12,
+    moves: [melee], intents: [{ weight: 1, moveId: melee.id }],
+  };
+}
+
+function bridgeState() {
+  return startCombat(
+    rng,
+    [member('front-hero', 'front', [melee, ranged, reach]), member('rear-mage', 'back', [spell, heal])],
+    [enemy('enemy-front', 'front'), enemy('enemy-back', 'back')],
+    'broken-stone-bridge',
+  );
+}
+
+describe('M56 tactical readability source of truth', () => {
+  it('keeps a protected rear enemy visible but disabled for melee with the engine reason', () => {
+    const state = bridgeState();
+    const actor = state.party[0];
+    const choices = tacticalTargetChoices(state, actor, melee);
+    expect(choices).toHaveLength(2);
+    expect(choices[0]).toMatchObject({ id: 'enemy-front', allowed: true });
+    expect(choices[1].id).toBe('enemy-back');
+    expect(choices[1].allowed).toBe(false);
+    expect(choices[1].label).toContain('後排');
+    expect(choices[1].label).toContain('前線保護');
+    expect(choices[1].reason).toMatch(/前線|後排|突破/);
+  });
+
+  it('treats reach like close-combat geometry instead of presenting it as ranged sniping', () => {
+    const state = bridgeState();
+    const choices = tacticalTargetChoices(state, state.party[0], reach);
+    expect(choices.find((choice) => choice.id === 'enemy-back')?.allowed).toBe(false);
+  });
+
+  it('shows ranged rear targeting as legal and previews the exact bridge cover penalty', () => {
+    const state = bridgeState();
+    const rear = tacticalTargetChoices(state, state.party[0], ranged).find((choice) => choice.id === 'enemy-back')!;
+    expect(rear.allowed).toBe(true);
+    expect(rear.coverHitModifier).toBe(-1);
+    expect(rear.label).toContain('掩體 -1');
+  });
+
+  it('lets true spellcraft target the rear without falsely showing a projectile-cover penalty', () => {
+    const state = bridgeState();
+    const mage = state.party[1];
+    const rear = tacticalTargetChoices(state, mage, spell).find((choice) => choice.id === 'enemy-back')!;
+    expect(rear.allowed).toBe(true);
+    expect(rear.coverHitModifier).toBe(0);
+    expect(rear.label).not.toContain('掩體');
+  });
+
+  it('labels physical close-combat AoE as frontline-only instead of claiming to hit every enemy', () => {
+    const state = bridgeState();
+    const [choice] = tacticalTargetChoices(state, state.party[0], sweep);
+    expect(choice.label).toContain('敵方前排全體');
+    expect(choice.targetCount).toBe(1);
+  });
+
+  it('labels ranged AoE with all legal targets and reports covered targets without hiding them', () => {
+    const state = bridgeState();
+    const [choice] = tacticalTargetChoices(state, state.party[0], volley);
+    expect(choice.label).toContain('敵方全體（2）');
+    expect(choice.label).toContain('1 名受掩體影響');
+    expect(choice.targetCount).toBe(2);
+  });
+
+  it('keeps ally support choices alive-only and includes row plus HP instead of enemy geometry', () => {
+    const state = bridgeState();
+    state.party[0].hp = 12;
+    const choices = tacticalTargetChoices(state, state.party[1], heal);
+    expect(choices).toHaveLength(2);
+    expect(choices[0].label).toContain('前排');
+    expect(choices[0].label).toContain('HP 12/30');
+    expect(choices.every((choice) => choice.allowed)).toBe(true);
+  });
+
+  it('summarizes frontline, protected rear, and terrain cover symmetrically for visible cards', () => {
+    const state = bridgeState();
+    expect(tacticalUnitSummary(state, 'enemy', state.enemies[0])).toBe('前排｜正面接戰');
+    expect(tacticalUnitSummary(state, 'enemy', state.enemies[1])).toBe('後排｜受前線保護｜掩體 -1');
+    expect(tacticalUnitSummary(state, 'party', state.party[1])).toBe('後排｜受前線保護｜掩體 -1');
+  });
+
+  it('does not invent cover or mutate combat state while producing labels', () => {
+    const state = startCombat(rng, [member('hero', 'front', [ranged])], [enemy('foe', 'front')]);
+    const before = JSON.stringify(state);
+    const label = tacticalUnitSummary(state, 'enemy', state.enemies[0]);
+    tacticalTargetChoices(state, state.party[0], ranged);
+    expect(label).toBe('前排｜正面接戰');
+    expect(JSON.stringify(state)).toBe(before);
+  });
+});

--- a/src/scripts/games/caravan/data/tacticalReadability.m56.ts
+++ b/src/scripts/games/caravan/data/tacticalReadability.m56.ts
@@ -1,0 +1,134 @@
+import {
+  legalEnemyTargetsForMove,
+  partyTargetAvailability,
+  targetCoverForecast,
+  type CombatState,
+  type CombatantBase,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import { projectileCoverProfile, type BattlefieldSide } from './battlefieldTerrain.m55';
+
+export interface TacticalTargetChoice {
+  id: string;
+  label: string;
+  allowed: boolean;
+  reason: string;
+  targetCount: number;
+  coverHitModifier: number;
+}
+
+function rowLabel(row: CombatantBase & { formationRow?: 'front' | 'back' }): '前排' | '後排' {
+  return row.formationRow === 'back' ? '後排' : '前排';
+}
+
+function livingFrontline(state: CombatState, side: BattlefieldSide): boolean {
+  const units = side === 'party' ? state.party : state.enemies;
+  return units.some((unit) => unit.hp > 0 && unit.formationRow !== 'back');
+}
+
+function coverLabel(modifier: number): string {
+  return modifier <= -2 ? `強掩體 ${modifier}` : `掩體 ${modifier}`;
+}
+
+/**
+ * M56 player information contract for a visible combatant card.
+ * It intentionally describes only rules the engine already enforces; no page should infer rows or cover itself.
+ */
+export function tacticalUnitSummary(
+  state: CombatState,
+  side: BattlefieldSide,
+  unit: CombatantBase & { formationRow?: 'front' | 'back' },
+): string {
+  if (unit.hp <= 0) return '倒下';
+  const row = rowLabel(unit);
+  if (row === '前排') return '前排｜正面接戰';
+
+  const frontlineAlive = livingFrontline(state, side);
+  const cover = projectileCoverProfile(
+    state.terrain,
+    side,
+    unit.formationRow,
+    'ranged',
+    false,
+    frontlineAlive,
+  );
+  const parts = ['後排'];
+  if (frontlineAlive) parts.push('受前線保護');
+  if (cover.applies) parts.push(coverLabel(cover.hitModifier));
+  return parts.join('｜');
+}
+
+function attackTargetLabel(state: CombatState, move: Move, target: CombatState['enemies'][number], allowed: boolean): string {
+  const parts = [rowLabel(target)];
+  const cover = targetCoverForecast(state, move, target);
+  if (!allowed && target.formationRow === 'back') parts.push('前線保護');
+  if (cover.applies) parts.push(coverLabel(cover.hitModifier));
+  return `${target.name}【${parts.join('｜')}】`;
+}
+
+function areaTargetChoice(state: CombatState, move: Move): TacticalTargetChoice[] {
+  const legal = legalEnemyTargetsForMove(state, move);
+  if (legal.length === 0) return [];
+  const alive = state.enemies.filter((enemy) => enemy.hp > 0);
+  const frontlineOnly = legal.length < alive.length && legal.every((enemy) => enemy.formationRow !== 'back');
+  const covered = legal.filter((enemy) => targetCoverForecast(state, move, enemy).applies);
+  const coverText = covered.length > 0 ? `｜${covered.length} 名受掩體影響` : '';
+  return [{
+    id: legal[0].id,
+    label: `${frontlineOnly ? '敵方前排全體' : '敵方全體'}（${legal.length}）${coverText}`,
+    allowed: true,
+    reason: '',
+    targetCount: legal.length,
+    coverHitModifier: covered.length > 0
+      ? Math.min(...covered.map((enemy) => targetCoverForecast(state, move, enemy).hitModifier))
+      : 0,
+  }];
+}
+
+/**
+ * The reusable M56 UI source of truth.
+ * - blocked rear targets remain visible but disabled, so the player can understand *why* they cannot be selected;
+ * - ranged / mystic attacks expose the legal rear option;
+ * - area actions report the exact engine target set rather than pretending every AoE hits every rank;
+ * - ally/self actions remain compatible with the original combat loop.
+ */
+export function tacticalTargetChoices(
+  state: CombatState,
+  actor: PartyMember,
+  move: Move,
+): TacticalTargetChoice[] {
+  if (move.target === 'self' || move.kind === 'guard') {
+    return [{ id: actor.id, label: actor.name, allowed: true, reason: '', targetCount: 1, coverHitModifier: 0 }];
+  }
+
+  if (move.target === 'ally') {
+    return state.party
+      .filter((member) => member.hp > 0)
+      .map((member) => ({
+        id: member.id,
+        label: `${member.name}【${rowLabel(member)}｜HP ${member.hp}/${member.maxHp}】`,
+        allowed: true,
+        reason: '',
+        targetCount: 1,
+        coverHitModifier: 0,
+      }));
+  }
+
+  if (move.kind === 'attack' && move.area) return areaTargetChoice(state, move);
+
+  return state.enemies
+    .filter((enemy) => enemy.hp > 0)
+    .map((enemy) => {
+      const availability = partyTargetAvailability(state, actor, move, enemy);
+      const cover = targetCoverForecast(state, move, enemy);
+      return {
+        id: enemy.id,
+        label: attackTargetLabel(state, move, enemy, availability.allowed),
+        allowed: availability.allowed,
+        reason: availability.reason,
+        targetCount: 1,
+        coverHitModifier: cover.hitModifier,
+      };
+    });
+}


### PR DESCRIPTION
## Stacked dependency

Draft stacked on #255 / `agent/caravan-m55-battlefield-cover`. No merge is requested.

## Summary

M56 turns the M49–M55 combat rules into a player-visible information contract instead of making players learn legal targeting by failed clicks.

The engine already knows enemy rows, frontline screening, legal targets, range bands and projectile cover. Before M56, the three dedicated high-level battle pages independently treated every living enemy as a normal attack target. M56 adds one reusable, read-only presentation adapter so pages no longer duplicate combat math.

### Shared tactical presentation source
`data/tacticalReadability.m56.ts` exposes:
- `tacticalUnitSummary()` — front/rear, frontline protection and active rear cover for visible cards
- `tacticalTargetChoices()` — every visible target, exact allowed/blocked state, engine blocker reason, actual area target count and current move-specific cover modifier

It delegates to the existing engine truth (`partyTargetAvailability`, `legalEnemyTargetsForMove`, `targetCoverForecast`) and does not mutate combat state.

### Honest target choices
- every living enemy remains visible
- protected rear targets are **disabled rather than hidden** for melee/reach
- the disabled choice carries the engine's exact reason
- ranged/mystic rear targets remain selectable when legal
- physical ranged choices show current cover, e.g. `後排｜掩體 -1`
- true spellcraft does not falsely display projectile cover or a positive terrain bonus
- close-combat AoE reports `敵方前排全體` when the screen blocks rear ranks instead of claiming to hit everyone
- ranged/mystic area actions report the real engine target set

### Unit cards
`ashen-reliquary-battle.astro`, `endurance.astro` and `convoy-defense.astro` now show the same tactical vocabulary for both armies:
- `前排｜正面接戰`
- `後排｜受前線保護`
- `後排｜受前線保護｜掩體 -1`
- `倒下`

The summary is recomputed from runtime state, so a rear unit promoted after frontline collapse immediately becomes a frontline target in both UI and resolver.

### Endurance fairness bug fixed
M54 promised that an illegal protected-rear click returns `acted:false` and does not spend the turn.

The endurance page previously called `runEnemyTurns()` unconditionally after `partyAct()`, so an illegal click could still give the enemy a free response despite the engine not advancing the player turn.

M56 now checks `result.acted` before running enemy turns. The page still persists/re-renders so the blocker message remains visible. Live integration tests assert the turn index and current actor do not move on the blocked action.

### Convoy objective rules remain distinct
M46–M47 special actions are intentionally not forced through weapon targeting:
- `護住馬車` keeps convoy protection rules
- `喝止` keeps morale/Charisma/defiance rules
- only weapon/spell actions use M56 tactical target choices

## Multidimensional player adversarial review

Dedicated tests attack:
1. blocked rear enemies being hidden and creating mystery rules
2. illegal target clicks advancing turns
3. silent auto-retargeting onto a frontline enemy
4. reach being presented like ranged sniping
5. bows losing their legal covered-rear route
6. magic receiving fake positive terrain bonuses
7. area labels disagreeing with the actual resolver target set
8. ally support being polluted by enemy-line rules
9. enemy/player tactical information asymmetry
10. dead units remaining selectable
11. stale labels after frontline collapse
12. target-menu reads mutating combat state
13. dedicated pages drifting back to hp-only target helpers
14. convoy special actions being incorrectly routed through weapon geometry

## Scope safety

The main `play.astro` still contains the same historical target-selection debt, but it is a very large single file containing town, market, roster, expedition, events, trade and battle UI. The current GitHub connector only supports whole-file replacement, so M56 deliberately does **not** risk rewriting the entire main game page for a small target-UI patch.

M56 establishes the shared API specifically so a later patch-capable/local UI pass can wire `play.astro` without duplicating any M54/M55 rule. This PR does not claim the main page is already fixed.

## Scope diff

Relative to validated M55 head `7803b0f3147c660fa939843f703cab4bf5b422bd`, M56 is ahead by 9 commits / behind by 0 and changes exactly 9 files:
- M56 shared tactical presentation helper
- M56 rule/integration/adversarial tests
- three dedicated high-level combat pages
- M56 CI workflow
- M56 design document

No save schema, economy, progression, encounter stats, weapon numbers or combat balance values are changed.

## Validation

Validated M56 head: `5366363dd30d5b7838d5bf92997af5ce579a719c`.

At this exact head **19/19 Caravan GitHub Actions workflows passed**:
- production build
- M56 tactical presentation rules
- M56 live + dedicated-page integration
- M56 multidimensional player adversarial review
- M55 battlefield cover
- M54 enemy formation
- M53 reach/polearms
- M52 shields/handedness
- M51 veteran mastery/reposition
- M49–M50 formation/readability
- core combat + M41 magic
- M40 live Reliquary combat
- M42 endurance/composition diversity including broad anti-guarantee windows
- M43 armory/endurance
- M44 spellcraft
- M45 ritual counterplay
- M46 convoy objective
- M47 morale
- M48 armor lifecycle/review

PR remains Draft/open/mergeable. No merge requested.

See `docs/caravan-m56-tactical-readability.md` for design rationale, player-information contract and rejected alternatives.