### PR TITLE
feat(caravan): add M57 battlefield line of effect

### DIFF
--- a/.github/workflows/caravan-m57-ci.yml
+++ b/.github/workflows/caravan-m57-ci.yml
@@ -1,0 +1,144 @@
+name: Caravan M57 Line of Effect CI
+
+on:
+  pull_request:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m57-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    paths:
+      - 'src/scripts/games/caravan/**'
+      - 'src/pages/caravan/**'
+      - '.github/workflows/caravan-m57-ci.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  build-and-player-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+
+      - name: Production build
+        run: npm run build
+
+      - name: M57 attack delivery and line-of-effect rules
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.test.ts
+
+      - name: M57 live Split Banner integration
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldLineOfEffect.integration.m57.test.ts
+
+      - name: M57 multidimensional player adversarial review
+        run: npx vitest run --reporter=verbose src/scripts/games/caravan/data/battlefieldLineOfEffect.balance.m57.test.ts
+
+      - name: M56 tactical readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/tacticalReadability.m56.test.ts
+          src/scripts/games/caravan/data/tacticalReadability.integration.m56.test.ts
+          src/scripts/games/caravan/data/tacticalReadability.balance.m56.test.ts
+
+      - name: M55 battlefield cover regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/battlefieldTerrain.m55.test.ts
+          src/scripts/games/caravan/data/battlefieldTerrain.integration.m55.test.ts
+          src/scripts/games/caravan/data/battlefieldTerrain.balance.m55.test.ts
+
+      - name: M54 enemy formation regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/enemyFormation.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.integration.m54.test.ts
+          src/scripts/games/caravan/data/enemyFormation.balance.m54.test.ts
+
+      - name: M53 reach and polearm regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/reachPolearms.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.integration.m53.test.ts
+          src/scripts/games/caravan/data/reachPolearms.balance.m53.test.ts
+
+      - name: M52 shield and handedness regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/offhandShields.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.integration.m52.test.ts
+          src/scripts/games/caravan/data/offhandShields.balance.m52.test.ts
+          src/scripts/games/caravan/data/shieldSemantics.m52.test.ts
+
+      - name: M51 veteran mastery regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/veteranMastery.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.integration.m51.test.ts
+          src/scripts/games/caravan/data/veteranMastery.balance.m51.test.ts
+
+      - name: M49-M50 formation and readability regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/martialEngagement.m49.test.ts
+          src/scripts/games/caravan/data/martialEngagement.balance.m49.test.ts
+          src/scripts/games/caravan/data/medievalTone.m49.test.ts
+          src/scripts/games/caravan/data/combatReadability.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.integration.m50.test.ts
+          src/scripts/games/caravan/data/combatReadability.balance.m50.test.ts
+
+      - name: Core combat and M41 magic regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/combat.test.ts
+          src/scripts/games/caravan/data/arcana.m41.test.ts
+
+      - name: M40 live Reliquary combat regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/ashenReliquaryCombat.m40.test.ts
+          src/scripts/games/caravan/data/ashenReliquaryAttempts.m40.test.ts
+
+      - name: M42 endurance and composition diversity regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/endurance.m42.test.ts
+          src/scripts/games/caravan/data/endurance.balance.m42.test.ts
+
+      - name: M43 armory and endurance regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armory.m43.test.ts
+          src/scripts/games/caravan/data/enduranceArmory.m43.test.ts
+          src/scripts/games/caravan/data/armory.balance.m43.test.ts
+
+      - name: M44 spellcraft counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/spellcraft.m44.test.ts
+          src/scripts/games/caravan/data/spellcraft.balance.m44.test.ts
+
+      - name: M45 ritual counterplay regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/rituals.m45.test.ts
+          src/scripts/games/caravan/data/rituals.balance.m45.test.ts
+
+      - name: M46 convoy and M47 morale regression
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/convoyDefense.m46.test.ts
+          src/scripts/games/caravan/data/convoyDefense.balance.m46.test.ts
+          src/scripts/games/caravan/data/convoyMorale.m47.test.ts
+          src/scripts/games/caravan/data/convoyMorale.balance.m47.test.ts
+
+      - name: M48 armor lifecycle and multidimensional review
+        run: >-
+          npx vitest run --reporter=verbose
+          src/scripts/games/caravan/data/armorProfiles.m48.test.ts
+          src/scripts/games/caravan/data/armorProfiles.balance.m48.test.ts

--- a/src/scripts/games/caravan/combat.ts
+++ b/src/scripts/games/caravan/combat.ts
@@ -34,6 +34,12 @@ import {
   type BattlefieldSide,
   type ProjectileCoverProfile,
 } from './data/battlefieldTerrain.m55';
+import {
+  attackDeliveryForMove,
+  lineOfEffectProfile,
+  type AttackDelivery,
+  type LineOfEffectProfile,
+} from './data/battlefieldLineOfEffect.m57';
 
 export interface Move {
   id: string; name: string;
@@ -48,6 +54,8 @@ export interface Move {
   armorPiercing?: number;
   /** M49：可覆寫自動判定的交戰距離；真正魔法仍由 arcana 規則優先判定。 */
   engagement?: EngagementBand;
+  /** M57：招式如何到達目標。未標時依近戰／遠程／魔法語意保守推導。 */
+  delivery?: AttackDelivery;
   /** M51：老兵橫向戰術——花完整一回合切換前後排。 */
   formationShift?: 'toggle';
   damage?: { dice: number; sides: number; bonusStat?: Stat };
@@ -139,7 +147,7 @@ export interface CombatState {
   party: PartyMember[]; enemies: EnemyUnit[];
   guarding: Record<string, boolean>;
   enemyIntents: Record<string, string>;
-  /** M55：本場地形只存在戰鬥 runtime；未設定即沿用舊版開闊戰場。 */
+  /** M55/M57：本場地形與作用線只存在戰鬥 runtime；未設定即沿用舊版開闊戰場。 */
   terrain?: BattlefieldTerrain;
   log: CombatEvent[];
   outcome: 'ongoing' | 'victory' | 'defeat' | 'retreated';
@@ -220,7 +228,7 @@ export function startCombat(
   const enemyBack = enemies.filter((enemy) => enemy.hp > 0 && enemy.formationRow === 'back').map((enemy) => enemy.name);
   state.log.push({
     kind: 'info',
-    text: `敵陣：前排 ${enemyFront.join('、') || '無'}｜後排 ${enemyBack.join('、') || '無'}。近戰與長柄必須先突破前線；遠程與真正魔法可以越線。`,
+    text: `敵陣：前排 ${enemyFront.join('、') || '無'}｜後排 ${enemyBack.join('、') || '無'}。近戰、長柄與貼身法術必須先突破前線；直線遠程／法術可越線但仍受實體作用線遮蔽；明確越頂招式可跨越遮蔽。`,
   });
   if (enemyFormation.promoted.length > 0) {
     state.log.push({ kind: 'info', text: '敵軍沒有可掩護後排的前線單位，所有敵人被迫暴露在近身接戰線。' });
@@ -451,6 +459,27 @@ export function targetCoverForecast(
   const isMystic = !!mysticRuleForMove(move);
   const engagement = engagementForMove(move, isMystic);
   return projectileCoverProfile(state.terrain, side, row, engagement, isMystic, frontlineAlive);
+}
+
+function emptyLineOfEffectProfile(move: Move): LineOfEffectProfile {
+  const delivery = attackDeliveryForMove(move);
+  return { delivery, bypassesFrontline: move.kind === 'attack' && delivery !== 'contact', blocked: false, message: '' };
+}
+
+/** M57：UI、玩家行動與敵方 AI 共用同一份「直線作用線是否被實體遮蔽物切斷」真相。 */
+export function targetLineOfEffectForecast(
+  state: CombatState,
+  move: Move,
+  target: CombatantBase,
+): LineOfEffectProfile {
+  if (move.kind !== 'attack') return emptyLineOfEffectProfile(move);
+  const partyTarget = state.party.find((member) => member.id === target.id);
+  const enemyTarget = state.enemies.find((enemy) => enemy.id === target.id);
+  if (!partyTarget && !enemyTarget) return emptyLineOfEffectProfile(move);
+  const row = partyTarget?.formationRow ?? enemyTarget?.formationRow;
+  const sideUnits = partyTarget ? state.party : state.enemies;
+  const frontlineAlive = sideUnits.some((unit) => unit.hp > 0 && unit.formationRow !== 'back');
+  return lineOfEffectProfile(state.terrain, row, frontlineAlive, move);
 }
 
 function performMove(
@@ -721,7 +750,7 @@ function chooseEnemyIntent(rng: Rng, enemy: EnemyUnit): string {
 }
 
 export function legalEnemyTargetsForMove(state: CombatState, move: Move): EnemyUnit[] {
-  return legalEnemyTargets(state.enemies, move);
+  return legalEnemyTargets(state.enemies, move, state.terrain);
 }
 
 export function partyTargetAvailability(
@@ -743,7 +772,7 @@ export function partyTargetAvailability(
   }
   const enemy = state.enemies.find((candidate) => candidate.id === target.id && candidate.hp > 0);
   if (!enemy) return { allowed: false, reason: '這個招式不能指定該目標。' };
-  const gate = enemyLineGate(state.enemies, move, enemy);
+  const gate = enemyLineGate(state.enemies, move, enemy, state.terrain);
   return { allowed: gate.allowed, reason: gate.reason };
 }
 
@@ -801,9 +830,13 @@ export function partyAct(
 
 function partyTargetsForEnemyMove(state: CombatState, move: Move): PartyMember[] {
   const alive = state.party.filter((member) => member.hp > 0);
-  if (alive.length === 0 || enemyCanBypassPartyFront(move)) return alive;
+  if (alive.length === 0) return alive;
   const front = alive.filter((member) => member.formationRow !== 'back');
-  return front.length > 0 ? front : alive;
+  if (front.length === 0) return alive;
+  if (!enemyCanBypassPartyFront(move)) return front;
+  return alive.filter((member) => (
+    member.formationRow !== 'back' || !targetLineOfEffectForecast(state, move, member).blocked
+  ));
 }
 
 export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
@@ -861,7 +894,12 @@ export function enemyAct(rng: Rng, state: CombatState, enemyId: string): void {
     const targetPool = partyTargetsForEnemyMove(state, move);
     if (targetPool.length === 0) return;
     target = targetPool.reduce((low, p) => (p.hp < low.hp ? p : low), targetPool[0]);
-    if (move.kind === 'attack' && !move.area && !state.guarding[target.id]) {
+    if (
+      move.kind === 'attack'
+      && !move.area
+      && attackDeliveryForMove(move) !== 'overhead'
+      && !state.guarding[target.id]
+    ) {
       const guardian = state.order
         .map((id) => state.party.find((member) => member.id === id))
         .find((member) => member && member.hp > 0 && state.guarding[member.id] && canGuardIntercept(member.formationRow));

--- a/src/scripts/games/caravan/data/battlefieldLineOfEffect.balance.m57.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldLineOfEffect.balance.m57.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  legalEnemyTargetsForMove,
+  partyTargetAvailability,
+  startCombat,
+  targetCoverForecast,
+  targetLineOfEffectForecast,
+  type EnemyUnit,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { createConvoyDefenseEncounter, convoyBraceValue } from './convoyDefense.m46';
+import { tacticalTargetChoices } from './tacticalReadability.m56';
+import { attackDeliveryForMove } from './battlefieldLineOfEffect.m57';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 4,
+  d20: () => 12,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const melee: Move = {
+  id: 'm57-review-melee', name: '武器斬擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 8, bonusStat: 'str' }, narration: '{actor}攻擊{target}。',
+};
+const reach: Move = {
+  id: 'm57-review-reach', name: '長槍', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'pierce', engagement: 'reach',
+  damage: { dice: 1, sides: 8, bonusStat: 'str' }, narration: '{actor}刺向{target}。',
+};
+const bow: Move = {
+  id: 'm57-review-bow', name: '長弓', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 8, bonusStat: 'dex' }, narration: '{actor}射向{target}。',
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 2, sides: 6, bonusStat: 'int' }, narration: '{actor}轟擊{target}。',
+};
+const arrowStorm: Move = {
+  ...bow, id: 'arrow-storm', name: '驟雨連射', area: true, damage: { dice: 1, sides: 4, bonusStat: 'dex' },
+};
+const meteor: Move = {
+  ...fireball, id: 'meteor-fall', name: '隕石墜', area: true,
+};
+const heal: Move = {
+  id: 'm57-review-heal', name: '治療', kind: 'support', target: 'ally', hitStat: 'cha',
+  heal: { dice: 1, sides: 8, bonusStat: 'cha' }, narration: '{actor}治療{target}。',
+};
+
+function member(id: string, row: 'front' | 'back', moves: Move[]): PartyMember {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 16, dex: 16, int: 16, cha: 14, con: 16 },
+    maxHp: 30, hp: 30, defense: 13, moves,
+  };
+}
+
+function enemy(id: string, row: 'front' | 'back'): EnemyUnit {
+  return {
+    id, name: id, formationRow: row,
+    stats: { str: 12, dex: 12, int: 10, cha: 10, con: 12 },
+    maxHp: 20, hp: 20, defense: 12,
+    moves: [melee], intents: [{ weight: 1, moveId: melee.id }],
+  };
+}
+
+function battlementState() {
+  return startCombat(
+    rng,
+    [member('fighter', 'front', [melee, reach]), member('archer', 'back', [bow, arrowStorm]), member('mage', 'back', [fireball, meteor, heal])],
+    createConvoyDefenseEncounter(),
+  );
+}
+
+describe('M57 multidimensional player-perspective adversarial review', () => {
+  it('does not make an overhead-capable class mandatory because every build still has legal frontline targets', () => {
+    const state = battlementState();
+    for (const [actorId, moveId] of [['fighter', melee.id], ['fighter', reach.id], ['archer', bow.id], ['mage', fireball.id]] as const) {
+      const actor = state.party.find((member) => member.id === actorId)!;
+      const move = actor.moves.find((entry) => entry.id === moveId)!;
+      expect(legalEnemyTargetsForMove(state, move).length, `${actorId}/${moveId} must retain a legal route`).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the physical martial solution explicit: break the screen rather than requiring spellcraft', () => {
+    const state = battlementState();
+    const fighter = state.party.find((member) => member.id === 'fighter')!;
+    const frontIds = state.enemies.filter((enemy) => enemy.formationRow !== 'back').map((enemy) => enemy.id);
+    expect(legalEnemyTargetsForMove(state, fighter.moves.find((move) => move.id === melee.id)! ).map((enemy) => enemy.id)).toEqual(frontIds);
+    expect(legalEnemyTargetsForMove(state, fighter.moves.find((move) => move.id === reach.id)! ).map((enemy) => enemy.id)).toEqual(frontIds);
+  });
+
+  it('does not let ordinary magic become a universal wall key', () => {
+    const state = battlementState();
+    const mage = state.party.find((member) => member.id === 'mage')!;
+    const spell = mage.moves.find((move) => move.id === fireball.id)!;
+    const rear = state.enemies.find((enemy) => enemy.formationRow === 'back')!;
+    expect(partyTargetAvailability(state, mage, spell, rear).allowed).toBe(false);
+    expect(targetLineOfEffectForecast(state, spell, rear).blocked).toBe(true);
+  });
+
+  it('does not let overhead delivery become a hidden positive accuracy or damage modifier', () => {
+    expect(attackDeliveryForMove(arrowStorm)).toBe('overhead');
+    expect(attackDeliveryForMove(meteor)).toBe('overhead');
+    expect(arrowStorm.hitBonus ?? 0).toBe(0);
+    expect(meteor.hitBonus ?? 0).toBe(0);
+    expect(arrowStorm.damage).toEqual({ dice: 1, sides: 4, bonusStat: 'dex' });
+    expect(meteor.damage).toEqual(fireball.damage);
+  });
+
+  it('keeps physical overhead and mystical overhead tactically distinct through M55 cover', () => {
+    const state = battlementState();
+    const rear = state.enemies.find((enemy) => enemy.formationRow === 'back')!;
+    const archer = state.party.find((member) => member.id === 'archer')!;
+    const mage = state.party.find((member) => member.id === 'mage')!;
+    const storm = archer.moves.find((move) => move.id === arrowStorm.id)!;
+    const fall = mage.moves.find((move) => move.id === meteor.id)!;
+    expect(targetCoverForecast(state, storm, rear).hitModifier).toBe(-2);
+    expect(targetCoverForecast(state, fall, rear).hitModifier).toBe(0);
+  });
+
+  it('keeps the convoy objective route alive even when a party ignores rear sniping entirely', () => {
+    const state = battlementState();
+    const fighter = state.party.find((member) => member.id === 'fighter')!;
+    expect(convoyBraceValue(fighter)).toBeGreaterThanOrEqual(3);
+    expect(convoyBraceValue(fighter)).toBeLessThanOrEqual(7);
+  });
+
+  it('does not pollute ally support with hostile line-of-effect restrictions', () => {
+    const state = battlementState();
+    const mage = state.party.find((member) => member.id === 'mage')!;
+    const liveHeal = mage.moves.find((move) => move.id === heal.id)!;
+    const choices = tacticalTargetChoices(state, mage, liveHeal);
+    expect(choices).toHaveLength(state.party.length);
+    expect(choices.every((choice) => choice.allowed)).toBe(true);
+    expect(choices.every((choice) => !choice.label.includes('實體遮蔽'))).toBe(true);
+  });
+
+  it('keeps open-ground legacy encounters unchanged', () => {
+    const state = startCombat(rng, [member('hero', 'front', [bow, fireball])], [enemy('front', 'front'), enemy('rear', 'back')], 'open-ground');
+    const hero = state.party[0];
+    const liveBow = hero.moves.find((move) => move.id === bow.id)!;
+    const liveFireball = hero.moves.find((move) => move.id === fireball.id)!;
+    expect(legalEnemyTargetsForMove(state, liveBow)).toHaveLength(2);
+    expect(legalEnemyTargetsForMove(state, liveFireball)).toHaveLength(2);
+  });
+
+  it('keeps the M55 broken bridge as cover rather than silently upgrading it into a wall', () => {
+    const state = startCombat(rng, [member('hero', 'front', [bow, fireball])], [enemy('front', 'front'), enemy('rear', 'back')], 'broken-stone-bridge');
+    const hero = state.party[0];
+    const rear = state.enemies.find((entry) => entry.id === 'rear')!;
+    const liveBow = hero.moves.find((move) => move.id === bow.id)!;
+    const liveFireball = hero.moves.find((move) => move.id === fireball.id)!;
+    expect(partyTargetAvailability(state, hero, liveBow, rear).allowed).toBe(true);
+    expect(targetCoverForecast(state, liveBow, rear).hitModifier).toBe(-1);
+    expect(partyTargetAvailability(state, hero, liveFireball, rear).allowed).toBe(true);
+  });
+
+  it('keeps target forecasting read-only instead of changing rows, HP, mana or terrain', () => {
+    const state = battlementState();
+    const mage = state.party.find((member) => member.id === 'mage')!;
+    const liveFireball = mage.moves.find((move) => move.id === fireball.id)!;
+    const rear = state.enemies.find((enemy) => enemy.formationRow === 'back')!;
+    const before = JSON.stringify(state);
+    targetLineOfEffectForecast(state, liveFireball, rear);
+    tacticalTargetChoices(state, mage, liveFireball);
+    expect(JSON.stringify(state)).toBe(before);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldLineOfEffect.integration.m57.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldLineOfEffect.integration.m57.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  enemyAct,
+  legalEnemyTargetsForMove,
+  partyAct,
+  partyTargetAvailability,
+  startCombat,
+  targetCoverForecast,
+  type Move,
+  type PartyMember,
+} from '../combat';
+import type { Rng } from '../rng';
+import { collapseEnemyFrontLine } from './enemyFormation.m54';
+import { createConvoyDefenseEncounter } from './convoyDefense.m46';
+import { tacticalTargetChoices, tacticalUnitSummary } from './tacticalReadability.m56';
+
+const rng: Rng = {
+  next: () => 0,
+  roll: () => 4,
+  d20: () => 20,
+  pick: (items) => items[0],
+  weightedPick: (items) => items.find((item) => item.weight > 0)!.value,
+};
+
+const sword: Move = {
+  id: 'm57-sword', name: '長劍', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}斬向{target}。',
+};
+const bow: Move = {
+  id: 'm57-bow', name: '長弓', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射向{target}。',
+};
+const arrowStorm: Move = {
+  ...bow, id: 'arrow-storm', name: '驟雨連射', area: true, damage: { dice: 1, sides: 4, bonusStat: 'dex' },
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 2, sides: 6, bonusStat: 'int' }, narration: '{actor}擲出火球轟向{target}。',
+};
+const meteor: Move = {
+  ...fireball, id: 'meteor-fall', name: '隕石墜', area: true,
+};
+const lamentTouch: Move = {
+  id: 'reliquary-lament-touch', name: '哀歌觸碰', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'frost',
+  damage: { dice: 1, sides: 7, bonusStat: 'int' }, narration: '{actor}觸碰{target}。',
+};
+
+function member(id: string, row: 'front' | 'back', moves: Move[], hp = 30): PartyMember {
+  return {
+    id,
+    name: id,
+    formationRow: row,
+    stats: { str: 16, dex: 16, int: 16, cha: 12, con: 14 },
+    maxHp: 30,
+    hp,
+    defense: 12,
+    moves,
+  };
+}
+
+function convoyState() {
+  return startCombat(
+    rng,
+    [
+      member('front-sword', 'front', [sword], 30),
+      member('rear-ranger', 'back', [bow, arrowStorm], 8),
+      member('rear-mage', 'back', [fireball, meteor, lamentTouch], 6),
+    ],
+    createConvoyDefenseEncounter(),
+  );
+}
+
+describe('M57 live line-of-effect integration at Split Banner Pass', () => {
+  it('authors ruined battlements and keeps the arsonist behind a real frontline', () => {
+    const state = convoyState();
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    expect(state.terrain?.id).toBe('ruined-battlements');
+    expect(arsonist.formationRow).toBe('back');
+    expect(tacticalUnitSummary(state, 'enemy', arsonist)).toContain('實體遮蔽');
+    expect(state.enemies.filter((enemy) => enemy.hp > 0 && enemy.formationRow !== 'back')).toHaveLength(2);
+  });
+
+  it('blocks both a direct bow shot and a direct fireball from sniping the protected rear caster', () => {
+    const state = convoyState();
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    const ranger = state.party.find((member) => member.id === 'rear-ranger')!;
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const liveBow = ranger.moves.find((move) => move.id === bow.id)!;
+    const liveFireball = mage.moves.find((move) => move.id === fireball.id)!;
+    expect(partyTargetAvailability(state, ranger, liveBow, arsonist).allowed).toBe(false);
+    expect(partyTargetAvailability(state, mage, liveFireball, arsonist).allowed).toBe(false);
+    const bowChoice = tacticalTargetChoices(state, ranger, liveBow).find((choice) => choice.id === arsonist.id)!;
+    const fireChoice = tacticalTargetChoices(state, mage, liveFireball).find((choice) => choice.id === arsonist.id)!;
+    expect(bowChoice.label).toContain('實體遮蔽');
+    expect(fireChoice.label).toContain('實體遮蔽');
+    expect(fireChoice.label).not.toContain('掩體 -2');
+  });
+
+  it('rejects a blocked spell before spending either the turn or mana', () => {
+    const state = convoyState();
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    const liveFireball = mage.moves.find((move) => move.id === fireball.id)!;
+    const beforeTurn = state.turnIndex;
+    const beforeMana = mage.mystic!.current;
+    const beforeHp = arsonist.hp;
+    const result = partyAct(rng, state, mage.id, liveFireball.id, arsonist.id);
+    expect(result.acted).toBe(false);
+    expect(result.reason).toMatch(/直線作用線|實體|越頂|突破/);
+    expect(state.turnIndex).toBe(beforeTurn);
+    expect(mage.mystic!.current).toBe(beforeMana);
+    expect(arsonist.hp).toBe(beforeHp);
+  });
+
+  it('lets Arrow Storm go overhead but still applies the enemy strong-cover penalty per rear target', () => {
+    const state = convoyState();
+    const ranger = state.party.find((member) => member.id === 'rear-ranger')!;
+    const liveStorm = ranger.moves.find((move) => move.id === arrowStorm.id)!;
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    expect(legalEnemyTargetsForMove(state, liveStorm).map((enemy) => enemy.id)).toContain(arsonist.id);
+    expect(targetCoverForecast(state, liveStorm, arsonist).hitModifier).toBe(-2);
+    const [choice] = tacticalTargetChoices(state, ranger, liveStorm);
+    expect(choice.label).toContain('越頂');
+    expect(choice.label).toContain('受掩體影響');
+    expect(choice.coverHitModifier).toBe(-2);
+  });
+
+  it('lets Meteor Fall go overhead without inventing a magical cover bonus or penalty', () => {
+    const state = convoyState();
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const liveMeteor = mage.moves.find((move) => move.id === meteor.id)!;
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    expect(legalEnemyTargetsForMove(state, liveMeteor).map((enemy) => enemy.id)).toContain(arsonist.id);
+    expect(targetCoverForecast(state, liveMeteor, arsonist).hitModifier).toBe(0);
+    const [choice] = tacticalTargetChoices(state, mage, liveMeteor);
+    expect(choice.label).toContain('越頂');
+    expect(choice.coverHitModifier).toBe(0);
+  });
+
+  it('treats the pre-M57 Lament Touch as contact magic that cannot bypass a living screen', () => {
+    const state = convoyState();
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const touch = mage.moves.find((move) => move.id === lamentTouch.id)!;
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    const availability = partyTargetAvailability(state, mage, touch, arsonist);
+    expect(availability.allowed).toBe(false);
+    expect(availability.reason).toMatch(/貼身|前排|突破/);
+  });
+
+  it('removes the rear obstruction once the enemy frontline is actually gone', () => {
+    const state = convoyState();
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    for (const enemy of state.enemies) {
+      if (enemy.id !== arsonist.id) enemy.hp = 0;
+    }
+    const collapse = collapseEnemyFrontLine(state.enemies);
+    expect(collapse.promoted).toContain(arsonist.id);
+    expect(arsonist.formationRow).toBe('front');
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const liveFireball = mage.moves.find((move) => move.id === fireball.id)!;
+    expect(partyTargetAvailability(state, mage, liveFireball, arsonist).allowed).toBe(true);
+  });
+
+  it('applies the same solid obstruction to enemy direct magic instead of sniping the lowest-HP party rear', () => {
+    const state = convoyState();
+    const arsonist = state.enemies.find((enemy) => enemy.id === 'convoy-ash-arsonist')!;
+    state.enemyIntents[arsonist.id] = 'convoy-ash-bolt';
+    const front = state.party.find((member) => member.id === 'front-sword')!;
+    const ranger = state.party.find((member) => member.id === 'rear-ranger')!;
+    const mage = state.party.find((member) => member.id === 'rear-mage')!;
+    const before = { front: front.hp, ranger: ranger.hp, mage: mage.hp };
+    enemyAct(rng, state, arsonist.id);
+    expect(front.hp).toBeLessThan(before.front);
+    expect(ranger.hp).toBe(before.ranger);
+    expect(mage.hp).toBe(before.mage);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.test.ts
+++ b/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Move } from '../combat';
+import { BATTLEFIELD_TERRAINS } from './battlefieldTerrain.m55';
+import {
+  attackDeliveryForMove,
+  lineOfEffectProfile,
+  moveCanBypassFrontline,
+  solidRearObstructionActive,
+} from './battlefieldLineOfEffect.m57';
+
+const melee: Move = {
+  id: 'm57-melee', name: '劍擊', kind: 'attack', target: 'enemy', hitStat: 'str', element: 'slash',
+  damage: { dice: 1, sides: 6, bonusStat: 'str' }, narration: '{actor}斬向{target}。',
+};
+const ranged: Move = {
+  id: 'm57-ranged', name: '長弓射擊', kind: 'attack', target: 'enemy', hitStat: 'dex', element: 'pierce', engagement: 'ranged',
+  damage: { dice: 1, sides: 6, bonusStat: 'dex' }, narration: '{actor}射向{target}。',
+};
+const fireball: Move = {
+  id: 'fireball', name: '火球', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
+  damage: { dice: 2, sides: 6, bonusStat: 'int' }, narration: '{actor}以火球轟擊{target}。',
+};
+const explicitOverhead: Move = {
+  ...ranged, id: 'm57-overhead', name: '拋射', delivery: 'overhead',
+};
+const explicitContactSpell: Move = {
+  ...fireball, id: 'm57-contact-spell', name: '灼熱觸碰', delivery: 'contact',
+};
+
+describe('M57 attack delivery and solid line-of-effect rules', () => {
+  it('infers ordinary melee as contact and ordinary ranged/spell projectiles as direct', () => {
+    expect(attackDeliveryForMove(melee)).toBe('contact');
+    expect(attackDeliveryForMove(ranged)).toBe('direct');
+    expect(attackDeliveryForMove(fireball)).toBe('direct');
+    expect(moveCanBypassFrontline(melee)).toBe(false);
+    expect(moveCanBypassFrontline(ranged)).toBe(true);
+    expect(moveCanBypassFrontline(fireball)).toBe(true);
+  });
+
+  it('honors explicit delivery instead of magic identity', () => {
+    expect(attackDeliveryForMove(explicitOverhead)).toBe('overhead');
+    expect(attackDeliveryForMove(explicitContactSpell)).toBe('contact');
+    expect(moveCanBypassFrontline(explicitContactSpell)).toBe(false);
+  });
+
+  it('normalizes unambiguous pre-M57 authored moves without changing their fiction', () => {
+    const arrowStorm: Move = { ...ranged, id: 'arrow-storm', name: '驟雨連射', area: true };
+    const meteor: Move = { ...fireball, id: 'meteor-fall', name: '隕石墜', area: true };
+    const judgement: Move = { ...fireball, id: 'judgement-hammer', name: '聖裁之錘', hitStat: 'cha', element: 'holy' };
+    const lament: Move = { ...fireball, id: 'reliquary-lament-touch', name: '哀歌觸碰', element: 'frost' };
+    expect(attackDeliveryForMove(arrowStorm)).toBe('overhead');
+    expect(attackDeliveryForMove(meteor)).toBe('overhead');
+    expect(attackDeliveryForMove(judgement)).toBe('contact');
+    expect(attackDeliveryForMove(lament)).toBe('contact');
+  });
+
+  it('activates solid obstruction only for a protected rear rank', () => {
+    const terrain = BATTLEFIELD_TERRAINS['ruined-battlements'];
+    expect(solidRearObstructionActive(terrain, 'back', true)).toBe(true);
+    expect(solidRearObstructionActive(terrain, 'front', true)).toBe(false);
+    expect(solidRearObstructionActive(terrain, 'back', false)).toBe(false);
+    expect(solidRearObstructionActive(BATTLEFIELD_TERRAINS['broken-stone-bridge'], 'back', true)).toBe(false);
+  });
+
+  it('blocks direct attacks to a protected rear target but never invents a hit penalty', () => {
+    const profile = lineOfEffectProfile(BATTLEFIELD_TERRAINS['ruined-battlements'], 'back', true, fireball);
+    expect(profile).toMatchObject({ delivery: 'direct', bypassesFrontline: true, blocked: true });
+    expect(profile.message).toMatch(/直線作用線|後排|越頂|突破/);
+    expect(profile).not.toHaveProperty('hitModifier');
+  });
+
+  it('lets explicit overhead attacks cross solid obstruction without a positive combat bonus', () => {
+    const profile = lineOfEffectProfile(BATTLEFIELD_TERRAINS['ruined-battlements'], 'back', true, explicitOverhead);
+    expect(profile).toEqual({ delivery: 'overhead', bypassesFrontline: true, blocked: false, message: '' });
+  });
+
+  it('leaves open ground and the M55 broken bridge behavior unchanged', () => {
+    expect(lineOfEffectProfile(BATTLEFIELD_TERRAINS['open-ground'], 'back', true, fireball).blocked).toBe(false);
+    expect(lineOfEffectProfile(BATTLEFIELD_TERRAINS['broken-stone-bridge'], 'back', true, ranged).blocked).toBe(false);
+  });
+});

--- a/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.ts
+++ b/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.ts
@@ -1,0 +1,70 @@
+import type { Move } from '../combat';
+import type { FormationRow } from '../save';
+import { mysticRuleForMove } from './arcana';
+import type { BattlefieldTerrain } from './battlefieldTerrain.m55';
+import { engagementForMove } from './martialEngagement.m49';
+
+export type AttackDelivery = 'contact' | 'direct' | 'overhead';
+
+export interface LineOfEffectProfile {
+  delivery: AttackDelivery;
+  bypassesFrontline: boolean;
+  blocked: boolean;
+  message: string;
+}
+
+/**
+ * M57 separates *how an attack reaches the target* from whether it is mundane or mystical.
+ * Magic is therefore no longer a synonym for "ignores space": a touch spell is contact,
+ * an ordinary bolt/fireball is direct, and only explicitly authored lobbed/descending attacks
+ * are overhead.
+ */
+export function attackDeliveryForMove(move: Move): AttackDelivery {
+  if (move.delivery) return move.delivery;
+  const engagement = engagementForMove(move, !!mysticRuleForMove(move));
+  if (engagement === 'melee' || engagement === 'reach') return 'contact';
+  return 'direct';
+}
+
+export function moveCanBypassFrontline(move: Move): boolean {
+  return move.kind === 'attack' && attackDeliveryForMove(move) !== 'contact';
+}
+
+export function solidRearObstructionActive(
+  terrain: BattlefieldTerrain | undefined,
+  targetRow: FormationRow | undefined,
+  frontlineAlive: boolean,
+): boolean {
+  return !!terrain
+    && terrain.rearLineObstruction === 'solid'
+    && targetRow === 'back'
+    && frontlineAlive;
+}
+
+/**
+ * A solid M57 obstruction blocks only a *direct* line to a protected rear target.
+ * Contact attacks are already governed by the frontline gate. Explicit overhead attacks may
+ * pass above the obstruction, but receive no positive accuracy/damage bonus for doing so.
+ */
+export function lineOfEffectProfile(
+  terrain: BattlefieldTerrain | undefined,
+  targetRow: FormationRow | undefined,
+  frontlineAlive: boolean,
+  move: Move,
+): LineOfEffectProfile {
+  const delivery = attackDeliveryForMove(move);
+  const bypassesFrontline = move.kind === 'attack' && delivery !== 'contact';
+  if (
+    move.kind !== 'attack'
+    || !solidRearObstructionActive(terrain, targetRow, frontlineAlive)
+    || delivery !== 'direct'
+  ) {
+    return { delivery, bypassesFrontline, blocked: false, message: '' };
+  }
+  return {
+    delivery,
+    bypassesFrontline,
+    blocked: true,
+    message: `${terrain!.name}的實體殘牆與車陣切斷了通往後排的直線作用線；${move.name}必須改打前排、使用明確越頂招式，或先突破戰線。`,
+  };
+}

--- a/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.ts
+++ b/src/scripts/games/caravan/data/battlefieldLineOfEffect.m57.ts
@@ -14,6 +14,20 @@ export interface LineOfEffectProfile {
 }
 
 /**
+ * These moves predate the M57 delivery field but their authored names/narrations already make
+ * the geometry unambiguous. New moves should author `delivery` directly; this compatibility map
+ * prevents old content from changing fiction merely because the new rule did not exist yet.
+ */
+const LEGACY_OVERHEAD_MOVE_IDS = new Set([
+  'arrow-storm',
+  'meteor-fall',
+]);
+const LEGACY_CONTACT_MYSTIC_MOVE_IDS = new Set([
+  'judgement-hammer',
+  'reliquary-lament-touch',
+]);
+
+/**
  * M57 separates *how an attack reaches the target* from whether it is mundane or mystical.
  * Magic is therefore no longer a synonym for "ignores space": a touch spell is contact,
  * an ordinary bolt/fireball is direct, and only explicitly authored lobbed/descending attacks
@@ -21,6 +35,8 @@ export interface LineOfEffectProfile {
  */
 export function attackDeliveryForMove(move: Move): AttackDelivery {
   if (move.delivery) return move.delivery;
+  if (LEGACY_OVERHEAD_MOVE_IDS.has(move.id)) return 'overhead';
+  if (LEGACY_CONTACT_MYSTIC_MOVE_IDS.has(move.id)) return 'contact';
   const engagement = engagementForMove(move, !!mysticRuleForMove(move));
   if (engagement === 'melee' || engagement === 'reach') return 'contact';
   return 'direct';

--- a/src/scripts/games/caravan/data/battlefieldTerrain.m55.ts
+++ b/src/scripts/games/caravan/data/battlefieldTerrain.m55.ts
@@ -4,6 +4,7 @@ import type { EngagementBand } from './martialEngagement.m49';
 export type BattlefieldTerrainId = 'open-ground' | 'broken-stone-bridge' | 'ruined-battlements';
 export type BattlefieldSide = 'party' | 'enemy';
 export type CoverGrade = 'none' | 'partial' | 'strong';
+export type RearLineObstruction = 'none' | 'solid';
 
 export interface BattlefieldTerrain {
   id: BattlefieldTerrainId;
@@ -11,6 +12,8 @@ export interface BattlefieldTerrain {
   description: string;
   partyRearCover: CoverGrade;
   enemyRearCover: CoverGrade;
+  /** M57：是否有足以切斷「直線」作用線的實體殘牆／車陣。 */
+  rearLineObstruction: RearLineObstruction;
 }
 
 export interface ProjectileCoverProfile {
@@ -27,6 +30,7 @@ export const BATTLEFIELD_TERRAINS: Record<BattlefieldTerrainId, BattlefieldTerra
     description: '沒有足以改變投射命中的固定掩體。',
     partyRearCover: 'none',
     enemyRearCover: 'none',
+    rearLineObstruction: 'none',
   },
   'broken-stone-bridge': {
     id: 'broken-stone-bridge',
@@ -34,13 +38,15 @@ export const BATTLEFIELD_TERRAINS: Record<BattlefieldTerrainId, BattlefieldTerra
     description: '殘破女牆與橋柱替雙方仍受前線保護的後排提供部分投射掩體；物理遠程命中 -1。前線崩潰、後排被迫上前後便失去這項保護。',
     partyRearCover: 'partial',
     enemyRearCover: 'partial',
+    rearLineObstruction: 'none',
   },
   'ruined-battlements': {
     id: 'ruined-battlements',
     name: '傾圮城垛',
-    description: '守方殘牆形成更厚實的射線遮蔽；部分掩體命中 -1，強掩體命中 -2。',
+    description: '殘牆、關隘折角與車陣切斷雙方對受前線保護後排的直線作用線；越頂攻勢仍可跨越，但物理投射仍承受部分／強掩體。',
     partyRearCover: 'partial',
     enemyRearCover: 'strong',
+    rearLineObstruction: 'solid',
   },
 };
 
@@ -59,10 +65,11 @@ export function rearCoverForSide(terrain: BattlefieldTerrain, side: BattlefieldS
 }
 
 /**
- * M55 only models partial projectile cover, not solid line-of-sight blockers.
+ * M55 only models partial projectile cover, not the M57 solid line-of-effect blocker.
  * It therefore modifies physical ranged attacks against a protected rear rank and nothing else:
- * melee/reach are already governed by the line model, while genuine spellcraft keeps its own
- * magical geometry until a future explicit LOS system exists.
+ * melee/reach are governed by the line model, while spell delivery/solid obstruction is handled
+ * separately by M57. An overhead physical projectile can clear a wall and still be harder to land
+ * accurately among battlements, so cover remains relevant after a legal M57 bypass.
  */
 export function projectileCoverProfile(
   terrain: BattlefieldTerrain | undefined,

--- a/src/scripts/games/caravan/data/convoyDefense.m46.ts
+++ b/src/scripts/games/caravan/data/convoyDefense.m46.ts
@@ -190,12 +190,13 @@ const hookStrike: Move = {
 const ashBolt: Move = {
   id: 'convoy-ash-bolt', name: '灰火箭', kind: 'attack', target: 'enemy', hitStat: 'int', element: 'fire',
   damage: { dice: 1, sides: 7, bonusStat: 'int' },
-  narration: '{actor}捻碎焦黑符紙，灰火箭穿過車陣擊中{target}，造成 {amount} 點傷害！',
+  narration: '{actor}捻碎焦黑符紙，灰火箭沿關隘缺口撲向{target}，造成 {amount} 點傷害！',
 };
 
 function reaverCaptain(): EnemyUnit {
   return {
     id: 'convoy-reaver-captain', name: '斷旗劫騎・領頭者',
+    battlefieldTerrainId: 'ruined-battlements',
     stats: { str: 15, dex: 12, int: 8, cha: 12, con: 15 }, maxHp: 32, hp: 32, defense: 14,
     weaknesses: ['blunt', 'holy'], resists: ['slash'], maxPoise: 3,
     armorProtection: armorProtectionForDiscipline('mail'),

--- a/src/scripts/games/caravan/data/enemyFormation.balance.m54.test.ts
+++ b/src/scripts/games/caravan/data/enemyFormation.balance.m54.test.ts
@@ -148,13 +148,13 @@ describe('M54 multidimensional player adversarial review', () => {
     expect(playerBack.hp).toBe(playerBack.maxHp);
   });
 
-  it('keeps magic exempt from mundane row pressure on both sides', () => {
+  it('keeps projected magic exempt from mundane row pressure on open battlefields', () => {
     const caster = foe('caster', 'back', [magic]);
     const screen = foe('screen', 'front');
     const state = startCombat(rng, [unit('front', 'front'), unit('rear', 'back', [magic], 8)], [screen, caster]);
     expect(caster.formationRow).toBe('back');
     expect(formationAttackProfile(caster.formationRow, magic, true).hitModifier).toBe(0);
     expect(enemyCanBypassPartyFront(magic)).toBe(true);
-    expect(state.log.some((entry) => entry.text.includes('近戰與長柄必須先突破前線'))).toBe(true);
+    expect(state.log.some((entry) => entry.text.includes('必須先突破前線'))).toBe(true);
   });
 });

--- a/src/scripts/games/caravan/data/enemyFormation.m54.ts
+++ b/src/scripts/games/caravan/data/enemyFormation.m54.ts
@@ -1,6 +1,12 @@
 import type { FormationRow } from '../save';
 import type { EnemyUnit, Move } from '../combat';
 import { mysticRuleForMove } from './arcana';
+import type { BattlefieldTerrain } from './battlefieldTerrain.m55';
+import {
+  attackDeliveryForMove,
+  lineOfEffectProfile,
+  moveCanBypassFrontline,
+} from './battlefieldLineOfEffect.m57';
 import { engagementForMove, type EngagementBand } from './martialEngagement.m49';
 
 export interface EnemyLineGate {
@@ -107,42 +113,62 @@ export function livingEnemyFrontExists(enemies: EnemyUnit[]): boolean {
 }
 
 /**
- * A living enemy frontline physically protects rear targets from close-combat attacks.
- * Ranged weapons and true magic can bypass the line; melee and reach must break it first.
- * This is a hard target gate, but rejected attempts must not spend the player's turn.
+ * M54/M57 enemy-line gate.
+ * A protected rear target can be reached only if the attack's delivery can cross the frontline;
+ * even then, a direct attack may still be stopped by a solid authored battlefield obstruction.
+ * This is intentionally symmetric for mundane and mystical attacks: "magic" alone never means
+ * contactless, wall-piercing or overhead.
  */
-export function enemyLineGate(enemies: EnemyUnit[], move: Move, target: EnemyUnit): EnemyLineGate {
+export function enemyLineGate(
+  enemies: EnemyUnit[],
+  move: Move,
+  target: EnemyUnit,
+  terrain?: BattlefieldTerrain,
+): EnemyLineGate {
   if (move.kind !== 'attack' || target.hp <= 0) {
     return { allowed: target.hp > 0, reason: target.hp > 0 ? '' : '目標已經倒下。', engagement: null };
   }
   const engagement = engagementForMove(move, !!mysticRuleForMove(move));
-  if (target.formationRow !== 'back' || !livingEnemyFrontExists(enemies)) {
+  const frontlineAlive = livingEnemyFrontExists(enemies);
+  if (target.formationRow !== 'back' || !frontlineAlive) {
     return { allowed: true, reason: '', engagement };
   }
-  if (engagement === 'ranged' || engagement === 'mystic') {
-    return { allowed: true, reason: '', engagement };
+
+  if (!moveCanBypassFrontline(move)) {
+    const delivery = attackDeliveryForMove(move);
+    const label = engagement === 'reach'
+      ? '長柄武器'
+      : engagement === 'mystic' && delivery === 'contact'
+        ? '貼身法術／聖技'
+        : '近戰武器';
+    return {
+      allowed: false,
+      reason: `${target.name}仍在敵方後排，前線尚未突破；${label}必須先處理仍存活的前排敵人。`,
+      engagement,
+    };
   }
-  const label = engagement === 'reach' ? '長柄武器' : '近戰武器';
-  return {
-    allowed: false,
-    reason: `${target.name}仍在敵方後排，前線尚未突破；${label}必須先處理仍存活的前排敵人。`,
-    engagement,
-  };
+
+  const line = lineOfEffectProfile(terrain, target.formationRow, frontlineAlive, move);
+  if (line.blocked) return { allowed: false, reason: line.message, engagement };
+  return { allowed: true, reason: '', engagement };
 }
 
-/** Party attacks that can legally reach the enemy line. Used by both single-target and area attacks. */
-export function legalEnemyTargets(enemies: EnemyUnit[], move: Move): EnemyUnit[] {
+/** Party attacks that can legally reach the enemy line and any authored solid obstruction. */
+export function legalEnemyTargets(
+  enemies: EnemyUnit[],
+  move: Move,
+  terrain?: BattlefieldTerrain,
+): EnemyUnit[] {
   const alive = enemies.filter((enemy) => enemy.hp > 0);
   if (move.kind !== 'attack') return alive;
-  return alive.filter((enemy) => enemyLineGate(alive, move, enemy).allowed);
+  return alive.filter((enemy) => enemyLineGate(alive, move, enemy, terrain).allowed);
 }
 
 /**
- * Enemy targeting uses the same line logic in reverse.
- * Close combat attacks the player's frontline; ranged/mystic attacks may threaten anyone.
+ * Enemy targeting uses the same delivery logic in reverse.
+ * Contact attacks stay on the player's frontline; direct/overhead attacks may cross the line,
+ * after which M57 terrain obstruction is checked per target by the combat engine.
  */
 export function enemyCanBypassPartyFront(move: Move): boolean {
-  if (move.kind !== 'attack') return false;
-  const engagement = engagementForMove(move, !!mysticRuleForMove(move));
-  return engagement === 'ranged' || engagement === 'mystic';
+  return moveCanBypassFrontline(move);
 }

--- a/src/scripts/games/caravan/data/tacticalReadability.m56.ts
+++ b/src/scripts/games/caravan/data/tacticalReadability.m56.ts
@@ -2,12 +2,17 @@ import {
   legalEnemyTargetsForMove,
   partyTargetAvailability,
   targetCoverForecast,
+  targetLineOfEffectForecast,
   type CombatState,
   type CombatantBase,
   type Move,
   type PartyMember,
 } from '../combat';
 import { projectileCoverProfile, type BattlefieldSide } from './battlefieldTerrain.m55';
+import {
+  attackDeliveryForMove,
+  solidRearObstructionActive,
+} from './battlefieldLineOfEffect.m57';
 
 export interface TacticalTargetChoice {
   id: string;
@@ -32,8 +37,9 @@ function coverLabel(modifier: number): string {
 }
 
 /**
- * M56 player information contract for a visible combatant card.
- * It intentionally describes only rules the engine already enforces; no page should infer rows or cover itself.
+ * M56/M57 player information contract for a visible combatant card.
+ * It intentionally describes only rules the engine already enforces; no page should infer rows,
+ * cover or solid line obstruction itself.
  */
 export function tacticalUnitSummary(
   state: CombatState,
@@ -55,6 +61,7 @@ export function tacticalUnitSummary(
   );
   const parts = ['後排'];
   if (frontlineAlive) parts.push('受前線保護');
+  if (solidRearObstructionActive(state.terrain, unit.formationRow, frontlineAlive)) parts.push('實體遮蔽');
   if (cover.applies) parts.push(coverLabel(cover.hitModifier));
   return parts.join('｜');
 }
@@ -62,7 +69,10 @@ export function tacticalUnitSummary(
 function attackTargetLabel(state: CombatState, move: Move, target: CombatState['enemies'][number], allowed: boolean): string {
   const parts = [rowLabel(target)];
   const cover = targetCoverForecast(state, move, target);
-  if (!allowed && target.formationRow === 'back') parts.push('前線保護');
+  const line = targetLineOfEffectForecast(state, move, target);
+  if (!allowed && line.blocked) parts.push('實體遮蔽');
+  else if (!allowed && target.formationRow === 'back') parts.push('前線保護');
+  if (line.delivery === 'overhead') parts.push('越頂');
   if (cover.applies) parts.push(coverLabel(cover.hitModifier));
   return `${target.name}【${parts.join('｜')}】`;
 }
@@ -73,10 +83,11 @@ function areaTargetChoice(state: CombatState, move: Move): TacticalTargetChoice[
   const alive = state.enemies.filter((enemy) => enemy.hp > 0);
   const frontlineOnly = legal.length < alive.length && legal.every((enemy) => enemy.formationRow !== 'back');
   const covered = legal.filter((enemy) => targetCoverForecast(state, move, enemy).applies);
+  const deliveryText = attackDeliveryForMove(move) === 'overhead' ? '｜越頂' : '';
   const coverText = covered.length > 0 ? `｜${covered.length} 名受掩體影響` : '';
   return [{
     id: legal[0].id,
-    label: `${frontlineOnly ? '敵方前排全體' : '敵方全體'}（${legal.length}）${coverText}`,
+    label: `${frontlineOnly ? '敵方前排全體' : '敵方全體'}（${legal.length}）${deliveryText}${coverText}`,
     allowed: true,
     reason: '',
     targetCount: legal.length,
@@ -87,9 +98,10 @@ function areaTargetChoice(state: CombatState, move: Move): TacticalTargetChoice[
 }
 
 /**
- * The reusable M56 UI source of truth.
+ * The reusable M56/M57 UI source of truth.
  * - blocked rear targets remain visible but disabled, so the player can understand *why* they cannot be selected;
- * - ranged / mystic attacks expose the legal rear option;
+ * - direct attacks expose solid line blockers instead of pretending magic can pass through walls;
+ * - explicit overhead attacks advertise the bypass while still exposing any physical cover penalty;
  * - area actions report the exact engine target set rather than pretending every AoE hits every rank;
  * - ally/self actions remain compatible with the original combat loop.
  */


### PR DESCRIPTION
## Stacked dependency

Draft stacked on #259 / `agent/caravan-m56-tactical-readability`. No merge is requested.

## Summary

M57 corrects a remaining medieval sword-and-magic spatial inconsistency: M54 previously treated every true spell as if it could bypass formation geometry, while M55 deliberately stopped short of claiming that magic passes through walls.

M57 separates **attack delivery** from damage type or magical identity:
- `contact` — melee/reach and explicitly close magical/holy attacks; must break a living frontline
- `direct` — arrows, bolts and ordinary projected spell effects; may cross an open frontline but cannot pass an authored solid rear obstruction
- `overhead` — explicitly lobbed/descending attacks; may cross a solid obstruction but receive no hidden accuracy or damage bonus

This means “magic” is no longer a synonym for “ignores space.” A touch spell stays close-range; a projected fireball follows a direct line; only an explicitly descending/lobbed effect can clear a solid obstruction.

### Pre-M57 compatibility
Existing moves whose authored fiction is already unambiguous are normalized conservatively:
- `arrow-storm` / 驟雨連射 → overhead
- `meteor-fall` / 隕石墜 → overhead
- `judgement-hammer` / 聖裁之錘 → contact
- `reliquary-lament-touch` / 哀歌觸碰 → contact

Future content can author `Move.delivery` directly. No damage, hit bonus, resource cost or class progression value was changed.

## First live battlefield: Split Banner Pass

The M46 Split Banner convoy encounter now authors `ruined-battlements` / 傾圮城垛.

While a side still has a living frontline:
- broken walls, gate bends and the wagon line cut direct lines to that side's protected rear rank
- ordinary bows and projected spells cannot directly snipe through the solid obstruction
- the same restriction applies to enemy gray-fire magic; AI receives no wall exemption
- explicit overhead attacks may cross the obstruction
- physical overhead projectiles still use M55 cover math after they cross it

So clearing the wall is not the same as ignoring battlements: Arrow Storm can reach the enemy rear but still suffers that rear's strong-cover penalty; Meteor Fall can descend over the obstruction but receives neither a cover penalty nor a positive terrain bonus.

## Player routes deliberately preserved

M57 is not a class lock. The live convoy still supports:
- swords / polearms breaking the frontline and exposing the rear
- ordinary ranged/direct magic attacking legal frontline targets
- prepared overhead attacks attacking across the obstruction
- guarding / bracing the wagon as a non-kill objective route
- morale/surrender play from M47

Once the frontline collapses, surviving rear units are promoted under M54 and the rear-only obstruction ceases to protect them.

## Resource and turn fairness

Blocked direct attacks are rejected before action execution:
- no turn advance
- no mana/favor spend
- no overcast backlash
- no hidden auto-retarget

The exact line-of-effect forecast is also exposed to the M56 tactical-readability adapter so UI labels can distinguish `前線保護`, `實體遮蔽` and `越頂` instead of making the player infer geometry through failed clicks.

## Guard interaction

Single-target contact/direct attacks may still be intercepted by a valid frontline guardian. Explicit overhead delivery is not unrealistically redirected by a frontline body standing under a descending/lobbed attack.

## Historical M54 correction

The first M57 CI pass exposed one stale M54 assertion that hard-coded the exact old battle-start sentence `近戰與長柄必須先突破前線`. M57 necessarily expands that explanation to include contact magic and direct/overhead semantics.

The historical test was changed only from an exact wording lock to the semantic invariant `必須先突破前線`. Its behavioral checks still prove that projected Fireball crosses an open enemy screen and receives no row bonus. M57 did not use that failure as a reason to weaken combat rules.

## Multidimensional player adversarial review

Dedicated M57 tests attack:
1. magic being treated as an automatic wall key
2. contact spells bypassing a living frontline
3. ordinary physical ranged fire passing through solid battlements
4. enemy AI receiving a hidden obstruction exemption
5. overhead becoming a hidden hit/damage buff
6. physical and magical overhead losing their distinct M55-cover interaction
7. blocked spell clicks consuming mana or a turn
8. frontline collapse leaving stale rear obstruction
9. ally healing/support being polluted by hostile geometry
10. open-ground encounters accidentally gaining walls
11. the M55 broken bridge being silently upgraded from cover to a solid blocker
12. forecasting/UI reads mutating combat state
13. pure martial parties losing a valid combat route
14. convoy objective play becoming invalid unless the party brings a ranged/magic bypass class

## Scope diff

Relative to validated M56 head `5366363dd30d5b7838d5bf92997af5ce579a719c`, M57 is ahead by 12 commits / behind by 0 and changes exactly 11 files:
- M57 attack-delivery / line-of-effect module
- M57 rule, live-integration and adversarial-review tests
- M57 CI workflow
- combat engine integration
- M54 formation gate + one semantic historical assertion
- M55 terrain schema extension
- M56 tactical-readability integration
- M46 Split Banner battlefield authoring

No save schema, economy, equipment numbers, class damage values, rewards or progression rules changed.

## Validation

Validated M57 head: `6c925f9fad9e43bd3fe1b8db12f8875942a12483`.

At this exact head **20/20 Caravan GitHub Actions workflows passed**, including:
- production build
- M57 attack-delivery rules
- M57 live Split Banner line-of-effect integration
- M57 multidimensional player adversarial review
- M56 tactical readability
- M55 battlefield cover
- M54 enemy formation
- M53 reach/polearms
- M52 shields/handedness
- M51 veteran mastery/reposition
- M49–M50 formation/readability
- core combat + M41 magic
- M40 live Reliquary combat
- M42 endurance/composition diversity
- M43 armory/endurance
- M44 spellcraft
- M45 ritual counterplay
- M46 convoy objective
- M47 morale
- M48 armor lifecycle/review

PR remains Draft/open/mergeable. No merge requested.